### PR TITLE
[HA Proxy] Add metric_type mapping to info datastream

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -2,8 +2,8 @@
 - version: "1.8.0"
   changes:
     - description: Add `metric_type` mapping for `info` datastream.
-      type: enhacement
-      link: https://github.com/elastic/integrations/pull/1
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7164
 - version: "1.7.2"
   changes:
     - description: Add missing event.duration field mapping.

--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Add `metric_type` mapping for `info` datastream.
+      type: enhacement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.2"
   changes:
     - description: Add missing event.duration field mapping.

--- a/packages/haproxy/data_stream/info/fields/fields.yml
+++ b/packages/haproxy/data_stream/info/fields/fields.yml
@@ -3,55 +3,69 @@
   fields:
     - name: processes
       type: long
+      metric_type: gauge
       description: |
         Number of processes.
     - name: process_num
       type: long
+      metric_type: gauge
       description: |
         Process number.
     - name: threads
       type: long
+      metric_type: gauge
       description: |
         Number of threads.
     - name: run_queue
       type: long
+      metric_type: gauge
     - name: stopping
       type: long
+      metric_type: gauge
       description: |
         Number of stopping jobs.
     - name: jobs
       type: long
+      metric_type: gauge
       description: |
         Number of all jobs.
     - name: unstoppable_jobs
       type: long
+      metric_type: gauge
       description: |
         Number of unstoppable jobs.
     - name: listeners
       type: long
+      metric_type: gauge
       description: |
         Number of listeners.
     - name: dropped_logs
       type: long
+      metric_type: gauge
       description: |
         Number of dropped logs.
     - name: busy_polling
       type: long
+      metric_type: gauge
       description: |
         Number of busy polling.
     - name: failed_resolutions
       type: long
+      metric_type: gauge
       description: |
         Number of failed resolutions.
     - name: tasks
       type: long
+      metric_type: gauge
     - name: uptime.sec
       type: long
+      metric_type: gauge
       description: |
         Current uptime in seconds.
     - name: memory.max.bytes
       type: long
       format: bytes
+      metric_type: gauge
       description: |
         Maximum amount of memory usage in bytes (the 'Memmax_MB' value converted to bytes).
     - name: bytes
@@ -62,10 +76,12 @@
           fields:
             - name: total
               type: long
+              metric_type: gauge
               description: |
                 Number of bytes sent out.
             - name: rate
               type: long
+              metric_type: gauge
               description: |
                 Average bytes output rate.
     - name: peers
@@ -73,10 +89,12 @@
       fields:
         - name: active
           type: long
+          metric_type: gauge
           description: |
             Number of active peers.
         - name: connected
           type: long
+          metric_type: gauge
           description: |
             Number of connected peers.
     - name: pool
@@ -84,18 +102,22 @@
       fields:
         - name: allocated
           type: long
+          metric_type: gauge
           description: |
             Size of the allocated pool.
         - name: used
           type: long
+          metric_type: gauge
           description: |
             Number of members used from the allocated pool.
         - name: failed
           type: long
+          metric_type: counter
           description: |
             Number of failed connections to pool members.
     - name: ulimit_n
       type: long
+      metric_type: gauge
       description: |
         Maximum number of open files for the process.
     - name: compress
@@ -106,14 +128,17 @@
           fields:
             - name: in
               type: long
+              metric_type: gauge
               description: |
                 Incoming compressed data in bits per second.
             - name: out
               type: long
+              metric_type: gauge
               description: |
                 Outgoing compressed data in bits per second.
             - name: rate_limit
               type: long
+              metric_type: gauge
               description: |
                 Rate limit of compressed data in bits per second.
     - name: connection
@@ -124,52 +149,65 @@
           fields:
             - name: value
               type: long
+              metric_type: gauge
               description: |
                 Number of connections in the last second.
             - name: limit
               type: long
+              metric_type: gauge
               description: |
                 Rate limit of connections.
             - name: max
               type: long
+              metric_type: gauge
               description: |
                 Maximum rate of connections.
         - name: current
           type: long
+          metric_type: gauge
           description: |
             Current connections.
         - name: total
           type: long
+          metric_type: counter
           description: |
             Total connections.
         - name: ssl.current
           type: long
+          metric_type: gauge
           description: |
             Current SSL connections.
         - name: ssl.total
           type: long
+          metric_type: counter
           description: |
             Total SSL connections.
         - name: ssl.max
           type: long
+          metric_type: gauge
           description: |
             Maximum SSL connections.
         - name: max
           type: long
