### PR TITLE
trellix_epo_cloud: work around static CEL now global behaviour

### DIFF
--- a/packages/trellix_epo_cloud/changelog.yml
+++ b/packages/trellix_epo_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Work around CEL `now` static global behaviour.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7004
 - version: "1.0.0"
   changes:
     - description: Release Trellix ePO Cloud as GA.

--- a/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
@@ -36,7 +36,7 @@ program: |
           ?
             state.cursor.last_timestamp.parse_time(time_layout.RFC3339Nano)
           :
-            (now - duration(state.initial_interval))
+            (now() - duration(state.initial_interval))
         ).format(time_layout.RFC3339Nano)]
       }.format_query()).with({
         "Header": {

--- a/packages/trellix_epo_cloud/manifest.yml
+++ b/packages/trellix_epo_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.6.0
 name: trellix_epo_cloud
 title: Trellix ePO Cloud
-version: "1.0.0"
+version: "1.0.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Trellix ePO Cloud with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

The `now` global is currently static for the life of the filebeat CEL input meaning that it may be potentially many hours in the past. Fix this by using the dynamic `now()` function which is evaluated at the time of the sub-expression's evaluation.

See elastic/beats#36107 for details.

In this case the work-around is not really any different to using the `now` global once elastic/beats#36107 is merged and released, but this should be reverted as after that as in the general case, the `now()` function should be avoided unless needed.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/6621#discussion_r1266898025
- Relates elastic/beats#36107

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
