### PR TITLE
[microsoft_exchange_online_message_trace] - update package-spec to 2.9.0

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.0"
   changes:
     - description: Convert dashboards to Lens.

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7128
 - version: "1.7.0"
   changes:
     - description: Convert dashboards to Lens.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -41,13 +41,17 @@
                 "delivery_timestamp": "2022-09-05T18:10:13.4907658",
                 "direction": "inbound",
                 "from": {
-                    "address": "azure-noreply@azure.microsoft.com"
+                    "address": [
+                        "azure-noreply@azure.microsoft.com"
+                    ]
                 },
                 "local_id": "cf7a249a-5edd-4350-130a-08da8f69e0f6",
                 "message_id": "\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\u003e",
                 "subject": "PIM: A privileged directory role was assigned outside of PIM",
                 "to": {
-                    "address": "linus@contoso.com"
+                    "address": [
+                        "linus@contoso.com"
+                    ]
                 }
             },
             "event": {
@@ -141,13 +145,17 @@
                 "delivery_timestamp": "2022-10-21T17:25:30.6006882Z",
                 "direction": "inbound",
                 "from": {
-                    "address": "noreply@azure.microsoft.com"
+                    "address": [
+                        "noreply@azure.microsoft.com"
+                    ]
                 },
                 "local_id": "a6f62809-5cda-4454-0962-08dab38940d6",
                 "message_id": "\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\u003e",
                 "subject": "testmail 1",
                 "to": {
-                    "address": "linus@contoso.com"
+                    "address": [
+                        "linus@contoso.com"
+                    ]
                 }
             },
             "event": {
@@ -240,13 +248,17 @@
                 "delivery_timestamp": "2022-10-21T17:25:36.969376Z",
                 "direction": "inbound",
                 "from": {
-                    "address": "noreply@azure.microsoft.com"
+                    "address": [
+                        "noreply@azure.microsoft.com"
+                    ]
                 },
                 "local_id": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
                 "message_id": "\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\u003e",
                 "subject": "testmail 2",
                 "to": {
-                    "address": "linus@contoso.com"
+                    "address": [
+                        "linus@contoso.com"
+                    ]
                 }
             },
             "event": {
@@ -339,13 +351,17 @@
                 "delivery_timestamp": "2022-10-21T17:25:36.969376Z",
                 "direction": "internal",
                 "from": {
-                    "address": "noreply@contoso.com"
+                    "address": [
+                        "noreply@contoso.com"
+                    ]
                 },
                 "local_id": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
                 "message_id": "\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\u003e",
                 "subject": "testmail 2",
                 "to": {
-                    "address": "linus@contoso.com"
+                    "address": [
+                        "linus@contoso.com"
+                    ]
                 }
             },
             "event": {

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -18,9 +18,13 @@ processors:
       copy_from: microsoft.online_message_trace.Status
       ignore_empty_value: true
   - set:
-      field: email.from.address
+      field: _temp_.email.from.address
       copy_from: microsoft.online_message_trace.SenderAddress
       ignore_empty_value: true
+  - append:
+      field: email.from.address
+      value: '{{{_temp_.email.from.address}}}'
+      if: ctx._temp_?.email?.from?.address != null
   - set:
       field: source.user.id
       copy_from: microsoft.online_message_trace.SenderAddress
@@ -50,9 +54,13 @@ processors:
       copy_from: microsoft.online_message_trace.Subject
       ignore_empty_value: true
   - set:
-      field: email.to.address
+      field: _temp_.email.to.address
       copy_from: microsoft.online_message_trace.RecipientAddress
       ignore_empty_value: true
+  - append:
+      field: email.to.address
+      value: '{{{_temp_.email.to.address}}}'
+      if: ctx._temp_?.email?.to?.address != null
   - set:
       field: destination.user.id
       copy_from: microsoft.online_message_trace.RecipientAddress
@@ -135,13 +143,13 @@ processors:
 
   # Extraction of domain
   - grok:
-      field: email.from.address
+      field: _temp_.email.from.address
       patterns:
         - "^%{DATA}@%{DATA:source.domain}$"
       ignore_failure: false
       ignore_missing: true
   - grok:
-      field: email.to.address
+      field: _temp_.email.to.address
       patterns:
         - "^%{DATA}@%{DATA:destination.domain}$"
       ignore_failure: false
@@ -177,17 +185,17 @@ processors:
   # Extract Username from mail
   - append:
       field: related.user
-      value: '{{{email.to.address}}}'
+      value: '{{{_temp_.email.to.address}}}'
       allow_duplicates: false
-      if: ctx.email?.to?.address != null && ctx.email.to.address != ""
+      if: ctx._temp_?.email?.to?.address != null && ctx._temp_.email.to.address != ""
   - append:
       field: related.user
-      value: '{{{email.from.address}}}'
+      value: '{{{_temp_.email.from.address}}}'
       allow_duplicates: false
-      if: ctx.email?.from?.address != null && ctx.email.from.address != ""
+      if: ctx._temp_?.email?.from?.address != null && ctx._temp_.email.from.address != ""
 
   - dissect:
-      field: "email.to.address"
+      field: _temp_.email.to.address
       pattern: '%{_temp_.to_user_name}@%{_temp_.to_user_domain}'
       ignore_missing: true
   - append:
@@ -197,7 +205,7 @@ processors:
       if: ctx._temp_?.to_user_name != null && ctx._temp_.to_user_name != ""
 
   - dissect:
-      field: "email.from.address"
+      field: _temp_.email.from.address
       pattern: '%{_temp_.from_user_name}@%{_temp_.from_user_domain}'
       ignore_missing: true
   - append:
@@ -218,24 +226,24 @@ processors:
       if: ctx._temp_?.from_user_name != null && ctx._temp_.from_user_name != "" && ctx.email?.direction == "outbound" || ctx.email?.direction == "internal"
   - append:
       field: user.email
-      value: '{{{email.to.address}}}'
+      value: '{{{_temp_.email.to.address}}}'
       allow_duplicates: false
-      if: ctx.email?.to?.address != null && ctx.email.to.address != "" && ctx.email?.direction == "inbound" || ctx.email?.direction == "internal"
+      if: ctx._temp_?.email?.to?.address != null && ctx._temp_.email.to.address != "" && ctx.email?.direction == "inbound" || ctx.email?.direction == "internal"
   - append:
       field: user.email
-      value: '{{{email.from.address}}}'
+      value: '{{{_temp_.email.from.address}}}'
       allow_duplicates: false
-      if: ctx.email?.from?.address != null && ctx.email.from.address != "" && ctx.email?.direction == "outbound" || ctx.email?.direction == "internal"
+      if: ctx._temp_?.email?.from?.address != null && ctx._temp_.email.from.address != "" && ctx.email?.direction == "outbound" || ctx.email?.direction == "internal"
   - append:
       field: user.id
-      value: '{{{email.to.address}}}'
+      value: '{{{_temp_.email.to.address}}}'
       allow_duplicates: false
-      if: ctx.email?.to?.address != null && ctx.email.to.address != "" && ctx.email?.direction == "inbound" || ctx.email?.direction == "internal"
+      if: ctx._temp_?.email?.to?.address != null && ctx._temp_.email.to.address != "" && ctx.email?.direction == "inbound" || ctx.email?.direction == "internal"
   - append:
       field: user.id
-      value: '{{{email.from.address}}}'
+      value: '{{{_temp_.email.from.address}}}'
       allow_duplicates: false
-      if: ctx.email?.from?.address != null && ctx.email.from.address != "" && ctx.email?.direction == "outbound" || ctx.email?.direction == "internal"
+      if: ctx._temp_?.email?.from?.address != null && ctx._temp_.email.from.address != "" && ctx.email?.direction == "outbound" || ctx.email?.direction == "internal"
   - script:
       lang: painless
       description: Reduce user.* to keyword if a single element.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-09-05T18:10:13.490Z",
     "agent": {
-        "ephemeral_id": "8de97862-77fa-4e44-91be-5d3947dd67aa",
-        "id": "6f0c420a-c434-4d40-90cb-956665a6fdd6",
+        "ephemeral_id": "f42c0a8e-b2c0-4772-ab85-278acafa95f5",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "microsoft_exchange_online_message_trace.log",
@@ -31,15 +31,21 @@
         },
         "ip": "216.160.83.56",
         "registered_domain": "contoso.com",
-        "top_level_domain": "com"
+        "top_level_domain": "com",
+        "user": {
+            "domain": "contoso.com",
+            "email": "linus@contoso.com",
+            "id": "linus@contoso.com",
+            "name": "linus"
+        }
     },
     "ecs": {
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "6f0c420a-c434-4d40-90cb-956665a6fdd6",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.2"
     },
     "email": {
         "attachments": {
@@ -49,21 +55,25 @@
         },
         "delivery_timestamp": "2022-09-05T18:10:13.4907658",
         "from": {
-            "address": "azure-noreply@microsoft.com"
+            "address": [
+                "azure-noreply@microsoft.com"
+            ]
         },
         "local_id": "cf7a249a-5edd-4350-130a-08da8f69e0f6",
         "message_id": "\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\u003e",
         "subject": "PIM: A privileged directory role was assigned outside of PIM",
         "to": {
-            "address": "linus@contoso.com"
+            "address": [
+                "linus@contoso.com"
+            ]
         }
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-02-05T23:16:02.721Z",
+        "created": "2023-07-24T14:46:09.199Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
         "end": "2022-09-06T09:01:46.036Z",
-        "ingested": "2023-02-05T23:16:03Z",
+        "ingested": "2023-07-24T14:46:12Z",
         "original": "{\"EndDate\":\"2022-09-06T09:01:46.0369423Z\",\"FromIP\":\"81.2.69.144\",\"Index\":0,\"MessageId\":\"\\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\\u003e\",\"MessageTraceId\":\"cf7a249a-5edd-4350-130a-08da8f69e0f6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-09-05T18:10:13.4907658\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"azure-noreply@microsoft.com\",\"Size\":87891,\"StartDate\":\"2022-09-04T09:01:46.0369423Z\",\"Status\":\"Delivered\",\"Subject\":\"PIM: A privileged directory role was assigned outside of PIM\",\"ToIP\":\"216.160.83.56\"}",
         "outcome": "Delivered",
         "start": "2022-09-04T09:01:46.036Z"
@@ -89,6 +99,14 @@
             "ToIP": "216.160.83.56"
         }
     },
