### PR TITLE
tenable_sc: add tenable_sc.vulnerability.age field

### DIFF
--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Add `tenable_sc.vulnerability.age` field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7210
+    - description: Update User-Agent version sent to API.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7210
 - version: "1.12.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -19,7 +19,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.6.2)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
   - set:
       target: body.query.tool
       value: 'sumip'

--- a/packages/tenable_sc/data_stream/asset/sample_event.json
+++ b/packages/tenable_sc/data_stream/asset/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-01-13T12:38:22.330Z",
+    "@timestamp": "2023-08-01T23:17:58.727Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "b9f53463-dbc2-4a97-81ca-4c9bc699d776",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.asset",
@@ -16,18 +16,18 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "host"
         ],
-        "created": "2023-01-13T12:38:22.330Z",
+        "created": "2023-08-01T23:17:58.727Z",
         "dataset": "tenable_sc.asset",
-        "ingested": "2023-01-13T12:38:23Z",
+        "ingested": "2023-08-01T23:17:59Z",
         "kind": "state",
         "original": "{\"biosGUID\":\"9e8c4d43-982b-4405-a76c-d56c1d6cf117\",\"dnsName\":\"rnkmigauv2l8zeyf.example\",\"hostUniqueness\":\"repositoryID,ip,dnsName\",\"ip\":\"0.0.228.153\",\"lastAuthRun\":\"\",\"lastUnauthRun\":\"\",\"macAddress\":\"00:00:00:47:05:0d\",\"mcafeeGUID\":\"\",\"netbiosName\":\"UNKNOWN\\\\RNKMIGAUV2L8ZEYF.EXAMPLE\",\"osCPE\":\"cpe:/o:microsoft:windows_10:::x64-home\",\"pluginSet\":\"201901281542\",\"policyName\":\"Basic Agent Scan\",\"repository\":{\"dataFormat\":\"IPv4\",\"description\":\"\",\"id\":\"2\",\"name\":\"Staged-Large\",\"sciID\":\"1\"},\"score\":\"307\",\"severityCritical\":\"6\",\"severityHigh\":\"4\",\"severityInfo\":\"131\",\"severityLow\":\"0\",\"severityMedium\":\"9\",\"total\":\"150\",\"tpmID\":\"\",\"uniqueness\":\"repositoryID,ip,dnsName\",\"uuid\":\"4add65d0-27fc-491c-91ba-3f498a61f49e\"}",
         "type": [

--- a/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
@@ -19,7 +19,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.6.2)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
   - set:
       target: url.params.fields
       value: id,name,description,family,type,copyright,version,sourceFile,dependencies,requiredPorts,requiredUDPPorts,cpe,srcPort,dstPort,protocol,riskFactor,solution,seeAlso,synopsis,checkType,exploitEase,exploitAvailable,exploitFrameworks,cvssVector,cvssVectorBF,baseScore,temporalScore,cvssV3Vector,cvssV3VectorBF,cvssV3BaseScore,cvssV3TemporalScore,vprScore,vprContext,stigSeverity,pluginPubDate,pluginModDate,patchPubDate,patchModDate,vulnPubDate,modifiedTime,md5,xrefs

--- a/packages/tenable_sc/data_stream/plugin/sample_event.json
+++ b/packages/tenable_sc/data_stream/plugin/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-09-27T01:33:53.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "4f61175a-8284-4d28-8c76-0106e7caec68",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.plugin",
@@ -16,15 +16,15 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:39:03.654Z",
+        "created": "2023-08-01T23:18:42.892Z",
         "dataset": "tenable_sc.plugin",
