### PR TITLE
[AWS][API Gateway] Set dimension fields

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.4"
+  changes:
+    - description: Set dimensions fields for API Gateway data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.46.3"
   changes:
     - description: Add missing S3 fields for vpcflow 

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set dimensions fields for API Gateway data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/6950
 - version: "1.46.3"
   changes:
     - description: Add missing S3 fields for vpcflow 

--- a/packages/aws/data_stream/apigateway_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/apigateway_metrics/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -14,6 +15,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs
@@ -60,3 +62,6 @@
   name: container.labels
 - external: ecs
   name: container.name
+- name: agent.id
+  external: ecs
+  dimension: true

--- a/packages/aws/data_stream/apigateway_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/apigateway_metrics/fields/fields.yml
@@ -79,21 +79,27 @@
       fields:
         - name: ApiId
           type: keyword
+          dimension: true
           description: Each API created in API Gateway is assigned a unique ApiId, which is used to distinguish and reference that specific API within the system.
         - name: Stage
           type: keyword
+          dimension: true
           description: It represents a specific version of the API that is accessible to clients. A stage allows you to manage different environments or versions of your API, such as development, testing, and production.
         - name: Route
           type: keyword
+          dimension: true
           description: Routes define the path and HTTP methods that clients can use to access different functionalities of the API.
         - name: ApiName
           type: keyword
+          dimension: true
           description: It represents a human-readable name that helps identify and differentiate the API within the API Gateway service.
         - name: Method
           type: keyword
+          dimension: true
           description: It represents the HTTP method which defines the action that can be performed on a resource, such as retrieving, creating, updating, or deleting data.
         - name: Resource
           type: keyword
+          dimension: true
           description: It represents an endpoint within the API that corresponds to a specific functionality, typically associated with a URL path segment.
     - name: cloudwatch
       type: group

--- a/packages/aws/docs/apigateway.md
+++ b/packages/aws/docs/apigateway.md
@@ -140,6 +140,7 @@ An example event for `apigateway` looks as following:
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
 | aws.apigateway.metrics.4XXError.sum | The number of client-side errors captured in a given period. | long |  | counter |
 | aws.apigateway.metrics.4xx.sum | The number of client-side errors captured in a given period. | long |  | counter |
 | aws.apigateway.metrics.5XXError.sum | The number of server-side errors captured in a given period. | long |  | counter |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.46.3
+version: 1.46.4
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Set the dimension fields for API Gateway data stream.

The dimension fields are:
- ECS fields (decision for these fields is [here](https://github.com/elastic/integrations/issues/5193#issuecomment-1536090359)):
  - agent.id
  - cloud.account.id
  - cloud.region
- Other fields:
  - aws.dimensions.ApiId
  - aws.dimensions.ApiName
  - aws.dimensions.Method
  - aws.dimensions.Resource
  - aws.dimensions.Route
  - aws.dimensions.Stage


Passed the [tests](https://github.com/elastic/TSDB-migration-test-kit) with 2 elastic agents running at the same time.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.