+          metric_type: gauge
           description: |
             Maximum connections.
         - name: hard_max
           type: long
+          metric_type: gauge
     - name: requests.total
       type: long
+      metric_type: counter
       description: |
         Total number of requests.
     - name: sockets.max
       type: long
+      metric_type: gauge
       description: |
         Maximum number of sockets.
     - name: requests.max
       type: long
+      metric_type: gauge
       description: |
         Maximum number of requests.
     - name: pipes
@@ -177,14 +215,17 @@
       fields:
         - name: used
           type: integer
+          metric_type: gauge
           description: |
             Number of used pipes during kernel-based tcp splicing.
         - name: free
           type: integer
+          metric_type: gauge
           description: |
             Number of free pipes.
         - name: max
           type: integer
+          metric_type: gauge
           description: |
             Maximum number of used pipes.
     - name: session
@@ -192,14 +233,17 @@
       fields:
         - name: rate.value
           type: integer
+          metric_type: gauge
           description: |
             Rate of session per seconds.
         - name: rate.limit
           type: integer
+          metric_type: gauge
           description: |
             Rate limit of sessions.
         - name: rate.max
           type: integer
+          metric_type: gauge
           description: |
             Maximum rate of sessions.
     - name: ssl
@@ -207,14 +251,17 @@
       fields:
         - name: rate.value
           type: integer
+          metric_type: gauge
           description: |
             Rate of SSL requests.
         - name: rate.limit
           type: integer
+          metric_type: gauge
           description: |
             Rate limit of SSL requests.
         - name: rate.max
           type: integer
+          metric_type: gauge
           description: |
             Maximum rate of SSL requests.
         - name: frontend
@@ -222,15 +269,18 @@
           fields:
             - name: key_rate.value
               type: integer
+              metric_type: gauge
               description: |
                 Key rate of SSL frontend.
             - name: key_rate.max
               type: integer
+              metric_type: gauge
               description: |
                 Maximum key rate of SSL frontend.
             - name: session_reuse.pct
               type: scaled_float
               format: percent
+              metric_type: gauge
               description: |
                 Rate of reuse of SSL frontend sessions.
         - name: backend
@@ -238,18 +288,22 @@
           fields:
             - name: key_rate.value
               type: integer
+              metric_type: gauge
               description: |
                 Key rate of SSL backend sessions.
             - name: key_rate.max
               type: integer
+              metric_type: gauge
               description: |
                 Maximum key rate of SSL backend sessions.
         - name: cached_lookups
           type: long
+          metric_type: counter
           description: |
             Number of SSL cache lookups.
         - name: cache_misses
           type: long
+          metric_type: counter
           description: |
             Number of SSL cache misses.
     - name: zlib_mem_usage
@@ -257,14 +311,17 @@
       fields:
         - name: value
           type: integer
+          metric_type: gauge
           description: |
             Memory usage of zlib.
         - name: max
           type: integer
+          metric_type: gauge
           description: |
             Maximum memory usage of zlib.
     - name: idle.pct
       type: scaled_float
       format: percent
+      metric_type: gauge
       description: |
         Percentage of idle time.

