### PR TITLE
[hashicorp_vault] - update package spec to 2.9.0

### DIFF
--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Update package spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.12.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
+++ b/packages/hashicorp_vault/data_stream/audit/fields/fields.yml
@@ -47,14 +47,14 @@
             - name: policy_results.allowed
               type: boolean
             - name: policy_results.granting_policies
-              type: array
-              object_type: object
-            - name: policy_results.granting_policies.name
-              type: keyword
-            - name: policy_results.granting_policies.namespace_id
-              type: keyword
-            - name: policy_results.granting_policies.type
-              type: keyword
+              type: group
+              fields:
+                - name: name
+                  type: keyword
+                - name: namespace_id
+                  type: keyword
+                - name: type
+                  type: keyword
             - name: remaining_uses
               type: long
             - name: token_issue_time

--- a/packages/hashicorp_vault/data_stream/audit/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/audit/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-08-18T17:07:22.769Z",
+    "@timestamp": "2023-07-20T13:39:22.108Z",
     "agent": {
-        "ephemeral_id": "623671b3-bcc9-4060-9806-e1cb0b945aae",
-        "id": "03109bfa-7015-46bd-9433-3879357210cd",
+        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.audit",
@@ -16,9 +16,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "03109bfa-7015-46bd-9433-3879357210cd",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.8.2"
     },
     "event": {
         "action": "update",
@@ -27,10 +27,10 @@
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "e54c706f-1a3d-9662-3705-872e05c9c39f",
-        "ingested": "2022-08-18T17:07:55Z",
+        "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
+        "ingested": "2023-07-20T13:39:50Z",
         "kind": "event",
-        "original": "{\"time\":\"2022-08-18T17:07:22.76907021Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"e54c706f-1a3d-9662-3705-872e05c9c39f\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-07-20T13:39:22.1089946Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"07b55e76-c58c-7911-f1a2-a19692c37e43\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
             "change"
@@ -42,7 +42,7 @@
                 "token_type": "default"
             },
             "request": {
-                "id": "e54c706f-1a3d-9662-3705-872e05c9c39f",
+                "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
                 "namespace": {
                     "id": "root"
                 },
@@ -54,23 +54,24 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.23.0.7"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.76-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {

--- a/packages/hashicorp_vault/data_stream/log/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-01-13T01:56:49.423Z",
+    "@timestamp": "2023-07-20T13:40:29.312Z",
     "agent": {
-        "ephemeral_id": "519f95f7-ce93-4b23-b4ba-cb55bee8d69c",
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.log",
@@ -16,16 +16,16 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2022-01-13T01:57:16Z",
+        "ingested": "2023-07-20T13:40:57Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2022-01-13T01:56:49.423084Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-07-20T13:40:29.312131Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {
@@ -38,22 +38,22 @@
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.18.0.4"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:12:00:04"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-44-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.47-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -64,7 +64,7 @@
             "path": "/tmp/service_logs/log.json"
         },
         "level": "info",
-        "offset": 679
+        "offset": 709
     },
     "message": "proxy environment",
     "tags": [

--- a/packages/hashicorp_vault/data_stream/metrics/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/metrics/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-01-13T01:58:13.388Z",
+    "@timestamp": "2023-07-20T13:42:02.506Z",
     "agent": {
-        "ephemeral_id": "6c9fb82b-59c7-43dd-b429-5d5a8f60f994",
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "ephemeral_id": "08f3f73e-194c-4c7b-b9a9-5de2971266e7",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.metrics",
@@ -16,129 +16,20 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
-        "duration": 2522433,
-        "ingested": "2022-01-13T01:58:13Z",
+        "duration": 8463400,
+        "ingested": "2023-07-20T13:42:03Z",
         "kind": "metric"
     },
     "hashicorp_vault": {
         "metrics": {
-            "go_gc_duration_seconds_count": {
-                "counter": 6,
-                "rate": 0
-            },
-            "go_gc_duration_seconds_sum": {
-                "counter": 0.000178341,
-                "rate": 0
-            },
-            "go_goroutines": {
-                "value": 235
-            },
-            "go_memstats_alloc_bytes": {
-                "value": 12255384
-            },
-            "go_memstats_alloc_bytes_total": {
-                "counter": 34001072,
-                "rate": 0
-            },
-            "go_memstats_buck_hash_sys_bytes": {
-                "value": 1463139
-            },
-            "go_memstats_frees_total": {
-                "counter": 150857,
-                "rate": 0
-            },
-            "go_memstats_gc_cpu_fraction": {
-                "value": 0.0019060616740776953
-            },
-            "go_memstats_gc_sys_bytes": {
-                "value": 5881672
-            },
-            "go_memstats_heap_alloc_bytes": {
-                "value": 12255384
-            },
-            "go_memstats_heap_idle_bytes": {
-                "value": 50307072
-            },
-            "go_memstats_heap_inuse_bytes": {
-                "value": 15523840
-            },
-            "go_memstats_heap_objects": {
-                "value": 47319
-            },
-            "go_memstats_heap_released_bytes": {
-                "value": 44326912
-            },
-            "go_memstats_heap_sys_bytes": {
-                "value": 65830912
-            },
-            "go_memstats_last_gc_time_seconds": {
-                "value": 1642039090.5779526
-            },
-            "go_memstats_lookups_total": {
-                "counter": 0,
-                "rate": 0
-            },
-            "go_memstats_mallocs_total": {
-                "counter": 198176,
-                "rate": 0
-            },
-            "go_memstats_mcache_inuse_bytes": {
-                "value": 1200
-            },
-            "go_memstats_mcache_sys_bytes": {
-                "value": 16384
-            },
-            "go_memstats_mspan_inuse_bytes": {
-                "value": 175440
-            },
-            "go_memstats_mspan_sys_bytes": {
-                "value": 196608
-            },
-            "go_memstats_next_gc_bytes": {
-                "value": 24046448
-            },
-            "go_memstats_other_sys_bytes": {
-                "value": 389469
-            },
-            "go_memstats_stack_inuse_bytes": {
-                "value": 1277952
-            },
-            "go_memstats_stack_sys_bytes": {
-                "value": 1277952
-            },
-            "go_memstats_sys_bytes": {
-                "value": 75056136
-            },
-            "go_threads": {
-                "value": 6
-            },
-            "process_cpu_seconds_total": {
-                "counter": 0.12,
-                "rate": 0
-            },
-            "process_max_fds": {
-                "value": 1048576
-            },
-            "process_open_fds": {
-                "value": 12
-            },
-            "process_resident_memory_bytes": {
-                "value": 94257152
-            },
-            "process_start_time_seconds": {
-                "value": 1642039069.4
-            },
-            "process_virtual_memory_bytes": {
-                "value": 852996096
-            },
-            "process_virtual_memory_max_bytes": {
-                "value": -1
+            "vault_barrier_get": {
+                "value": 0.06210000067949295
             }
         }
     },
@@ -146,27 +37,29 @@
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.18.0.4"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:12:00:04"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-44-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.47-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "labels": {
+        "host": "hashicorp_vault",
         "instance": "hashicorp_vault:8200",
-        "job": "hashicorp_vault"
+        "job": "hashicorp_vault",
+        "quantile": "0.9"
     },
     "metricset": {
         "period": 5000

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -83,13 +83,13 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-08-18T17:07:22.769Z",
+    "@timestamp": "2023-07-20T13:39:22.108Z",
     "agent": {
-        "ephemeral_id": "623671b3-bcc9-4060-9806-e1cb0b945aae",
-        "id": "03109bfa-7015-46bd-9433-3879357210cd",
+        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.audit",
@@ -100,9 +100,9 @@ An example event for `audit` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "03109bfa-7015-46bd-9433-3879357210cd",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.8.2"
     },
     "event": {
         "action": "update",
@@ -111,10 +111,10 @@ An example event for `audit` looks as following:
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "e54c706f-1a3d-9662-3705-872e05c9c39f",
-        "ingested": "2022-08-18T17:07:55Z",
+        "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
+        "ingested": "2023-07-20T13:39:50Z",
         "kind": "event",
-        "original": "{\"time\":\"2022-08-18T17:07:22.76907021Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"e54c706f-1a3d-9662-3705-872e05c9c39f\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-07-20T13:39:22.1089946Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"07b55e76-c58c-7911-f1a2-a19692c37e43\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
             "change"
@@ -126,7 +126,7 @@ An example event for `audit` looks as following:
                 "token_type": "default"
             },
             "request": {
-                "id": "e54c706f-1a3d-9662-3705-872e05c9c39f",
+                "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
                 "namespace": {
                     "id": "root"
                 },
@@ -138,23 +138,24 @@ An example event for `audit` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.23.0.7"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:17:00:07"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.76-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.4 LTS (Focal Fossa)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -201,7 +202,6 @@ An example event for `audit` looks as following:
 | hashicorp_vault.audit.auth.no_default_policy | Indicates that the default policy should not be added by core when creating a token. The default policy will still be added if it's explicitly defined. | boolean |
 | hashicorp_vault.audit.auth.policies | Policies is the list of policies that the authenticated user is associated with. | keyword |
 | hashicorp_vault.audit.auth.policy_results.allowed |  | boolean |
-| hashicorp_vault.audit.auth.policy_results.granting_policies |  | array |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.name |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.namespace_id |  | keyword |
 | hashicorp_vault.audit.auth.policy_results.granting_policies.type |  | keyword |
@@ -317,13 +317,13 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-01-13T01:56:49.423Z",
+    "@timestamp": "2023-07-20T13:40:29.312Z",
     "agent": {
-        "ephemeral_id": "519f95f7-ce93-4b23-b4ba-cb55bee8d69c",
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.log",
@@ -334,16 +334,16 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "9878d192-22ad-49b6-a6c2-9959b0815d04",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2022-01-13T01:57:16Z",
+        "ingested": "2023-07-20T13:40:57Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2022-01-13T01:56:49.423084Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-07-20T13:40:29.312131Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {
@@ -356,22 +356,22 @@ An example event for `log` looks as following:
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.18.0.4"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:12:00:04"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-44-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.47-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -382,7 +382,7 @@ An example event for `log` looks as following:
             "path": "/tmp/service_logs/log.json"
         },
         "level": "info",
-        "offset": 679
+        "offset": 709
     },
     "message": "proxy environment",
     "tags": [

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,14 +1,12 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.12.0"
-license: basic
+version: "1.13.0"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:
   - security
   - iam
-release: ga
 conditions:
   kibana.version: "^7.17.0 || ^8.0.0"
 screenshots:


### PR DESCRIPTION
## What does this PR do?

Updates package spec to 2.9.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/hashicorp_vault
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870
