### PR TITLE
[o365] - update package-spec to 2.9.0

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.19.0"
   changes:
-    - description: Update package to ECS 8.8.0.
+    - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7169
 - version: "1.18.0"
   changes:
     - description: Migrate to CEL input from o365audit input

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Update package to ECS 8.8.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.0"
   changes:
     - description: Migrate to CEL input from o365audit input

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -2,7 +2,7 @@
   type: group
   fields:
     - name: Actor
-      type: array
+      type: group
       fields:
         - name: ID
           type: keyword
@@ -21,7 +21,7 @@
     - name: AlertId
       type: keyword
     - name: AlertLinks
-      type: array
+      type: flattened
     - name: AlertType
       type: keyword
     - name: AppId
@@ -117,7 +117,7 @@
     - name: MailboxOwnerUPN
       type: keyword
     - name: Members
-      type: array
+      type: flattened
     - name: Members.*
       type: object
     - name: ModifiedProperties.*.*
@@ -139,7 +139,7 @@
     - name: Parameters.*
       type: object
     - name: PolicyDetails
-      type: array
+      type: flattened
     - name: PolicyId
       type: keyword
     - name: RecordType
@@ -171,7 +171,7 @@
     - name: SupportTicketId
       type: keyword
     - name: Target
-      type: array
+      type: group
       fields:
         - name: ID
           type: keyword

