### PR TITLE
[Kubernetes] Reroute container logs based on pod annotations

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -86,9 +86,9 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. 
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations. 
 
-For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By setting the pod label `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
+For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By annotating the pod with `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
 

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -84,6 +84,12 @@ the masters won't be visible. In these cases it won't be possible to use `schedu
 The container-logs dataset requires access to the log files in each Kubernetes node where the container logs are stored.
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
+#### Routing
+
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. For example, by setting the pod label `elastic.co/dataset: nginx`, the integration will send all the container logs to the `nginx` dataset.
+
+To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
+
 ### audit-logs
 
 The audit-logs dataset requires access to the log files on each Kubernetes node where the audit logs are stored.

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -86,7 +86,9 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. For example, by setting the pod label `elastic.co/dataset: nginx`, the integration will send all the container logs to the `nginx` dataset.
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. 
+
+For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By setting the pod label `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
 

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -61,6 +61,12 @@ Here is an example where we route the container logs for a pod running the Elast
 kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
 ```
 
+Here's a similar example to change the namespace on a pod running Nginx:
+
+```shell
+kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
+```
+
 ### Labels Reference
 
 Here are the labels available for customization:

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -53,7 +53,7 @@ spec:
 
 ### Set routing at runtime
 
-Suppose you want to change the container logs routing on a running container. In that case, you can set the same labels using `kubectl,` and the integration will apply it immediately sending all the following documents to the new destination:
+Suppose you want to change the container logs routing on a running container. In that case, you can set the same labels using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
 
 Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
 

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -7,12 +7,66 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 By default only {{ url "filebeat-input-filestream-parsers" "container parser" }} is enabled. Additional log parsers can be added as an advanced options configuration.
 
+
 ## Rerouting based on pod labels
 
-You can customize the routing of the container logs by using Kubernetes labels applied to pods.
+You can customize the routing of container logs by sending them to different datasets and namespaces using pods labels.
 
-The integration can use Kubernetes labels on pods to reroute the logs document to a different dataset or namespace without writing a custom pipeline.
+Routing customization can happen at:
 
-To route the document logs to a different dataset, you can set the `kubernetes.labels.elastic.co/dataset` label with the value of the desired dataset.
+- pod definition time, e.g., using a deployment.
+- pod runtime, setting the labels using `kubectl`.
 
-To route the document logs to a different namespace, you can set the `kubernetes.labels.elastic.co/namespace` label with the value of the desired namespace.
+
+### Set routing at pod definition time
+
+Here is an example of an Nginx deployment where we set both `elastic.co/dataset` and `elastic.co/namespace` labels to route the container logs to specific datasets and namespace, respectively.
+
+```yaml
+# nginx-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        elastic.co/dataset: kubernetes.container_logs.nginx
+        elastic.co/namespace: staging
+        app.kubernetes.io/name: myservice
+        app.kubernetes.io/version: v0.1.0
+        app.kubernetes.io/instance: myservice-abcxzy
+    spec:
+      containers:
+        - name: nginx-container
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+```
+
+
+### Set routing at runtime
+
+Suppose you want to change the container logs routing on a running container. In that case, you can set the same labels using `kubectl,` and the integration will apply it immediately sending all the following documents to the new destination:
+
+Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
+
+```shell
+kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
+```
+
+### Labels Reference
+
+Here are the labels available for customization:
+
+
+| Label                  | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `elastic.co/dataset`   | Defines the target dataset for this pod. |
+| `elastic.co/namespace` | Defines the target namespace for this pod.    |

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -54,7 +54,7 @@ spec:
 
 ### Set routing at runtime
 
-Suppose you want to change the container logs routing on a running container. In that case, you can annotate pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
+Suppose you want to change the container logs routing on a running container. In that case, you can annotate the pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
 
 Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
 
@@ -68,16 +68,16 @@ Here's a similar example to change the namespace on a pod running Nginx:
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
 ```
 
-You can restore the standard routing by removing the labels:
+You can restore the standard routing by removing the annotations:
 
 ```shell
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset-
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace-
 ```
 
-### Labels Reference
+### Annotations Reference
 
