### PR TITLE
[elastic_agent] Add path_unmatch to filebeat_input metrics mappings

### DIFF
--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -21,21 +21,6 @@
       object_type: double
       object_type_mapping_type: "*"
       description: Map all fields with `path_match:``*.histogram.*` to `double`
-    - name: '*_total'
-      type: object
-      object_type: long
-      object_type_mapping_type: "*"
-      description: Map all fields with `path_match:``*_total` to `long`
-    - name: '*_gauge'
-      type: object
-      object_type: long
-      object_type_mapping_type: "*"
-      description: Map all fields with `path_match:``*_gauge` to `long`
-    - name: '*_length'
-      type: object
-      object_type: long
-      object_type_mapping_type: "*"
-      description: Map all fields with `path_match:``*_length` to `long`
     # CEL specific fields
     - name: resource
       type: keyword

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
@@ -6,3 +6,22 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: true
+      # Use this instead of fields.yml so that path_unmatch can be used.
+      dynamic_templates:
+        - filebeat_input.*_gauge:
+            path_match: filebeat_input.*_gauge
+            path_unmatch: '*.histogram.*'
+            mapping:
+              type: long
+            match_mapping_type: '*'
+        - filebeat_input.*_length:
+            path_match: filebeat_input.*_length
+            path_unmatch: '*.histogram.*'
+            mapping:
+              type: long
+            match_mapping_type: '*'
+        - filebeat_input.*_total:
+            path_match: filebeat_input.*_total
+            path_unmatch: '*.histogram.*'
+            mapping:
+              type: long


### PR DESCRIPTION
## What does this PR do?

Explicitly specify not to match `*.histogram.*` paths.

Fixes https://github.com/elastic/beats/issues/35933

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Mappings

metrics-elastic_agent.filebeat_input@package

```json
{
  "dynamic": true,
  "dynamic_templates": [
    {
      "container.labels": {
        "path_match": "container.labels.*",
        "mapping": {
          "type": "keyword"
        },
        "match_mapping_type": "string"
      }
    },
    {
      "filebeat_input.*.histogram.count": {
        "path_match": "filebeat_input.*.histogram.count",
        "mapping": {
          "type": "long"
        },
        "match_mapping_type": "*"
      }
    },
    {
      "filebeat_input.*.histogram.*": {
        "path_match": "filebeat_input.*.histogram.*",
        "mapping": {
          "type": "double"
        },
        "match_mapping_type": "*"
      }
    },
    {
      "filebeat_input.*_gauge": {
        "path_match": "filebeat_input.*_gauge",
        "path_unmatch": "*.histogram.*",
        "mapping": {
          "type": "long"
        },
        "match_mapping_type": "*"
      }
    },
    {
      "filebeat_input.*_length": {
        "path_match": "filebeat_input.*_length",
        "path_unmatch": "*.histogram.*",
        "mapping": {
          "type": "long"
        },
        "match_mapping_type": "*"
      }
    },
    {
      "filebeat_input.*_total": {
        "path_match": "filebeat_input.*_total",
        "path_unmatch": "*.histogram.*",
        "mapping": {
          "type": "long"
        }
      }
    }
  ],
  "properties": {
    "cloud": {
      "properties": {
        "availability_zone": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "image": {
          "properties": {
            "id": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "instance": {
          "properties": {
            "name": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "id": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "provider": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "machine": {
          "properties": {
            "type": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "project": {
          "properties": {
            "id": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "region": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "account": {
          "properties": {
            "id": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        }
      }
    },
    "container": {
      "properties": {
        "image": {
          "properties": {
            "name": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "name": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "id": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    },
    "agent": {
      "properties": {
        "build": {
          "properties": {
            "original": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "name": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "id": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "ephemeral_id": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "type": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "version": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    },
    "@timestamp": {
      "ignore_malformed": false,
      "type": "date"
    },
    "ecs": {
      "properties": {
        "version": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    },
    "log": {
      "properties": {
        "level": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    },
    "data_stream": {
      "properties": {
        "namespace": {
          "type": "constant_keyword"
        },
        "type": {
          "type": "constant_keyword"
        },
        "dataset": {
          "type": "constant_keyword"
        }
      }
    },
    "host": {
      "properties": {
        "hostname": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "os": {
          "properties": {
            "build": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "kernel": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "codename": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "name": {
              "ignore_above": 1024,
              "type": "keyword",
              "fields": {
                "text": {
                  "type": "text"
                }
              }
            },
            "family": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "version": {
              "ignore_above": 1024,
              "type": "keyword"
            },
            "platform": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        },
        "domain": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "ip": {
          "type": "ip"
        },
        "containerized": {
          "type": "boolean"
        },
        "name": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "id": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "type": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "mac": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "architecture": {
          "ignore_above": 1024,
          "type": "keyword"
        }
      }
    },
    "filebeat_input": {
      "properties": {
        "input": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "resource": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "id": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "bind_address": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "device": {
          "ignore_above": 1024,
          "type": "keyword"
        },
        "cel_executions": {
          "type": "long"
        },
        "system_packet_drops": {
          "type": "long"
        }
      }
    }
  }
}
```
