### PR TITLE
[AWS Fargate] Remove sum of counters in dashboard

### DIFF
--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.5
+  changes:
+    - description: Update DiskIO Write and Read visualizations to use last_value instead of average.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/689
 - version: 0.2.4
   changes:
     - description: Migrate AWS Fargate input control to new control panel.

--- a/packages/awsfargate/kibana/dashboard/awsfargate-20dc7c50-2e89-11eb-991c-c5fd3b7f5a63.json
+++ b/packages/awsfargate/kibana/dashboard/awsfargate-20dc7c50-2e89-11eb-991c-c5fd3b7f5a63.json
@@ -745,11 +745,6 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-c8d70f88-6554-41ca-ac1e-a3cf8b992972",
                                 "type": "index-pattern"
                             }
@@ -801,14 +796,15 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "DiskIO Read",
-                                                    "operationType": "average",
+                                                    "operationType": "last_value",
                                                     "params": {
                                                         "format": {
                                                             "id": "bytes",
                                                             "params": {
                                                                 "decimals": 2
                                                             }
-                                                        }
+                                                        },
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "awsfargate.task_stats.diskio.read.bytes"
@@ -863,6 +859,7 @@
                             }
                         },
                         "title": "DiskIO Read [Metrics AWSFargate]",
+                        "type": "lens",
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -885,11 +882,6 @@
                     "attributes": {
                         "description": "",
                         "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-current-indexpattern",
-                                "type": "index-pattern"
-                            },
                             {
                                 "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-c8d70f88-6554-41ca-ac1e-a3cf8b992972",
@@ -943,14 +935,15 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "DiskIO Write",
-                                                    "operationType": "average",
+                                                    "operationType": "last_value",
                                                     "params": {
                                                         "format": {
                                                             "id": "bytes",
                                                             "params": {
                                                                 "decimals": 2
                                                             }
-                                                        }
+                                                        },
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "awsfargate.task_stats.diskio.write.bytes"
@@ -1005,6 +998,7 @@
                             }
                         },
                         "title": "DiskIO Write [Metrics AWSFargate]",
+                        "type": "lens",
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -1085,17 +1079,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "d7a6623a-14cf-411c-ab73-ded3734a359b:indexpattern-datasource-current-indexpattern",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "d7a6623a-14cf-411c-ab73-ded3734a359b:indexpattern-datasource-layer-c8d70f88-6554-41ca-ac1e-a3cf8b992972",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "89b0cd8b-13d9-4a43-8f93-3410aff125c3:indexpattern-datasource-current-indexpattern",
             "type": "index-pattern"
         },
         {

--- a/packages/awsfargate/manifest.yml
+++ b/packages/awsfargate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: awsfargate
 title: AWS Fargate
-version: 0.2.4
+version: 0.2.5
 license: basic
 description: Collects metrics from containers and tasks running on Amazon ECS clusters with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Update DiskIO Write and Read visualizations to use `last_value` instead of `average`.

This is necessary because `awsfargate.task_stats.diskio.read.bytes` and `awsfargate.task_stats.diskio.write.bytes`, the metrics used for these visualizations, are counters. This means that the only 2 aggregations supported for them are `max` and `last_value`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6732.

## Screenshots

Current visualizations with this change:

![image](https://github.com/elastic/integrations/assets/113898685/fcb8d654-29e6-4c3c-aa1b-38f9ea1a1a2c)