-Here are the labels available for customization:
+Here are the annotations available to customize routing:
 
 
 | Label                  | Description                                              |

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -6,3 +6,13 @@ It requires access to the log files in each Kubernetes node where the container 
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 By default only {{ url "filebeat-input-filestream-parsers" "container parser" }} is enabled. Additional log parsers can be added as an advanced options configuration.
+
+## Rerouting based on pod labels
+
+You can customize the routing of the container logs by using Kubernetes labels applied to pods.
+
+The integration can use Kubernetes labels on pods to reroute the logs document to a different dataset or namespace without writing a custom pipeline.
+
+To route the document logs to a different dataset, you can set the `kubernetes.labels.elastic.co/dataset` label with the value of the desired dataset.
+
+To route the document logs to a different namespace, you can set the `kubernetes.labels.elastic.co/namespace` label with the value of the desired namespace.

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -10,7 +10,7 @@ By default only {{ url "filebeat-input-filestream-parsers" "container parser" }}
 
 ## Rerouting based on pod annotations
 
-You can customize the routing of container logs events and sending them to different datasets and namespaces using pods annotations.
+You can customize the routing of container logs events and sending them to different datasets and namespaces using pods' annotations.
 
 Routing customization can happen at:
 

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -68,5 +68,5 @@ Here are the labels available for customization:
 
 | Label                  | Description                                  |
 | ---------------------- | -------------------------------------------- |
-| `elastic.co/dataset`   | Defines the target dataset for this pod. |
-| `elastic.co/namespace` | Defines the target namespace for this pod.    |
+| `elastic.co/dataset`   | Defines the target dataset for this pod.     |
+| `elastic.co/namespace` | Defines the target namespace for this pod.   |

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -8,19 +8,19 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 By default only {{ url "filebeat-input-filestream-parsers" "container parser" }} is enabled. Additional log parsers can be added as an advanced options configuration.
 
 
-## Rerouting based on pod labels
+## Rerouting based on pod annotations
 
-You can customize the routing of container logs by sending them to different datasets and namespaces using pods labels.
+You can customize the routing of container logs events and sending them to different datasets and namespaces using pods annotations.
 
 Routing customization can happen at:
 
 - pod definition time, e.g., using a deployment.
-- pod runtime, setting the labels using `kubectl`.
+- pod runtime, annotating pods using `kubectl`.
 
 
 ### Set routing at pod definition time
 
-Here is an example of an Nginx deployment where we set both `elastic.co/dataset` and `elastic.co/namespace` labels to route the container logs to specific datasets and namespace, respectively.
+Here is an example of an Nginx deployment where we set both `elastic.co/dataset` and `elastic.co/namespace` annotations to route the container logs to specific datasets and namespace, respectively.
 
 ```yaml
 # nginx-deployment.yaml
@@ -35,12 +35,13 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        elastic.co/dataset: kubernetes.container_logs.nginx
+        elastic.co/namespace: nginx
       labels:
         app: nginx
-        elastic.co/dataset: kubernetes.container_logs.nginx
-        elastic.co/namespace: staging
         app.kubernetes.io/name: myservice
-        app.kubernetes.io/version: v0.1.0
+        app.kubernetes.io/version: v0.1.2
         app.kubernetes.io/instance: myservice-abcxzy
     spec:
       containers:
@@ -53,18 +54,25 @@ spec:
 
 ### Set routing at runtime
 
-Suppose you want to change the container logs routing on a running container. In that case, you can set the same labels using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
+Suppose you want to change the container logs routing on a running container. In that case, you can annotate pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
 
 Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
 
 ```shell
-kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
 ```
 
 Here's a similar example to change the namespace on a pod running Nginx:
 
 ```shell
-kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
+```
+
+You can restore the standard routing by removing the labels:
+
+```shell
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset-
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace-
 ```
 
 ### Labels Reference

--- a/packages/kubernetes/_dev/build/docs/container-logs.md
+++ b/packages/kubernetes/_dev/build/docs/container-logs.md
@@ -72,7 +72,7 @@ kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.
 Here are the labels available for customization:
 
 
-| Label                  | Description                                  |
-| ---------------------- | -------------------------------------------- |
-| `elastic.co/dataset`   | Defines the target dataset for this pod.     |
-| `elastic.co/namespace` | Defines the target namespace for this pod.   |
+| Label                  | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `elastic.co/dataset`   | Defines the target data stream's dataset for this pod.   |
+| `elastic.co/namespace` | Defines the target data stream's namespace for this pod. |

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.45.0"
   changes:
-    - description: Reroute container logs based on pod labels
+    - description: Reroute container logs based on pod annotations.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7118
 - version: "1.44.0"

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.0"
+  changes:
+    - description: Reroute container logs based on pod labels
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7118
 - version: "1.44.0"
   changes:
     - description: Introducing kubernetes.deployment.status.* metrics

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
@@ -3,8 +3,9 @@ fields:
     dataset: kubernetes.container_logs
     namespace: default
   kubernetes:
-    labels:
+    annotations:
       elastic_co/dataset: kubernetes.container_logs.nginx
       elastic_co/namespace: nginx
+    labels:
       app_kubernetes_io/version: "v0.1.0"
       app_kubernetes_io/name: "myservice"

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
@@ -1,0 +1,9 @@
+fields:
+  data_stream:
+    dataset: kubernetes.container_logs
+    namespace: default
+  kubernetes:
+    labels:
+      elastic_co/namespace: nginx
+      app_kubernetes_io/version: "v0.1.0"
+      app_kubernetes_io/name: "myservice"

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
@@ -4,6 +4,7 @@ fields:
     namespace: default
   kubernetes:
     labels:
+      elastic_co/dataset: kubernetes.container_logs.nginx
       elastic_co/namespace: nginx
       app_kubernetes_io/version: "v0.1.0"
       app_kubernetes_io/name: "myservice"

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log
@@ -1,0 +1,4 @@
+2023/07/25 15:24:11 [notice] 1#1: start worker process 33
+2023/07/25 15:24:11 [notice] 1#1: start worker process 34
+2023/07/25 15:24:11 [notice] 1#1: start worker process 35
+2023/07/25 15:24:11 [notice] 1#1: using the "epoll" event method

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -1,0 +1,76 @@
+{
+    "expected": [
+        {
+            "data_stream": {
+                "dataset": "kubernetes.container_logs",
+                "namespace": "default"
+            },
+            "kubernetes": {
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/namespace": "nginx"
+                }
+            },
+            "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 33",
+            "service": {
+                "name": "myservice",
+                "version": "v0.1.0"
+            }
+        },
+        {
+            "data_stream": {
+                "dataset": "kubernetes.container_logs",
+                "namespace": "default"
+            },
+            "kubernetes": {
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/namespace": "nginx"
+                }
+            },
+            "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 34",
+            "service": {
+                "name": "myservice",
+                "version": "v0.1.0"
+            }
+        },
+        {
+            "data_stream": {
+                "dataset": "kubernetes.container_logs",
+                "namespace": "default"
+            },
+            "kubernetes": {
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/namespace": "nginx"
+                }
+            },
+            "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 35",
+            "service": {
+                "name": "myservice",
+                "version": "v0.1.0"
+            }
+        },
+        {
+            "data_stream": {
+                "dataset": "kubernetes.container_logs",
+                "namespace": "default"
+            },
+            "kubernetes": {
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/namespace": "nginx"
+                }
+            },
+            "message": "2023/07/25 15:24:11 [notice] 1#1: using the \"epoll\" event method",
+            "service": {
+                "name": "myservice",
+                "version": "v0.1.0"
+            }
+        }
+    ]
+}

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -2,13 +2,15 @@
     "expected": [
         {
             "data_stream": {
-                "dataset": "kubernetes.container_logs",
-                "namespace": "default"
+                "dataset": "kubernetes.container_logs.nginx",
+                "namespace": "nginx",
+                "type": "logs"
             },
             "kubernetes": {
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
                     "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
                 }
             },
@@ -20,13 +22,15 @@
         },
         {
             "data_stream": {
-                "dataset": "kubernetes.container_logs",
-                "namespace": "default"
+                "dataset": "kubernetes.container_logs.nginx",
+                "namespace": "nginx",
+                "type": "logs"
             },
             "kubernetes": {
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
                     "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
                 }
             },
@@ -38,13 +42,15 @@
         },
         {
             "data_stream": {
-                "dataset": "kubernetes.container_logs",
-                "namespace": "default"
+                "dataset": "kubernetes.container_logs.nginx",
+                "namespace": "nginx",
+                "type": "logs"
             },
             "kubernetes": {
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
                     "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
                 }
             },
@@ -56,13 +62,15 @@
         },
         {
             "data_stream": {
-                "dataset": "kubernetes.container_logs",
-                "namespace": "default"
+                "dataset": "kubernetes.container_logs.nginx",
+                "namespace": "nginx",
+                "type": "logs"
             },
             "kubernetes": {
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
                     "app_kubernetes_io/version": "v0.1.0",
+                    "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
                 }
             },

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -7,11 +7,13 @@
                 "type": "logs"
             },
             "kubernetes": {
-                "labels": {
-                    "app_kubernetes_io/name": "myservice",
-                    "app_kubernetes_io/version": "v0.1.0",
+                "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
+                },
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0"
                 }
             },
             "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 33",
@@ -27,11 +29,13 @@
                 "type": "logs"
             },
             "kubernetes": {
-                "labels": {
-                    "app_kubernetes_io/name": "myservice",
-                    "app_kubernetes_io/version": "v0.1.0",
+                "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
+                },
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0"
                 }
             },
             "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 34",
@@ -47,11 +51,13 @@
                 "type": "logs"
             },
             "kubernetes": {
-                "labels": {
-                    "app_kubernetes_io/name": "myservice",
-                    "app_kubernetes_io/version": "v0.1.0",
+                "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
+                },
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0"
                 }
             },
             "message": "2023/07/25 15:24:11 [notice] 1#1: start worker process 35",
@@ -67,11 +73,13 @@
                 "type": "logs"
             },
             "kubernetes": {
-                "labels": {
-                    "app_kubernetes_io/name": "myservice",
-                    "app_kubernetes_io/version": "v0.1.0",
+                "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
                     "elastic_co/namespace": "nginx"
+                },
+                "labels": {
+                    "app_kubernetes_io/name": "myservice",
+                    "app_kubernetes_io/version": "v0.1.0"
                 }
             },
             "message": "2023/07/25 15:24:11 [notice] 1#1: using the \"epoll\" event method",

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -16,6 +16,22 @@ parsers:
 {{ additionalParsersConfig }}
 
 processors:
+{{!
+  Why do we need to add the following processors?
+  -----------------------------------------------
+
+  The kubernetes provider supports[^1] pods annotations, making it possible to add
+  them to the event using the `include_annotations` configuration option.
+  
+  However, adding annotations to the event is disabled by default, and it is
+  not possible to enable it on Fleet-managed agents.
+
+  The following processors are a workaround to add the annotations to the event
+  without using the `include_annotations` configuration option.
+
+  
+  [^1]: https://github.com/elastic/elastic-agent/blob/37ec2bb7ee1d2cc6c0fccf2f0cd0a44eb3d61efd/internal/pkg/composable/providers/kubernetes/pod.go#L311-L315
+}}
 - add_fields:
     target: kubernetes
     fields:

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -15,8 +15,27 @@ parsers:
     format: {{ containerParserFormat }}
 {{ additionalParsersConfig }}
 
-{{#if processors}}
 processors:
+  - add_fields:
+      target: kubernetes
+      fields:
+        annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
+        annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+  - drop_fields:
+      fields:
+        - kubernetes.annotations.elastic_co/dataset
+      when:
+        equals:
+          kubernetes.annotations.elastic_co/dataset: ""
+      ignore_missing: true
+  - drop_fields:
+      fields:
+        - kubernetes.annotations.elastic_co/namespace
+      when:
+        equals:
+          kubernetes.annotations.elastic_co/namespace: ""
+      ignore_missing: true
+{{#if processors}}      
 {{processors}}
 {{/if}}
 

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -16,25 +16,25 @@ parsers:
 {{ additionalParsersConfig }}
 
 processors:
-  - add_fields:
-      target: kubernetes
-      fields:
-        annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
-        annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
-  - drop_fields:
-      fields:
-        - kubernetes.annotations.elastic_co/dataset
-      when:
-        equals:
-          kubernetes.annotations.elastic_co/dataset: ""
-      ignore_missing: true
-  - drop_fields:
-      fields:
-        - kubernetes.annotations.elastic_co/namespace
-      when:
-        equals:
-          kubernetes.annotations.elastic_co/namespace: ""
-      ignore_missing: true
+- add_fields:
+    target: kubernetes
+    fields:
+      annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
+      annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+- drop_fields:
+    fields:
+      - kubernetes.annotations.elastic_co/dataset
+    when:
+      equals:
+        kubernetes.annotations.elastic_co/dataset: ""
+    ignore_missing: true
+- drop_fields:
+    fields:
+      - kubernetes.annotations.elastic_co/namespace
+    when:
+      equals:
+        kubernetes.annotations.elastic_co/namespace: ""
+    ignore_missing: true
 {{#if processors}}      
 {{processors}}
 {{/if}}

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -6,8 +6,8 @@ processors:
       value: '8.8.0'
   - set:
       field: service.name
-      value: '{{kubernetes.labels.app_kubernetes_io/name}}'
-      if: ctx?.kubernetes?.labels['app_kubernetes_io/name'] != null
+      copy_from: kubernetes.labels.app_kubernetes_io/name
+      ignore_empty_value: true
   - set:
       field: service.name
       value: '{{kubernetes.container.name}}'

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -14,13 +14,6 @@ processors:
       field: service.version
       copy_from: kubernetes.labels.app_kubernetes_io/version
       ignore_empty_value: true
-  - reroute:
-      dataset:
-        - '{{kubernetes.labels.elastic_co/dataset}}'
-        - '{{data_stream.dataset}}'
-      namespace:
-        - '{{kubernetes.labels.elastic_co/namespace}}'
-        - '{{data_stream.namespace}}'
 on_failure:
   - set:
       field: event.kind

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,5 @@
 ---
-description: Pipeline for parsing container logs
+description: Pipeline for Kubernetes container logs
 processors:
   - set:
       field: ecs.version
@@ -11,3 +11,10 @@ processors:
       namespace:
         - '{{kubernetes.labels.elastic_co/namespace}}'
         - '{{data_stream.namespace}}'
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -2,20 +2,18 @@
 description: Pipeline for Kubernetes container logs
 processors:
   - set:
-      field: ecs.version
-      value: '8.8.0'
-  - set:
       field: service.name
       copy_from: kubernetes.labels.app_kubernetes_io/name
       ignore_empty_value: true
   - set:
       field: service.name
-      value: '{{kubernetes.container.name}}'
-      if: ctx?.service?.name == null && ctx?.kubernetes?.container?.name != null
+      copy_from: kubernetes.container.name
+      override: false
+      ignore_empty_value: true
   - set:
       field: service.version
-      value: '{{kubernetes.labels.app_kubernetes_io/version}}'
-      if: ctx?.kubernetes?.labels['app_kubernetes_io/version'] != null
+      copy_from: kubernetes.labels.app_kubernetes_io/version
+      ignore_empty_value: true
   - reroute:
       dataset:
         - '{{kubernetes.labels.elastic_co/dataset}}'

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,0 +1,13 @@
+---
+description: Pipeline for parsing container logs
+processors:
+  - set:
+      field: ecs.version
+      value: '8.8.0'
+  - reroute:
+      dataset:
+        - '{{kubernetes.labels.elastic_co/dataset}}'
+        - '{{data_stream.dataset}}'
+      namespace:
+        - '{{kubernetes.labels.elastic_co/namespace}}'
+        - '{{data_stream.namespace}}'

--- a/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/kubernetes/data_stream/container_logs/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,18 @@ processors:
   - set:
       field: ecs.version
       value: '8.8.0'
+  - set:
+      field: service.name
+      value: '{{kubernetes.labels.app_kubernetes_io/name}}'
+      if: ctx?.kubernetes?.labels['app_kubernetes_io/name'] != null
+  - set:
+      field: service.name
+      value: '{{kubernetes.container.name}}'
+      if: ctx?.service?.name == null && ctx?.kubernetes?.container?.name != null
+  - set:
+      field: service.version
+      value: '{{kubernetes.labels.app_kubernetes_io/version}}'
+      if: ctx?.kubernetes?.labels['app_kubernetes_io/version'] != null
   - reroute:
       dataset:
         - '{{kubernetes.labels.elastic_co/dataset}}'

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -155,3 +155,11 @@
       type: keyword
       description: >-
         Kubernetes container image
+    - name: service.name
+      type: keyword
+      description: >-
+        Kubernetes service name
+    - name: service.version
+      type: keyword
+      description: >-
+        Kubernetes service version

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -155,11 +155,3 @@
       type: keyword
       description: >-
         Kubernetes container image
-    - name: service.name
-      type: keyword
-      description: >-
-        Kubernetes service name
-    - name: service.version
-      type: keyword
-      description: >-
-        Kubernetes service version

--- a/packages/kubernetes/data_stream/container_logs/fields/ecs.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/ecs.yml
@@ -22,3 +22,7 @@
   name: orchestrator.cluster.name
 - external: ecs
   name: orchestrator.cluster.url
+- external: ecs
+  name: service.name
+- external: ecs
+  name: service.version

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -1,5 +1,6 @@
 title: "Kubernetes container logs"
 type: logs
+dataset: kubernetes.container_logs
 streams:
   - input: filestream
     title: Collect Kubernetes container logs
@@ -79,3 +80,11 @@ streams:
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch.dynamic_dataset: true
 elasticsearch.dynamic_namespace: true
+# routing_rules:
+#   kubernetes.container_logs:
+#     dataset:
+#       - "{{labels.data_stream.namespace}}"
+#       - kubernetes.container_logs
+#     namespace:
+#       - "{{labels.data_stream.namespace}}"
+#       - default

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -80,11 +80,3 @@ streams:
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch.dynamic_dataset: true
 elasticsearch.dynamic_namespace: true
-# routing_rules:
-#   kubernetes.container_logs:
-#     dataset:
-#       - "{{labels.data_stream.namespace}}"
-#       - kubernetes.container_logs
-#     namespace:
-#       - "{{labels.data_stream.namespace}}"
-#       - default

--- a/packages/kubernetes/data_stream/container_logs/routing_rules.yml
+++ b/packages/kubernetes/data_stream/container_logs/routing_rules.yml
@@ -4,9 +4,7 @@
     - target_dataset:
         - "{{kubernetes.labels.elastic_co/dataset}}"
         - "{{data_stream.dataset}}"
-        - kubernetes.container_logs
       namespace:
         - "{{kubernetes.labels.elastic_co/namespace}}"
         - "{{data_stream.namespace}}"
-        - default
       if: "ctx?.kubernetes?.labels != null"

--- a/packages/kubernetes/data_stream/container_logs/routing_rules.yml
+++ b/packages/kubernetes/data_stream/container_logs/routing_rules.yml
@@ -7,4 +7,4 @@
       namespace:
         - "{{kubernetes.labels.elastic_co/namespace}}"
         - "{{data_stream.namespace}}"
-      if: "ctx?.kubernetes?.labels != null"
+      if: "ctx.kubernetes?.labels != null"

--- a/packages/kubernetes/data_stream/container_logs/routing_rules.yml
+++ b/packages/kubernetes/data_stream/container_logs/routing_rules.yml
@@ -1,0 +1,12 @@
+# Route container logs entries to the correct dataset and namespace based on the pod labels
+- source_dataset: kubernetes.container_logs
+  rules:
+    - target_dataset:
+        - "{{kubernetes.labels.elastic_co/dataset}}"
+        - "{{data_stream.dataset}}"
+        - kubernetes.container_logs
+      namespace:
+        - "{{kubernetes.labels.elastic_co/namespace}}"
+        - "{{data_stream.namespace}}"
+        - default
+      if: "ctx?.kubernetes?.labels != null"

--- a/packages/kubernetes/data_stream/container_logs/routing_rules.yml
+++ b/packages/kubernetes/data_stream/container_logs/routing_rules.yml
@@ -1,10 +1,11 @@
-# Route container logs entries to the correct dataset and namespace based on the pod labels
+# Route container logs events to the correct dataset and namespace
+# based on pod annotations.
 - source_dataset: kubernetes.container_logs
   rules:
     - target_dataset:
-        - "{{kubernetes.labels.elastic_co/dataset}}"
+        - "{{kubernetes.annotations.elastic_co/dataset}}"
         - "{{data_stream.dataset}}"
       namespace:
-        - "{{kubernetes.labels.elastic_co/namespace}}"
+        - "{{kubernetes.annotations.elastic_co/namespace}}"
         - "{{data_stream.namespace}}"
-      if: "ctx.kubernetes?.labels != null"
+      if: "ctx.kubernetes?.annotations != null"

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -86,9 +86,9 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. 
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations. 
 
-For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By setting the pod label `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
+For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By annotating the pod with `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -84,6 +84,12 @@ the masters won't be visible. In these cases it won't be possible to use `schedu
 The container-logs dataset requires access to the log files in each Kubernetes node where the container logs are stored.
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
+#### Routing
+
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. For example, by setting the pod label `elastic.co/dataset: nginx`, the integration will send all the container logs to the `nginx` dataset.
+
+To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
+
 ### audit-logs
 
 The audit-logs dataset requires access to the log files on each Kubernetes node where the audit logs are stored.

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -86,7 +86,9 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. For example, by setting the pod label `elastic.co/dataset: nginx`, the integration will send all the container logs to the `nginx` dataset.
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod labels. 
+
+For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By setting the pod label `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
 

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -61,6 +61,12 @@ Here is an example where we route the container logs for a pod running the Elast
 kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
 ```
 
