### PR TITLE
[microsoft_dhcp] Add DHCP qresult descriptions

### DIFF
--- a/packages/microsoft_dhcp/changelog.yml
+++ b/packages/microsoft_dhcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Add QResult description based on numerical value
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999
 - version: "1.17.0"
   changes:
     - description: Add long description to event.reason

--- a/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/microsoft_dhcp/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -97,6 +97,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -141,6 +142,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -185,6 +187,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -231,6 +234,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -275,6 +279,7 @@
                 "dhcp": {
                     "dns_error_code": "10054",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -319,6 +324,7 @@
                 "dhcp": {
                     "dns_error_code": "10054",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -409,6 +415,7 @@
             "microsoft": {
                 "dhcp": {
                     "result": "0",
+                    "result_description": "NoQuarantine",
                     "transaction_id": "17739"
                 }
             },
@@ -458,6 +465,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "0",
+                    "result_description": "NoQuarantine",
                     "transaction_id": "3096562285",
                     "vendor": {
                         "hex": "0x4D53465420352E30",
@@ -499,6 +507,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -543,6 +552,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -585,6 +595,7 @@
                 "dhcp": {
                     "dns_error_code": "0",
                     "result": "6",
+                    "result_description": "No Quarantine Information",
                     "transaction_id": "0"
                 }
             },
@@ -732,6 +743,7 @@
                     "dns_error_code": "0",
                     "relay_agent_info": "0x0106766C323E3580",
                     "result": "0",
+                    "result_description": "NoQuarantine",
                     "transaction_id": "3327778676",
                     "vendor": {
                         "hex": "0x4850452E20485045204F6666696312336F6D6E65637420313825302A31325847542D345346502B20537769746368",

--- a/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
+++ b/packages/microsoft_dhcp/data_stream/log/elasticsearch/ingest_pipeline/dhcp.yml
@@ -373,6 +373,27 @@ processors:
         }
         def hm = new HashMap(params[ctx.event.code]);
         hm.forEach((k, v) -> ctx.event[k] = v);
+  - script:
+      description: Set the QResult description based on numerical value.
+      lang: painless
+      tag: Add QResult Description
+      params:
+        "0":
+          result_description: NoQuarantine
+        "1":
+          result_description: Quarantine
+        "2":
+          result_description: Drop Packet
+        "3":
+          result_description: Probation
+        "6":
+          result_description: No Quarantine Information
+      source: |-
+        if (ctx.microsoft?.dhcp?.result == null || params.get(ctx.microsoft.dhcp.result) == null) {
+          return;
+        }
+        def hm = new HashMap(params[ctx.microsoft.dhcp.result]);
+        hm.forEach((k, v) -> ctx.microsoft.dhcp[k] = v);
   - set:
       field: event.outcome
       value: success

--- a/packages/microsoft_dhcp/data_stream/log/fields/fields.yml
+++ b/packages/microsoft_dhcp/data_stream/log/fields/fields.yml
@@ -8,7 +8,11 @@
     - name: result
       type: keyword
       description: |
-        The DHCP result type, for example "NoQuarantine", "Drop Packet" etc.
+        The DHCP result type in numerical value, for example "NoQuarantine" is 0, "Quaratine" is 1, "Drop Packet" is 2 etc.
+    - name: result_description
+      type: keyword
+      description: |
+        The DHCP result type from numerical value, for example, 0 is "NoQuarantine", 1 is "Quarantine", 2 is "Drop Packet" etc.
     - name: probation_time
       type: keyword
       description: |

--- a/packages/microsoft_dhcp/data_stream/log/sample_event.json
+++ b/packages/microsoft_dhcp/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2001-01-01T01:01:01.000-05:00",
     "agent": {
-        "ephemeral_id": "d8fa21a0-e19c-4412-917a-0b3b12afb08d",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "a53c1bd7-936f-4ca8-8740-84d1504d537e",
+        "id": "4e45636b-5ca2-4145-9926-801ca8065d87",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "microsoft_dhcp.log",
@@ -16,9 +16,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "4e45636b-5ca2-4145-9926-801ca8065d87",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.9.0"
     },
     "event": {
         "action": "dhcp-dns-update",
@@ -28,13 +28,11 @@
         ],
         "code": "35",
         "dataset": "microsoft_dhcp.log",
-        "ingested": "2023-07-24T14:29:55Z",
+        "ingested": "2023-08-01T16:33:06Z",
         "kind": "event",
         "original": "35,01/01/01,01:01:01,DNS update request failed,192.168.2.1,host.test.com,000000000000,",
         "outcome": "failure",
-        "reason": [
-            "DNS update request failed."
-        ],
+        "reason": "DNS update request failed.",
         "timezone": "America/New_York",
         "type": [
             "connection",
@@ -65,10 +63,10 @@
     "observer": {
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.22.0.10"
+            "192.168.16.7"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-10-07"
         ]
     },
     "tags": [

--- a/packages/microsoft_dhcp/docs/README.md
+++ b/packages/microsoft_dhcp/docs/README.md
@@ -22,11 +22,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2001-01-01T01:01:01.000-05:00",
     "agent": {
-        "ephemeral_id": "d8fa21a0-e19c-4412-917a-0b3b12afb08d",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "a53c1bd7-936f-4ca8-8740-84d1504d537e",
+        "id": "4e45636b-5ca2-4145-9926-801ca8065d87",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "microsoft_dhcp.log",
@@ -37,9 +37,9 @@ An example event for `log` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "4e45636b-5ca2-4145-9926-801ca8065d87",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.9.0"
     },
     "event": {
         "action": "dhcp-dns-update",
@@ -49,13 +49,11 @@ An example event for `log` looks as following:
         ],
         "code": "35",
         "dataset": "microsoft_dhcp.log",
-        "ingested": "2023-07-24T14:29:55Z",
+        "ingested": "2023-08-01T16:33:06Z",
         "kind": "event",
         "original": "35,01/01/01,01:01:01,DNS update request failed,192.168.2.1,host.test.com,000000000000,",
         "outcome": "failure",
-        "reason": [
-            "DNS update request failed."
-        ],
+        "reason": "DNS update request failed.",
         "timezone": "America/New_York",
         "type": [
             "connection",
@@ -86,10 +84,10 @@ An example event for `log` looks as following:
     "observer": {
         "hostname": "docker-fleet-agent",
         "ip": [
-            "172.22.0.10"
+            "192.168.16.7"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-10-07"
         ]
     },
     "tags": [
@@ -137,7 +135,8 @@ An example event for `log` looks as following:
 | microsoft.dhcp.error_code | DHCP server error code. | keyword |
 | microsoft.dhcp.probation_time | The probation time before lease ends on specific IP. | keyword |
 | microsoft.dhcp.relay_agent_info | Information about DHCP relay agent used for the DHCP request. | keyword |
-| microsoft.dhcp.result | The DHCP result type, for example "NoQuarantine", "Drop Packet" etc. | keyword |
+| microsoft.dhcp.result | The DHCP result type in numerical value, for example "NoQuarantine" is 0, "Quaratine" is 1, "Drop Packet" is 2 etc. | keyword |
+| microsoft.dhcp.result_description | The DHCP result type from numerical value, for example, 0 is "NoQuarantine", 1 is "Quarantine", 2 is "Drop Packet" etc. | keyword |
 | microsoft.dhcp.subnet_prefix | The number of bits for the subnet prefix. | keyword |
 | microsoft.dhcp.transaction_id | The DHCP transaction ID. | keyword |
 | microsoft.dhcp.user.hex | Hex representation of the user. | keyword |

--- a/packages/microsoft_dhcp/manifest.yml
+++ b/packages/microsoft_dhcp/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: microsoft_dhcp
 title: Microsoft DHCP
-version: "1.17.0"
+version: "1.18.0"
 description: Collect logs from Microsoft DHCP with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement


## What does this PR do?
Today the QResult is stored in the event logs as a number which is usually 6 or 0 which will mean nothing to the end user if they don't understand the correlation. 

This PR will add a new field called `microsoft.dhcp.result_description` to events based on that numerical value of the quarantine result. The event logs contain the mapping for this data and cannot be found in Microsoft's official documentation.

This is from the DHCP event log when it gets created (Notice the QResult Line):
```
...snipped for brevity...
34	DNS update request failed.as the DNS update request queue limit exceeded.
35	DNS update request failed.
36	Packet dropped because the server is in failover standby role or the hash of the client ID does not match.
50+	Codes above 50 are used for Rogue Server Detection information.

QResult: 0: NoQuarantine, 1:Quarantine, 2:Drop Packet, 3:Probation,6:No Quarantine Information ProbationTime:Year-Month-Day Hour:Minute:Second:MilliSecond.

ID,Date,Time,Description,IP Address,Host Name,MAC Address,User Name, TransactionID, QResult,Probationtime, CorrelationID,Dhcid,VendorClass(Hex),VendorClass(ASCII),UserClass(Hex),UserClass(ASCII),RelayAgentInformation,DnsRegError.
24,07/28/23,00:00:52,Database Cleanup Begin,,,,,0,6,,,,,,,,,0
```

The mappings are as follows:
```
      description: Set the QResult description based on numerical value.
      lang: painless
      tag: Add QResult Description
      params:
        "0":
          result_description: NoQuarantine
        "1":
          result_description: Quarantine
        "2":
          result_description: Drop Packet
        "3":
          result_description: Probation
        "6":
          result_description: No Quarantine Information
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