+    "related": {
+        "user": [
+            "linus@contoso.com",
+            "azure-noreply@microsoft.com",
+            "linus",
+            "azure-noreply"
+        ]
+    },
     "source": {
         "domain": "microsoft.com",
         "geo": {
@@ -105,7 +123,13 @@
         },
         "ip": "81.2.69.144",
         "registered_domain": "microsoft.com",
-        "top_level_domain": "com"
+        "top_level_domain": "com",
+        "user": {
+            "domain": "microsoft.com",
+            "email": "azure-noreply@microsoft.com",
+            "id": "azure-noreply@microsoft.com",
+            "name": "azure-noreply"
+        }
     },
     "tags": [
         "preserve_original_event",

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -119,11 +119,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2022-09-05T18:10:13.490Z",
     "agent": {
-        "ephemeral_id": "8de97862-77fa-4e44-91be-5d3947dd67aa",
-        "id": "6f0c420a-c434-4d40-90cb-956665a6fdd6",
+        "ephemeral_id": "f42c0a8e-b2c0-4772-ab85-278acafa95f5",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.5.1"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "microsoft_exchange_online_message_trace.log",
@@ -149,15 +149,21 @@ An example event for `log` looks as following:
         },
         "ip": "216.160.83.56",
         "registered_domain": "contoso.com",
-        "top_level_domain": "com"
+        "top_level_domain": "com",
+        "user": {
+            "domain": "contoso.com",
+            "email": "linus@contoso.com",
+            "id": "linus@contoso.com",
+            "name": "linus"
+        }
     },
     "ecs": {
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "6f0c420a-c434-4d40-90cb-956665a6fdd6",
+        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
         "snapshot": false,
-        "version": "8.5.1"
+        "version": "8.8.2"
     },
     "email": {
         "attachments": {
@@ -167,21 +173,25 @@ An example event for `log` looks as following:
         },
         "delivery_timestamp": "2022-09-05T18:10:13.4907658",
         "from": {
-            "address": "azure-noreply@microsoft.com"
+            "address": [
+                "azure-noreply@microsoft.com"
+            ]
         },
         "local_id": "cf7a249a-5edd-4350-130a-08da8f69e0f6",
         "message_id": "\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\u003e",
         "subject": "PIM: A privileged directory role was assigned outside of PIM",
         "to": {
-            "address": "linus@contoso.com"
+            "address": [
+                "linus@contoso.com"
+            ]
         }
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-02-05T23:16:02.721Z",
+        "created": "2023-07-24T14:46:09.199Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
         "end": "2022-09-06T09:01:46.036Z",
-        "ingested": "2023-02-05T23:16:03Z",
+        "ingested": "2023-07-24T14:46:12Z",
         "original": "{\"EndDate\":\"2022-09-06T09:01:46.0369423Z\",\"FromIP\":\"81.2.69.144\",\"Index\":0,\"MessageId\":\"\\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\\u003e\",\"MessageTraceId\":\"cf7a249a-5edd-4350-130a-08da8f69e0f6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-09-05T18:10:13.4907658\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"azure-noreply@microsoft.com\",\"Size\":87891,\"StartDate\":\"2022-09-04T09:01:46.0369423Z\",\"Status\":\"Delivered\",\"Subject\":\"PIM: A privileged directory role was assigned outside of PIM\",\"ToIP\":\"216.160.83.56\"}",
         "outcome": "Delivered",
         "start": "2022-09-04T09:01:46.036Z"
@@ -207,6 +217,14 @@ An example event for `log` looks as following:
             "ToIP": "216.160.83.56"
         }
     },
+    "related": {
+        "user": [
+            "linus@contoso.com",
+            "azure-noreply@microsoft.com",
+            "linus",
+            "azure-noreply"
+        ]
+    },
     "source": {
         "domain": "microsoft.com",
         "geo": {
@@ -223,7 +241,13 @@ An example event for `log` looks as following:
         },
         "ip": "81.2.69.144",
         "registered_domain": "microsoft.com",
-        "top_level_domain": "com"
+        "top_level_domain": "com",
+        "user": {
+            "domain": "microsoft.com",
+            "email": "azure-noreply@microsoft.com",
+            "id": "azure-noreply@microsoft.com",
+            "name": "azure-noreply"
+        }
     },
     "tags": [
         "preserve_original_event",

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.7.0"
-release: ga
-license: basic
+version: "1.8.0"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Update package spec to 2.9.0
- Ensure email.from.address is an array
- Ensure email.to.address is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/microsoft_exchange_online_message_trace
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870