### PR TITLE
fortigate_fortimail: handle block rule addition and removal

### DIFF
--- a/packages/fortinet_fortimail/changelog.yml
+++ b/packages/fortinet_fortimail/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.0"
+  changes:
+    - description: Handle block rule addition and removal.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7191
 - version: "2.5.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log
+++ b/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log
@@ -17,3 +17,5 @@
 <190>date=2023-02-06,time=19:35:20.062,device_id=FEVM02TM23000064,log_id=0704003868,type=kevent,subtype=update,pri=information,,msg="Loaded avdb 91.00325(02/06/0023 05:39) using av engine 6.283"
 <190>date=2023-02-06,time=19:35:20.068,device_id=FEVM02TM23000064,log_id=0704001887,type=kevent,subtype=update,pri=information,,msg="Update result: virus db:yes, virus engine:no, spam db:no, spam engine:no"
 <190>date=2023-02-07,time=14:38:16.642,device_id=FEVM02TM23000064,log_id=0704001887,type=kevent,subtype=update,pri=information,,msg="Internet service DB update succeeded"
+<191>date=2023-07-28,time=04:48:36.567,device_id=FEVM02xxnnnnnn,log_id=0702001939,type=kevent,subtype=system,pri=debug, user=,ui=,action=none,status=none,msg="authserver: removed block rule for 81.2.69.144"
+<191>date=2023-07-28,time=03:58:41.726,device_id=FEVM02xxnnnnnn,log_id=0702001941,type=kevent,subtype=system,pri=debug, user=,ui=,action=none,status=none,msg="authserver: added block rule for 81.2.69.144 until 2023-07-28 04:48 -0400"

--- a/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -1412,7 +1412,7 @@
                 ]
             },
             "ecs": {
-                "version": "8.8.0"
+                "version": "8.9.0"
             },
             "event": {
                 "action": "removed_block_rule",
@@ -1476,7 +1476,7 @@
                 ]
             },
             "ecs": {
-                "version": "8.8.0"
+                "version": "8.9.0"
             },
             "event": {
                 "action": "added_block_rule",

--- a/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
+++ b/packages/fortinet_fortimail/data_stream/log/_dev/test/pipeline/test-system.log-expected.json
@@ -1403,6 +1403,134 @@
                 "preserve_original_event",
                 "preserve_duplicate_custom_fields"
             ]
