### PR TITLE
[MySQL] TSDB Enablement

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.5"
+  changes:
+    - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.4"
   changes:
     - description: Fix to correct the aggregate function used in dashboard for fields having `metric_type` value `counter`.

--- a/packages/mysql/data_stream/galera_status/manifest.yml
+++ b/packages/mysql/data_stream/galera_status/manifest.yml
@@ -19,3 +19,5 @@ streams:
         default: false
     title: MySQL galera_status metrics
     description: Collect MySQL galera_status metrics
+elasticsearch:
+   index_mode: "time_series"

--- a/packages/mysql/data_stream/performance/manifest.yml
+++ b/packages/mysql/data_stream/performance/manifest.yml
@@ -19,3 +19,5 @@ streams:
         required: true
         show_user: true
         default: false
+elasticsearch:
+   index_mode: "time_series"

--- a/packages/mysql/data_stream/status/manifest.yml
+++ b/packages/mysql/data_stream/status/manifest.yml
@@ -19,3 +19,5 @@ streams:
         default: false
     title: MySQL status metrics
     description: Collect MySQL status metrics
+elasticsearch:
+   index_mode: "time_series"

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: mysql
 title: MySQL
-version: "1.12.4"
+version: "1.12.5"
 license: basic
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

This PR enables TSDB by default for the MySQL package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues


- Closes #5277 
