### PR TITLE
[Cloud Security Posture] Remove preview tag before the 8.9 release

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -19,7 +19,7 @@
     - description: Update CloudFormation template to use al2023 AMI and increased EBS volume size
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6699
-- version: "1.4.0-preview22"
+- version: "1.4.0"
   changes:
     - description: Populate new CloudFormation param ElasticArtifactServer
       type: enhancement


### PR DESCRIPTION
Remove the preview tags from the 1.4.x integration's version before the 8.9 release.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

