### PR TITLE
[Kubernetes] Bump package-spec format_version to 2.9.0

### DIFF
--- a/packages/kubernetes/data_stream/pod/fields/fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/fields.yml
@@ -139,6 +139,3 @@
           metric_type: counter
           description: |
             Total major page faults
-    - name: ip
-      type: ip
-      description: Kubernetes pod IP

--- a/packages/kubernetes/data_stream/state_node/sample_event.json
+++ b/packages/kubernetes/data_stream/state_node/sample_event.json
@@ -81,7 +81,7 @@
         "address": "kube-state-metrics:8080"
     },
     "event": {
-        "dataset": "kubernetes.node",
+        "dataset": "kubernetes.state_node",
         "module": "kubernetes",
         "duration": 8194220
     }

--- a/packages/kubernetes/data_stream/state_persistentvolume/sample_event.json
+++ b/packages/kubernetes/data_stream/state_persistentvolume/sample_event.json
@@ -6,7 +6,7 @@
     "event": {
         "module": "kubernetes",
         "duration": 12149615,
-        "dataset": "kubernetes.persistentvolume"
+        "dataset": "kubernetes.state_persistentvolume"
     },
     "agent": {
         "version": "8.0.0",

--- a/packages/kubernetes/data_stream/state_pod/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_pod/fields/fields.yml
@@ -1,10 +1,6 @@
 - name: kubernetes.pod
   type: group
   fields:
-    - name: ip
-      type: ip
-      description: |
-        Kubernetes pod IP
     - name: host_ip
       type: ip
       description: |

--- a/packages/kubernetes/data_stream/state_resourcequota/sample_event.json
+++ b/packages/kubernetes/data_stream/state_resourcequota/sample_event.json
@@ -30,7 +30,7 @@
         "type": "kubernetes"
     },
     "event": {
-        "dataset": "kubernetes.resourcequota",
+        "dataset": "kubernetes.state_resourcequota",
         "module": "kubernetes",
         "duration": 6324269
     },

--- a/packages/kubernetes/data_stream/state_storageclass/sample_event.json
+++ b/packages/kubernetes/data_stream/state_storageclass/sample_event.json
@@ -43,7 +43,7 @@
     "event": {
         "module": "kubernetes",
         "duration": 5713503,
-        "dataset": "kubernetes.storageclass"
+        "dataset": "kubernetes.state_storageclass"
     },
     "metricset": {
         "name": "state_storageclass",

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -1134,7 +1134,7 @@ An example event for `state_node` looks as following:
         "address": "kube-state-metrics:8080"
     },
     "event": {
-        "dataset": "kubernetes.node",
+        "dataset": "kubernetes.state_node",
         "module": "kubernetes",
         "duration": 8194220
     }
@@ -1229,7 +1229,7 @@ An example event for `state_persistentvolume` looks as following:
     "event": {
         "module": "kubernetes",
         "duration": 12149615,
-        "dataset": "kubernetes.persistentvolume"
+        "dataset": "kubernetes.state_persistentvolume"
     },
     "agent": {
         "version": "8.0.0",
@@ -1968,7 +1968,7 @@ An example event for `state_resourcequota` looks as following:
         "type": "kubernetes"
     },
     "event": {
-        "dataset": "kubernetes.resourcequota",
+        "dataset": "kubernetes.state_resourcequota",
         "module": "kubernetes",
         "duration": 6324269
     },
