### PR TITLE
[jamf_compliance_reporter] - update package spec to 2.9.0

### DIFF
--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.4.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7095
 - version: "1.4.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/jamf_compliance_reporter/data_stream/log/sample_event.json
+++ b/packages/jamf_compliance_reporter/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-10-02T16:17:08.000Z",
     "agent": {
-        "ephemeral_id": "d5ffc842-05cf-43da-96fe-905f95ab2e41",
-        "id": "4f9748a6-cc5b-4160-bfdb-b533f9ba576a",
+        "ephemeral_id": "3210e168-0038-4c64-bf69-6bd94996ed48",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.4.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "jamf_compliance_reporter.log",
@@ -16,9 +16,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "4f9748a6-cc5b-4160-bfdb-b533f9ba576a",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.4.0"
+        "version": "8.8.2"
     },
     "event": {
         "action": "preference_list_event",
@@ -27,7 +27,7 @@
             "process"
         ],
         "dataset": "jamf_compliance_reporter.log",
-        "ingested": "2022-11-04T11:01:45Z",
+        "ingested": "2023-07-20T19:38:36Z",
         "kind": "event",
         "type": [
             "info"
@@ -45,7 +45,7 @@
         }
     },
     "input": {
-        "type": "tcp"
+        "type": "http_endpoint"
     },
     "jamf_compliance_reporter": {
         "log": {
@@ -107,11 +107,6 @@
                     "uuid": "3X6E4X3X-9285-4X7X-9X0X-X3X62XX379XX"
                 }
             }
-        }
-    },
-    "log": {
-        "source": {
-            "address": "192.168.224.7:58764"
         }
     },
     "related": {

--- a/packages/jamf_compliance_reporter/docs/README.md
+++ b/packages/jamf_compliance_reporter/docs/README.md
@@ -69,11 +69,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2019-10-02T16:17:08.000Z",
     "agent": {
-        "ephemeral_id": "d5ffc842-05cf-43da-96fe-905f95ab2e41",
-        "id": "4f9748a6-cc5b-4160-bfdb-b533f9ba576a",
+        "ephemeral_id": "3210e168-0038-4c64-bf69-6bd94996ed48",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.4.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "jamf_compliance_reporter.log",
@@ -84,9 +84,9 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "4f9748a6-cc5b-4160-bfdb-b533f9ba576a",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.4.0"
+        "version": "8.8.2"
     },
     "event": {
         "action": "preference_list_event",
@@ -95,7 +95,7 @@ An example event for `log` looks as following:
             "process"
         ],
         "dataset": "jamf_compliance_reporter.log",
-        "ingested": "2022-11-04T11:01:45Z",
+        "ingested": "2023-07-20T19:38:36Z",
         "kind": "event",
         "type": [
             "info"
@@ -113,7 +113,7 @@ An example event for `log` looks as following:
         }
     },
     "input": {
-        "type": "tcp"
+        "type": "http_endpoint"
     },
     "jamf_compliance_reporter": {
         "log": {
@@ -175,11 +175,6 @@ An example event for `log` looks as following:
                     "uuid": "3X6E4X3X-9285-4X7X-9X0X-X3X62XX379XX"
                 }
             }
-        }
-    },
-    "log": {
-        "source": {
-            "address": "192.168.224.7:58764"
         }
     },
     "related": {

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,13 +1,11 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.4.0"
-license: basic
+version: "1.5.0"
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration
 categories:
   - security
-release: ga
 conditions:
   kibana.version: ^8.7.1
 screenshots:


### PR DESCRIPTION
## What does this PR do?

- Update package spec to 2.9.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/jamf_compliance_reporter
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870
