### PR TITLE
[aws_logs] Add system tests for awss3 input

### DIFF
--- a/packages/aws_logs/data_stream/generic/_dev/deploy/tf/env.yml
+++ b/packages/aws_logs/data_stream/generic/_dev/deploy/tf/env.yml
@@ -1,0 +1,9 @@
+version: '2.3'
+services:
+  terraform:
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION:-us-east-1}

--- a/packages/aws_logs/data_stream/generic/_dev/deploy/tf/main.tf
+++ b/packages/aws_logs/data_stream/generic/_dev/deploy/tf/main.tf
@@ -1,0 +1,64 @@
+variable "TEST_RUN_ID" {
+  default = "detached"
+}
+
+provider "aws" {
+  default_tags {
+    tags = {
+      environment  = var.ENVIRONMENT
+      repo         = var.REPO
+      branch       = var.BRANCH
+      build        = var.BUILD_ID
+      created_date = var.CREATED_DATE
+    }
+  }
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "elastic-package-aws-logs-bucket-${var.TEST_RUN_ID}"
+}
+
+resource "aws_sqs_queue" "queue" {
+  name       = "elastic-package-aws-logs-queue-${var.TEST_RUN_ID}"
+  policy     = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:*:*:elastic-package-aws-logs-queue-${var.TEST_RUN_ID}",
+      "Condition": {
+        "ArnEquals": { "aws:SourceArn": "${aws_s3_bucket.bucket.arn}" }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
+
+  queue {
+    queue_arn = aws_sqs_queue.queue.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}
+
+resource "aws_s3_object" "object" {
+  bucket = aws_s3_bucket.bucket.id
+  key    = "new_object_key"
+  source = "/workspace/main.tf"
+
+  # The filemd5() function is available in Terraform 0.11.12 and later
+  # For Terraform 0.11.11 and earlier, use the md5() function and the file() function:
+  # etag = "${md5(file("path/to/file"))}"
+  etag       = filemd5("/workspace/main.tf")
+  depends_on = [aws_sqs_queue.queue]
+}
+
+output "queue_url" {
+  value = aws_sqs_queue.queue.url
+}

--- a/packages/aws_logs/data_stream/generic/_dev/deploy/tf/variables.tf
+++ b/packages/aws_logs/data_stream/generic/_dev/deploy/tf/variables.tf
@@ -1,0 +1,30 @@
+variable "BRANCH" {
+  description = "Branch name or pull request for tagging purposes"
+  default     = "unknown-branch"
+}
+
+variable "BUILD_ID" {
+  description = "Build ID in the CI for tagging purposes"
+  default     = "unknown-build"
+}
+
+variable "CREATED_DATE" {
+  description = "Creation date in epoch time for tagging purposes"
+  default     = "unknown-date"
+}
+
+variable "ENVIRONMENT" {
+  default = "unknown-environment"
+}
+
+variable "REPO" {
+  default = "unknown-repo-name"
+}
+
+variable "bucket_name" {
+  default = "elastic-package-aws-logs-bucket"
+}
+
+variable "queue_name" {
+  default = "elastic-package-aws-logs-queue"
+}

--- a/packages/aws_logs/data_stream/generic/_dev/test/system/test-default-config.yml
+++ b/packages/aws_logs/data_stream/generic/_dev/test/system/test-default-config.yml
@@ -1,0 +1,14 @@
+input: aws-s3
+wait_for_data_timeout: 20m # AWS CloudWatch may delay metrics delivery for more than 10 minutes.
+vars:
+  access_key_id: '{{AWS_ACCESS_KEY_ID}}'
+  secret_access_key: '{{AWS_SECRET_ACCESS_KEY}}'
+  session_token: '{{AWS_SESSION_TOKEN}}'
+data_stream:
+  vars:
+    period: 5m
+    latency: 10m
+    queue_url: '{{TF_OUTPUT_queue_url}}'
+    tags_filter: |-
+      - key: Name
+        value: "elastic-package-test-{{TEST_RUN_ID}}"

--- a/packages/aws_logs/data_stream/generic/_dev/test/system/test-default-config.yml
+++ b/packages/aws_logs/data_stream/generic/_dev/test/system/test-default-config.yml
@@ -6,9 +6,4 @@ vars:
   session_token: '{{AWS_SESSION_TOKEN}}'
 data_stream:
   vars:
-    period: 5m
-    latency: 10m
     queue_url: '{{TF_OUTPUT_queue_url}}'
-    tags_filter: |-
-      - key: Name
-        value: "elastic-package-test-{{TEST_RUN_ID}}"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

Add `system tests` for `awss3` input in `aws_logs` integration

## What does this PR do?

Adds system test by using `terraform service deployer` and using the `SQS queue_url` generated in `terraform outputs`.

Created test after the implementation of https://github.com/elastic/elastic-package/pull/1272

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~- [ ] I have verified that all data streams collect metrics or logs.~
~- [ ] I have added an entry to my package's `changelog.yml` file.~
~- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Setup AWS credentials and add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to the env vars.
- Navigate to `packages/aws_logs`
- Spin up elastic stack using `elastic-package stack up -d -v`
- Run tests using `elastic-package test system -v`
- Take down elastic stack `elastic-package stack down -v`