@@ -2481,7 +2481,7 @@ An example event for `state_storageclass` looks as following:
     "event": {
         "module": "kubernetes",
         "duration": 5713503,
-        "dataset": "kubernetes.storageclass"
+        "dataset": "kubernetes.state_storageclass"
     },
     "metricset": {
         "name": "state_storageclass",

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,15 +1,13 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
 version: 1.43.1
-license: basic
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:
   - observability
   - containers
   - kubernetes
-release: ga
 conditions:
   kibana.version: "^8.8.0"
 screenshots:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Upgrade the integration package-spec format_version from `1.0.0` to `2.9.0` and addresses all the reported by elastic-package.

Here're the adjustments needed due to the new validations introduced with the newer package-spec versions:

- Remove the deprecated attributes `license` and `release` from the manifest.yml
- Remove duplicated `pod.ip` definitions
- Update datasets in `sample_event.json` files

We need this upgrade in preparation for the introduction of the [routing rules](https://github.com/elastic/integrations/pull/7118) that require a more recent versions of the package-spec.

## Failed validations

### Context

- Stack: 8.9.0
- Integration: 1.43.1
- elastic-package: v0.84.0


### Changes

```shell
$ git diff
diff --git a/packages/kubernetes/manifest.yml b/packages/kubernetes/manifest.yml
index 45ddd5c33..15343b610 100644
--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
 version: 1.43.1
```

### elastic-package check

```shell
$ elastic-package check
2023/08/04 15:44:30  WARN CommitHash is undefined, in both /Users/zmoog/.elastic-package/version and the compiled binary, config may be out of date.
Format the package
Done
Lint the package
Error: checking package failed: linting package failed: found 4 validation errors:
   1. file "/Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/manifest.yml" is invalid: field (root): Additional property release is not allowed
   2. file "/Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/manifest.yml" is invalid: field (root): Additional property license is not allowed
   3. field "kubernetes.pod.ip" is defined multiple times for data stream "pod", found in: /Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/data_stream/pod/fields/base-fields.yml, /Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/data_stream/pod/fields/fields.yml
   4. field "kubernetes.pod.ip" is defined multiple times for data stream "state_pod", found in: /Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml, /Users/zmoog/code/projects/zmoog/integrations/packages/kubernetes/data_stream/state_pod/fields/fields.yml
```

### elastic-package test static

```shell
$ elastic-package test -vvv static                                                                                                                                         main  ✭
2023/08/04 16:04:59 DEBUG Enable verbose logging
Run static tests for the package
--- Test results for package: kubernetes - START ---
FAILURE DETAILS:
kubernetes/state_node Verify sample_event.json:
[0] field "event.dataset" should have value "kubernetes.state_node", it has "kubernetes.node"
kubernetes/state_persistentvolume Verify sample_event.json:
[0] field "event.dataset" should have value "kubernetes.state_persistentvolume", it has "kubernetes.persistentvolume"
kubernetes/state_resourcequota Verify sample_event.json:
[0] field "event.dataset" should have value "kubernetes.state_resourcequota", it has "kubernetes.resourcequota"
kubernetes/state_storageclass Verify sample_event.json:
[0] field "event.dataset" should have value "kubernetes.state_storageclass", it has "kubernetes.storageclass"


╭────────────┬─────────────────────────────┬───────────┬──────────────────────────┬────────────────────────────────────────────┬──────────────╮
│ PACKAGE    │ DATA STREAM                 │ TEST TYPE │ TEST NAME                │ RESULT                                     │ TIME ELAPSED │
├────────────┼─────────────────────────────┼───────────┼──────────────────────────┼────────────────────────────────────────────┼──────────────┤
│ kubernetes │ apiserver                   │ static    │ Verify sample_event.json │ PASS                                       │  38.962292ms │
│ kubernetes │ audit_logs                  │ static    │ Verify sample_event.json │ PASS                                       │  31.776584ms │
│ kubernetes │ container                   │ static    │ Verify sample_event.json │ PASS                                       │  37.501291ms │
│ kubernetes │ container_logs              │ static    │ Verify sample_event.json │ PASS                                       │  42.820959ms │
│ kubernetes │ controllermanager           │ static    │ Verify sample_event.json │ PASS                                       │  39.386125ms │
│ kubernetes │ event                       │ static    │ Verify sample_event.json │ PASS                                       │   32.25325ms │
│ kubernetes │ node                        │ static    │ Verify sample_event.json │ PASS                                       │  35.808792ms │
│ kubernetes │ pod                         │ static    │ Verify sample_event.json │ PASS                                       │  34.016709ms │
│ kubernetes │ proxy                       │ static    │ Verify sample_event.json │ PASS                                       │  38.732542ms │
│ kubernetes │ scheduler                   │ static    │ Verify sample_event.json │ PASS                                       │  32.846834ms │
│ kubernetes │ state_container             │ static    │ Verify sample_event.json │ PASS                                       │  31.724083ms │
│ kubernetes │ state_cronjob               │ static    │ Verify sample_event.json │ PASS                                       │   32.95025ms │
│ kubernetes │ state_daemonset             │ static    │ Verify sample_event.json │ PASS                                       │  32.213667ms │
│ kubernetes │ state_deployment            │ static    │ Verify sample_event.json │ PASS                                       │  34.571541ms │
│ kubernetes │ state_job                   │ static    │ Verify sample_event.json │ PASS                                       │  43.513625ms │
│ kubernetes │ state_node                  │ static    │ Verify sample_event.json │ FAIL: one or more errors found in document │  40.349708ms │
│ kubernetes │ state_persistentvolume      │ static    │ Verify sample_event.json │ FAIL: one or more errors found in document │   32.80525ms │
│ kubernetes │ state_persistentvolumeclaim │ static    │ Verify sample_event.json │ PASS                                       │  36.171792ms │
│ kubernetes │ state_pod                   │ static    │ Verify sample_event.json │ PASS                                       │  33.346625ms │
│ kubernetes │ state_replicaset            │ static    │ Verify sample_event.json │ PASS                                       │  32.471084ms │
│ kubernetes │ state_resourcequota         │ static    │ Verify sample_event.json │ FAIL: one or more errors found in document │   40.11425ms │
│ kubernetes │ state_service               │ static    │ Verify sample_event.json │ PASS                                       │  33.864791ms │
│ kubernetes │ state_statefulset           │ static    │ Verify sample_event.json │ PASS                                       │  34.204333ms │
│ kubernetes │ state_storageclass          │ static    │ Verify sample_event.json │ FAIL: one or more errors found in document │   31.76375ms │
│ kubernetes │ system                      │ static    │ Verify sample_event.json │ PASS                                       │  53.379333ms │
│ kubernetes │ volume                      │ static    │ Verify sample_event.json │ PASS                                       │  34.518375ms │
╰────────────┴─────────────────────────────┴───────────┴──────────────────────────┴────────────────────────────────────────────┴──────────────╯
--- Test results for package: kubernetes - END   ---
Done
Error: one or more test cases failed
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
--> 
- Relates #7118


<!-- Optional
## Screenshots
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
