### PR TITLE
[Sentinel One] Convert visualisations to Lens

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Convert dashboards to Lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6932
 - version: "1.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/sentinel_one/kibana/dashboard/sentinel_one-0dd17490-bbb8-11ec-82b7-8fcb232e9538.json
+++ b/packages/sentinel_one/kibana/dashboard/sentinel_one-0dd17490-bbb8-11ec-82b7-8fcb232e9538.json
@@ -1,7 +1,6 @@
 {
     "attributes": {
         "description": "",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -36,6 +35,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -57,7 +58,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "58329672-9ca4-4454-9d78-c619ef956a6a": {
                                             "columnOrder": [
@@ -87,12 +88,15 @@
                             "visualization": {
                                 "accessor": "d8990d07-439a-4335-9646-8fbcab6e268d",
                                 "layerId": "58329672-9ca4-4454-9d78-c619ef956a6a",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Number of Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {}
                 },
@@ -105,7 +109,7 @@
                 },
                 "panelIndex": "ac59079e-c791-449b-aeeb-d47504921dff",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -130,7 +134,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "01d7bdc3-638b-4d23-9ae6-d24678743470": {
                                             "columnOrder": [
@@ -160,7 +164,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": false,
                                         "params": {
@@ -182,12 +186,15 @@
                             "visualization": {
                                 "accessor": "831e34ee-b0d6-44b1-81b7-2bfee2a628ab",
                                 "layerId": "01d7bdc3-638b-4d23-9ae6-d24678743470",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Total Resolved Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {}
                 },
@@ -200,7 +207,7 @@
                 },
                 "panelIndex": "1684da14-7484-42a6-91d6-b9659883e20d",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -225,7 +232,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "8a4ab761-ffa9-4e3d-bd66-9cf0b7ee9849": {
                                             "columnOrder": [
@@ -255,7 +262,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": false,
                                         "params": {
@@ -277,12 +284,15 @@
                             "visualization": {
                                 "accessor": "f3d83b7a-fc35-4c85-83f8-b41e12baddf6",
                                 "layerId": "8a4ab761-ffa9-4e3d-bd66-9cf0b7ee9849",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Unresolved Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -297,7 +307,7 @@
                 "panelIndex": "030f8164-5e7d-4fb6-a779-d0537748a819",
                 "title": "Total Unresolved Threats [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -327,7 +337,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6f8f021f-aef7-458f-a0bb-445bd78741db": {
                                             "columnOrder": [
@@ -357,7 +367,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": false,
                                         "params": {
@@ -378,7 +388,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "sentinel_one.threat.mitigation.status",
                                         "negate": false,
                                         "params": {
@@ -400,12 +410,15 @@
                             "visualization": {
                                 "accessor": "1ede434b-a316-4e79-85b6-ffbfc41f379a",
                                 "layerId": "6f8f021f-aef7-458f-a0bb-445bd78741db",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Active Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -420,7 +433,7 @@
                 "panelIndex": "075409b1-9d74-4399-8348-3101a2d22392",
                 "title": "Active Threats [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -450,7 +463,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "31be526e-c389-4f6d-93e8-27f1b7dcd0d0": {
                                             "columnOrder": [
@@ -480,7 +493,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": true,
                                         "params": {
@@ -501,7 +514,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "sentinel_one.threat.mitigation.status",
                                         "negate": false,
                                         "params": {
@@ -523,12 +536,15 @@
                             "visualization": {
                                 "accessor": "8ae53844-358d-4472-9d64-d7c2708fc29c",
                                 "layerId": "31be526e-c389-4f6d-93e8-27f1b7dcd0d0",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Blocked Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -543,7 +559,7 @@
                 "panelIndex": "3ff8c08e-3a29-488c-b481-9b51accaae95",
                 "title": "Total Blocked Threats [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -573,7 +589,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1c27890e-f153-4984-8c2f-6004a3779f71": {
                                             "columnOrder": [
@@ -603,7 +619,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.mitigation.status",
                                         "negate": false,
                                         "params": {
@@ -624,7 +640,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": true,
                                         "params": {
@@ -646,12 +662,15 @@
                             "visualization": {
                                 "accessor": "eb8375d7-8836-43bb-840a-88c8c2f11b43",
                                 "layerId": "1c27890e-f153-4984-8c2f-6004a3779f71",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Mitigated Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -666,7 +685,7 @@
                 "panelIndex": "d2411b38-52ad-47c2-b364-f1f42b7cd26a",
                 "title": "Total Mitigated Threats [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -696,7 +715,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "98a05273-ef46-4b59-8caa-86b7de9c9724": {
                                             "columnOrder": [
@@ -726,7 +745,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.incident.status",
                                         "negate": true,
                                         "params": {
@@ -747,7 +766,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-1",
+                                        "index": "filter-index-pattern-1",
                                         "key": "sentinel_one.agent.console_migration_status",
                                         "negate": false,
                                         "params": {
@@ -769,12 +788,15 @@
                             "visualization": {
                                 "accessor": "9295a43b-ccd0-4d23-abf8-73586af8dac7",
                                 "layerId": "98a05273-ef46-4b59-8caa-86b7de9c9724",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "size": "xl",
+                                "textAlign": "center",
+                                "titlePosition": "bottom"
                             }
                         },
                         "title": "Detected - Suspicious Threats [Logs SentinelOne]",
                         "type": "lens",
-                        "visualizationType": "lnsMetric"
+                        "visualizationType": "lnsLegacyMetric"
                     },
                     "enhancements": {},
                     "hidePanelTitles": false
@@ -789,145 +811,7 @@
                 "panelIndex": "14069c35-b940-4540-82f8-1ef2bb73dfe1",
                 "title": "Total Detected - Suspicious Threats [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-9d8d04b8-42e9-488a-9c18-39f38153e46a",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "filter-index-pattern-0",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "datasourceStates": {
-                                "indexpattern": {
-                                    "layers": {
-                                        "9d8d04b8-42e9-488a-9c18-39f38153e46a": {
-                                            "columnOrder": [
-                                                "3629412b-4ee6-4169-92d4-d5d8ebb7ab62",
-                                                "324989fb-f85e-4bbc-b7f9-b85472d54928"
-                                            ],
-                                            "columns": {
-                                                "324989fb-f85e-4bbc-b7f9-b85472d54928": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count",
-                                                    "operationType": "unique_count",
-                                                    "scale": "ratio",
-                                                    "sourceField": "sentinel_one.threat.id"
-                                                },
-                                                "3629412b-4ee6-4169-92d4-d5d8ebb7ab62": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Prevalent Threats",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "324989fb-f85e-4bbc-b7f9-b85472d54928",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "sentinel_one.threat.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
-                                        "key": "sentinel_one.threat.incident.status",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "resolved"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "sentinel_one.threat.incident.status": "resolved"
-                                        }
-                                    }
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "324989fb-f85e-4bbc-b7f9-b85472d54928"
-                                        ],
-                                        "layerId": "9d8d04b8-42e9-488a-9c18-39f38153e46a",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_stacked",
-                                        "showGridlines": false,
-                                        "xAccessor": "3629412b-4ee6-4169-92d4-d5d8ebb7ab62"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "title": "Empty XY chart",
-                                "valueLabels": "hide",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightExtent": {
-                                    "mode": "full"
-                                }
-                            }
-                        },
-                        "title": "Most Prevalent Threats [Logs SentinelOne]",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "213a2279-8bb5-491b-b0f0-d5a7a2473670",
-                    "w": 24,
-                    "x": 24,
-                    "y": 14
-                },
-                "panelIndex": "213a2279-8bb5-491b-b0f0-d5a7a2473670",
-                "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -947,7 +831,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "ec6bf891-aedf-4b92-af42-54c04e749174": {
                                             "columnOrder": [
@@ -998,15 +882,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "7dc311c6-df3f-40ca-88e5-3925010191be"
-                                        ],
                                         "layerId": "ec6bf891-aedf-4b92-af42-54c04e749174",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "9934d429-8319-435c-8c72-57a56541dfcb",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "9934d429-8319-435c-8c72-57a56541dfcb"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "7dc311c6-df3f-40ca-88e5-3925010191be"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1027,7 +914,146 @@
                 },
                 "panelIndex": "14523f88-ccbb-45bc-9758-7263315630cb",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-current-indexpattern",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-9d8d04b8-42e9-488a-9c18-39f38153e46a",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "filter-index-pattern-0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9d8d04b8-42e9-488a-9c18-39f38153e46a": {
+                                            "columnOrder": [
+                                                "3629412b-4ee6-4169-92d4-d5d8ebb7ab62",
+                                                "324989fb-f85e-4bbc-b7f9-b85472d54928"
+                                            ],
+                                            "columns": {
+                                                "324989fb-f85e-4bbc-b7f9-b85472d54928": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "unique_count",
+                                                    "scale": "ratio",
+                                                    "sourceField": "sentinel_one.threat.id"
+                                                },
+                                                "3629412b-4ee6-4169-92d4-d5d8ebb7ab62": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Prevalent Threats",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "324989fb-f85e-4bbc-b7f9-b85472d54928",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "sentinel_one.threat.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "filter-index-pattern-0",
+                                        "key": "sentinel_one.threat.incident.status",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "resolved"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "sentinel_one.threat.incident.status": "resolved"
+                                        }
+                                    }
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "324989fb-f85e-4bbc-b7f9-b85472d54928"
+                                        ],
+                                        "layerId": "9d8d04b8-42e9-488a-9c18-39f38153e46a",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_stacked",
+                                        "showGridlines": false,
+                                        "xAccessor": "3629412b-4ee6-4169-92d4-d5d8ebb7ab62"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "auto",
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "Most Prevalent Threats [Logs SentinelOne]",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "213a2279-8bb5-491b-b0f0-d5a7a2473670",
+                    "w": 24,
+                    "x": 24,
+                    "y": 14
+                },
+                "panelIndex": "213a2279-8bb5-491b-b0f0-d5a7a2473670",
+                "type": "lens",
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1052,7 +1078,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f83c655e-003c-4cc5-a2e3-789acb23b691": {
                                             "columnOrder": [
@@ -1108,7 +1134,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.agent.is_active",
                                         "negate": false,
                                         "type": "exists"
@@ -1128,15 +1154,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "d427f2bd-912c-476e-85a7-3110216b3b8d"
-                                        ],
                                         "layerId": "f83c655e-003c-4cc5-a2e3-789acb23b691",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "7fead18f-d40b-4539-ace7-5328e84140d2",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "7fead18f-d40b-4539-ace7-5328e84140d2"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "d427f2bd-912c-476e-85a7-3110216b3b8d"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1158,7 +1187,7 @@
                 },
                 "panelIndex": "dc9ba6b7-0c35-4333-99ad-653d57c20fd7",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1178,7 +1207,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "6f4336e8-7451-476e-89a5-fe65d93be571": {
                                             "columnOrder": [
@@ -1229,15 +1258,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "59424e47-b686-440e-b754-51a079ad1417"
-                                        ],
                                         "layerId": "6f4336e8-7451-476e-89a5-fe65d93be571",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "7c71fee2-7e8b-48d2-8344-767b3e76f207",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "7c71fee2-7e8b-48d2-8344-767b3e76f207"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "59424e47-b686-440e-b754-51a079ad1417"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1258,7 +1290,7 @@
                 },
                 "panelIndex": "0ae44b6f-3e90-4fce-96a0-a0bdf069ab0e",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1278,7 +1310,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c5e5c6f0-5d4d-48f4-9ad4-727d5f1c0ebd": {
                                             "columnOrder": [
@@ -1329,15 +1361,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "039a2941-5111-4bf1-a02a-af4a8fe09609"
-                                        ],
                                         "layerId": "c5e5c6f0-5d4d-48f4-9ad4-727d5f1c0ebd",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "86f6d3c9-4b8b-4d98-afae-df8ba9fd0e43",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "86f6d3c9-4b8b-4d98-afae-df8ba9fd0e43"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "039a2941-5111-4bf1-a02a-af4a8fe09609"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -1358,7 +1393,7 @@
                 },
                 "panelIndex": "accf3797-c215-44a4-829d-c9ff30758f7b",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1378,7 +1413,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a64559b1-90c9-4859-9d5f-2585172bcda4": {
                                             "columnOrder": [
@@ -1441,6 +1476,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1469,7 +1505,7 @@
                 },
                 "panelIndex": "301b13f1-59c8-40e0-80f8-ecc1892b938d",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1489,7 +1525,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "da28cab9-5d08-4b0b-bbd6-2cf9952051b2": {
                                             "columnOrder": [
@@ -1552,6 +1588,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1580,7 +1617,7 @@
                 },
                 "panelIndex": "b8f90700-ca73-40c7-9257-8612aa86cc9f",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1600,7 +1637,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "87c51fc8-6c57-4d1c-a3f5-8b420f1d392c": {
                                             "columnOrder": [
@@ -1663,6 +1700,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1691,7 +1729,7 @@
                 },
                 "panelIndex": "9bdf752f-f767-44a4-bf05-51e0a27b7bbf",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1711,7 +1749,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "3f121a5b-0179-4329-a945-a3d23d83172f": {
                                             "columnOrder": [
@@ -1770,7 +1808,9 @@
                                     }
                                 ],
                                 "layerId": "3f121a5b-0179-4329-a945-a3d23d83172f",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Top 10 File Extension [Logs SentinelOne]",
@@ -1788,7 +1828,7 @@
                 },
                 "panelIndex": "ed9a7061-e640-41f3-a838-3772f86e4be4",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1808,7 +1848,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "8662c82e-ca55-4ddc-81b6-2c4f9a3afbf8": {
                                             "columnOrder": [
@@ -1871,6 +1911,7 @@
                                 ],
                                 "legend": {
                                     "isVisible": true,
+                                    "legendSize": "auto",
                                     "position": "right"
                                 },
                                 "preferredSeriesType": "bar_stacked",
@@ -1901,78 +1942,120 @@
                 "panelIndex": "e17f8b5f-d5de-4921-bb3a-9d3e7ef58ae4",
                 "title": "Distribution of Threats by Incident Status [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {
-                                        "customLabel": "Count",
-                                        "field": "sentinel_one.threat.id"
-                                    },
-                                    "schema": "metric",
-                                    "type": "cardinality"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-72498694-dd0d-4f76-9d38-d0e7a211b6a9",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "72498694-dd0d-4f76-9d38-d0e7a211b6a9": {
+                                            "columnOrder": [
+                                                "872c0c1b-aedd-4cf0-a98a-60443e689fc5",
+                                                "7d83b2e8-f6df-4b3e-868c-9452cf579fb0"
+                                            ],
+                                            "columns": {
+                                                "7d83b2e8-f6df-4b3e-868c-9452cf579fb0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "872c0c1b-aedd-4cf0-a98a-60443e689fc5": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Technique ID",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "7d83b2e8-f6df-4b3e-868c-9452cf579fb0",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "threat.technique.id"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Technique Name",
-                                        "field": "threat.technique.id",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "index": "logs-*",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "7d83b2e8-f6df-4b3e-868c-9452cf579fb0",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "columnId": "872c0c1b-aedd-4cf0-a98a-60443e689fc5",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "72498694-dd0d-4f76-9d38-d0e7a211b6a9",
+                                "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
                                 }
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
-                        "title": "Top 10 Threat Techniques [Logs SentinelOne]",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "6d788430-6b2b-4e7c-9468-36b0aebf8468",
+                    "i": "3e6f6367-85e2-45ee-a9c2-a14d5739f952",
                     "w": 24,
                     "x": 0,
                     "y": 89
                 },
-                "panelIndex": "6d788430-6b2b-4e7c-9468-36b0aebf8468",
-                "type": "visualization",
-                "version": "7.17.0"
+                "panelIndex": "3e6f6367-85e2-45ee-a9c2-a14d5739f952",
+                "title": "Top 10 Threat Techniques [Logs SentinelOne]",
+                "type": "lens",
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -1997,7 +2080,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "71ff1569-960a-408c-8e00-df6b68186912": {
                                             "columnOrder": [
@@ -2053,7 +2136,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
+                                        "index": "filter-index-pattern-0",
                                         "key": "sentinel_one.threat.agent.infected",
                                         "negate": false,
                                         "type": "exists"
@@ -2073,15 +2156,18 @@
                                 "layers": [
                                     {
                                         "categoryDisplay": "default",
-                                        "groups": [
-                                            "9a221d90-b37c-4947-899a-a8806d7d25f1"
-                                        ],
                                         "layerId": "71ff1569-960a-408c-8e00-df6b68186912",
                                         "layerType": "data",
                                         "legendDisplay": "default",
-                                        "metric": "d24c6b72-358d-4f01-ade3-cf9c228946e0",
+                                        "legendSize": "auto",
+                                        "metrics": [
+                                            "d24c6b72-358d-4f01-ade3-cf9c228946e0"
+                                        ],
                                         "nestedLegend": false,
-                                        "numberDisplay": "percent"
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "9a221d90-b37c-4947-899a-a8806d7d25f1"
+                                        ]
                                     }
                                 ],
                                 "shape": "pie"
@@ -2104,7 +2190,7 @@
                 "panelIndex": "1888de07-0e2f-4fc4-80e9-f3102e8b97b3",
                 "title": "Distribution of Threats by Infected Agents [Logs SentinelOne]",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
@@ -2124,7 +2210,7 @@
                         ],
                         "state": {
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "9fe7a9cc-3417-4166-bdfc-5cdb85599981": {
                                             "columnOrder": [
@@ -2183,7 +2269,9 @@
                                     }
                                 ],
                                 "layerId": "9fe7a9cc-3417-4166-bdfc-5cdb85599981",
-                                "layerType": "data"
+                                "layerType": "data",
+                                "rowHeight": "single",
+                                "rowHeightLines": 1
                             }
                         },
                         "title": "Distribution of Threats by Detection Engine [Logs SentinelOne] ",
@@ -2201,88 +2289,130 @@
                 },
                 "panelIndex": "6080a8f0-54d7-4fae-884f-f34dbed69ea8",
                 "type": "lens",
-                "version": "7.17.0"
+                "version": "8.7.1"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {
-                                        "customLabel": "Count",
-                                        "field": "sentinel_one.threat.id"
-                                    },
-                                    "schema": "metric",
-                                    "type": "cardinality"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-7cff55a3-869c-4529-a8bf-39b8d5ad3fa1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "7cff55a3-869c-4529-a8bf-39b8d5ad3fa1": {
+                                            "columnOrder": [
+                                                "32957c07-beb9-4cc6-99a8-f6e1c686c105",
+                                                "92c9fb3d-991c-4c5e-b5e4-f73d60aed93f"
+                                            ],
+                                            "columns": {
+                                                "32957c07-beb9-4cc6-99a8-f6e1c686c105": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Threat Classification",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "92c9fb3d-991c-4c5e-b5e4-f73d60aed93f",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "sentinel_one.threat.classification"
+                                                },
+                                                "92c9fb3d-991c-4c5e-b5e4-f73d60aed93f": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
                                 },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Threat Classification",
-                                        "field": "sentinel_one.threat.classification",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10
-                                    },
-                                    "schema": "segment",
-                                    "type": "terms"
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            ],
-                            "searchSource": {
-                                "filter": [],
-                                "index": "logs-*",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "columnId": "32957c07-beb9-4cc6-99a8-f6e1c686c105"
+                                    },
+                                    {
+                                        "columnId": "92c9fb3d-991c-4c5e-b5e4-f73d60aed93f"
+                                    }
+                                ],
+                                "layerId": "7cff55a3-869c-4529-a8bf-39b8d5ad3fa1",
+                                "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
                                 }
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "maxFontSize": 72,
-                            "minFontSize": 18,
-                            "orientation": "single",
-                            "palette": {
-                                "name": "default",
-                                "type": "palette"
-                            },
-                            "scale": "linear",
-                            "showLabel": true
-                        },
-                        "title": "Top Threats by Classification [Logs SentinelOne]",
-                        "type": "tagcloud",
-                        "uiState": {}
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "55d0b7da-986b-4e98-b476-f3768233dc8f",
+                    "i": "f7c0e875-f75f-4d06-b4dd-a8e50965eabe",
                     "w": 24,
                     "x": 24,
                     "y": 104
                 },
-                "panelIndex": "55d0b7da-986b-4e98-b476-f3768233dc8f",
-                "type": "visualization",
-                "version": "7.17.0"
+                "panelIndex": "f7c0e875-f75f-4d06-b4dd-a8e50965eabe",
+                "title": "Top 10 Threats by Classification [Logs SentinelOne]",
+                "type": "lens",
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs SentinelOne] Threats",
         "version": 1
     },
-    "coreMigrationVersion": "7.17.0",
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-07-12T11:18:11.726Z",
     "id": "sentinel_one-0dd17490-bbb8-11ec-82b7-8fcb232e9538",
     "migrationVersion": {
-        "dashboard": "7.17.0"
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -2412,6 +2542,16 @@
         },
         {
             "id": "logs-*",
+            "name": "14523f88-ccbb-45bc-9758-7263315630cb:indexpattern-datasource-current-indexpattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "14523f88-ccbb-45bc-9758-7263315630cb:indexpattern-datasource-layer-ec6bf891-aedf-4b92-af42-54c04e749174",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "213a2279-8bb5-491b-b0f0-d5a7a2473670:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
@@ -2423,16 +2563,6 @@
         {
             "id": "logs-*",
             "name": "213a2279-8bb5-491b-b0f0-d5a7a2473670:filter-index-pattern-0",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "14523f88-ccbb-45bc-9758-7263315630cb:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "14523f88-ccbb-45bc-9758-7263315630cb:indexpattern-datasource-layer-ec6bf891-aedf-4b92-af42-54c04e749174",
             "type": "index-pattern"
         },
         {
@@ -2522,7 +2652,7 @@
         },
         {
             "id": "logs-*",
-            "name": "6d788430-6b2b-4e7c-9468-36b0aebf8468:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "3e6f6367-85e2-45ee-a9c2-a14d5739f952:indexpattern-datasource-layer-72498694-dd0d-4f76-9d38-d0e7a211b6a9",
             "type": "index-pattern"
         },
         {
@@ -2552,7 +2682,7 @@
         },
         {
             "id": "logs-*",
-            "name": "55d0b7da-986b-4e98-b476-f3768233dc8f:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "f7c0e875-f75f-4d06-b4dd-a8e50965eabe:indexpattern-datasource-layer-7cff55a3-869c-4529-a8bf-39b8d5ad3fa1",
             "type": "index-pattern"
         }
     ],

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: sentinel_one
 title: SentinelOne
-version: "1.10.0"
+version: "1.11.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- Updated the visualisations of the Threat dashboard to Lens

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Part of #6787

## Screenshots

Two visualisation changed that don't affect screenshots:

**Before**
![Screenshot 2023-07-12 at 13 07 14](https://github.com/elastic/integrations/assets/29475387/fee3992f-0b9b-40b1-a191-88782cd73e65)

![Screenshot 2023-07-12 at 13 07 23](https://github.com/elastic/integrations/assets/29475387/4e9f1367-2d98-4618-801f-3b46b45553c5)

**After**
![Screenshot 2023-07-12 at 13 18 30](https://github.com/elastic/integrations/assets/29475387/7335a6e8-6bce-4ca5-9d4c-90c36a7d8677)

![Screenshot 2023-07-12 at 13 18 38](https://github.com/elastic/integrations/assets/29475387/742d615b-61e1-4723-ae19-fefd7c88e6df)

