### PR TITLE
[AWS Fargate] Enable TSDB by default

### DIFF
--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable TSDB for task stats data stream. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6997
+      link: https://github.com/elastic/integrations/pull/6998
 - version: 0.2.5
   changes:
     - description: Update DiskIO Write and Read visualizations to use last_value instead of average.

--- a/packages/awsfargate/changelog.yml
+++ b/packages/awsfargate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.3.0
+  changes:
+    - description: Enable TSDB for task stats data stream. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6997
 - version: 0.2.5
   changes:
     - description: Update DiskIO Write and Read visualizations to use last_value instead of average.

--- a/packages/awsfargate/data_stream/task_stats/manifest.yml
+++ b/packages/awsfargate/data_stream/task_stats/manifest.yml
@@ -1,6 +1,8 @@
 type: metrics
 title: AWS Fargate task_stats metrics
 release: beta
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: awsfargate/metrics
     vars:

--- a/packages/awsfargate/manifest.yml
+++ b/packages/awsfargate/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: awsfargate
 title: AWS Fargate
-version: 0.2.5
+version: 0.3.0
 license: basic
 description: Collects metrics from containers and tasks running on Amazon ECS clusters with Elastic Agent.
 type: integration
@@ -10,7 +10,7 @@ categories:
   - aws
 release: beta
 conditions:
-  kibana.version: "^8.3.0"
+  kibana.version: "^8.8.0"
 owner:
   github: elastic/obs-cloud-monitoring
 screenshots:


### PR DESCRIPTION
## What does this PR do?

Enable TSDB by default.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Relates to https://github.com/elastic/integrations/issues/6732.