### PR TITLE
Fix dashes in IP address fields in m365_defender pipeline_device.yml

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Fix conversion of dashes in IP addresses.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/6972
 - version: "1.13.0"
   changes:
     - description: Convert dashboards to Lens.

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
@@ -252,7 +252,7 @@ processors:
   - convert:
       field: json.properties.FileOriginIP
       target_field: m365_defender.event.file.origin_ip
-      if: ctx.json?.properties?.FileOriginIP != ''
+      if: ctx.json?.properties?.FileOriginIP != '' && ctx.json?.properties?.FileOriginIP != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -272,7 +272,7 @@ processors:
   - convert:
       field: json.properties.RemoteIP
       target_field: m365_defender.event.remote.ip
-      if: ctx.json?.properties?.RemoteIP != ''
+      if: ctx.json?.properties?.RemoteIP != '' && ctx.json?.properties?.RemoteIP != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -292,7 +292,7 @@ processors:
   - convert:
       field: json.properties.LocalIP
       target_field: m365_defender.event.local.ip
-      if: ctx.json?.properties?.LocalIP != ''
+      if: ctx.json?.properties?.LocalIP != '' && ctx.json?.properties?.LocalIP != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -312,7 +312,7 @@ processors:
   - convert:
       field: json.properties.RequestSourceIP
       target_field: m365_defender.event.request.source_ip
-      if: ctx.json?.properties?.RequestSourceIP != ''
+      if: ctx.json?.properties?.RequestSourceIP != '' && ctx.json?.properties?.RequestSourceIP != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -476,7 +476,7 @@ processors:
   - convert:
       field: json.properties.PublicIP
       target_field: m365_defender.event.public_ip.value
-      if: ctx.json?.properties?.PublicIP != ''
+      if: ctx.json?.properties?.PublicIP != '' && ctx.json?.properties?.PublicIP != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -1152,7 +1152,7 @@ processors:
       ignore_missing: true
   - json:
       field: json.properties.IPAddresses
-      if: ctx.json?.properties?.IPAddresses != null && ctx.json.properties.IPAddresses instanceof String && ctx.json.properties.IPAddresses != ''
+      if: ctx.json?.properties?.IPAddresses != null && ctx.json.properties.IPAddresses instanceof String && ctx.json.properties.IPAddresses != '' && ctx.json.properties.IPAddresses != '-'
       on_failure:
         - append:
             field: error.message
@@ -1164,7 +1164,7 @@ processors:
   - convert:
       field: json.properties.IPv4Dhcp
       target_field: m365_defender.event.ipv4_dhcp
-      if: ctx.json?.properties?.IPv4Dhcp != ''
+      if: ctx.json?.properties?.IPv4Dhcp != '' && ctx.json?.properties?.IPv4Dhcp != '-'
       type: ip
       ignore_missing: true
       on_failure:
@@ -1179,7 +1179,7 @@ processors:
   - convert:
       field: json.properties.IPv6Dhcp
       target_field: m365_defender.event.ipv6_dhcp
-      if: ctx.json?.properties?.IPv6Dhcp != ''
+      if: ctx.json?.properties?.IPv6Dhcp != '' && ctx.json?.properties?.IPv6Dhcp != '-'
       type: ip
       ignore_missing: true
       on_failure:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Adds additional conditions to `convert` processor calls that convert strings to IP addresses. They fail if the string field contains only a dash `-`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