-        "ingested": "2023-01-13T12:39:04Z",
+        "ingested": "2023-08-01T23:18:43Z",
         "kind": "event",
         "original": "{\"baseScore\":\"7.8\",\"checkType\":\"remote\",\"copyright\":\"This script is Copyright (C) 2003-2020 John Lampe\",\"cpe\":\"\",\"cvssV3BaseScore\":null,\"cvssV3TemporalScore\":null,\"cvssV3Vector\":\"\",\"cvssV3VectorBF\":\"0\",\"cvssVector\":\"AV:N/AC:L/Au:N/C:N/I:N/A:C/E:U/RL:OF/RC:C\",\"cvssVectorBF\":\"2164920932\",\"dependencies\":\"find_service1.nasl,http_version.nasl,www_fingerprinting_hmap.nasl\",\"description\":\"Microsoft IIS, running Frontpage extensions, is vulnerable to a remote denial of service attack usually called the 'malformed web submission' vulnerability.  An attacker, exploiting this vulnerability, will be able to render the service unusable.\\n\\nIf this machine serves a business-critical function, there could be an impact to the business.\",\"dstPort\":null,\"exploitAvailable\":\"false\",\"exploitEase\":\"No known exploits are available\",\"exploitFrameworks\":\"\",\"family\":{\"id\":\"11\",\"name\":\"Web Servers\",\"type\":\"active\"},\"id\":\"10585\",\"md5\":\"38b2147401eb5c3a15af52182682f345\",\"modifiedTime\":\"1632706433\",\"name\":\"Microsoft IIS Frontpage Server Extensions (FPSE) Malformed Form DoS\",\"patchModDate\":\"-1\",\"patchPubDate\":\"-1\",\"pluginModDate\":\"1591963200\",\"pluginPubDate\":\"1058875200\",\"protocol\":\"\",\"requiredPorts\":\"\",\"requiredUDPPorts\":\"\",\"riskFactor\":\"High\",\"seeAlso\":\"https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2000/ms00-100\",\"solution\":\"Microsoft has released a set of patches for IIS 4.0 and 5.0.\",\"sourceFile\":\"IIS_frontpage_DOS_2.nasl\",\"srcPort\":null,\"stigSeverity\":null,\"synopsis\":\"The remote web server is vulnerable to a denial of service\",\"temporalScore\":\"5.8\",\"type\":\"active\",\"version\":\"1.28\",\"vprContext\":\"[{\\\"id\\\":\\\"age_of_vuln\\\",\\\"name\\\":\\\"Vulnerability Age\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"730 days +\\\"},{\\\"id\\\":\\\"cvssV3_impactScore\\\",\\\"name\\\":\\\"CVSS v3 Impact Score\\\",\\\"type\\\":\\\"number\\\",\\\"value\\\":3.6000000000000001},{\\\"id\\\":\\\"exploit_code_maturity\\\",\\\"name\\\":\\\"Exploit Code Maturity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Unproven\\\"},{\\\"id\\\":\\\"product_coverage\\\",\\\"name\\\":\\\"Product Coverage\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Low\\\"},{\\\"id\\\":\\\"threat_intensity_last_28\\\",\\\"name\\\":\\\"Threat Intensity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very Low\\\"},{\\\"id\\\":\\\"threat_recency\\\",\\\"name\\\":\\\"Threat Recency\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"\\u003e 365 days\\\"},{\\\"id\\\":\\\"threat_sources_last_28\\\",\\\"name\\\":\\\"Threat Sources\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"}]\",\"vprScore\":\"4.4\",\"vulnPubDate\":\"977486400\",\"xrefs\":\"CVE:CVE-2001-0096, BID:2144, MSFT:MS00-100, MSKB:280322\"}",
         "type": [

--- a/packages/tenable_sc/data_stream/vulnerability/_dev/test/pipeline/test-vulnerability.log-expected.json
+++ b/packages/tenable_sc/data_stream/vulnerability/_dev/test/pipeline/test-vulnerability.log-expected.json
@@ -47,6 +47,7 @@
             "tenable_sc": {
                 "vulnerability": {
                     "accept_risk": "0",
+                    "age": 721,
                     "check_type": "remote",
                     "custom_hash": "Fuc8qcWC98GkPGCrMlfPwDoJMORaLOCRNvpzE/NzpsA=",
                     "dns": {
@@ -171,6 +172,7 @@
             "tenable_sc": {
                 "vulnerability": {
                     "accept_risk": "0",
+                    "age": 721,
                     "check_type": "remote",
                     "custom_hash": "Fuc8qcWC98GkPGCrMlfPwDoJMORaLOCRNvpzE/NzpsA=",
                     "dns": {
@@ -295,6 +297,7 @@
             "tenable_sc": {
                 "vulnerability": {
                     "accept_risk": "0",
+                    "age": 940,
                     "base_score": "0.0",
                     "check_type": "remote",
                     "custom_hash": "qVUXK2YtClsBlXncLYHLhVzynYK4hG2NbT0hY6guQm0=",
@@ -483,6 +486,7 @@
             "tenable_sc": {
                 "vulnerability": {
                     "accept_risk": "0",
+                    "age": 791,
                     "base_score": "7.5",
                     "check_type": "local",
                     "cpe": [
@@ -705,6 +709,7 @@
             "tenable_sc": {
                 "vulnerability": {
                     "accept_risk": "0",
+                    "age": 224,
                     "base_score": "6.8",
                     "check_type": "local",
                     "cpe": [

--- a/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -19,7 +19,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.6.2)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
   - set:
       target: body.query.tool
       value: 'vulndetails'

--- a/packages/tenable_sc/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_sc/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -279,6 +279,12 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+  - script:
+      lang: painless
+      tag: set_vulnerability_age
+      if: ctx.tenable_sc?.vulnerability?.first_seen != null && ctx.tenable_sc?.vulnerability?.last_seen != null
+      source: |
+        ctx.tenable_sc.vulnerability.age = ChronoUnit.DAYS.between(ZonedDateTime.parse(ctx.tenable_sc.vulnerability.first_seen), ZonedDateTime.parse(ctx.tenable_sc.vulnerability.last_seen));
   - set:
       field: tenable_sc.vulnerability.exploit.is_available
       value: true

--- a/packages/tenable_sc/data_stream/vulnerability/fields/fields.yml
+++ b/packages/tenable_sc/data_stream/vulnerability/fields/fields.yml
@@ -5,6 +5,10 @@
       type: keyword
       description: |
         N/A.
+    - name: age
+      type: long
+      description: |
+        The time in days between the first and last time the vulnerability was seen.
     - name: base_score
       type: keyword
       description: |

--- a/packages/tenable_sc/data_stream/vulnerability/sample_event.json
+++ b/packages/tenable_sc/data_stream/vulnerability/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-09-25T16:08:45.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "db98e8d3-4aeb-4dbb-a311-6531eb1bac0c",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.vulnerability",
@@ -16,18 +16,18 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "threat"
         ],
-        "created": "2023-01-13T12:39:40.914Z",
+        "created": "2023-08-01T23:19:26.710Z",
         "dataset": "tenable_sc.vulnerability",
-        "ingested": "2023-01-13T12:39:41Z",
+        "ingested": "2023-08-01T23:19:29Z",
         "kind": "event",
         "original": "{\"acceptRisk\":\"0\",\"baseScore\":\"0.0\",\"bid\":\"\",\"checkType\":\"remote\",\"cpe\":\"\",\"cve\":\"CVE-1999-0524\",\"cvssV3BaseScore\":\"0.0\",\"cvssV3TemporalScore\":\"\",\"cvssV3Vector\":\"AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N\",\"cvssVector\":\"AV:L/AC:L/Au:N/C:N/I:N/A:N\",\"description\":\"The remote host answers to an ICMP timestamp request.  This allows an attacker to know the date that is set on the targeted machine, which may assist an unauthenticated, remote attacker in defeating time-based authentication protocols.\\n\\nTimestamps returned from machines running Windows Vista / 7 / 2008 / 2008 R2 are deliberately incorrect, but usually within 1000 seconds of the actual system time.\",\"dnsName\":\"_gateway.lxd\",\"exploitAvailable\":\"No\",\"exploitEase\":\"\",\"exploitFrameworks\":\"\",\"family\":{\"id\":\"30\",\"name\":\"General\",\"type\":\"active\"},\"firstSeen\":\"1551284872\",\"hasBeenMitigated\":\"0\",\"hostUniqueness\":\"repositoryID,ip,dnsName\",\"ip\":\"10.238.64.1\",\"ips\":\"10.238.64.1\",\"lastSeen\":\"1632586125\",\"macAddress\":\"00:16:3e:a1:12:f7\",\"netbiosName\":\"\",\"operatingSystem\":\"Linux Kernel 2.6\",\"patchPubDate\":\"-1\",\"pluginID\":\"10114\",\"pluginInfo\":\"10114 (0/1) ICMP Timestamp Request Remote Date Disclosure\",\"pluginModDate\":\"1570190400\",\"pluginName\":\"ICMP Timestamp Request Remote Date Disclosure\",\"pluginPubDate\":\"933508800\",\"pluginText\":\"\\u003cplugin_output\\u003eThe remote clock is synchronized with the local clock.\\n\\u003c/plugin_output\\u003e\",\"port\":\"0\",\"protocol\":\"ICMP\",\"recastRisk\":\"0\",\"repository\":{\"dataFormat\":\"IPv4\",\"description\":\"\",\"id\":\"1\",\"name\":\"Live\",\"sciID\":\"1\"},\"riskFactor\":\"None\",\"seeAlso\":\"\",\"severity\":{\"description\":\"Informative\",\"id\":\"0\",\"name\":\"Info\"},\"solution\":\"Filter out the ICMP timestamp requests (13), and the outgoing ICMP timestamp replies (14).\",\"stigSeverity\":\"\",\"synopsis\":\"It is possible to determine the exact time set on the remote host.\",\"temporalScore\":\"\",\"uniqueness\":\"repositoryID,ip,dnsName\",\"uuid\":\"\",\"version\":\"1.48\",\"vprContext\":\"[{\\\"id\\\":\\\"age_of_vuln\\\",\\\"name\\\":\\\"Vulnerability Age\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"730 days +\\\"},{\\\"id\\\":\\\"cvssV3_impactScore\\\",\\\"name\\\":\\\"CVSS v3 Impact Score\\\",\\\"type\\\":\\\"number\\\",\\\"value\\\":0},{\\\"id\\\":\\\"exploit_code_maturity\\\",\\\"name\\\":\\\"Exploit Code Maturity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Unproven\\\"},{\\\"id\\\":\\\"product_coverage\\\",\\\"name\\\":\\\"Product Coverage\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very High\\\"},{\\\"id\\\":\\\"threat_intensity_last_28\\\",\\\"name\\\":\\\"Threat Intensity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very Low\\\"},{\\\"id\\\":\\\"threat_recency\\\",\\\"name\\\":\\\"Threat Recency\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"},{\\\"id\\\":\\\"threat_sources_last_28\\\",\\\"name\\\":\\\"Threat Sources\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"}]\",\"vprScore\":\"0.8\",\"vulnPubDate\":\"788961600\",\"xref\":\"CWE #200\"}",
         "type": [
@@ -71,6 +71,7 @@
     "tenable_sc": {
         "vulnerability": {
             "accept_risk": "0",
+            "age": 940,
             "base_score": "0.0",
             "check_type": "remote",
             "custom_hash": "qVUXK2YtClsBlXncLYHLhVzynYK4hG2NbT0hY6guQm0=",

--- a/packages/tenable_sc/docs/README.md
+++ b/packages/tenable_sc/docs/README.md
@@ -29,13 +29,13 @@ An example event for `asset` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-01-13T12:38:22.330Z",
+    "@timestamp": "2023-08-01T23:17:58.727Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "b9f53463-dbc2-4a97-81ca-4c9bc699d776",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.asset",
@@ -46,18 +46,18 @@ An example event for `asset` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "host"
         ],
-        "created": "2023-01-13T12:38:22.330Z",
+        "created": "2023-08-01T23:17:58.727Z",
         "dataset": "tenable_sc.asset",
-        "ingested": "2023-01-13T12:38:23Z",
+        "ingested": "2023-08-01T23:17:59Z",
         "kind": "state",
         "original": "{\"biosGUID\":\"9e8c4d43-982b-4405-a76c-d56c1d6cf117\",\"dnsName\":\"rnkmigauv2l8zeyf.example\",\"hostUniqueness\":\"repositoryID,ip,dnsName\",\"ip\":\"0.0.228.153\",\"lastAuthRun\":\"\",\"lastUnauthRun\":\"\",\"macAddress\":\"00:00:00:47:05:0d\",\"mcafeeGUID\":\"\",\"netbiosName\":\"UNKNOWN\\\\RNKMIGAUV2L8ZEYF.EXAMPLE\",\"osCPE\":\"cpe:/o:microsoft:windows_10:::x64-home\",\"pluginSet\":\"201901281542\",\"policyName\":\"Basic Agent Scan\",\"repository\":{\"dataFormat\":\"IPv4\",\"description\":\"\",\"id\":\"2\",\"name\":\"Staged-Large\",\"sciID\":\"1\"},\"score\":\"307\",\"severityCritical\":\"6\",\"severityHigh\":\"4\",\"severityInfo\":\"131\",\"severityLow\":\"0\",\"severityMedium\":\"9\",\"total\":\"150\",\"tpmID\":\"\",\"uniqueness\":\"repositoryID,ip,dnsName\",\"uuid\":\"4add65d0-27fc-491c-91ba-3f498a61f49e\"}",
         "type": [
@@ -227,11 +227,11 @@ An example event for `plugin` looks as following:
 {
     "@timestamp": "2021-09-27T01:33:53.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "4f61175a-8284-4d28-8c76-0106e7caec68",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.plugin",
@@ -242,15 +242,15 @@ An example event for `plugin` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-01-13T12:39:03.654Z",
+        "created": "2023-08-01T23:18:42.892Z",
         "dataset": "tenable_sc.plugin",
-        "ingested": "2023-01-13T12:39:04Z",
+        "ingested": "2023-08-01T23:18:43Z",
         "kind": "event",
         "original": "{\"baseScore\":\"7.8\",\"checkType\":\"remote\",\"copyright\":\"This script is Copyright (C) 2003-2020 John Lampe\",\"cpe\":\"\",\"cvssV3BaseScore\":null,\"cvssV3TemporalScore\":null,\"cvssV3Vector\":\"\",\"cvssV3VectorBF\":\"0\",\"cvssVector\":\"AV:N/AC:L/Au:N/C:N/I:N/A:C/E:U/RL:OF/RC:C\",\"cvssVectorBF\":\"2164920932\",\"dependencies\":\"find_service1.nasl,http_version.nasl,www_fingerprinting_hmap.nasl\",\"description\":\"Microsoft IIS, running Frontpage extensions, is vulnerable to a remote denial of service attack usually called the 'malformed web submission' vulnerability.  An attacker, exploiting this vulnerability, will be able to render the service unusable.\\n\\nIf this machine serves a business-critical function, there could be an impact to the business.\",\"dstPort\":null,\"exploitAvailable\":\"false\",\"exploitEase\":\"No known exploits are available\",\"exploitFrameworks\":\"\",\"family\":{\"id\":\"11\",\"name\":\"Web Servers\",\"type\":\"active\"},\"id\":\"10585\",\"md5\":\"38b2147401eb5c3a15af52182682f345\",\"modifiedTime\":\"1632706433\",\"name\":\"Microsoft IIS Frontpage Server Extensions (FPSE) Malformed Form DoS\",\"patchModDate\":\"-1\",\"patchPubDate\":\"-1\",\"pluginModDate\":\"1591963200\",\"pluginPubDate\":\"1058875200\",\"protocol\":\"\",\"requiredPorts\":\"\",\"requiredUDPPorts\":\"\",\"riskFactor\":\"High\",\"seeAlso\":\"https://docs.microsoft.com/en-us/security-updates/SecurityBulletins/2000/ms00-100\",\"solution\":\"Microsoft has released a set of patches for IIS 4.0 and 5.0.\",\"sourceFile\":\"IIS_frontpage_DOS_2.nasl\",\"srcPort\":null,\"stigSeverity\":null,\"synopsis\":\"The remote web server is vulnerable to a denial of service\",\"temporalScore\":\"5.8\",\"type\":\"active\",\"version\":\"1.28\",\"vprContext\":\"[{\\\"id\\\":\\\"age_of_vuln\\\",\\\"name\\\":\\\"Vulnerability Age\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"730 days +\\\"},{\\\"id\\\":\\\"cvssV3_impactScore\\\",\\\"name\\\":\\\"CVSS v3 Impact Score\\\",\\\"type\\\":\\\"number\\\",\\\"value\\\":3.6000000000000001},{\\\"id\\\":\\\"exploit_code_maturity\\\",\\\"name\\\":\\\"Exploit Code Maturity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Unproven\\\"},{\\\"id\\\":\\\"product_coverage\\\",\\\"name\\\":\\\"Product Coverage\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Low\\\"},{\\\"id\\\":\\\"threat_intensity_last_28\\\",\\\"name\\\":\\\"Threat Intensity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very Low\\\"},{\\\"id\\\":\\\"threat_recency\\\",\\\"name\\\":\\\"Threat Recency\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"\\u003e 365 days\\\"},{\\\"id\\\":\\\"threat_sources_last_28\\\",\\\"name\\\":\\\"Threat Sources\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"}]\",\"vprScore\":\"4.4\",\"vulnPubDate\":\"977486400\",\"xrefs\":\"CVE:CVE-2001-0096, BID:2144, MSFT:MS00-100, MSKB:280322\"}",
         "type": [
@@ -492,11 +492,11 @@ An example event for `vulnerability` looks as following:
 {
     "@timestamp": "2021-09-25T16:08:45.000Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "db98e8d3-4aeb-4dbb-a311-6531eb1bac0c",
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.8.2"
     },
     "data_stream": {
         "dataset": "tenable_sc.vulnerability",
@@ -507,18 +507,18 @@ An example event for `vulnerability` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "a20cdb6f-895d-4b3d-8104-2f2a3063208b",
+        "snapshot": false,
+        "version": "8.8.2"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "threat"
         ],
-        "created": "2023-01-13T12:39:40.914Z",
+        "created": "2023-08-01T23:19:26.710Z",
         "dataset": "tenable_sc.vulnerability",
-        "ingested": "2023-01-13T12:39:41Z",
+        "ingested": "2023-08-01T23:19:29Z",
         "kind": "event",
         "original": "{\"acceptRisk\":\"0\",\"baseScore\":\"0.0\",\"bid\":\"\",\"checkType\":\"remote\",\"cpe\":\"\",\"cve\":\"CVE-1999-0524\",\"cvssV3BaseScore\":\"0.0\",\"cvssV3TemporalScore\":\"\",\"cvssV3Vector\":\"AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N\",\"cvssVector\":\"AV:L/AC:L/Au:N/C:N/I:N/A:N\",\"description\":\"The remote host answers to an ICMP timestamp request.  This allows an attacker to know the date that is set on the targeted machine, which may assist an unauthenticated, remote attacker in defeating time-based authentication protocols.\\n\\nTimestamps returned from machines running Windows Vista / 7 / 2008 / 2008 R2 are deliberately incorrect, but usually within 1000 seconds of the actual system time.\",\"dnsName\":\"_gateway.lxd\",\"exploitAvailable\":\"No\",\"exploitEase\":\"\",\"exploitFrameworks\":\"\",\"family\":{\"id\":\"30\",\"name\":\"General\",\"type\":\"active\"},\"firstSeen\":\"1551284872\",\"hasBeenMitigated\":\"0\",\"hostUniqueness\":\"repositoryID,ip,dnsName\",\"ip\":\"10.238.64.1\",\"ips\":\"10.238.64.1\",\"lastSeen\":\"1632586125\",\"macAddress\":\"00:16:3e:a1:12:f7\",\"netbiosName\":\"\",\"operatingSystem\":\"Linux Kernel 2.6\",\"patchPubDate\":\"-1\",\"pluginID\":\"10114\",\"pluginInfo\":\"10114 (0/1) ICMP Timestamp Request Remote Date Disclosure\",\"pluginModDate\":\"1570190400\",\"pluginName\":\"ICMP Timestamp Request Remote Date Disclosure\",\"pluginPubDate\":\"933508800\",\"pluginText\":\"\\u003cplugin_output\\u003eThe remote clock is synchronized with the local clock.\\n\\u003c/plugin_output\\u003e\",\"port\":\"0\",\"protocol\":\"ICMP\",\"recastRisk\":\"0\",\"repository\":{\"dataFormat\":\"IPv4\",\"description\":\"\",\"id\":\"1\",\"name\":\"Live\",\"sciID\":\"1\"},\"riskFactor\":\"None\",\"seeAlso\":\"\",\"severity\":{\"description\":\"Informative\",\"id\":\"0\",\"name\":\"Info\"},\"solution\":\"Filter out the ICMP timestamp requests (13), and the outgoing ICMP timestamp replies (14).\",\"stigSeverity\":\"\",\"synopsis\":\"It is possible to determine the exact time set on the remote host.\",\"temporalScore\":\"\",\"uniqueness\":\"repositoryID,ip,dnsName\",\"uuid\":\"\",\"version\":\"1.48\",\"vprContext\":\"[{\\\"id\\\":\\\"age_of_vuln\\\",\\\"name\\\":\\\"Vulnerability Age\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"730 days +\\\"},{\\\"id\\\":\\\"cvssV3_impactScore\\\",\\\"name\\\":\\\"CVSS v3 Impact Score\\\",\\\"type\\\":\\\"number\\\",\\\"value\\\":0},{\\\"id\\\":\\\"exploit_code_maturity\\\",\\\"name\\\":\\\"Exploit Code Maturity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Unproven\\\"},{\\\"id\\\":\\\"product_coverage\\\",\\\"name\\\":\\\"Product Coverage\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very High\\\"},{\\\"id\\\":\\\"threat_intensity_last_28\\\",\\\"name\\\":\\\"Threat Intensity\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"Very Low\\\"},{\\\"id\\\":\\\"threat_recency\\\",\\\"name\\\":\\\"Threat Recency\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"},{\\\"id\\\":\\\"threat_sources_last_28\\\",\\\"name\\\":\\\"Threat Sources\\\",\\\"type\\\":\\\"string\\\",\\\"value\\\":\\\"No recorded events\\\"}]\",\"vprScore\":\"0.8\",\"vulnPubDate\":\"788961600\",\"xref\":\"CWE #200\"}",
         "type": [
@@ -562,6 +562,7 @@ An example event for `vulnerability` looks as following:
     "tenable_sc": {
         "vulnerability": {
             "accept_risk": "0",
+            "age": 940,
             "base_score": "0.0",
             "check_type": "remote",
             "custom_hash": "qVUXK2YtClsBlXncLYHLhVzynYK4hG2NbT0hY6guQm0=",
@@ -757,6 +758,7 @@ An example event for `vulnerability` looks as following:
 | related.ip | All of the IPs seen on your event. | ip |
 | tags | List of keywords used to tag each event. | keyword |
 | tenable_sc.vulnerability.accept_risk | N/A. | keyword |
+| tenable_sc.vulnerability.age | The time in days between the first and last time the vulnerability was seen. | long |
 | tenable_sc.vulnerability.base_score | Intrinsic and fundamental characteristics of a vulnerability that are constant over time and user environments. | keyword |
 | tenable_sc.vulnerability.bid | The Bugtraq ID. | keyword |
 | tenable_sc.vulnerability.check_type | The type of the compliance check that detected the vulnerability. | keyword |

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: tenable_sc
 title: Tenable.sc
 # The version must be updated in the pipeline as well. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "1.12.0"
+version: "1.13.0"
 license: basic
 description: |
   Collect logs from Tenable.sc with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Retains a calculated vulnerability age in days from the first and last seen dates.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #7198

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
