### PR TITLE
[Windows] Add dimension fields for perfmon datastream to support TSDB.

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimension fields for perfmon datastream to support TSDB.
       type: enhancement
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/7113
 - version: "1.26.0"
   changes:
     - description: Set `event.action` to sysmon name in sysmon_operational.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.0"
+  changes:
+    - description: Add dimension fields for perfmon datastream to support TSDB.
+      type: enhancement
+      link: tbd
 - version: "1.26.0"
   changes:
     - description: Set `event.action` to sysmon name in sysmon_operational.

--- a/packages/windows/data_stream/perfmon/fields/agent.yml
+++ b/packages/windows/data_stream/perfmon/fields/agent.yml
@@ -9,6 +9,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      dimension: true
       description: 'The cloud account or organization id used to identify different entities in a multi-tenant environment.
 
         Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
@@ -16,12 +17,14 @@
     - name: availability_zone
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Availability zone in which this host is running.
       example: us-east-1c
     - name: instance.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
@@ -39,12 +42,14 @@
     - name: provider
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
       example: aws
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
@@ -65,6 +70,7 @@
     - name: id
       level: core
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Unique container id.
     - name: image.name
@@ -133,6 +139,7 @@
     - name: name
       level: core
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: 'Name of the host.
 

--- a/packages/windows/data_stream/perfmon/fields/agent.yml
+++ b/packages/windows/data_stream/perfmon/fields/agent.yml
@@ -202,4 +202,11 @@
       example: "stretch"
       description: >
         OS codename, if any.
-
+- name: agent
+  title: Agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      dimension: true

--- a/packages/windows/data_stream/perfmon/fields/fields.yml
+++ b/packages/windows/data_stream/perfmon/fields/fields.yml
@@ -3,10 +3,12 @@
   fields:
     - name: object
       type: keyword
+      dimension: true
       description: |
         Object value.
     - name: instance
       type: keyword
+      dimension: true
       description: |
         Instance value.
     - name: metrics.*.*

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -1299,6 +1299,7 @@ The Windows `perfmon` data stream provides performance counter values.
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| agent.id |  | keyword |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
 | cloud.availability_zone | Availability zone in which this host is running. | keyword |
 | cloud.image.id | Image ID for the cloud instance. | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.26.0
+version: 1.27.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR add dimension fields for windows perfmon data stream to enable TSDB.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues


- Relates #6993
