### PR TITLE
Added IP related field mapping to ECS

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Added ECS definition of dns.resolved_ip to network_traffic.tls
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7189
 - version: "1.20.0"
   changes:
     - description: Document duration units.

--- a/packages/network_traffic/data_stream/tls/fields/ecs.yml
+++ b/packages/network_traffic/data_stream/tls/fields/ecs.yml
@@ -263,6 +263,8 @@
 - external: ecs
   name: destination.geo.region_name
 - external: ecs
+  name: dns.resolved_ip
+- external: ecs
   name: server.geo.city_name
 - external: ecs
   name: server.geo.continent_name

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.38.3"
+  changes:
+    - description: Added ECS definition of ip and geo_point related fields to system.application
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7189
+    - description: Added ECS definition of ip and geo_point related fields to system.application
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7189
 - version: "1.38.1"
   changes:
     - description: Remove duplicated fields in diskio datastream

--- a/packages/system/data_stream/application/fields/ecs.yml
+++ b/packages/system/data_stream/application/fields/ecs.yml
@@ -1,7 +1,25 @@
 - external: ecs
+  name: client.geo.location
+- external: ecs
+  name: client.ip
+- external: ecs
+  name: client.nat.ip
+- external: ecs
+  name: destination.geo.location
+- external: ecs
+  name: destination.ip
+- external: ecs
+  name: destination.nat.ip
+- external: ecs
+  name: dns.resolved_ip
+- external: ecs
   name: error.message
 - external: ecs
   name: error.code
+- external: ecs
+  name: event.action
+- external: ecs
+  name: event.category
 - external: ecs
   name: event.code
 - external: ecs
@@ -9,6 +27,42 @@
 - external: ecs
   name: event.ingested
 - external: ecs
+  name: event.kind
+- external: ecs
+  name: event.module
+- external: ecs
   name: event.original
 - external: ecs
+  name: event.outcome
+- external: ecs
+  name: event.provider
+- external: ecs
+  name: event.sequence
+- external: ecs
+  name: event.type
+- external: ecs
+  name: host.geo.location
+- external: ecs
+  name: host.ip
+- external: ecs
   name: message
+- external: ecs
+  name: observer.geo.location
+- external: ecs
+  name: observer.ip
+- external: ecs
+  name: server.geo.location
+- external: ecs
+  name: server.ip
+- external: ecs
+  name: server.nat.ip
+- external: ecs
+  name: source.geo.location
+- external: ecs
+  name: source.ip
+- external: ecs
+  name: source.nat.ip
+- external: ecs
+  name: threat.indicator.geo.location
+- external: ecs
+  name: threat.indicator.ip

--- a/packages/system/data_stream/system/fields/ecs.yml
+++ b/packages/system/data_stream/system/fields/ecs.yml
@@ -1,4 +1,18 @@
 - external: ecs
+  name: client.geo.location
+- external: ecs
+  name: client.ip
+- external: ecs
+  name: client.nat.ip
+- external: ecs
+  name: destination.geo.location
+- external: ecs
+  name: destination.ip
+- external: ecs
+  name: destination.nat.ip
+- external: ecs
+  name: dns.resolved_ip
+- external: ecs
   name: error.message
 - external: ecs
   name: error.code
@@ -27,4 +41,28 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.geo.location
+- external: ecs
+  name: host.ip
+- external: ecs
   name: message
+- external: ecs
+  name: observer.geo.location
+- external: ecs
+  name: observer.ip
+- external: ecs
+  name: server.geo.location
+- external: ecs
+  name: server.ip
+- external: ecs
+  name: server.nat.ip
+- external: ecs
+  name: source.geo.location
+- external: ecs
+  name: source.ip
+- external: ecs
+  name: source.nat.ip
+- external: ecs
+  name: threat.indicator.geo.location
+- external: ecs
+  name: threat.indicator.ip

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.3"
+  changes:
+    - description: Added ECS definition of dns.resolved_ip to zeek.connection
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7189
 - version: "2.11.2"
   changes:
     - description: Add missing processors support for dhcp and smb_mapping logs.

--- a/packages/zeek/data_stream/connection/fields/ecs.yml
+++ b/packages/zeek/data_stream/connection/fields/ecs.yml
@@ -31,6 +31,8 @@
 - external: ecs
   name: destination.port
 - external: ecs
+  name: dns.resolved_ip
+- external: ecs
   name: ecs.version
 - external: ecs
   name: error.message


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Add IP fields mapping to ECS for a few packages including system.system, system.application, zeek, network_traffic.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #7187