### PR TITLE
[HID] Add missing lens visualization

### DIFF
--- a/packages/hid_bravura_monitor/changelog.yml
+++ b/packages/hid_bravura_monitor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.1"
+  changes:
+    - description: Add missing lens visualization
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6980
 - version: "1.9.0"
   changes:
     - description: Convert dashboards to Lens

--- a/packages/hid_bravura_monitor/kibana/dashboard/hid_bravura_monitor-d3a33820-fa02-11eb-a1ab-1964dffd1499.json
+++ b/packages/hid_bravura_monitor/kibana/dashboard/hid_bravura_monitor-d3a33820-fa02-11eb-a1ab-1964dffd1499.json
@@ -1090,127 +1090,194 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [
-                                {
-                                    "enabled": true,
-                                    "id": "1",
-                                    "params": {},
-                                    "schema": "metric",
-                                    "type": "count"
-                                },
-                                {
-                                    "enabled": true,
-                                    "id": "2",
-                                    "params": {
-                                        "customLabel": "Target ID",
-                                        "field": "hid_bravura_monitor.perf.targetid",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10000
-                                    },
-                                    "schema": "bucket",
-                                    "type": "terms"
-                                },
-                                {
-                                    "enabled": true,
-                                    "id": "3",
-                                    "params": {
-                                        "customLabel": "Address",
-                                        "field": "hid_bravura_monitor.perf.address",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10000
-                                    },
-                                    "schema": "bucket",
-                                    "type": "terms"
-                                },
-                                {
-                                    "enabled": true,
-                                    "id": "4",
-                                    "params": {
-                                        "customLabel": "Process",
-                                        "field": "log.logger",
-                                        "missingBucket": false,
-                                        "missingBucketLabel": "Missing",
-                                        "order": "desc",
-                                        "orderBy": "1",
-                                        "otherBucket": false,
-                                        "otherBucketLabel": "Other",
-                                        "size": 10000
-                                    },
-                                    "schema": "bucket",
-                                    "type": "terms"
-                                }
-                            ],
-                            "searchSource": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "hid_bravura_monitor.perf.kind",
-                                            "negate": false,
-                                            "params": {
-                                                "query": "PerfConnector"
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-ffcdf31e-12f5-4101-9911-0d36d3139206",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "94c46b2d-9a01-42c6-86a6-b639ce204d59",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ffcdf31e-12f5-4101-9911-0d36d3139206": {
+                                            "columnOrder": [
+                                                "793dccab-3900-45c8-8fdb-dc580d5772ae",
+                                                "00877092-3d21-4a0f-a869-c793246ec298",
+                                                "450aa203-9921-483f-b0ed-3e04f16863fa",
+                                                "cf35a5ea-970a-4bc1-9888-d58545acc946"
+                                            ],
+                                            "columns": {
+                                                "00877092-3d21-4a0f-a869-c793246ec298": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Address",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cf35a5ea-970a-4bc1-9888-d58545acc946",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "hid_bravura_monitor.perf.address"
+                                                },
+                                                "450aa203-9921-483f-b0ed-3e04f16863fa": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Process",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cf35a5ea-970a-4bc1-9888-d58545acc946",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "log.logger"
+                                                },
+                                                "793dccab-3900-45c8-8fdb-dc580d5772ae": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Target ID",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cf35a5ea-970a-4bc1-9888-d58545acc946",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "hid_bravura_monitor.perf.targetid"
+                                                },
+                                                "cf35a5ea-970a-4bc1-9888-d58545acc946": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
                                             },
-                                            "type": "phrase"
-                                        },
-                                        "query": {
-                                            "match_phrase": {
-                                                "hid_bravura_monitor.perf.kind": "PerfConnector"
-                                            }
+                                            "incompleteColumns": {}
                                         }
                                     }
-                                ],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "perPage": 10,
-                            "percentageCol": "",
-                            "showMetricsAtAllLevels": false,
-                            "showPartialRows": false,
-                            "showToolbar": true,
-                            "showTotal": false,
-                            "sort": {
-                                "columnIndex": null,
-                                "direction": null
                             },
