### PR TITLE
akamai: add event limit parameter to HTTPJSON stream

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.0"
+  changes:
+    - description: Add event limit parameter to REST endpoint stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7132
 - version: "2.11.0"
   changes:
     - description: Document valid duration units.

--- a/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
+++ b/packages/akamai/data_stream/siem/agent/stream/httpjson.yml.hbs
@@ -27,6 +27,11 @@ request.transforms:
       target: url.params.offset
       value: >-
         [[ if (index .cursor "last_offset") ]][[ .cursor.last_offset ]][[ end ]]
+{{#if event_limit}}
+  - set:
+      target: url.params.limit
+      value: '{{event_limit}}'
+{{/if}}
   - set:
       target: header.XTimestamp
       value: '[[ formatDate (now) "20060102T15:04:05-0700" ]]'

--- a/packages/akamai/data_stream/siem/manifest.yml
+++ b/packages/akamai/data_stream/siem/manifest.yml
@@ -66,6 +66,13 @@ streams:
         show_user: true
         default: 24h
         description: Initial interval to poll for events. Default is 24 hours. Supported units for this parameter are h/m/s.
+      - name: event_limit
+        type: integer
+        multi: false
+        required: false
+        show_user: false
+        title: Event Limit
+        description: Defines the approximate maximum number of security events each fetch returns, in both offset and time-based modes. The default limit is 10000 and the maximum limit available is 600000. Listing an unlimited number of logs isn't possible. Expect requests to return a slightly higher number of security events than you set in the limit parameter, because data is stored in different buckets.
       - name: proxy_url
         type: text
         title: Proxy URL

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.11.0"
+version: "2.12.0"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds an event limit parameter to the HTTPJSON stream.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
