### PR TITLE
[microsoft_defender_endpoint] - update package-spec to 2.9.0

### DIFF
--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -126,3 +126,4 @@ screenshots:
     type: image/png
 owner:
   github: elastic/security-external-integrations
+

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.16.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.15.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7124
 - version: "2.15.0"
   changes:
     - description: Convert visualizations to lens.

--- a/packages/microsoft_defender_endpoint/data_stream/log/_dev/test/pipeline/test-defenderatp.log-expected.json
+++ b/packages/microsoft_defender_endpoint/data_stream/log/_dev/test/pipeline/test-defenderatp.log-expected.json
@@ -75,7 +75,9 @@
             "threat": {
                 "framework": "MITRE ATT\u0026CK",
                 "technique": {
-                    "name": "Malware"
+                    "name": [
+                        "Malware"
+                    ]
                 }
             }
         },
@@ -173,7 +175,9 @@
             "threat": {
                 "framework": "MITRE ATT\u0026CK",
                 "technique": {
-                    "name": "DefenseEvasion"
+                    "name": [
+                        "DefenseEvasion"
+                    ]
                 }
             },
             "user": {
@@ -256,7 +260,9 @@
             "threat": {
                 "framework": "MITRE ATT\u0026CK",
                 "technique": {
-                    "name": "DefenseEvasion"
+                    "name": [
+                        "DefenseEvasion"
+                    ]
                 }
             },
             "user": {
@@ -347,7 +353,9 @@
             "threat": {
                 "framework": "MITRE ATT\u0026CK",
                 "technique": {
-                    "name": "Malware"
+                    "name": [
+                        "Malware"
+                    ]
                 }
             }
         },

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -162,10 +162,10 @@ processors:
       field: threat.framework
       value: MITRE ATT&CK
       if: ctx.json?.category != null
-  - rename:
-      field: json.category
-      target_field: threat.technique.name
-      ignore_missing: true
+  - append:
+      field: threat.technique.name
+      value: '{{{json.category}}}'
+      if: ctx.json?.category != null
   - rename:
       field: json.description
       target_field: rule.description
@@ -304,6 +304,7 @@ processors:
         - json.alertCreationTime
         - json.severity
         - json.relatedUser
+        - json.category
       ignore_missing: true
   - rename:
       field: json

--- a/packages/microsoft_defender_endpoint/data_stream/log/sample_event.json
+++ b/packages/microsoft_defender_endpoint/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-05-12T07:01:02.145Z",
+    "@timestamp": "2023-07-24T14:20:13.467Z",
     "agent": {
-        "ephemeral_id": "5ad04d6b-7576-496c-aadf-72e9c1e72eab",
-        "id": "26dd4270-014a-48d2-8f5d-6aa3f48a273c",
+        "ephemeral_id": "6602c8b6-3007-4b99-8871-28728195e542",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.7.1"
+        "version": "8.8.2"
     },
     "cloud": {
         "account": {
@@ -25,9 +25,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "26dd4270-014a-48d2-8f5d-6aa3f48a273c",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.7.1"
+        "version": "8.8.2"
     },
     "event": {
         "action": "Execution",
@@ -40,7 +40,7 @@
         "duration": 101466100,
         "end": "2021-01-26T20:31:33.0577322Z",
         "id": "da637472900382838869_1364969609",
-        "ingested": "2023-05-12T07:01:03Z",
+        "ingested": "2023-07-24T14:20:16Z",
         "kind": "alert",
         "provider": "defender_endpoint",
         "severity": 2,
@@ -99,7 +99,9 @@
     "threat": {
         "framework": "MITRE ATT\u0026CK",
         "technique": {
-            "name": "Execution"
+            "name": [
+                "Execution"
+            ]
         }
     },
     "user": {

--- a/packages/microsoft_defender_endpoint/docs/README.md
+++ b/packages/microsoft_defender_endpoint/docs/README.md
@@ -47,13 +47,13 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-05-12T07:01:02.145Z",
+    "@timestamp": "2023-07-24T14:20:13.467Z",
     "agent": {
-        "ephemeral_id": "5ad04d6b-7576-496c-aadf-72e9c1e72eab",
-        "id": "26dd4270-014a-48d2-8f5d-6aa3f48a273c",
+        "ephemeral_id": "6602c8b6-3007-4b99-8871-28728195e542",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.7.1"
+        "version": "8.8.2"
     },
     "cloud": {
         "account": {
@@ -73,9 +73,9 @@ An example event for `log` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "26dd4270-014a-48d2-8f5d-6aa3f48a273c",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.7.1"
+        "version": "8.8.2"
     },
     "event": {
         "action": "Execution",
@@ -88,7 +88,7 @@ An example event for `log` looks as following:
         "duration": 101466100,
         "end": "2021-01-26T20:31:33.0577322Z",
         "id": "da637472900382838869_1364969609",
-        "ingested": "2023-05-12T07:01:03Z",
+        "ingested": "2023-07-24T14:20:16Z",
         "kind": "alert",
         "provider": "defender_endpoint",
         "severity": 2,
@@ -147,7 +147,9 @@ An example event for `log` looks as following:
     "threat": {
         "framework": "MITRE ATT\u0026CK",
         "technique": {
-            "name": "Execution"
+            "name": [
+                "Execution"
+            ]
         }
     },
     "user": {

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,13 +1,11 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.15.0"
+version: "2.16.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"
   - "edr_xdr"
-release: ga
-license: basic
 type: integration
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package spec to 2.9.0
- Ensure that threat.technique.name is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/microsoft_defender_endpoint
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870