-                            "totalFunc": "sum"
-                        },
-                        "title": "Connector List",
-                        "type": "table",
-                        "uiState": {
-                            "vis": {
-                                "params": {
-                                    "sort": {
-                                        "columnIndex": null,
-                                        "direction": null
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "94c46b2d-9a01-42c6-86a6-b639ce204d59",
+                                        "key": "hid_bravura_monitor.perf.kind",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "PerfConnector"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "hid_bravura_monitor.perf.kind": "PerfConnector"
+                                        }
                                     }
                                 }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "left",
+                                        "columnId": "cf35a5ea-970a-4bc1-9888-d58545acc946"
+                                    },
+                                    {
+                                        "alignment": "left",
+                                        "columnId": "793dccab-3900-45c8-8fdb-dc580d5772ae"
+                                    },
+                                    {
+                                        "alignment": "left",
+                                        "columnId": "00877092-3d21-4a0f-a869-c793246ec298"
+                                    },
+                                    {
+                                        "alignment": "left",
+                                        "columnId": "450aa203-9921-483f-b0ed-3e04f16863fa"
+                                    }
+                                ],
+                                "headerRowHeight": "single",
+                                "layerId": "ffcdf31e-12f5-4101-9911-0d36d3139206",
+                                "layerType": "data",
+                                "paging": {
+                                    "enabled": true,
+                                    "size": 10
+                                },
+                                "rowHeight": "single"
                             }
-                        }
-                    }
+                        },
+                        "title": "Connector List (converted)",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 16,
@@ -1220,7 +1287,8 @@
                     "y": 29
                 },
                 "panelIndex": "1efe3f34-de43-4ffb-992d-8b21cbb771a0",
-                "type": "visualization",
+                "title": "Connector List",
+                "type": "lens",
                 "version": "8.7.1"
             },
             {
@@ -1245,7 +1313,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-17T12:51:36.912Z",
+    "created_at": "2023-07-19T18:18:32.649Z",
     "id": "hid_bravura_monitor-d3a33820-fa02-11eb-a1ab-1964dffd1499",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1343,12 +1411,12 @@
         },
         {
             "id": "logs-*",
-            "name": "1efe3f34-de43-4ffb-992d-8b21cbb771a0:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "1efe3f34-de43-4ffb-992d-8b21cbb771a0:indexpattern-datasource-layer-ffcdf31e-12f5-4101-9911-0d36d3139206",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "1efe3f34-de43-4ffb-992d-8b21cbb771a0:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "name": "1efe3f34-de43-4ffb-992d-8b21cbb771a0:94c46b2d-9a01-42c6-86a6-b639ce204d59",
             "type": "index-pattern"
         },
         {

--- a/packages/hid_bravura_monitor/kibana/search/hid_bravura_monitor-bfc7f7c0-1473-11eb-bb7b-bb041e8cf289.json
+++ b/packages/hid_bravura_monitor/kibana/search/hid_bravura_monitor-bfc7f7c0-1473-11eb-bb7b-bb041e8cf289.json
@@ -1180,7 +1180,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-17T07:44:48.922Z",
+    "created_at": "2023-07-19T18:11:22.629Z",
     "id": "hid_bravura_monitor-bfc7f7c0-1473-11eb-bb7b-bb041e8cf289",
     "migrationVersion": {
         "search": "8.0.0"

--- a/packages/hid_bravura_monitor/manifest.yml
+++ b/packages/hid_bravura_monitor/manifest.yml
@@ -1,6 +1,6 @@
 name: hid_bravura_monitor
 title: Bravura Monitor
-version: "1.9.0"
+version: "1.9.1"
 categories: ["security", "iam"]
 description: Collect logs from Bravura Security Fabric with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

One of the visualizations from https://github.com/elastic/integrations/pull/6980 did not get converted to lens, this PR adds that new visualisation.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