--- a/packages/o365/data_stream/audit/sample_event.json
+++ b/packages/o365/data_stream/audit/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-02-07T16:43:53.000Z",
     "agent": {
-        "ephemeral_id": "5f159e79-7be4-4825-8443-f19762d873a7",
-        "id": "98fd725a-f0a1-43b2-9951-08d918d20d87",
+        "ephemeral_id": "79788e62-6885-49cb-b397-b329ddb0f349",
+        "id": "c0ee214c-57e5-4a60-80ba-e4dc247eb02e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.9.0"
     },
     "client": {
         "address": "213.97.47.133",
@@ -20,9 +20,9 @@
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "98fd725a-f0a1-43b2-9951-08d918d20d87",
+        "id": "c0ee214c-57e5-4a60-80ba-e4dc247eb02e",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.9.0"
     },
     "event": {
         "action": "PageViewed",
@@ -33,9 +33,8 @@
         "code": "SharePoint",
         "dataset": "o365.audit",
         "id": "99d005e6-a4c6-46fd-117c-08d7abeceab5",
-        "ingested": "2023-07-12T07:48:33Z",
+        "ingested": "2023-07-27T16:10:06Z",
         "kind": "event",
-        "original": "{\"ListItemUniqueId\": \"59a8433d-9bb8-cfef-6edc-4c0fc8b86875\", \"ItemType\": \"Page\", \"Workload\": \"OneDrive\", \"OrganizationId\": \"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\", \"UserId\": \"asr@testsiem.onmicrosoft.com\", \"CreationTime\": \"2020-02-07T16:43:53\", \"Site\": \"d5180cfc-3479-44d6-b410-8c985ac894e3\", \"ClientIP\": \"213.97.47.133\", \"WebId\": \"8c5c94bb-8396-470c-87d7-8999f440cd30\", \"UserType\": 0, \"Version\": 1, \"EventSource\": \"SharePoint\", \"UserAgent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0\", \"UserKey\": \"i:0h.f|membership|1003200096971f55@live.com\", \"CustomUniqueId\": true, \"Operation\": \"PageViewed\", \"ObjectId\": \"https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/_layouts/15/onedrive.aspx\", \"Id\": \"99d005e6-a4c6-46fd-117c-08d7abeceab5\", \"CorrelationId\": \"622b339f-4000-a000-f25f-92b3478c7a25\", \"RecordType\": 4}",
         "outcome": "success",
         "provider": "OneDrive",
         "type": [
@@ -47,7 +46,7 @@
         "name": "testsiem.onmicrosoft.com"
     },
     "input": {
-        "type": "o365audit"
+        "type": "cel"
     },
     "network": {
         "type": "ipv4"
@@ -85,9 +84,9 @@
         "ip": "213.97.47.133"
     },
     "tags": [
+        "preserve_original_event",
         "forwarded",
-        "o365-audit",
-        "preserve_original_event"
+        "o365-cel"
     ],
     "user": {
         "domain": "testsiem.onmicrosoft.com",

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -42,11 +42,11 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2020-02-07T16:43:53.000Z",
     "agent": {
-        "ephemeral_id": "5f159e79-7be4-4825-8443-f19762d873a7",
-        "id": "98fd725a-f0a1-43b2-9951-08d918d20d87",
+        "ephemeral_id": "79788e62-6885-49cb-b397-b329ddb0f349",
+        "id": "c0ee214c-57e5-4a60-80ba-e4dc247eb02e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.1.0"
+        "version": "8.9.0"
     },
     "client": {
         "address": "213.97.47.133",
@@ -61,9 +61,9 @@ An example event for `audit` looks as following:
         "version": "8.8.0"
     },
     "elastic_agent": {
-        "id": "98fd725a-f0a1-43b2-9951-08d918d20d87",
+        "id": "c0ee214c-57e5-4a60-80ba-e4dc247eb02e",
         "snapshot": false,
-        "version": "8.1.0"
+        "version": "8.9.0"
     },
     "event": {
         "action": "PageViewed",
@@ -74,9 +74,8 @@ An example event for `audit` looks as following:
         "code": "SharePoint",
         "dataset": "o365.audit",
         "id": "99d005e6-a4c6-46fd-117c-08d7abeceab5",
-        "ingested": "2023-07-12T07:48:33Z",
+        "ingested": "2023-07-27T16:10:06Z",
         "kind": "event",
-        "original": "{\"ListItemUniqueId\": \"59a8433d-9bb8-cfef-6edc-4c0fc8b86875\", \"ItemType\": \"Page\", \"Workload\": \"OneDrive\", \"OrganizationId\": \"b86ab9d4-fcf1-4b11-8a06-7a8f91b47fbd\", \"UserId\": \"asr@testsiem.onmicrosoft.com\", \"CreationTime\": \"2020-02-07T16:43:53\", \"Site\": \"d5180cfc-3479-44d6-b410-8c985ac894e3\", \"ClientIP\": \"213.97.47.133\", \"WebId\": \"8c5c94bb-8396-470c-87d7-8999f440cd30\", \"UserType\": 0, \"Version\": 1, \"EventSource\": \"SharePoint\", \"UserAgent\": \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0\", \"UserKey\": \"i:0h.f|membership|1003200096971f55@live.com\", \"CustomUniqueId\": true, \"Operation\": \"PageViewed\", \"ObjectId\": \"https://testsiem-my.sharepoint.com/personal/asr_testsiem_onmicrosoft_com/_layouts/15/onedrive.aspx\", \"Id\": \"99d005e6-a4c6-46fd-117c-08d7abeceab5\", \"CorrelationId\": \"622b339f-4000-a000-f25f-92b3478c7a25\", \"RecordType\": 4}",
         "outcome": "success",
         "provider": "OneDrive",
         "type": [
@@ -88,7 +87,7 @@ An example event for `audit` looks as following:
         "name": "testsiem.onmicrosoft.com"
     },
     "input": {
-        "type": "o365audit"
+        "type": "cel"
     },
     "network": {
         "type": "ipv4"
@@ -126,9 +125,9 @@ An example event for `audit` looks as following:
         "ip": "213.97.47.133"
     },
     "tags": [
+        "preserve_original_event",
         "forwarded",
-        "o365-audit",
-        "preserve_original_event"
+        "o365-cel"
     ],
     "user": {
         "domain": "testsiem.onmicrosoft.com",
@@ -231,7 +230,7 @@ An example event for `audit` looks as following:
 | o365.audit.ActorYammerUserId |  | keyword |
 | o365.audit.AlertEntityId |  | keyword |
 | o365.audit.AlertId |  | keyword |
-| o365.audit.AlertLinks |  | array |
+| o365.audit.AlertLinks |  | flattened |
 | o365.audit.AlertType |  | keyword |
 | o365.audit.AppId |  | keyword |
 | o365.audit.ApplicationDisplayName |  | keyword |
@@ -279,7 +278,7 @@ An example event for `audit` looks as following:
 | o365.audit.MailboxOwnerMasterAccountSid |  | keyword |
 | o365.audit.MailboxOwnerSid |  | keyword |
 | o365.audit.MailboxOwnerUPN |  | keyword |
-| o365.audit.Members |  | array |
+| o365.audit.Members |  | flattened |
 | o365.audit.Members.\* |  | object |
 | o365.audit.ModifiedProperties.\*.\* |  | object |
 | o365.audit.Name |  | keyword |
@@ -290,7 +289,7 @@ An example event for `audit` looks as following:
 | o365.audit.OrganizationName |  | keyword |
 | o365.audit.OriginatingServer |  | keyword |
 | o365.audit.Parameters.\* |  | object |
-| o365.audit.PolicyDetails |  | array |
+| o365.audit.PolicyDetails |  | flattened |
 | o365.audit.PolicyId |  | keyword |
 | o365.audit.RecordType |  | keyword |
 | o365.audit.ResultStatus |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,11 +1,9 @@
 name: o365
 title: Microsoft 365
-version: "1.18.0"
-release: ga
+version: "1.19.0"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: [security, productivity_security]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package spec to 2.9.0
- Ensure that user.roles is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.8.0 -ecs-git-ref=v8.8.0 -format-version=2.9.0 packages/o365
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870