+        },
+        {
+            "@timestamp": "2023-07-28T04:48:36.567Z",
+            "client": {
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "removed_block_rule",
+                "code": "0702001939",
+                "kind": "event",
+                "original": "\u003c191\u003edate=2023-07-28,time=04:48:36.567,device_id=FEVM02xxnnnnnn,log_id=0702001939,type=kevent,subtype=system,pri=debug, user=,ui=,action=none,status=none,msg=\"authserver: removed block rule for 81.2.69.144\"",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "fortinet_fortimail": {
+                "log": {
+                    "action": "none",
+                    "date": "2023-07-28",
+                    "device_id": "FEVM02xxnnnnnn",
+                    "id": "0702001939",
+                    "message": "authserver: removed block rule for 81.2.69.144",
+                    "priority": "debug",
+                    "priority_number": 191,
+                    "status": "none",
+                    "sub_type": "system",
+                    "time": "04:48:36.567",
+                    "type": "kevent"
+                }
+            },
+            "log": {
+                "level": "debug",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 191,
+                    "severity": {
+                        "code": 7
+                    }
+                }
+            },
+            "message": "authserver: removed block rule for 81.2.69.144",
+            "observer": {
+                "product": "FortiMail",
+                "serial_number": "FEVM02xxnnnnnn",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        },
+        {
+            "@timestamp": "2023-07-28T03:58:41.726Z",
+            "client": {
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "ecs": {
+                "version": "8.8.0"
+            },
+            "event": {
+                "action": "added_block_rule",
+                "code": "0702001941",
+                "kind": "event",
+                "original": "\u003c191\u003edate=2023-07-28,time=03:58:41.726,device_id=FEVM02xxnnnnnn,log_id=0702001941,type=kevent,subtype=system,pri=debug, user=,ui=,action=none,status=none,msg=\"authserver: added block rule for 81.2.69.144 until 2023-07-28 04:48 -0400\"",
+                "outcome": "unknown",
+                "type": [
+                    "info"
+                ]
+            },
+            "fortinet_fortimail": {
+                "log": {
+                    "action": "none",
+                    "date": "2023-07-28",
+                    "device_id": "FEVM02xxnnnnnn",
+                    "id": "0702001941",
+                    "message": "authserver: added block rule for 81.2.69.144 until 2023-07-28 04:48 -0400",
+                    "priority": "debug",
+                    "priority_number": 191,
+                    "status": "none",
+                    "sub_type": "system",
+                    "time": "03:58:41.726",
+                    "type": "kevent"
+                }
+            },
+            "log": {
+                "level": "debug",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 191,
+                    "severity": {
+                        "code": 7
+                    }
+                }
+            },
+            "message": "authserver: added block rule for 81.2.69.144 until 2023-07-28 04:48 -0400",
+            "observer": {
+                "product": "FortiMail",
+                "serial_number": "FEVM02xxnnnnnn",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "related": {
+                "ip": [
+                    "81.2.69.144"
+                ]
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
         }
     ]
 }

--- a/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
+++ b/packages/fortinet_fortimail/data_stream/log/elasticsearch/ingest_pipeline/pipeline_system.yml
@@ -86,10 +86,13 @@ processors:
         - '^%{PREFIX} %{DATA}%{IP:fortinet_fortimail.log.ip}%{GREEDYDATA:temp.msg}$'
         - '^%{PREFIX}%{GREEDYDATA:temp.msg}$'
         - '^%{DATA}%{USER} %{DATA}%{IP:fortinet_fortimail.log.ip}%{GREEDYDATA:temp.msg}$'
+        - '^authserver: %{BLOCK_ACTION:temp.block_action} block rule for %{IP:temp.block_ip}$'
+        - '^authserver: %{BLOCK_ACTION:temp.block_action} block rule for %{IP:temp.block_ip} until %{GREEDYDATA}$'
         - '^%{DATA}%{USER} %{GREEDYDATA:temp.msg}$'
       pattern_definitions:
         PREFIX: '%{DATA}(?i)interface %{NUMBER:fortinet_fortimail.log.port:long}%{DATA} %{USER}'
         USER: '(?i)user %{NOTSPACE:temp.user}'
+        BLOCK_ACTION: '(?:added|removed)'
   - set:
       field: source.port
       copy_from: fortinet_fortimail.log.port
@@ -99,6 +102,20 @@ processors:
       value: '{{{fortinet_fortimail.log.ip}}}'
       allow_duplicates: false
       if: ctx.fortinet_fortimail?.log?.ip != null
+  - append:
+      field: related.ip
+      value: '{{{temp.block_ip}}}'
+      allow_duplicates: false
+      if: ctx.temp?.block_ip != null
+  - append:
+      field: client.ip
+      value: '{{{temp.block_ip}}}'
+      allow_duplicates: false
+      if: ctx.temp?.block_ip != null
+  - set:
+      field: event.action
+      value: '{{{temp.block_action}}}_block_rule'
+      if: ctx.temp?.block_ip != null
   - append:
       field: fortinet_fortimail.log.user
       value: '{{{temp.user}}}'
@@ -122,6 +139,7 @@ processors:
       field: event.action
       copy_from: fortinet_fortimail.log.action
       ignore_empty_value: true
+      override: false
   - rename:
       field: temp.module
       target_field: fortinet_fortimail.log.module

--- a/packages/fortinet_fortimail/manifest.yml
+++ b/packages/fortinet_fortimail/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortimail
 title: Fortinet FortiMail
-version: "2.5.0"
+version: "2.6.0"
 description: Collect logs from Fortinet FortiMail instances with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Parse out affected host IP when block rules are added or removed.
  
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #7180 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
