### PR TITLE
[hashicorp_vault] Fix mappings of granting policies

### DIFF
--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Fix mappings of policy_results.granting_policies
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
+++ b/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
@@ -47,14 +47,14 @@
             - name: policy_results.allowed
               type: boolean
             - name: policy_results.granting_policies
-              type: array
-              object_type: object
-            - name: policy_results.granting_policies.name
-              type: keyword
-            - name: policy_results.granting_policies.namespace_id
-              type: keyword
-            - name: policy_results.granting_policies.type
-              type: keyword
+              type: nested
+              fields:
+                - name: name
+                  type: keyword
+                - name: namespace_id
+                  type: keyword
+                - name: type
+                  type: keyword
             - name: remaining_uses
               type: long
             - name: token_issue_time

--- a/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
+++ b/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
@@ -48,13 +48,12 @@
               type: boolean
             - name: policy_results.granting_policies
               type: nested
-              fields:
-                - name: name
-                  type: keyword
-                - name: namespace_id
-                  type: keyword
-                - name: type
-                  type: keyword
+            - name: policy_results.granting_policies.name
+              type: keyword
+            - name: policy_results.granting_policies.namespace_id
+              type: keyword
+            - name: policy_results.granting_policies.type
+              type: keyword
             - name: remaining_uses
               type: long
             - name: token_issue_time

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -201,7 +201,6 @@ An example event for `audit` looks as following:
 | hashicorp_vault.audit.auth.no_default_policy | Indicates that the default policy should not be added by core when creating a token. The default policy will still be added if it's explicitly defined. | boolean |
 | hashicorp_vault.audit.auth.policies | Policies is the list of policies that the authenticated user is associated with. | keyword |
 | hashicorp_vault.audit.auth.policy_results.allowed |  | boolean |
-| hashicorp_vault.audit.auth.policy_results.granting_policies |  | array |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.name |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.namespace_id |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.type |  | keyword |

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -201,6 +201,7 @@ An example event for `audit` looks as following:
 | hashicorp_vault.audit.auth.no_default_policy | Indicates that the default policy should not be added by core when creating a token. The default policy will still be added if it's explicitly defined. | boolean |
 | hashicorp_vault.audit.auth.policies | Policies is the list of policies that the authenticated user is associated with. | keyword |
 | hashicorp_vault.audit.auth.policy_results.allowed |  | boolean |
+| hashicorp_vault.audit.auth.policy_results.granting_policies |  | nested |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.name |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.namespace_id |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.type |  | keyword |

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,16 +1,15 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.12.0"
-license: basic
+version: "1.12.1"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:
   - security
   - iam
-release: ga
 conditions:
   kibana.version: "^7.17.0 || ^8.0.0"
+  elastic.subscription: basic
 screenshots:
   - src: /img/hashicorp_vault-audit-dashboard.png
     title: Audit Log Dashboard


### PR DESCRIPTION
## What does this PR do?

Mapping of `hashicorp_vault.audit.auth.policy_results.granting_policies` is of array type, but this is probably not what is intended for this field. It contains a list of objects, and this can be only represented in Elasticsearch using the `nested` type.

Array type is not allowed starting on Package Spec 2.0, as it doesn't do what package developers usually expect.

Issue found in https://github.com/elastic/package-spec/pull/527#issuecomment-1634381234.

~~Mapping of nested types is not installed because of https://github.com/elastic/kibana/issues/138596.~~ Mapping of child fields follows https://github.com/elastic/kibana/issues/138596#issuecomment-1212967456.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- https://github.com/elastic/kibana/issues/138596

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
