### PR TITLE
[AWS] Enable TSDB by default for API Gateway and EMR data streams

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.7"
+  changes:
+    - description: Enable time series data streams for the API Gateway and EMR data streams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6887
 - version: "1.46.6"
   changes:
     - description: Update metric type and set dimension fields for AWS EMR data stream.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -26,7 +26,7 @@
       link: https://github.com/elastic/integrations/pull/6916
 - version: "1.46.2"
   changes:
-    - description: Enable time series data streams for the S3 daily storage and S3 request datasets. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
+    - description: Enable time series data streams for the S3 daily storage and S3 request datasets. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6887
 - version: "1.46.1"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the API Gateway and EMR data streams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6887
+      link: https://github.com/elastic/integrations/pull/6969
 - version: "1.46.6"
   changes:
     - description: Update metric type and set dimension fields for AWS EMR data stream.

--- a/packages/aws/data_stream/apigateway_metrics/manifest.yml
+++ b/packages/aws/data_stream/apigateway_metrics/manifest.yml
@@ -1,5 +1,7 @@
 title: AWS API Gateway metrics
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/data_stream/emr_metrics/manifest.yml
+++ b/packages/aws/data_stream/emr_metrics/manifest.yml
@@ -1,6 +1,8 @@
 title: AWS EMR metrics
 type: metrics
 release: beta
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.46.6
+version: 1.46.7
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?
Enable TSDB by default for API Gateway and EMR data streams

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.