### PR TITLE
[keycloak] - update package-spec to 2.9.0

### DIFF
--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Update package to ECS 8.8.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.11.0"
   changes:
-    - description: Update package to ECS 8.8.0.
+    - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7120
 - version: "1.10.0"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/keycloak/data_stream/log/sample_event.json
+++ b/packages/keycloak/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2021-10-22T21:01:42.667-05:00",
+    "@timestamp": "2021-10-22T21:01:42.667+05:00",
     "agent": {
-        "ephemeral_id": "3fa6009c-adab-4e39-9c43-05f16ba9ef47",
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "ephemeral_id": "5861dcd8-02a1-48fe-943d-45eb7fd83e5e",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "keycloak.log",
@@ -16,37 +16,37 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "keycloak.log",
-        "ingested": "2022-01-01T23:08:55Z",
+        "ingested": "2023-07-24T13:27:46Z",
         "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
-        "timezone": "-05:00"
+        "timezone": "+05:00"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.18.0.5"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:12:00:05"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-43-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.47-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -58,7 +58,7 @@
         },
         "level": "INFO",
         "logger": "org.jboss.resteasy.resteasy_jaxrs.i18n",
-        "offset": 928
+        "offset": 658
     },
     "message": "RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
     "process": {

--- a/packages/keycloak/docs/README.md
+++ b/packages/keycloak/docs/README.md
@@ -132,13 +132,13 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-10-22T21:01:42.667-05:00",
+    "@timestamp": "2021-10-22T21:01:42.667+05:00",
     "agent": {
-        "ephemeral_id": "3fa6009c-adab-4e39-9c43-05f16ba9ef47",
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "ephemeral_id": "5861dcd8-02a1-48fe-943d-45eb7fd83e5e",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "keycloak.log",
@@ -149,37 +149,37 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "b1d83907-ff3e-464a-b79a-cf843f6f0bba",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "keycloak.log",
-        "ingested": "2022-01-01T23:08:55Z",
+        "ingested": "2023-07-24T13:27:46Z",
         "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
-        "timezone": "-05:00"
+        "timezone": "+05:00"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4ccba669f0df47fa3f57a9e4169ae7f1",
+        "id": "f61391496aaa43bb94736676494450c5",
         "ip": [
-            "172.18.0.5"
+            "172.22.0.10"
         ],
         "mac": [
-            "02:42:ac:12:00:05"
+            "02-42-AC-16-00-0A"
         ],
         "name": "docker-fleet-agent",
         "os": {
-            "codename": "Core",
-            "family": "redhat",
-            "kernel": "5.11.0-43-generic",
-            "name": "CentOS Linux",
-            "platform": "centos",
+            "codename": "focal",
+            "family": "debian",
+            "kernel": "5.10.47-linuxkit",
+            "name": "Ubuntu",
+            "platform": "ubuntu",
             "type": "linux",
-            "version": "7 (Core)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {
@@ -191,7 +191,7 @@ An example event for `log` looks as following:
         },
         "level": "INFO",
         "logger": "org.jboss.resteasy.resteasy_jaxrs.i18n",
-        "offset": 928
+        "offset": 658
     },
     "message": "RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
     "process": {

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,11 +1,9 @@
 name: keycloak
 title: Keycloak
-version: "1.10.0"
-release: ga
+version: "1.11.0"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: [security, iam]
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
## What does this PR do?

- Update package spec to 2.9.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/keycloak
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870