### PR TITLE
updating rule names to match current

### DIFF
--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
-- version: "1.3.0"
+- version: "1.2.2"
   changes:
     - description: Update to use new Threat Indicator Match rule names.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/6793
 - version: "1.2.1"
   changes:

--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update to use new Threat Indicator Match rule names.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/6793
+      link: https://github.com/elastic/integrations/pull/6942
 - version: "1.2.1"
   changes:
     - description: Update to use security-solution-default.

--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Update to use new Threat Indicator Match rule names.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6793
 - version: "1.2.1"
   changes:
     - description: Update to use security-solution-default.

--- a/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
+++ b/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
@@ -216,14 +216,39 @@
                                         "index": "c4f72a3f-d887-4210-8a8c-a7580687c5d3",
                                         "key": "kibana.alert.rule.name",
                                         "negate": false,
-                                        "params": {
-                                            "query": "Threat Intel Indicator Match"
-                                        },
-                                        "type": "phrase"
+                                        "params": [
+                                            "Threat Intel IP Address Indicator Match",
+                                            "Threat Intel Hash Indicator Match",
+                                            "Threat Intel Windows Registry Indicator Match",
+                                            "Threat Intel URL Indicator Match"
+                                        ],
+                                        "type": "phrases"
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "kibana.alert.rule.name": "Threat Intel Indicator Match"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel IP Address Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel Hash Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel Windows Registry Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel URL Indicator Match"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }
@@ -797,14 +822,39 @@
                                         "index": "69de1ad2-e63e-4d3f-bd3a-0531efbf7b2f",
                                         "key": "kibana.alert.rule.name",
                                         "negate": false,
-                                        "params": {
-                                            "query": "Threat Intel Indicator Match"
-                                        },
-                                        "type": "phrase"
+                                        "params": [
+                                            "Threat Intel IP Address Indicator Match",
+                                            "Threat Intel Hash Indicator Match",
+                                            "Threat Intel Windows Registry Indicator Match",
+                                            "Threat Intel URL Indicator Match"
+                                        ],
+                                        "type": "phrases"
                                     },
                                     "query": {
-                                        "match_phrase": {
-                                            "kibana.alert.rule.name": "Threat Intel Indicator Match"
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel IP Address Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel Hash Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel Windows Registry Indicator Match"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "kibana.alert.rule.name": "Threat Intel URL Indicator Match"
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 }

--- a/packages/ti_util/manifest.yml
+++ b/packages/ti_util/manifest.yml
@@ -1,12 +1,12 @@
 name: ti_util
 title: "Threat Intelligence Utilities"
-version: 1.2.1
+version: 1.3.0
 description: Prebuilt Threat Intelligence dashboard for Elastic Security
 categories:
   - security
   - threat_intel
 conditions:
-  kibana.version: ^8.4.0
+  kibana.version: ^8.5.0
 format_version: 2.7.0
 type: integration
 screenshots:

--- a/packages/ti_util/manifest.yml
+++ b/packages/ti_util/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_util
 title: "Threat Intelligence Utilities"
-version: 1.3.0
+version: 1.2.2
 description: Prebuilt Threat Intelligence dashboard for Elastic Security
 categories:
   - security


### PR DESCRIPTION
## What does this PR do?

This updates the filter for two lens visualizations on the dashboard to use the current rule names.

In 8.8 we deprecated the existing rules in favor of [new, more specific names](https://www.elastic.co/guide/en/security/current/prebuilt-rule-8-8-6-prebuilt-rules-8-8-6-summary.html). This change was then backported to 8.5. So, this PR updates those names and sets the min version to 8.5

For more context, see https://elastic.slack.com/archives/C02TNUE3P6F/p1688126475454089

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] ~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