--- a/packages/haproxy/docs/README.md
+++ b/packages/haproxy/docs/README.md
@@ -428,105 +428,105 @@ The fields reported are:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| haproxy.info.busy_polling | Number of busy polling. | long |
-| haproxy.info.bytes.out.rate | Average bytes output rate. | long |
-| haproxy.info.bytes.out.total | Number of bytes sent out. | long |
-| haproxy.info.compress.bps.in | Incoming compressed data in bits per second. | long |
-| haproxy.info.compress.bps.out | Outgoing compressed data in bits per second. | long |
-| haproxy.info.compress.bps.rate_limit | Rate limit of compressed data in bits per second. | long |
-| haproxy.info.connection.current | Current connections. | long |
-| haproxy.info.connection.hard_max |  | long |
-| haproxy.info.connection.max | Maximum connections. | long |
-| haproxy.info.connection.rate.limit | Rate limit of connections. | long |
-| haproxy.info.connection.rate.max | Maximum rate of connections. | long |
-| haproxy.info.connection.rate.value | Number of connections in the last second. | long |
-| haproxy.info.connection.ssl.current | Current SSL connections. | long |
-| haproxy.info.connection.ssl.max | Maximum SSL connections. | long |
-| haproxy.info.connection.ssl.total | Total SSL connections. | long |
-| haproxy.info.connection.total | Total connections. | long |
-| haproxy.info.dropped_logs | Number of dropped logs. | long |
-| haproxy.info.failed_resolutions | Number of failed resolutions. | long |
-| haproxy.info.idle.pct | Percentage of idle time. | scaled_float |
-| haproxy.info.jobs | Number of all jobs. | long |
-| haproxy.info.listeners | Number of listeners. | long |
-| haproxy.info.memory.max.bytes | Maximum amount of memory usage in bytes (the 'Memmax_MB' value converted to bytes). | long |
-| haproxy.info.peers.active | Number of active peers. | long |
-| haproxy.info.peers.connected | Number of connected peers. | long |
-| haproxy.info.pipes.free | Number of free pipes. | integer |
-| haproxy.info.pipes.max | Maximum number of used pipes. | integer |
-| haproxy.info.pipes.used | Number of used pipes during kernel-based tcp splicing. | integer |
-| haproxy.info.pool.allocated | Size of the allocated pool. | long |
-| haproxy.info.pool.failed | Number of failed connections to pool members. | long |
-| haproxy.info.pool.used | Number of members used from the allocated pool. | long |
-| haproxy.info.process_num | Process number. | long |
-| haproxy.info.processes | Number of processes. | long |
-| haproxy.info.requests.max | Maximum number of requests. | long |
-| haproxy.info.requests.total | Total number of requests. | long |
-| haproxy.info.run_queue |  | long |
-| haproxy.info.session.rate.limit | Rate limit of sessions. | integer |
-| haproxy.info.session.rate.max | Maximum rate of sessions. | integer |
-| haproxy.info.session.rate.value | Rate of session per seconds. | integer |
-| haproxy.info.sockets.max | Maximum number of sockets. | long |
-| haproxy.info.ssl.backend.key_rate.max | Maximum key rate of SSL backend sessions. | integer |
-| haproxy.info.ssl.backend.key_rate.value | Key rate of SSL backend sessions. | integer |
-| haproxy.info.ssl.cache_misses | Number of SSL cache misses. | long |
-| haproxy.info.ssl.cached_lookups | Number of SSL cache lookups. | long |
-| haproxy.info.ssl.frontend.key_rate.max | Maximum key rate of SSL frontend. | integer |
-| haproxy.info.ssl.frontend.key_rate.value | Key rate of SSL frontend. | integer |
-| haproxy.info.ssl.frontend.session_reuse.pct | Rate of reuse of SSL frontend sessions. | scaled_float |
-| haproxy.info.ssl.rate.limit | Rate limit of SSL requests. | integer |
-| haproxy.info.ssl.rate.max | Maximum rate of SSL requests. | integer |
-| haproxy.info.ssl.rate.value | Rate of SSL requests. | integer |
-| haproxy.info.stopping | Number of stopping jobs. | long |
-| haproxy.info.tasks |  | long |
-| haproxy.info.threads | Number of threads. | long |
-| haproxy.info.ulimit_n | Maximum number of open files for the process. | long |
-| haproxy.info.unstoppable_jobs | Number of unstoppable jobs. | long |
-| haproxy.info.uptime.sec | Current uptime in seconds. | long |
-| haproxy.info.zlib_mem_usage.max | Maximum memory usage of zlib. | integer |
-| haproxy.info.zlib_mem_usage.value | Memory usage of zlib. | integer |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| process | These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation. | group |
-| process.pid | Process id. | long |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| haproxy.info.busy_polling | Number of busy polling. | long | gauge |
+| haproxy.info.bytes.out.rate | Average bytes output rate. | long | gauge |
+| haproxy.info.bytes.out.total | Number of bytes sent out. | long | gauge |
+| haproxy.info.compress.bps.in | Incoming compressed data in bits per second. | long | gauge |
+| haproxy.info.compress.bps.out | Outgoing compressed data in bits per second. | long | gauge |
+| haproxy.info.compress.bps.rate_limit | Rate limit of compressed data in bits per second. | long | gauge |
+| haproxy.info.connection.current | Current connections. | long | gauge |
+| haproxy.info.connection.hard_max |  | long | gauge |
+| haproxy.info.connection.max | Maximum connections. | long | gauge |
+| haproxy.info.connection.rate.limit | Rate limit of connections. | long | gauge |
+| haproxy.info.connection.rate.max | Maximum rate of connections. | long | gauge |
+| haproxy.info.connection.rate.value | Number of connections in the last second. | long | gauge |
+| haproxy.info.connection.ssl.current | Current SSL connections. | long | gauge |
+| haproxy.info.connection.ssl.max | Maximum SSL connections. | long | gauge |
+| haproxy.info.connection.ssl.total | Total SSL connections. | long | counter |
+| haproxy.info.connection.total | Total connections. | long | counter |
+| haproxy.info.dropped_logs | Number of dropped logs. | long | gauge |
+| haproxy.info.failed_resolutions | Number of failed resolutions. | long | gauge |
+| haproxy.info.idle.pct | Percentage of idle time. | scaled_float | gauge |
+| haproxy.info.jobs | Number of all jobs. | long | gauge |
+| haproxy.info.listeners | Number of listeners. | long | gauge |
+| haproxy.info.memory.max.bytes | Maximum amount of memory usage in bytes (the 'Memmax_MB' value converted to bytes). | long | gauge |
+| haproxy.info.peers.active | Number of active peers. | long | gauge |
+| haproxy.info.peers.connected | Number of connected peers. | long | gauge |
+| haproxy.info.pipes.free | Number of free pipes. | integer | gauge |
+| haproxy.info.pipes.max | Maximum number of used pipes. | integer | gauge |
+| haproxy.info.pipes.used | Number of used pipes during kernel-based tcp splicing. | integer | gauge |
+| haproxy.info.pool.allocated | Size of the allocated pool. | long | gauge |
+| haproxy.info.pool.failed | Number of failed connections to pool members. | long | counter |
+| haproxy.info.pool.used | Number of members used from the allocated pool. | long | gauge |
+| haproxy.info.process_num | Process number. | long | gauge |
+| haproxy.info.processes | Number of processes. | long | gauge |
+| haproxy.info.requests.max | Maximum number of requests. | long | gauge |
+| haproxy.info.requests.total | Total number of requests. | long | counter |
+| haproxy.info.run_queue |  | long | gauge |
+| haproxy.info.session.rate.limit | Rate limit of sessions. | integer | gauge |
+| haproxy.info.session.rate.max | Maximum rate of sessions. | integer | gauge |
+| haproxy.info.session.rate.value | Rate of session per seconds. | integer | gauge |
+| haproxy.info.sockets.max | Maximum number of sockets. | long | gauge |
+| haproxy.info.ssl.backend.key_rate.max | Maximum key rate of SSL backend sessions. | integer | gauge |
+| haproxy.info.ssl.backend.key_rate.value | Key rate of SSL backend sessions. | integer | gauge |
+| haproxy.info.ssl.cache_misses | Number of SSL cache misses. | long | counter |
+| haproxy.info.ssl.cached_lookups | Number of SSL cache lookups. | long | counter |
+| haproxy.info.ssl.frontend.key_rate.max | Maximum key rate of SSL frontend. | integer | gauge |
+| haproxy.info.ssl.frontend.key_rate.value | Key rate of SSL frontend. | integer | gauge |
+| haproxy.info.ssl.frontend.session_reuse.pct | Rate of reuse of SSL frontend sessions. | scaled_float | gauge |
+| haproxy.info.ssl.rate.limit | Rate limit of SSL requests. | integer | gauge |
+| haproxy.info.ssl.rate.max | Maximum rate of SSL requests. | integer | gauge |
+| haproxy.info.ssl.rate.value | Rate of SSL requests. | integer | gauge |
+| haproxy.info.stopping | Number of stopping jobs. | long | gauge |
+| haproxy.info.tasks |  | long | gauge |
+| haproxy.info.threads | Number of threads. | long | gauge |
+| haproxy.info.ulimit_n | Maximum number of open files for the process. | long | gauge |
+| haproxy.info.unstoppable_jobs | Number of unstoppable jobs. | long | gauge |
+| haproxy.info.uptime.sec | Current uptime in seconds. | long | gauge |
+| haproxy.info.zlib_mem_usage.max | Maximum memory usage of zlib. | integer | gauge |
+| haproxy.info.zlib_mem_usage.value | Memory usage of zlib. | integer | gauge |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| process | These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation. | group |  |
+| process.pid | Process id. | long |  |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 ### stat

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: "1.7.2"
+version: "1.8.0"
 description: Collect logs and metrics from HAProxy servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
Type of Change
- Enhancement

## What does this PR do?

Add `metric_type` mapping to info datastream of HA Proxy

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry


## Related issues

- relates #7138

## Screenshots

<img width="2547" alt="image" src="https://github.com/elastic/integrations/assets/101976829/caeedec1-1c5f-4a32-a496-e961af032899">