+Here's a similar example to change the namespace on a pod running Nginx:
+
+```shell
+kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
+```
+
 ### Labels Reference
 
 Here are the labels available for customization:

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -7,12 +7,66 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 By default only [container parser](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#_parsers) is enabled. Additional log parsers can be added as an advanced options configuration.
 
+
 ## Rerouting based on pod labels
 
-You can customize the routing of the container logs by using Kubernetes labels applied to pods.
+You can customize the routing of container logs by sending them to different datasets and namespaces using pods labels.
 
-The integration can use Kubernetes labels on pods to reroute the logs document to a different dataset or namespace without writing a custom pipeline.
+Routing customization can happen at:
 
-To route the document logs to a different dataset, you can set the `kubernetes.labels.elastic.co/dataset` label with the value of the desired dataset.
+- pod definition time, e.g., using a deployment.
+- pod runtime, setting the labels using `kubectl`.
 
-To route the document logs to a different namespace, you can set the `kubernetes.labels.elastic.co/namespace` label with the value of the desired namespace.
+
+### Set routing at pod definition time
+
+Here is an example of an Nginx deployment where we set both `elastic.co/dataset` and `elastic.co/namespace` labels to route the container logs to specific datasets and namespace, respectively.
+
+```yaml
+# nginx-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        elastic.co/dataset: kubernetes.container_logs.nginx
+        elastic.co/namespace: staging
+        app.kubernetes.io/name: myservice
+        app.kubernetes.io/version: v0.1.0
+        app.kubernetes.io/instance: myservice-abcxzy
+    spec:
+      containers:
+        - name: nginx-container
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+```
+
+
+### Set routing at runtime
+
+Suppose you want to change the container logs routing on a running container. In that case, you can set the same labels using `kubectl,` and the integration will apply it immediately sending all the following documents to the new destination:
+
+Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
+
+```shell
+kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset=kubernetes.container_logs.agents
+```
+
+### Labels Reference
+
+Here are the labels available for customization:
+
+
+| Label                  | Description                                  |
+| ---------------------- | -------------------------------------------- |
+| `elastic.co/dataset`   | Defines the target dataset for this pod. |
+| `elastic.co/namespace` | Defines the target namespace for this pod.    |

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -54,7 +54,7 @@ spec:
 
 ### Set routing at runtime
 
-Suppose you want to change the container logs routing on a running container. In that case, you can annotatethe pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
+Suppose you want to change the container logs routing on a running container. In that case, you can annotate the pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
 
 Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
 
@@ -68,16 +68,16 @@ Here's a similar example to change the namespace on a pod running Nginx:
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
 ```
 
-You can restore the standard routing by removing the labels:
+You can restore the standard routing by removing the annotations:
 
 ```shell
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset-
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace-
 ```
 
-### Labels Reference
+### Annotations Reference
 
-Here are the labels available for customization:
+Here are the annotations available to customize routing:
 
 
 | Label                  | Description                                              |

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -6,3 +6,13 @@ It requires access to the log files in each Kubernetes node where the container 
 This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 By default only [container parser](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#_parsers) is enabled. Additional log parsers can be added as an advanced options configuration.
+
+## Rerouting based on pod labels
+
+You can customize the routing of the container logs by using Kubernetes labels applied to pods.
+
+The integration can use Kubernetes labels on pods to reroute the logs document to a different dataset or namespace without writing a custom pipeline.
+
+To route the document logs to a different dataset, you can set the `kubernetes.labels.elastic.co/dataset` label with the value of the desired dataset.
+
+To route the document logs to a different namespace, you can set the `kubernetes.labels.elastic.co/namespace` label with the value of the desired namespace.

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -68,5 +68,5 @@ Here are the labels available for customization:
 
 | Label                  | Description                                  |
 | ---------------------- | -------------------------------------------- |
-| `elastic.co/dataset`   | Defines the target dataset for this pod. |
-| `elastic.co/namespace` | Defines the target namespace for this pod.    |
+| `elastic.co/dataset`   | Defines the target dataset for this pod.     |
+| `elastic.co/namespace` | Defines the target namespace for this pod.   |

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -10,7 +10,7 @@ By default only [container parser](https://www.elastic.co/guide/en/beats/filebea
 
 ## Rerouting based on pod annotations
 
-You can customize the routing of container logs events and sending them to different datasets and namespaces using pods annotations.
+You can customize the routing of container logs events and sending them to different datasets and namespaces using pods' annotations.
 
 Routing customization can happen at:
 

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -72,7 +72,7 @@ kubectl -n kube-system label pods elastic-agent-managed-daemonset-6p22g elastic.
 Here are the labels available for customization:
 
 
-| Label                  | Description                                  |
-| ---------------------- | -------------------------------------------- |
-| `elastic.co/dataset`   | Defines the target dataset for this pod.     |
-| `elastic.co/namespace` | Defines the target namespace for this pod.   |
+| Label                  | Description                                              |
+| ---------------------- | -------------------------------------------------------- |
+| `elastic.co/dataset`   | Defines the target data stream's dataset for this pod.   |
+| `elastic.co/namespace` | Defines the target data stream's namespace for this pod. |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.44.0
+version: 1.45.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

If available, the reroute processor uses the pod's annotations `kubernetes.annotations.elastic.co/dataset` and `kubernetes.annotations.elastic.co/namespace` in the event to route log documents to a custom dataset and namespace. It falls back to the original values if such annotations are not available in the event.

In addition, the integration sets the following fields:

- `service.name` with the value of `app.kubernetes.io/name` label or `kubernetes.container.name` field, in this order of preference.
- `service.version` with the value of `app.kubernetes.io/version` label, if present.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

- [x] Build a proof of concept
- [x] Draft docs
- [x] https://github.com/elastic/integrations/pull/7144 
- [x] Get feedback
- [ ] Check if we can opt-out of de-dotting
- [x] https://github.com/elastic/elastic-package/pull/1372
- [x] https://github.com/elastic/elastic-package/issues/1388
- [ ] Performance: check integration ingestion performance with and without routing rules. https://github.com/zmoog/public-notes/issues/44
- [x] Expand the docs
- [x] Update the minimum `kibana.version`


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Using this deployment to run nginx to generate container logs:

```yaml
# nginx-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      annotations:
        elastic.co/namespace: nginx
      labels:
        app: nginx
        app.kubernetes.io/name: myservice
        app.kubernetes.io/version: v0.1.0
        app.kubernetes.io/instance: myservice-abcxzy
    spec:
      containers:
        - name: nginx-container
          image: nginx:latest
          ports:
            - containerPort: 80
```

Here's the workflow to deply and scape it up and down to generate logs in a single command:

```shell
# Create the deployment
kubectl apply -f nginx-deployment.yaml

# Scale the deployment up and down to generate logs quickly
kubectl scale deployment nginx-deployment --replicas=2
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to #6845 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

Rendering of the container-logs docs that will replace the https://docs.elastic.co/integrations/kubernetes/container-logs page:

![CleanShot 2023-09-08 at 10 39 47@2x](https://github.com/elastic/integrations/assets/25941/7481b798-0420-46c1-af14-6f83b6123553)

