### PR TITLE
[infoblox_nios] - update package spec to 2.9.0

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7057
 - version: "1.10.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Update package spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
@@ -70,7 +70,9 @@
             },
             "host": {
                 "domain": "ns1.infoblox.localdomain",
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -128,7 +130,9 @@
             },
             "host": {
                 "domain": "infoblox.localdomain",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -186,7 +190,9 @@
                 ]
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -236,7 +242,9 @@
                 "outcome": "failure"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -281,7 +289,9 @@
                 "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -329,7 +339,9 @@
                 "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 13:07:33.343Z [user]: Password_Reset_Error - - to=AdminConnector auth=LOCALgroup=admin-group apparently_via=GUI"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -374,7 +386,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -421,7 +435,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:37:29.261Z [admin]: Created Network 192.168.0.0/24 network_view=default: Set extensible_attributes=[],address=\"192.168.2.0\",auto_create_reversezone=False,cidr=24,comment=\"\",common_properties=[domain_name_servers=[],routers=[]],dhcp_members=[[grid_member=Member:infoblox.localdomain]],disabled=False,discovery_member=NULL,enable_discovery=False,enable_immediate_discovery=False,network_view=NetworkView:default,use_basic_polling_settings=False,use_member_enable_discovery=False,vlans=[]"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -468,7 +484,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 11:46:38.877Z [admin]: Modified MemberDhcp infoblox.localdomain: Changed enable_service:False-\u003eTrue"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -515,7 +533,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService: Args services=[\"ALL\"],parents=[],force=True,mode=\"GROUPED\""
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -561,7 +581,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset Block: Set comment=\"\",disabled=True,name=\"Block\",type=\"BLACKLIST\""
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -608,7 +630,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:28:24.476Z [admin]: Called - TransferTrafficCapture message=Download\\040Traffic\\040capture\\040file: Args message=\"Download Traffic capture file\",members=[Member:infoblox.localdomain]"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -654,7 +678,9 @@
                 "original": "\u003c29\u003eMar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.238Z [service_account_test]: Created HostAddress 10.0.0.1 network_view=default: Set address=\"10.0.0.1\",configure_for_dhcp=False,match_option=\"MAC_ADDRESS\",parent=HostRecord:._default.tld.domain.subdomain.hostrecord"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -701,7 +727,9 @@
                 "original": "\u003c29\u003eMar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.239Z [service_account_test]: Created HostRecord somerecord.subdomain.domain.tld DnsView=default alias=somealias.subdomain.domain.tld address=10.0.0.1: Set extensible_attributes=[[name=\"NAC-Policy\",value=\"Host\"]],addresses=[address=\"10.0.0.1\"],aliases=[HostAlias:._default.tld.domain.subdomain.somealias.._default.tld.domain.subdomain.somehostrecord],fqdn=\"somerecord.subdomain.domain.tld\""
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -748,7 +776,9 @@
                 "original": "\u003c29\u003eMar 21 16:08:48 10.0.0.1 httpd: 2022-03-21 15:08:48.455Z [service_account_test]: Deleted HostRecord somerecord.subdomain.domain.tld DnsView=default address=10.0.0.0"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -795,7 +825,9 @@
                 "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Deleted CaaRecord somecaarecord.domain.tld DnsView=default "
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -842,7 +874,9 @@
                 "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Created HostAddress 192.168.0.0 network_view=default: Set address=\"192.168.0.0\",configure_for_dhcp=True,mac_address=\"01:01:01:01:01:01\",match_option=\"MAC_ADDRESS\",network=Network:192.168.0.0/24\\054network_view\\075default,parent=HostRecord:._default.test.test3,reserved_interface=NULL,use_for_ea_inheritance=True"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -889,7 +923,9 @@
                 "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -936,7 +972,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 12:40:05.241Z [adminuser]: Modified Grid Unibe-DNS-Grid: Changed backup_setting:[password=\"******\",restore_password=\"******\"]-\u003e[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]-\u003e[password=\"******\"],csp_settings:[csp_join_token=\"******\"]-\u003e[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]-\u003e[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]-\u003e[password=\"******\"],http_proxy_server_setting:NULL-\u003e[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]-\u003e[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]-\u003e[[address=\"67.43.156.15\"]]"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -982,7 +1020,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 syslog: any random text"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1015,7 +1055,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1058,7 +1100,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1101,7 +1145,9 @@
                 "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
