### PR TITLE
[GCP] change ownership in manifest

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.1"
+  changes:
+    - description: Change ownership in manifest.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6614
 - version: "2.22.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.22.0"
+version: "2.22.1"
 release: ga
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
@@ -240,4 +240,4 @@ policy_templates:
         title: Collect GCP Cloud Run Metrics
         description: Collect GCP Cloud Run Metrics
 owner:
-  github: elastic/security-external-integrations
+  github: elastic/obs-cloud-monitoring


### PR DESCRIPTION
## What does this PR do?

Just a small nit to make the manifest owner the same as azure/aws, while both teams are owners in the CODEOWNERS file already.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

