### PR TITLE
Add additional mappings for fleet-server logs

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.0"
+  changes:
+    - description: Add fleet-server attributes to log.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7096
 - version: "1.8.0"
   changes:
     - description: Added new Health dashboards for Input Metrics

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -51,6 +51,9 @@
       type: keyword
       ignore_above: 1024
       description: Previous component health
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
 - name: unit
   type: group
   description: Agent unit that the log message is about, only available on Elastic Agent 8.6.0+

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/ecs.yml
@@ -14,3 +14,19 @@
   external: ecs
 - name: log.level
   external: ecs
+- name: error.message
+  external: ecs
+- name: http.request.id
+  external: ecs
+- name: http.request.body.bytes
+  external: ecs
+- name: http.request.method
+  external: ecs
+- name: http.response.status_code
+  external: ecs
+- name: http.response.body.bytes
+  external: ecs
+- name: http.version
+  external: ecs
+- name: url.full
+  external: ecs

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
@@ -26,3 +26,54 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+- name: http
+  title: HTTP
+  description: Fields related to HTTP requests
+  type: group
+  fields:
+    - name: request.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The HTTP request ID.
+    - name: request.body.bytes
+      level: extended
+      type: integer
+      description: The request body length byte count.
+    - name: request.method
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The HTTP request method.
+    - name: response.status_code
+      level: extended
+      type: short
+      description: The response status code.
+    - name: response.body.bytes
+      level: extended
+      type: integer
+      description: The response body length byte count.
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The HTTP request version.
+- name: url.full
+  type: keyword
+  ignore_above: 1024
+  description: The full URL being requested.
+- name: fleet
+  title: Fleet Server
+  description: Fleet server annotations.
+  type: group
+  fields:
+    - name: access.apikey.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The API key used when a fleet endpoint is accessed.
+    - name: agent.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The ID of the agent interactiing with a fleet endpoint.

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
@@ -26,42 +26,10 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-- name: http
-  title: HTTP
-  description: Fields related to HTTP requests
-  type: group
-  fields:
-    - name: request.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: The HTTP request ID.
-    - name: request.body.bytes
-      level: extended
-      type: integer
-      description: The request body length byte count.
-    - name: request.method
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: The HTTP request method.
-    - name: response.status_code
-      level: extended
-      type: short
-      description: The response status code.
-    - name: response.body.bytes
-      level: extended
-      type: integer
-      description: The response body length byte count.
-    - name: version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: The HTTP request version.
-- name: url.full
+- name: policy_id
   type: keyword
   ignore_above: 1024
-  description: The full URL being requested.
+  description: The policy ID fleet-server is operating on when starting a monitor or similar internal workflow.
 - name: fleet
   title: Fleet Server
   description: Fleet server annotations.
@@ -76,4 +44,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The ID of the agent interactiing with a fleet endpoint.
+      description: The ID of the agent interacting with a fleet endpoint.
+    - name: policy.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The ID of the policy being used in a request to a fleet endpoint.

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.8.0
+version: 1.9.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

Add missing mappings for fleet-server logs.

New attributes appear in the log stream:
<img width="2530" alt="Screenshot 2023-07-24 at 11 06 27 AM" src="https://github.com/elastic/integrations/assets/82832767/cf10c2be-5ac5-405b-8e3d-0c140b62699a">

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~

## Related issues

- Closes #5680 