### PR TITLE
[Istio] Enable TSDB by default

### DIFF
--- a/packages/istio/changelog.yml
+++ b/packages/istio/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Enable TSDB by default for all metrics data streams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7007
 - version: "0.3.2"
   changes:
     - description: Update "Pilot xds expired" visualization to use last value instead of average.

--- a/packages/istio/changelog.yml
+++ b/packages/istio/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable TSDB by default for all metrics data streams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7007
+      link: https://github.com/elastic/integrations/pull/7030
 - version: "0.3.2"
   changes:
     - description: Update "Pilot xds expired" visualization to use last value instead of average.

--- a/packages/istio/data_stream/istiod_metrics/manifest.yml
+++ b/packages/istio/data_stream/istiod_metrics/manifest.yml
@@ -1,6 +1,8 @@
 title: "Istiod Metrics"
 release: experimental
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: prometheus/metrics
     title: Istiod metrics

--- a/packages/istio/data_stream/proxy_metrics/manifest.yml
+++ b/packages/istio/data_stream/proxy_metrics/manifest.yml
@@ -1,6 +1,8 @@
 title: "Istio Proxy Metrics"
 release: experimental
 type: metrics
+elasticsearch:
+  index_mode: "time_series"
 streams:
   - input: prometheus/metrics
     title: Istio Proxy metrics

--- a/packages/istio/manifest.yml
+++ b/packages/istio/manifest.yml
@@ -3,7 +3,7 @@ name: istio
 title: Istio
 description: Collect logs and metrics from the service mesh Istio with Elastic Agent.
 type: integration
-version: 0.3.2
+version: 0.4.0
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
## What does this PR do?

Enable TSDB by default for all metrics data streams.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6567.