### PR TITLE
[Cloud Security] Add GCP rule templates

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -19,9 +19,6 @@
     - description: Update CloudFormation template to use al2023 AMI and increased EBS volume size
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6699
-    - description: Adds initial GCP rule templates
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/7147
 - version: "1.4.0"
   changes:
     - description: Populate new CloudFormation param ElasticArtifactServer

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -5,7 +5,7 @@
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
 
-- version: "1.5.0-preview25"
+- version: "1.5.0-preview26"
   changes:
     - description: Seperate KSPM and CSPM cloudformation templates
       type: enhancement
@@ -19,6 +19,9 @@
     - description: Update CloudFormation template to use al2023 AMI and increased EBS volume size
       type: enhancement
       link: https://github.com/elastic/integrations/pull/6699
+    - description: Adds initial GCP rule templates
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7147
 - version: "1.4.0"
   changes:
     - description: Populate new CloudFormation param ElasticArtifactServer

--- a/packages/cloud_security_posture/kibana/csp_rule_template/05480064-f899-53e8-b8ad-34172b09b400.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/05480064-f899-53e8-b8ad-34172b09b400.json
@@ -1,0 +1,38 @@
+{
+    "id": "05480064-f899-53e8-b8ad-34172b09b400",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Deleting user-managed Service Account Keys may break communication with the applications using the corresponding keys.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/iam/docs/understanding-service-accounts#managing_service_account_keys\n2. https://cloud.google.com/resource-manager/docs/organization-policy/restricting-service-accounts",
+            "id": "05480064-f899-53e8-b8ad-34172b09b400",
+            "name": "Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account",
+            "profile_applicability": "* Level 1",
+            "description": "User managed service accounts should not have user-managed keys.",
+            "rationale": "Anyone who has access to the keys will be able to access resources through the service account.\n\nGCP-managed keys are used by Cloud Platform services such as App Engine and Compute Engine.\nThese keys cannot be downloaded.\nGoogle will keep the keys and automatically rotate them on an approximately weekly basis.\nUser-managed keys are created, downloadable, and managed by users.\nThey expire 10 years from creation.\n\nFor user-managed keys, the user has to take ownership of key management activities which include:\n- Key storage\n- Key distribution\n- Key revocation\n- Key rotation\n- Protecting the keys from unauthorized users\n- Key recovery\n\nEven with key owner precautions, keys can be easily leaked by common development malpractices like checking keys into the source code or leaving them in the Downloads directory, or accidentally leaving them on support blogs/channels.\n\nIt is recommended to prevent user-managed service account keys.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to the IAM page in the GCP Console using `https://console.cloud.google.com/iam-admin/iam`\n\n2. In the left navigation pane, click `Service accounts`. All service accounts and their corresponding keys are listed.\n\n3. Click the service accounts and check if keys exist.\n\n**From Google Cloud CLI**\n\nList All the service accounts:\n\n```\ngcloud iam service-accounts list\n```\nIdentify user-managed service accounts as such account `EMAIL` ends with `iam.gserviceaccount.com`\n\nFor each user-managed service account, list the keys managed by the user:\n```\ngcloud iam service-accounts keys list --iam-account=<Service Account> --managed-by=user\n```\nNo keys should be listed.",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to the IAM page in the GCP Console using `https://console.cloud.google.com/iam-admin/iam`\n\n2. In the left navigation pane, click `Service accounts`. All service accounts and their corresponding keys are listed.\n\n3. Click the service account.\n\n4. Click the `edit` and delete the keys.\n\n**From Google Cloud CLI**\n\nTo delete a user managed Service Account Key,\n\n```\ngcloud iam service-accounts keys delete --iam-account=<user-managed-service-account-EMAIL> <KEY-ID>\n```\n\n**Prevention:**\nYou can disable service account key creation through the `Disable service account key creation` Organization policy by visiting [https://console.cloud.google.com/iam-admin/orgpolicies/iam-disableServiceAccountKeyCreation](https://console.cloud.google.com/iam-admin/orgpolicies/iam-disableServiceAccountKeyCreation).\nLearn more at: [https://cloud.google.com/resource-manager/docs/organization-policy/restricting-service-accounts](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-service-accounts)\n\nIn addition, if you do not need to have service accounts in your project, you can also prevent the creation of service accounts through the `Disable service account creation` Organization policy: [https://console.cloud.google.com/iam-admin/orgpolicies/iam-disableServiceAccountCreation](https://console.cloud.google.com/iam-admin/orgpolicies/iam-disableServiceAccountCreation).",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.4",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.4",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_4"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/2f7d9d2a-ec1f-545a-8258-ea62bbffad7f.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/2f7d9d2a-ec1f-545a-8258-ea62bbffad7f.json
@@ -1,0 +1,38 @@
+{
+    "id": "2f7d9d2a-ec1f-545a-8258-ea62bbffad7f",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "In order to change service account or scope for an instance, it needs to be stopped.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances\n2. https://cloud.google.com/compute/docs/access/service-accounts",
+            "id": "2f7d9d2a-ec1f-545a-8258-ea62bbffad7f",
+            "name": "Ensure That Instances Are Not Configured To Use the Default Service Account With Full Access to All Cloud APIs",
+            "profile_applicability": "* Level 1",
+            "description": "To support principle of least privileges and prevent potential privilege escalation it is recommended that instances are not assigned to default service account `Compute Engine default service account` with Scope `Allow full access to all Cloud APIs`.",
+            "rationale": "Along with ability to optionally create, manage and use user managed custom service accounts, Google Compute Engine provides default service account `Compute Engine default service account` for an instances to access necessary cloud services.\n`Project Editor` role is assigned to `Compute Engine default service account` hence, This service account has almost all capabilities over all cloud services except billing.\nHowever, when `Compute Engine default service account` assigned to an instance it can operate in 3 scopes.\n\n```\n1. Allow default access: Allows only minimum access required to run an Instance (Least Privileges)\n\n2. Allow full access to all Cloud APIs: Allow full access to all the cloud APIs/Services (Too much access)\n\n3. Set access for each API: Allows Instance administrator to choose only those APIs that are needed to perform specific business functionality expected by instance\n```\n\nWhen an instance is configured with `Compute Engine default service account` with Scope `Allow full access to all Cloud APIs`, based on IAM roles assigned to the user(s) accessing Instance, it may allow user to perform cloud operations/API calls that user is not supposed to perform leading to successful privilege escalation.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to the `VM instances` page by visiting: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).\n2. Click on each instance name to go to its `VM instance details` page.\n3. Under the `API and identity management`, ensure that `Cloud API access scopes` is not set to `Allow full access to all Cloud APIs`.\n\n**From Google Cloud CLI**\n\n4. List the instances in your project and get details on each instance:\n```\ngcloud compute instances list --format=json | jq -r '.\n| \"SA Scopes: \\(.[].serviceAccounts[].scopes) Name: \\(.[].name) Email: \\(.[].serviceAccounts[].email)\"'\n```\n5. Ensure that the service account section has an email that does not match the pattern `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`.\n\n**Exception:**\nVMs created by GKE should be excluded.\nThese VMs have names that start with `gke-` and are labeled `goog-gke-node",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to the `VM instances` page by visiting: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).\n\n2. Click on the impacted VM instance.\n\n3. If the instance is not stopped, click the `Stop` button. Wait for the instance to be stopped.\n\n4. Next, click the `Edit` button.\n\n5. Scroll down to the `Service Account` section.\n\n6. Select a different service account or ensure that `Allow full access to all Cloud APIs` is not selected.\n\n7. Click the `Save` button to save your changes and then click `START`.\n\n**From Google Cloud CLI**\n\n8. Stop the instance:\n```\ngcloud compute instances stop <INSTANCE_NAME>\n```\n9. Update the instance:\n```\ngcloud compute instances set-service-account <INSTANCE_NAME> --service-account=<SERVICE_ACCOUNT> --scopes [SCOPE1, SCOPE2...]\n```\n10. Restart the instance:\n```\ngcloud compute instances start <INSTANCE_NAME>\n```",
+            "section": "Virtual Machines",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 4.2",
+                "Virtual Machines"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "4.2",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_4_2"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/33a612ed-8dee-554d-9dd7-857bfc31a33a.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/33a612ed-8dee-554d-9dd7-857bfc31a33a.json
@@ -1,0 +1,38 @@
+{
+    "id": "33a612ed-8dee-554d-9dd7-857bfc31a33a",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "If you enable uniform bucket-level access, you revoke access from users who gain their access solely through object ACLs.\n\nCertain Google Cloud services, such as Stackdriver, Cloud Audit Logs, and Datastore, cannot export to Cloud Storage buckets that have uniform bucket-level access enabled.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/storage/docs/uniform-bucket-level-access\n2. https://cloud.google.com/storage/docs/using-uniform-bucket-level-access\n3. https://cloud.google.com/storage/docs/setting-org-policies#uniform-bucket",
+            "id": "33a612ed-8dee-554d-9dd7-857bfc31a33a",
+            "name": "Ensure That Cloud Storage Buckets Have Uniform Bucket-Level Access Enabled",
+            "profile_applicability": "* Level 2",
+            "description": "It is recommended that uniform bucket-level access is enabled on Cloud Storage buckets.",
+            "rationale": "It is recommended to use uniform bucket-level access to unify and simplify how you grant access to your Cloud Storage resources.\n\n\nCloud Storage offers two systems for granting users permission to access your buckets and objects: Cloud Identity and Access Management (Cloud IAM) and Access Control Lists (ACLs).\nThese systems act in parallel - in order for a user to access a Cloud Storage resource, only one of the systems needs to grant the user permission.\nCloud IAM is used throughout Google Cloud and allows you to grant a variety of permissions at the bucket and project levels.\nACLs are used only by Cloud Storage and have limited permission options, but they allow you to grant permissions on a per-object basis.\n\nIn order to support a uniform permissioning system, Cloud Storage has uniform bucket-level access.\nUsing this feature disables ACLs for all Cloud Storage resources: access to Cloud Storage resources then is granted exclusively through Cloud IAM.\nEnabling uniform bucket-level access guarantees that if a Storage bucket is not publicly accessible, no object in the bucket is publicly accessible either.",
+            "audit": "**From Google Cloud Console**\n\n1. Open the Cloud Storage browser in the Google Cloud Console by visiting: [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser)\n\n2. For each bucket, make sure that `Access control` column has the value `Uniform`.\n\n**From Google Cloud CLI**\n\n3. List all buckets in a project\n```\ngsutil ls\n```\n4. For each bucket, verify that uniform bucket-level access is enabled.\n```\ngsutil uniformbucketlevelaccess get gs://BUCKET_NAME/\n```\nIf uniform bucket-level access is enabled, the response looks like:\n\n```\nUniform bucket-level access setting for gs://BUCKET_NAME/:\n Enabled: True\n LockedTime: LOCK_DATE\n```",
+            "remediation": "**From Google Cloud Console**\n\n1. Open the Cloud Storage browser in the Google Cloud Console by visiting: [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser)\n\n2. In the list of buckets, click on the name of the desired bucket.\n\n3. Select the `Permissions` tab near the top of the page.\n\n4. In the text box that starts with `This bucket uses fine-grained access control...`, click `Edit`.\n\n5. In the pop-up menu that appears, select `Uniform`.\n\n6. Click `Save`.\n\n**From Google Cloud CLI**\n\nUse the on option in a uniformbucketlevelaccess set command:\n\n```\ngsutil uniformbucketlevelaccess set on gs://BUCKET_NAME/\n```\n\n**Prevention**\n\nYou can set up an Organization Policy to enforce that any new bucket has uniform bucket level access enabled.\nLearn more at:\n[https://cloud.google.com/storage/docs/setting-org-policies#uniform-bucket](https://cloud.google.com/storage/docs/setting-org-policies#uniform-bucket)",
+            "section": "Storage",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 5.2",
+                "Storage"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "5.2",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_5_2"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/677bdabb-ee3f-58a6-82f6-d40ccc4efe13.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/677bdabb-ee3f-58a6-82f6-d40ccc4efe13.json
@@ -1,0 +1,38 @@
+{
+    "id": "677bdabb-ee3f-58a6-82f6-d40ccc4efe13",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "After a successful key rotation, the older key version is required in order to decrypt the data encrypted by that previous key version.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/kms/docs/key-rotation#frequency_of_key_rotation\n2. https://cloud.google.com/kms/docs/re-encrypt-data",
+            "id": "677bdabb-ee3f-58a6-82f6-d40ccc4efe13",
+            "name": "Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days",
+            "profile_applicability": "* Level 1",
+            "description": "Google Cloud Key Management Service stores cryptographic keys in a hierarchical structure designed for useful and elegant access control management.\n\n\nThe format for the rotation schedule depends on the client library that is used.\nFor the gcloud command-line tool, the next rotation time must be in `ISO` or `RFC3339` format, and the rotation period must be in the form `INTEGER[UNIT]`, where units can be one of seconds (s), minutes (m), hours (h) or days (d).",
+            "rationale": "Set a key rotation period and starting time.\nA key can be created with a specified `rotation period`, which is the time between when new key versions are generated automatically.\nA key can also be created with a specified next rotation time.\nA key is a named object representing a `cryptographic key` used for a specific purpose.\nThe key material, the actual bits used for `encryption`, can change over time as new key versions are created.\n\nA key is used to protect some `corpus of data`.\nA collection of files could be encrypted with the same key and people with `decrypt` permissions on that key would be able to decrypt those files.\nTherefore, it's necessary to make sure the `rotation period` is set to a specific time.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `Cryptographic Keys` by visiting: [https://console.cloud.google.com/security/kms](https://console.cloud.google.com/security/kms).\n2. Click on each key ring, then ensure each key in the keyring has `Next Rotation` set for less than 90 days from the current date.\n\n**From Google Cloud CLI**\n\n3. Ensure rotation is scheduled by `ROTATION_PERIOD` and `NEXT_ROTATION_TIME` for each key :\n\n```\ngcloud kms keys list --keyring=<KEY_RING> --location=<LOCATION> --format=json'(rotationPeriod)'\n```\n\nEnsure outcome values for `rotationPeriod` and `nextRotationTime` satisfy the below criteria:\n\n`rotationPeriod is <= 129600m` \n`rotationPeriod is <= 7776000s` \n`rotationPeriod is <= 2160h` \n`rotationPeriod is <= 90d` \n`nextRotationTime is <= 90days` from current DATE",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to `Cryptographic Keys` by visiting: [https://console.cloud.google.com/security/kms](https://console.cloud.google.com/security/kms).\n2. Click on the specific key ring\n3. From the list of keys, choose the specific key and Click on `Right side pop up the blade (3 dots)`.\n4. Click on `Edit rotation period`.\n5. On the pop-up window, `Select a new rotation period` in days which should be less than 90 and then choose `Starting on` date (date from which the rotation period begins).\n\n**From Google Cloud CLI**\n\n6. Update and schedule rotation by `ROTATION_PERIOD` and `NEXT_ROTATION_TIME` for each key:\n\n```\ngcloud kms keys update new --keyring=KEY_RING --location=LOCATION --next-rotation-time=NEXT_ROTATION_TIME --rotation-period=ROTATION_PERIOD\n```",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.10",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.10",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_10"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/8daf3f8a-8cb0-58f4-955a-ce2dd2a11f75.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/8daf3f8a-8cb0-58f4-955a-ce2dd2a11f75.json
@@ -1,0 +1,38 @@
+{
+    "id": "8daf3f8a-8cb0-58f4-955a-ce2dd2a11f75",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Removing the binding for `allUsers` and `allAuthenticatedUsers` members denies accessing `cryptokeys` to anonymous or public users.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/sdk/gcloud/reference/kms/keys/remove-iam-policy-binding\n2. https://cloud.google.com/sdk/gcloud/reference/kms/keys/set-iam-policy\n3. https://cloud.google.com/sdk/gcloud/reference/kms/keys/get-iam-policy\n4. https://cloud.google.com/kms/docs/object-hierarchy#key_resource_id",
+            "id": "8daf3f8a-8cb0-58f4-955a-ce2dd2a11f75",
+            "name": "Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible",
+            "profile_applicability": "* Level 1",
+            "description": "It is recommended that the IAM policy on Cloud KMS `cryptokeys` should restrict anonymous and/or public access.",
+            "rationale": "Granting permissions to `allUsers` or `allAuthenticatedUsers` allows anyone to access the dataset.\nSuch access might not be desirable if sensitive data is stored at the location.\nIn this case, ensure that anonymous and/or public access to a Cloud KMS `cryptokey` is not allowed.",
+            "audit": "**From Google Cloud CLI**\n\n1. List all Cloud KMS `Cryptokeys`.\n```\ngcloud kms keys list --keyring=[key_ring_name] --location=global --format=json | jq '.[].name'\n```\n2. Ensure the below command's output does not contain `allUsers` or `allAuthenticatedUsers`.\n```\ngcloud kms keys get-iam-policy [key_name] --keyring=[key_ring_name] --location=global --format=json | jq '.bindings[].members[]'\n```",
+            "remediation": "**From Google Cloud CLI**\n\n1. List all Cloud KMS `Cryptokeys`.\n\n```\ngcloud kms keys list --keyring=[key_ring_name] --location=global --format=json | jq '.[].name'\n```\n2. Remove IAM policy binding for a KMS key to remove access to `allUsers` and `allAuthenticatedUsers` using the below command.\n\n```\ngcloud kms keys remove-iam-policy-binding [key_name] --keyring=[key_ring_name] --location=global --member='allAuthenticatedUsers' --role='[role]'\n\ngcloud kms keys remove-iam-policy-binding [key_name] --keyring=[key_ring_name] --location=global --member='allUsers' --role='[role]'\n```",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.9",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.9",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_9"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/933268ec-44e8-5fba-9ed7-535804521cc7.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/933268ec-44e8-5fba-9ed7-535804521cc7.json
@@ -1,0 +1,38 @@
+{
+    "id": "933268ec-44e8-5fba-9ed7-535804521cc7",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Removed roles should be assigned to another user based on business needs.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/kms/docs/separation-of-duties",
+            "id": "933268ec-44e8-5fba-9ed7-535804521cc7",
+            "name": "Ensure That Separation of Duties Is Enforced While Assigning KMS Related Roles to Users",
+            "profile_applicability": "* Level 2",
+            "description": "It is recommended that the principle of 'Separation of Duties' is enforced while assigning KMS related roles to users.",
+            "rationale": "The built-in/predefined IAM role `Cloud KMS Admin` allows the user/identity to create, delete, and manage service account(s).\nThe built-in/predefined IAM role `Cloud KMS CryptoKey Encrypter/Decrypter` allows the user/identity (with adequate privileges on concerned resources) to encrypt and decrypt data at rest using an encryption key(s).\n\nThe built-in/predefined IAM role `Cloud KMS CryptoKey Encrypter` allows the user/identity (with adequate privileges on concerned resources) to encrypt data at rest using an encryption key(s).\nThe built-in/predefined IAM role `Cloud KMS CryptoKey Decrypter` allows the user/identity (with adequate privileges on concerned resources) to decrypt data at rest using an encryption key(s).\n\nSeparation of duties is the concept of ensuring that one individual does not have all necessary permissions to be able to complete a malicious action.\nIn Cloud KMS, this could be an action such as using a key to access and decrypt data a user should not normally have access to.\nSeparation of duties is a business control typically used in larger organizations, meant to help avoid security or privacy incidents and errors.\nIt is considered best practice.\n\nNo user(s) should have `Cloud KMS Admin` and any of the `Cloud KMS CryptoKey Encrypter/Decrypter`, `Cloud KMS CryptoKey Encrypter`, `Cloud KMS CryptoKey Decrypter` roles assigned at the same time.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `IAM & Admin/IAM` by visiting: [https://console.cloud.google.com/iam-admin/iam](https://console.cloud.google.com/iam-admin/iam)\n\n2. Ensure no member has the roles `Cloud KMS Admin` and any of the `Cloud KMS CryptoKey Encrypter/Decrypter`, `Cloud KMS CryptoKey Encrypter`, `Cloud KMS CryptoKey Decrypter` assigned.\n\n**From Google Cloud CLI**\n\n3. List all users and role assignments:\n\n```\ngcloud projects get-iam-policy PROJECT_ID\n```\n\n4. Ensure that there are no common users found in the member section for roles `cloudkms.admin` and any one of `Cloud KMS CryptoKey Encrypter/Decrypter`, `Cloud KMS CryptoKey Encrypter`, `Cloud KMS CryptoKey Decrypter`",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to `IAM & Admin/IAM` using `https://console.cloud.google.com/iam-admin/iam`\n\n2. For any member having `Cloud KMS Admin` and any of the `Cloud KMS CryptoKey Encrypter/Decrypter`, `Cloud KMS CryptoKey Encrypter`, `Cloud KMS CryptoKey Decrypter` roles granted/assigned, click the `Delete Bin` icon to remove the role from the member.\n\nNote: Removing a role should be done based on the business requirement.",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.11",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.11",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_11"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/b56e76ca-b976-5b96-ab3f-359e5b51ddf2.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/b56e76ca-b976-5b96-ab3f-359e5b51ddf2.json
@@ -1,0 +1,38 @@
+{
+    "id": "b56e76ca-b976-5b96-ab3f-359e5b51ddf2",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/compute/docs/access/service-accounts\n2. https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances\n3. https://cloud.google.com/sdk/gcloud/reference/compute/instances/set-service-account",
+            "id": "b56e76ca-b976-5b96-ab3f-359e5b51ddf2",
+            "name": "Ensure That Instances Are Not Configured To Use the Default Service Account",
+            "profile_applicability": "* Level 1",
+            "description": "It is recommended to configure your instance to not use the default Compute Engine service account because it has the Editor role on the project.",
+            "rationale": "The default Compute Engine service account has the Editor role on the project, which allows read and write access to most Google Cloud Services.\nTo defend against privilege escalations if your VM is compromised and prevent an attacker from gaining access to all of your project, it is recommended to not use the default Compute Engine service account.\nInstead, you should create a new service account and assigning only the permissions needed by your instance.\n\nThe default Compute Engine service account is named `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to the `VM instances` page by visiting: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).\n2. Click on each instance name to go to its `VM instance details` page.\n3. Under the section `API and identity management`, ensure that the default Compute Engine service account is not used. This account is named `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`.\n\n**From Google Cloud CLI**\n\n4. List the instances in your project and get details on each instance:\n```\ngcloud compute instances list --format=json | jq -r '.\n| \"SA: \\(.[].serviceAccounts[].email) Name: \\(.[].name)\"'\n```\n5. Ensure that the service account section has an email that does not match the pattern `[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`.\n\n**Exception:**\nVMs created by GKE should be excluded.\nThese VMs have names that start with `gke-` and are labeled `goog-gke-node`.",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to the `VM instances` page by visiting: [https://console.cloud.google.com/compute/instances](https://console.cloud.google.com/compute/instances).\n2. Click on the instance name to go to its `VM instance details` page.\n3. Click `STOP` and then click `EDIT`.\n4. Under the section `API and identity management`, select a service account other than the default Compute Engine service account. You may first need to create a new service account.\n5. Click `Save` and then click `START`.\n\n**From Google Cloud CLI**\n\n6. Stop the instance:\n```\ngcloud compute instances stop <INSTANCE_NAME>\n```\n7. Update the instance:\n```\ngcloud compute instances set-service-account <INSTANCE_NAME> --service-account=<SERVICE_ACCOUNT> \n```\n8. Restart the instance:\n```\ngcloud compute instances start <INSTANCE_NAME>\n```",
+            "section": "Virtual Machines",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 4.1",
+                "Virtual Machines"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "4.1",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_4_1"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/b8f1182a-1b3e-5b08-8482-f74949163e97.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/b8f1182a-1b3e-5b08-8482-f74949163e97.json
@@ -1,0 +1,38 @@
+{
+    "id": "b8f1182a-1b3e-5b08-8482-f74949163e97",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "After revoking `Service Account User` or `Service Account Token Creator` roles at the project level from all impacted user account(s), these roles should be assigned to a user(s) for specific service account(s) according to business needs.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/iam/docs/service-accounts\n2. https://cloud.google.com/iam/docs/granting-roles-to-service-accounts\n3. https://cloud.google.com/iam/docs/understanding-roles\n4. https://cloud.google.com/iam/docs/granting-changing-revoking-access\n5. https://console.cloud.google.com/iam-admin/iam",
+            "id": "b8f1182a-1b3e-5b08-8482-f74949163e97",
+            "name": "Ensure That IAM Users Are Not Assigned the Service Account User or Service Account Token Creator Roles at Project Level",
+            "profile_applicability": "* Level 1",
+            "description": "It is recommended to assign the `Service Account User (iam.serviceAccountUser)` and `Service Account Token Creator (iam.serviceAccountTokenCreator)` roles to a user for a specific service account rather than assigning the role to a user at project level.",
+            "rationale": "A service account is a special Google account that belongs to an application or a virtual machine (VM), instead of to an individual end-user.\nApplication/VM-Instance uses the service account to call the service's Google API so that users aren't directly involved.\nIn addition to being an identity, a service account is a resource that has IAM policies attached to it.\nThese policies determine who can use the service account.\n\nUsers with IAM roles to update the App Engine and Compute Engine instances (such as App Engine Deployer or Compute Instance Admin) can effectively run code as the service accounts used to run these instances, and indirectly gain access to all the resources for which the service accounts have access.\nSimilarly, SSH access to a Compute Engine instance may also provide the ability to execute code as that instance/Service account.\n\nBased on business needs, there could be multiple user-managed service accounts configured for a project.\nGranting the `iam.serviceAccountUser` or `iam.serviceAccountTokenCreator` roles to a user for a project gives the user access to all service accounts in the project, including service accounts that may be created in the future.\nThis can result in elevation of privileges by using service accounts and corresponding `Compute Engine instances`.\n\nIn order to implement `least privileges` best practices, IAM users should not be assigned the `Service Account User` or `Service Account Token Creator` roles at the project level.\nInstead, these roles should be assigned to a user for a specific service account, giving that user access to the service account.\nThe `Service Account User` allows a user to bind a service account to a long-running job service, whereas the `Service Account Token Creator` role allows a user to directly impersonate (or assert) the identity of a service account.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to the IAM page in the GCP Console by visiting [https://console.cloud.google.com/iam-admin/iam](https://console.cloud.google.com/iam-admin/iam)\n\n2. Click on the filter table text bar, Type `Role: Service Account User`.\n\n3. Ensure no user is listed as a result of the filter.\n\n4. Click on the filter table text bar, Type `Role: Service Account Token Creator`.\n\n5. Ensure no user is listed as a result of the filter.\n\n**From Google Cloud CLI**\n\nTo ensure IAM users are not assigned Service Account User role at the project level:\n\n```\ngcloud projects get-iam-policy PROJECT_ID --format json | jq '.bindings[].role' | grep \"roles/iam.serviceAccountUser\"\n\ngcloud projects get-iam-policy PROJECT_ID --format json | jq '.bindings[].role' | grep \"roles/iam.serviceAccountTokenCreator\"\n```\n\nThese commands should not return any output.",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to the IAM page in the GCP Console by visiting: [https://console.cloud.google.com/iam-admin/iam](https://console.cloud.google.com/iam-admin/iam).\n\n2. Click on the filter table text bar. Type `Role: Service Account User`\n\n3. Click the `Delete Bin` icon in front of the role `Service Account User` for every user listed as a result of a filter.\n\n4. Click on the filter table text bar. Type `Role: Service Account Token Creator`\n\n5. Click the `Delete Bin` icon in front of the role `Service Account Token Creator` for every user listed as a result of a filter.\n\n**From Google Cloud CLI**\n\n6. Using a text editor, remove the bindings with the `roles/iam.serviceAccountUser` or `roles/iam.serviceAccountTokenCreator`. \n\nFor example, you can use the iam.json file shown below as follows:\n\n {\n \"bindings\": [\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n ],\n \"role\": \"roles/appengine.appViewer\"\n },\n {\n \"members\": [\n \"user:email1@gmail.com\"\n ],\n \"role\": \"roles/owner\"\n },\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n \"serviceAccount:123456789012-compute@developer.gserviceaccount.com\"\n ],\n \"role\": \"roles/editor\"\n }\n ],\n \"etag\": \"BwUjMhCsNvY=\"\n }\n\n7. Update the project's IAM policy:\n\n```\ngcloud projects set-iam-policy PROJECT_ID iam.json\n```",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.6",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.6",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_6"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/c13f49ab-845e-5a89-a05e-6a7c7b23f628.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/c13f49ab-845e-5a89-a05e-6a7c7b23f628.json
@@ -1,0 +1,38 @@
+{
+    "id": "c13f49ab-845e-5a89-a05e-6a7c7b23f628",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Removing `*Admin` or `*admin` or `Editor` or `Owner` role assignments from service accounts may break functionality that uses impacted service accounts. Required role(s) should be assigned to impacted service accounts in order to restore broken functionalities.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/sdk/gcloud/reference/iam/service-accounts/\n2. https://cloud.google.com/iam/docs/understanding-roles\n3. https://cloud.google.com/iam/docs/understanding-service-accounts",
+            "id": "c13f49ab-845e-5a89-a05e-6a7c7b23f628",
+            "name": "Ensure That Service Account Has No Admin Privileges",
+            "profile_applicability": "* Level 1",
+            "description": "A service account is a special Google account that belongs to an application or a VM, instead of to an individual end-user.\nThe application uses the service account to call the service's Google API so that users aren't directly involved.\nIt's recommended not to use admin access for ServiceAccount.",
+            "rationale": "Service accounts represent service-level security of the Resources (application or a VM) which can be determined by the roles assigned to it.\nEnrolling ServiceAccount with Admin rights gives full access to an assigned application or a VM.\nA ServiceAccount Access holder can perform critical actions like delete, update change settings, etc.\nwithout user intervention.\nFor this reason, it's recommended that service accounts not have Admin rights.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `IAM & admin/IAM` using `https://console.cloud.google.com/iam-admin/iam`\n2. Go to the `Members`\n3. Ensure that there are no `User-Managed user created service account(s)` with roles containing `*Admin` or `*admin` or role matching `Editor` or role matching `Owner`\n\n**From Google Cloud CLI**\n\n4. Get the policy that you want to modify, and write it to a JSON file:\n\n```\ngcloud projects get-iam-policy PROJECT_ID --format json > iam.json\n```\n\n5. The contents of the JSON file will look similar to the following. Note that `role` of members group associated with each `serviceaccount` does not contain `*Admin` or `*admin` or does not match `roles/editor` or does not match `roles/owner`.\n\nThis recommendation is only applicable to `User-Managed user-created` service accounts.\nThese accounts have the nomenclature: `SERVICE_ACCOUNT_NAME@PROJECT_ID.iam.gserviceaccount.com`.\nNote that some Google-managed, Google-created service accounts have the same naming format, and should be excluded (e.g., `appsdev-apps-dev-script-auth@system.gserviceaccount.com` which needs the Owner role).\n\n**Sample Json output:**\n\n {\n \"bindings\": [\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n ],\n \"role\": \"roles/appengine.appAdmin\"\n },\n {\n \"members\": [\n \"user:email1@gmail.com\"\n ],\n \"role\": \"roles/owner\"\n },\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n \"serviceAccount:123456789012-compute@developer.gserviceaccount.com\"\n ],\n \"role\": \"roles/editor\"\n }\n ],\n \"etag\": \"BwUjMhCsNvY=\",\n \"version\": 1\n }",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to `IAM & admin/IAM` using `https://console.cloud.google.com/iam-admin/iam`\n2. Go to the `Members`\n3. Identify `User-Managed user created` service account with roles containing `*Admin` or `*admin` or role matching `Editor` or role matching `Owner`\n4. Click the `Delete bin` icon to remove the role from the member (service account in this case)\n\n**From Google Cloud CLI**\n\n```\ngcloud projects get-iam-policy PROJECT_ID --format json > iam.json\n```\n\n5. Using a text editor, Remove `Role` which contains `roles/*Admin` or `roles/*admin` or matched `roles/editor` or matches 'roles/owner`. Add a role to the bindings array that defines the group members and the role for those members. \n\nFor example, to grant the role roles/appengine.appViewer to the `ServiceAccount` which is roles/editor, you would change the example shown below as follows:\n\n {\n \"bindings\": [\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n ],\n \"role\": \"roles/appengine.appViewer\"\n },\n {\n \"members\": [\n \"user:email1@gmail.com\"\n ],\n \"role\": \"roles/owner\"\n },\n {\n \"members\": [\n \"serviceAccount:our-project-123@appspot.gserviceaccount.com\",\n \"serviceAccount:123456789012-compute@developer.gserviceaccount.com\"\n ],\n \"role\": \"roles/editor\"\n }\n ],\n \"etag\": \"BwUjMhCsNvY=\"\n }\n6. Update the project's IAM policy:\n\n```\ngcloud projects set-iam-policy PROJECT_ID iam.json\n```",
+            "section": "Identity and Access Management",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 1.5",
+                "Identity and Access Management"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "1.5",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_1_5"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/d3d725bd-652f-573e-97f5-adfd002fab8e.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/d3d725bd-652f-573e-97f5-adfd002fab8e.json
@@ -1,0 +1,38 @@
+{
+    "id": "d3d725bd-652f-573e-97f5-adfd002fab8e",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "The dataset is not publicly accessible. Explicit modification of IAM privileges would be necessary to make them publicly accessible.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/bigquery/docs/dataset-access-controls",
+            "id": "d3d725bd-652f-573e-97f5-adfd002fab8e",
+            "name": "Ensure That BigQuery Datasets Are Not Anonymously or Publicly Accessible",
+            "profile_applicability": "* Level 1",
+            "description": "It is recommended that the IAM policy on BigQuery datasets does not allow anonymous and/or public access.",
+            "rationale": "Granting permissions to `allUsers` or `allAuthenticatedUsers` allows anyone to access the dataset.\nSuch access might not be desirable if sensitive data is being stored in the dataset.\nTherefore, ensure that anonymous and/or public access to a dataset is not allowed.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `BigQuery` by visiting: [https://console.cloud.google.com/bigquery](https://console.cloud.google.com/bigquery).\n2. Select a dataset from `Resources`.\n3. Click `SHARING` near the right side of the window and select `Permissions`.\n4. Validate that none of the attached roles contain `allUsers` or `allAuthenticatedUsers`.\n\n**From Google Cloud CLI**\n\nList the name of all datasets.\n```\nbq ls\n```\nRetrieve each dataset details using the following command:\n```\nbq show PROJECT_ID:DATASET_NAME\n```\nEnsure that `allUsers` and `allAuthenticatedUsers` have not been granted access to the dataset.",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to `BigQuery` by visiting: [https://console.cloud.google.com/bigquery](https://console.cloud.google.com/bigquery).\n2. Select the dataset from 'Resources'.\n3. Click `SHARING` near the right side of the window and select `Permissions`.\n4. Review each attached role.\n5. Click the delete icon for each member `allUsers` or `allAuthenticatedUsers`. On the popup click `Remove`.\n\n**From Google Cloud CLI**\n\nList the name of all datasets.\n```\nbq ls\n```\nRetrieve the data set details: \n```\nbq show --format=prettyjson PROJECT_ID:DATASET_NAME > PATH_TO_FILE\n```\nIn the access section of the JSON file, update the dataset information to remove all roles containing `allUsers` or `allAuthenticatedUsers`.\n\nUpdate the dataset:\n```\nbq update --source PATH_TO_FILE PROJECT_ID:DATASET_NAME\n```\n\n**Prevention:**\n\nYou can prevent Bigquery dataset from becoming publicly accessible by setting up the `Domain restricted sharing` organization policy at: https://console.cloud.google.com/iam-admin/orgpolicies/iam-allowedPolicyMemberDomains .",
+            "section": "BigQuery",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 7.1",
+                "BigQuery"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "7.1",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_7_1"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/eed3e284-5030-56db-b749-01d7120dc577.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/eed3e284-5030-56db-b749-01d7120dc577.json
@@ -1,0 +1,38 @@
+{
+    "id": "eed3e284-5030-56db-b749-01d7120dc577",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Using Customer-managed encryption keys (CMEK) will incur additional labor-hour investment to create, protect, and manage the keys.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/bigquery/docs/customer-managed-encryption",
+            "id": "eed3e284-5030-56db-b749-01d7120dc577",
+            "name": "Ensure That a Default Customer-Managed Encryption Key (CMEK) Is Specified for All BigQuery Data Sets",
+            "profile_applicability": "* Level 2",
+            "description": "BigQuery by default encrypts the data as rest by employing `Envelope Encryption` using Google managed cryptographic keys.\nThe data is encrypted using the `data encryption keys` and data encryption keys themselves are further encrypted using `key encryption keys`.\nThis is seamless and do not require any additional input from the user.\nHowever, if you want to have greater control, Customer-managed encryption keys (CMEK) can be used as encryption key management solution for BigQuery Data Sets.",
+            "rationale": "BigQuery by default encrypts the data as rest by employing `Envelope Encryption` using Google managed cryptographic keys.\nThis is seamless and does not require any additional input from the user.\n\nFor greater control over the encryption, customer-managed encryption keys (CMEK) can be used as encryption key management solution for BigQuery Data Sets.\nSetting a Default Customer-managed encryption key (CMEK) for a data set ensure any tables created in future will use the specified CMEK if none other is provided.\n\n```\nNote: Google does not store your keys on its servers and cannot access your protected data unless you provide the key.\nThis also means that if you forget or lose your key, there is no way for Google to recover the key or to recover any data encrypted with the lost key.\n```",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `Analytics`\n2. Go to `BigQuery`\n3. Under `Analysis` click on `SQL Workspaces`, select the project\n4. Select Data Set\n5. Ensure `Customer-managed key` is present under `Dataset info` section.\n6. Repeat for each data set in all projects.\n\n**From Google Cloud CLI**\n\nList all dataset names\n```\nbq ls\n```\nUse the following command to view each dataset details.\n```\nbq show <data_set_object>\n```\nVerify the `kmsKeyName` is present.",
+            "remediation": "**From Google Cloud CLI**\n\nThe default CMEK for existing data sets can be updated by specifying the default key in the `EncryptionConfiguration.kmsKeyName` field when calling the `datasets.insert` or `datasets.patch` methods",
+            "section": "BigQuery",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 7.3",
+                "BigQuery"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "7.3",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_7_3"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/f00c266c-0e28-5c49-b2b0-cd97603341ec.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/f00c266c-0e28-5c49-b2b0-cd97603341ec.json
@@ -1,0 +1,38 @@
+{
+    "id": "f00c266c-0e28-5c49-b2b0-cd97603341ec",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "Using Customer-managed encryption keys (CMEK) will incur additional labor-hour investment to create, protect, and manage the keys.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/bigquery/docs/customer-managed-encryption",
+            "id": "f00c266c-0e28-5c49-b2b0-cd97603341ec",
+            "name": "Ensure That All BigQuery Tables Are Encrypted With Customer-Managed Encryption Key (CMEK)",
+            "profile_applicability": "* Level 2",
+            "description": "BigQuery by default encrypts the data as rest by employing `Envelope Encryption` using Google managed cryptographic keys.\nThe data is encrypted using the `data encryption keys` and data encryption keys themselves are further encrypted using `key encryption keys`.\nThis is seamless and do not require any additional input from the user.\nHowever, if you want to have greater control, Customer-managed encryption keys (CMEK) can be used as encryption key management solution for BigQuery Data Sets.\nIf CMEK is used, the CMEK is used to encrypt the data encryption keys instead of using google-managed encryption keys.",
+            "rationale": "BigQuery by default encrypts the data as rest by employing `Envelope Encryption` using Google managed cryptographic keys.\nThis is seamless and does not require any additional input from the user.\n\nFor greater control over the encryption, customer-managed encryption keys (CMEK) can be used as encryption key management solution for BigQuery tables.\nThe CMEK is used to encrypt the data encryption keys instead of using google-managed encryption keys.\nBigQuery stores the table and CMEK association and the encryption/decryption is done automatically.\n\nApplying the Default Customer-managed keys on BigQuery data sets ensures that all the new tables created in the future will be encrypted using CMEK but existing tables need to be updated to use CMEK individually.\n\n```\nNote: Google does not store your keys on its servers and cannot access your protected data unless you provide the key.\nThis also means that if you forget or lose your key, there is no way for Google to recover the key or to recover any data encrypted with the lost key.\n```",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `Analytics`\n2. Go to `BigQuery`\n3. Under `SQL Workspace`, select the project\n4. Select Data Set, select the table\n5. Go to `Details` tab\n6. Under `Table info`, verify `Customer-managed key` is present.\n7. Repeat for each table in all data sets for all projects.\n\n**From Google Cloud CLI**\n\nList all dataset names\n```\nbq ls\n```\nUse the following command to view the table details.\nVerify the `kmsKeyName` is present.\n```\nbq show <table_object>\n```",
+            "remediation": "**From Google Cloud CLI**\nUse the following command to copy the data.\nThe source and the destination needs to be same in case copying to the original table.\n```\nbq cp --destination_kms_key <customer_managed_key> source_dataset.source_table destination_dataset.destination_table\n```",
+            "section": "BigQuery",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 7.2",
+                "BigQuery"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "7.2",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_7_2"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/kibana/csp_rule_template/fb4368ab-cdee-5188-814c-a8197411ba22.json
+++ b/packages/cloud_security_posture/kibana/csp_rule_template/fb4368ab-cdee-5188-814c-a8197411ba22.json
@@ -1,0 +1,38 @@
+{
+    "id": "fb4368ab-cdee-5188-814c-a8197411ba22",
+    "type": "csp-rule-template",
+    "attributes": {
+        "metadata": {
+            "impact": "No storage buckets would be publicly accessible. You would have to explicitly administer bucket access.",
+            "default_value": "",
+            "references": "1. https://cloud.google.com/storage/docs/access-control/iam-reference\n2. https://cloud.google.com/storage/docs/access-control/making-data-public\n3. https://cloud.google.com/storage/docs/gsutil/commands/iam",
+            "id": "fb4368ab-cdee-5188-814c-a8197411ba22",
+            "name": "Ensure That Cloud Storage Bucket Is Not Anonymously or Publicly Accessible",
+            "profile_applicability": "* Level 1",
+            "description": "It is recommended that IAM policy on Cloud Storage bucket does not allows anonymous or public access.",
+            "rationale": "Allowing anonymous or public access grants permissions to anyone to access bucket content.\nSuch access might not be desired if you are storing any sensitive data.\nHence, ensure that anonymous or public access to a bucket is not allowed.",
+            "audit": "**From Google Cloud Console**\n\n1. Go to `Storage browser` by visiting [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser).\n2. Click on each bucket name to go to its `Bucket details` page.\n3. Click on the `Permissions` tab.\n4. Ensure that `allUsers` and `allAuthenticatedUsers` are not in the `Members` list.\n\n**From Google Cloud CLI**\n\n5. List all buckets in a project\n\n```\ngsutil ls\n```\n\n6. Check the IAM Policy for each bucket:\n\n```\ngsutil iam get gs://BUCKET_NAME\n```\n\nNo role should contain `allUsers` and/or `allAuthenticatedUsers` as a member.\n\n**Using Rest API**\n\n7. List all buckets in a project\n\n```\nGet https://www.googleapis.com/storage/v1/b?project=<ProjectName>\n```\n\n8. Check the IAM Policy for each bucket\n\n```\nGET https://www.googleapis.com/storage/v1/b/<bucketName>/iam\n```\n\nNo role should contain `allUsers` and/or `allAuthenticatedUsers` as a member.",
+            "remediation": "**From Google Cloud Console**\n\n1. Go to `Storage browser` by visiting [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser).\n2. Click on the bucket name to go to its `Bucket details` page.\n3. Click on the `Permissions` tab. \n4. Click `Delete` button in front of `allUsers` and `allAuthenticatedUsers` to remove that particular role assignment.\n\n**From Google Cloud CLI**\n\nRemove `allUsers` and `allAuthenticatedUsers` access.\n```\ngsutil iam ch -d allUsers gs://BUCKET_NAME\ngsutil iam ch -d allAuthenticatedUsers gs://BUCKET_NAME\n```\n\n**Prevention:**\n\nYou can prevent Storage buckets from becoming publicly accessible by setting up the `Domain restricted sharing` organization policy at:[ https://console.cloud.google.com/iam-admin/orgpolicies/iam-allowedPolicyMemberDomains ](https://console.cloud.google.com/iam-admin/orgpolicies/iam-allowedPolicyMemberDomains).",
+            "section": "Storage",
+            "version": "1.0",
+            "tags": [
+                "CIS",
+                "GCP",
+                "CIS 5.1",
+                "Storage"
+            ],
+            "benchmark": {
+                "name": "CIS Google Cloud Platform Foundation",
+                "version": "v2.0.0",
+                "id": "cis_gcp",
+                "rule_number": "5.1",
+                "posture_type": "cspm"
+            },
+            "rego_rule_id": "cis_5_1"
+        }
+    },
+    "migrationVersion": {
+        "csp-rule-template": "8.7.0"
+    },
+    "coreMigrationVersion": "8.7.0"
+}

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview25"
+version: "1.5.0-preview26"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION


## What does this PR do?

Adds rule templates for [current](https://github.com/elastic/csp-security-policies/blob/main/RULES.md#gcp-cis-benchmark) rules

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- Closes https://github.com/elastic/security-team/issues/7181

