### PR TITLE
[TI_Anomali] Fix transform sort order field

### DIFF
--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Change sort order field in latest transform
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111 #TODO
 - version: "1.14.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Change sort order field in latest transform
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111 #TODO
+      link: https://github.com/elastic/integrations/pull/7000
 - version: "1.14.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/ti_anomali/data_stream/threatstream/_dev/test/pipeline/test-anomali-threatstream.json-expected.json
+++ b/packages/ti_anomali/data_stream/threatstream/_dev/test/pipeline/test-anomali-threatstream.json-expected.json
@@ -1,6 +1,7 @@
 {
     "expected": [
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -65,6 +66,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -127,6 +129,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -191,6 +194,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -245,6 +249,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -309,6 +314,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -373,6 +379,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -436,6 +443,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -488,6 +496,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -550,6 +559,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -614,6 +624,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -669,6 +680,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -724,6 +736,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -787,6 +800,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -842,6 +856,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -898,6 +913,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -953,6 +969,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1009,6 +1026,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1065,6 +1083,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1121,6 +1140,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1177,6 +1197,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1232,6 +1253,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1291,6 +1313,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1345,6 +1368,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1407,6 +1431,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1463,6 +1488,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1519,6 +1545,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1576,6 +1603,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1629,6 +1657,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1690,6 +1719,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1752,6 +1782,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1808,6 +1839,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1865,6 +1897,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1921,6 +1954,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -1977,6 +2011,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2031,6 +2066,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2087,6 +2123,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2142,6 +2179,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2197,6 +2235,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2259,6 +2298,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2313,6 +2353,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2367,6 +2408,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2423,6 +2465,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2486,6 +2529,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2543,6 +2587,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2605,6 +2650,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2666,6 +2712,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2722,6 +2769,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2776,6 +2824,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2832,6 +2881,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2887,6 +2937,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -2950,6 +3001,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3004,6 +3056,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3058,6 +3111,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3112,6 +3166,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3173,6 +3228,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3227,6 +3283,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3283,6 +3340,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3338,6 +3396,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3393,6 +3452,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3448,6 +3508,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3511,6 +3572,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3566,6 +3628,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3622,6 +3685,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3677,6 +3741,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3732,6 +3797,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3788,6 +3854,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3845,6 +3912,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3898,6 +3966,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -3960,6 +4029,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4015,6 +4085,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4069,6 +4140,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4123,6 +4195,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4185,6 +4258,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4239,6 +4313,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4294,6 +4369,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4348,6 +4424,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4411,6 +4488,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4466,6 +4544,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4522,6 +4601,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4589,6 +4669,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4652,6 +4733,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4706,6 +4788,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4764,6 +4847,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4826,6 +4910,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4888,6 +4973,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -4956,6 +5042,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5019,6 +5106,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5078,6 +5166,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5138,6 +5227,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5199,6 +5289,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5261,6 +5352,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5322,6 +5414,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5380,6 +5473,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5444,6 +5538,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5492,6 +5587,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5542,6 +5638,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "added_at": "2020-10-08T12:22:11.000Z",
@@ -5590,6 +5687,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "classification": "public",
@@ -5640,6 +5738,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "classification": "private",
@@ -5689,6 +5788,7 @@
             }
         },
         {
+            "@timestamp": "2020-10-08T12:22:11.000Z",
             "anomali": {
                 "threatstream": {
                     "classification": "private",

--- a/packages/ti_anomali/data_stream/threatstream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_anomali/data_stream/threatstream/elasticsearch/ingest_pipeline/default.yml
@@ -202,6 +202,20 @@ processors:
             field: error.message
             value: 'Error parsing date_last field value "{{{ json.date_last }}}": {{{ _ingest.on_failure_message }}}'
 
+  - set:
+      field: _temp_.timestamp
+      copy_from: json.added_at
+      if: ctx.json?.added_at != null
+  
+  - set:
+      field: _temp_.timestamp
+      copy_from: json.deleted_at
+      if: ctx.json?.deleted_at != null && ctx._temp_?.timestamp == null
+
+  - set:
+      field: "@timestamp"
+      copy_from: _temp_.timestamp
+      if: ctx._temp_?.timestamp != null
   #
   # Map IP geolocation fields.
   #
@@ -449,6 +463,7 @@ processors:
       ignore_missing: true
   - remove:
       field:
+        - _temp_
         - _conf
         - json.asn
         - json.date_first

--- a/packages/ti_anomali/data_stream/threatstream/manifest.yml
+++ b/packages/ti_anomali/data_stream/threatstream/manifest.yml
@@ -42,7 +42,6 @@ streams:
         multi: false
         required: false
         show_user: true
-        default: "abcd1234"
       - name: ssl
         type: yaml
         title: TLS

--- a/packages/ti_anomali/data_stream/threatstream/manifest.yml
+++ b/packages/ti_anomali/data_stream/threatstream/manifest.yml
@@ -42,6 +42,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        default: "abcd1234"
       - name: ssl
         type: yaml
         title: TLS

--- a/packages/ti_anomali/data_stream/threatstream/sample_event.json
+++ b/packages/ti_anomali/data_stream/threatstream/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-05-31T11:23:45.408Z",
+    "@timestamp": "2020-10-08T12:22:11.000Z",
     "agent": {
-        "ephemeral_id": "c6d5c470-bc00-4989-8926-eaac7bced0dd",
-        "id": "5f8289ef-b035-4afb-8a20-b21af809df44",
+        "ephemeral_id": "e24315ac-e4b2-474c-adf9-7b779a448e8e",
+        "id": "4ac38dc0-f2c0-4141-8bb2-ddeede2bd546",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.0"
+        "version": "8.8.1"
     },
     "anomali": {
         "threatstream": {
@@ -37,15 +37,15 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "5f8289ef-b035-4afb-8a20-b21af809df44",
-        "snapshot": true,
-        "version": "8.8.0"
+        "id": "4ac38dc0-f2c0-4141-8bb2-ddeede2bd546",
+        "snapshot": false,
+        "version": "8.8.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
         "dataset": "ti_anomali.threatstream",
-        "ingested": "2023-05-31T11:23:46Z",
+        "ingested": "2023-07-19T15:22:27Z",
         "kind": "enrichment",
         "original": "{\"added_at\":\"2020-10-08T12:22:11\",\"classification\":\"public\",\"confidence\":20,\"country\":\"FR\",\"date_first\":\"2020-10-08T12:21:50\",\"date_last\":\"2020-10-08T12:24:42\",\"detail2\":\"imported by user 184\",\"domain\":\"d4xgfj.example.net\",\"id\":3135167627,\"import_session_id\":1400,\"itype\":\"mal_domain\",\"lat\":-49.1,\"lon\":94.4,\"org\":\"OVH Hosting\",\"resource_uri\":\"/api/v1/intelligence/P46279656657/\",\"severity\":\"high\",\"source\":\"Default Organization\",\"source_feed_id\":3143,\"srcip\":\"89.160.20.156\",\"state\":\"active\",\"trusted_circle_ids\":\"122\",\"update_id\":3786618776,\"value_type\":\"domain\"}",
         "severity": 7,

--- a/packages/ti_anomali/docs/README.md
+++ b/packages/ti_anomali/docs/README.md
@@ -32,13 +32,13 @@ An example event for `threatstream` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-05-31T11:23:45.408Z",
+    "@timestamp": "2020-10-08T12:22:11.000Z",
     "agent": {
-        "ephemeral_id": "c6d5c470-bc00-4989-8926-eaac7bced0dd",
-        "id": "5f8289ef-b035-4afb-8a20-b21af809df44",
+        "ephemeral_id": "e24315ac-e4b2-474c-adf9-7b779a448e8e",
+        "id": "4ac38dc0-f2c0-4141-8bb2-ddeede2bd546",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.0"
+        "version": "8.8.1"
     },
     "anomali": {
         "threatstream": {
@@ -70,15 +70,15 @@ An example event for `threatstream` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "5f8289ef-b035-4afb-8a20-b21af809df44",
-        "snapshot": true,
-        "version": "8.8.0"
+        "id": "4ac38dc0-f2c0-4141-8bb2-ddeede2bd546",
+        "snapshot": false,
+        "version": "8.8.1"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "threat",
         "dataset": "ti_anomali.threatstream",
-        "ingested": "2023-05-31T11:23:46Z",
+        "ingested": "2023-07-19T15:22:27Z",
         "kind": "enrichment",
         "original": "{\"added_at\":\"2020-10-08T12:22:11\",\"classification\":\"public\",\"confidence\":20,\"country\":\"FR\",\"date_first\":\"2020-10-08T12:21:50\",\"date_last\":\"2020-10-08T12:24:42\",\"detail2\":\"imported by user 184\",\"domain\":\"d4xgfj.example.net\",\"id\":3135167627,\"import_session_id\":1400,\"itype\":\"mal_domain\",\"lat\":-49.1,\"lon\":94.4,\"org\":\"OVH Hosting\",\"resource_uri\":\"/api/v1/intelligence/P46279656657/\",\"severity\":\"high\",\"source\":\"Default Organization\",\"source_feed_id\":3143,\"srcip\":\"89.160.20.156\",\"state\":\"active\",\"trusted_circle_ids\":\"122\",\"update_id\":3786618776,\"value_type\":\"domain\"}",
         "severity": 7,

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -28,4 +28,4 @@ retention_policy:
 _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/transform.yml
@@ -14,12 +14,12 @@ latest:
   unique_key:
     - event.dataset
     - anomali.threatstream.id
-  sort: "event.ingested"
+  sort: "@timestamp"
 description: Latest Anomali IoC data
 frequency: 30s
 sync:
   time:
-    field: event.ingested
+    field: "@timestamp"
     delay: 60s
 retention_policy:
   time:

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_anomali
 title: Anomali
-version: "1.14.0"
+version: "1.14.1"
 release: ga
 description: Ingest threat intelligence indicators from Anomali with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- Existing sort order for latest transform is `event.ingested`. Since this is not precise to the millisecond level, whenever  events comes with both deleted and added for same indicator (within a second), the last activity is not preserved and the indicator is simply deleted. 
   - This PR changes the sort order and the sync fields to `@timestamp` which has millisecond resolution, and thus preserves the correct order of events to store in the destination indices.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7012

