### PR TITLE
[Cloud Security] Injest now copies cluster_id -> orchestrator.cluster.id if null (due to pre 8.8.0 agents)

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -4,7 +4,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-
+- version: "1.5.0-preview28"
+  changes:
+    - description: Added ingest processor to copy cluster_id to orchestrator.cluster.id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7185
 - version: "1.5.0-preview27"
   changes:
     - description: Seperate KSPM and CSPM cloudformation templates

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -11,7 +11,7 @@ processors:
     if: ctx.rule?.benchmark?.posture_type == null
 - set:
     field: orchestrator.cluster.id
-    value: ctx.cluster_id
+    copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
     if: ctx.orchestrator?.cluster?.id == null
 on_failure:

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
     value: 'kspm'
     description: 'Backward compatibility cloudbeat version < 8.7'
     if: ctx.rule?.benchmark?.posture_type == null
+- set:
+    field: orchestrator.cluster.id
+    value: ctx.cluster_id
+    description: 'Backward compatibility cloudbeat version < 8.8'
+    if: ctx.orchestrator?.cluster?.id == null
 on_failure:
 - set:
     field: error.message

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview27"
+version: "1.5.0-preview28"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## What does this PR do?

Adds backwards compatibility for the cluster_id field for agents pre 8.8.0

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/kibana/issues/155463