@@ -15,7 +15,9 @@
                 "original": "\u003c30\u003eApr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via eth3"
             },
             "host": {
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -60,7 +62,9 @@
                 "original": "\u003c30\u003eApr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via 192.168.0.2"
             },
             "host": {
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -157,7 +161,9 @@
             },
             "host": {
                 "domain": "infoblox.localdomain",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -207,7 +213,9 @@
                 "original": "\u003c30\u003eMar 27 08:32:59 10.0.0.1 dhcpd[2750]: DHCPDISCOVER from 00:50:56:83:d0:f6 via eth1 TransID 6214ab45: network 10.50.0.0/20: no free leases"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -480,7 +488,9 @@
                 "original": "\u003c30\u003eMar 31 15:30:05 10.0.0.1 dhcpd[15752]: DHCPOFFER on 192.168.0.4 to 26:9a:76:87:8a:06 via eth2 relay 192.168.0.3 lease-duration 1795 uid 01:26:9a:76:87:8a:06"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1150,7 +1160,9 @@
                 "original": "\u003c30\u003eMar 31 15:30:06 10.0.0.1 dhcpd[15752]: DHCPREQUEST for 192.168.0.4 from 9a:df:6e:f6:1f:23 via 172.26.0.1 TransID 15ca711f uid 01:9a:df:6e:f6:1f:23 (RENEW)"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1382,7 +1394,9 @@
                 "original": "\u003c30\u003eJul 12 15:07:57 67.43.156.0 dhcpd[8061]: DHCPOFFER on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 40977 offered-duration 43200 uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1499,7 +1513,9 @@
                 "original": "\u003c30\u003eMar 27 08:32:59 10.0.0.1 dhcpd[15752]: DHCPACK on 192.168.0.4 to 9a:df:6e:f6:1f:23 via eth2 relay 192.168.0.3 lease-duration 7257600 (RENEW) uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1618,7 +1634,9 @@
                 "original": "\u003c30\u003eJul 12 15:10:48 67.43.156.0 dhcpd[13468]: DHCPACK on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 7257600 (RENEW)"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1883,7 +1901,9 @@
                 "original": "\u003c30\u003eMar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 5713b740"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1931,7 +1951,9 @@
                 "original": "\u003c30\u003eMar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via eth2 TransID 5713b740"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2032,7 +2054,9 @@
                 "original": "\u003c30\u003eMar 18 11:44:52 10.0.0.1 dhcpd[32243]: DHCPDECLINE of 192.168.0.4 from 34:29:8f:71:b8:99 via 10.10.4.1 TransID 00000000: not found"
             },
             "host": {
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2664,7 +2688,9 @@
                 "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulated Solicit message from 2a02:cf40:: port 547 from client DUID 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23, transaction ID 0x698AD400"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2709,7 +2735,9 @@
                 "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Advertise NA: address 2a02:cf40:: to client with duid 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23 iaid = -1620146908 valid for 43200 seconds"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2756,7 +2784,9 @@
                 "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Relay-forward message from 2a02:cf40:: port 547, link address 2a02:cf40::1, peer address 2a02:cf40::2"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2804,7 +2834,9 @@
                 "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulating Advertise message to send to 2a02:cf40:: port 547"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2846,7 +2878,9 @@
                 "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Sending Relay-reply message to 2a02:cf40:: port 547"
             },
             "host": {
-                "ip": "67.43.156.0"
+                "ip": [
+                    "67.43.156.0"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2889,7 +2923,9 @@
             },
             "host": {
                 "domain": "infoblox.localdomain",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2949,7 +2985,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -2995,7 +3033,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -3044,7 +3084,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -3105,7 +3147,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -3172,7 +3216,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -3237,7 +3283,9 @@
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
-                "ip": "10.0.0.1"
+                "ip": [
+                    "10.0.0.1"
+                ]
             },
             "infoblox_nios": {
                 "log": {

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -1198,7 +1198,9 @@
                 "original": "\u003c30\u003eApr 14 16:17:20 10.50.1.227 named[2588]: infoblox-responses: 14-Apr-2022 16:17:20.046 client 192.168.1.90#57738: UDP: query: settings-win.data.microsoft.com IN A response: REFUSED -"
             },
             "host": {
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1260,7 +1262,9 @@
                 "original": "\u003c30\u003eApr 14 16:16:05 10.50.1.227 named[2588]: queries: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query: ocsp.digicert.com IN A + (192.168.1.10)"
             },
             "host": {
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1313,7 +1317,9 @@
                 "original": "\u003c30\u003eApr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288"
             },
             "host": {
-                "ip": "10.50.1.227"
+                "ip": [
+                    "10.50.1.227"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1390,7 +1396,9 @@
             },
             "host": {
                 "domain": "a1.foo.com",
-                "ip": "89.160.20.112"
+                "ip": [
+                    "89.160.20.112"
+                ]
             },
             "infoblox_nios": {
                 "log": {
@@ -1475,7 +1483,9 @@
             },
             "host": {
                 "domain": "a1.foo.com",
-                "ip": "89.160.20.112"
+                "ip": [
+                    "89.160.20.112"
+                ]
             },
             "infoblox_nios": {
                 "log": {

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -11,8 +11,8 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
         - "^%{GREEDYDATA:message}$"
   - rename:
       field: _conf.tz_offset
@@ -79,21 +79,21 @@ processors:
       value: '{{{event.created}}}'
       if: "ctx['@timestamp'] == null && ctx.event?.created != null"
   - convert:
-      field: host.ip
-      if: ctx.host?.ip != null && ctx.host.ip != ''
+      field: _tmp.host.ip
+      if: ctx._tmp?.host?.ip != null && ctx._tmp.host.ip != ''
       type: ip
       ignore_missing: true
       on_failure:
         - remove:
-            field: host.ip
+            field: _tmp.host.ip
             ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - append:
       field: related.ip
-      value: '{{{host.ip}}}'
-      if: ctx.host?.ip != null
+      value: '{{{_tmp.host.ip}}}'
+      if: ctx._tmp?.host?.ip != null
       allow_duplicates: false
       ignore_failure: true
   - append:
@@ -104,9 +104,8 @@ processors:
       ignore_failure: true
   - append:
       field: host.ip
-      value: '{{{host.ip}}}'
-      if: ctx.host?.ip != null
-      allow_duplicates: false
+      value: '{{{_tmp.host.ip}}}'
+      if: ctx._tmp?.host?.ip != null
       ignore_failure: true
   - lowercase:
       field: event.action
@@ -135,7 +134,9 @@ processors:
       ignore_failure: true
       ignore_missing: true
   - remove:
-      field: _conf
+      field:
+        - _conf
+        - _tmp
       ignore_failure: true
       ignore_missing: true
 on_failure:

--- a/packages/infoblox_nios/data_stream/log/sample_event.json
+++ b/packages/infoblox_nios/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2011-10-19T12:43:47.375Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "102cbca1-7eba-451e-977d-353ff4781b73",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "infoblox_nios.log",
@@ -16,20 +16,23 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "action": "first_login",
         "agent_id_status": "verified",
-        "created": "2023-03-22T14:26:54.000Z",
+        "created": "2023-03-22T14:26:54.000+05:00",
         "dataset": "infoblox_nios.log",
-        "ingested": "2023-01-13T12:24:26Z",
-        "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login"
+        "ingested": "2023-07-20T15:45:46Z",
+        "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login",
+        "timezone": "+0500"
     },
     "host": {
-        "ip": "10.0.0.1"
+        "ip": [
+            "10.0.0.1"
+        ]
     },
     "infoblox_nios": {
         "log": {
@@ -49,7 +52,7 @@
     },
     "log": {
         "source": {
-            "address": "172.27.0.4:60381"
+            "address": "172.22.0.4:50640"
         },
         "syslog": {
             "priority": 29

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -155,11 +155,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2011-10-19T12:43:47.375Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "102cbca1-7eba-451e-977d-353ff4781b73",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "infoblox_nios.log",
@@ -170,20 +170,23 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "action": "first_login",
         "agent_id_status": "verified",
-        "created": "2023-03-22T14:26:54.000Z",
+        "created": "2023-03-22T14:26:54.000+05:00",
         "dataset": "infoblox_nios.log",
-        "ingested": "2023-01-13T12:24:26Z",
-        "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login"
+        "ingested": "2023-07-20T15:45:46Z",
+        "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login",
+        "timezone": "+0500"
     },
     "host": {
-        "ip": "10.0.0.1"
+        "ip": [
+            "10.0.0.1"
+        ]
     },
     "infoblox_nios": {
         "log": {
@@ -203,7 +206,7 @@ An example event for `log` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.27.0.4:60381"
+            "address": "172.22.0.4:50640"
         },
         "syslog": {
             "priority": 29

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,15 +1,13 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.10.0"
-license: basic
+version: "1.11.0"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:
   - security
   - network
   - dns_security
-release: ga
 conditions:
   kibana.version: ^8.7.1
 screenshots:


### PR DESCRIPTION

## What does this PR do?

- Update package spec to 2.9.0
- Ensure host.ip is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/infoblox_nios
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870
