### PR TITLE
[Elastic Agent] Enable TSDB by default

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Enable time series data streams for the metrics datastreams except for endpoint security metrics. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/5618
 - version: "1.10.1"
   changes:
     - description: Set metric type for all metric fields.

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the metrics datastreams except for endpoint security metrics. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/5618
+      link: https://github.com/elastic/integrations/pull/7214
 - version: "1.10.1"
   changes:
     - description: Set metric type for all metric fields.

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.11.0"
   changes:
-    - description: Enable time series data streams for the metrics datastreams except for endpoint security metrics. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+    - description: Enable time series data streams for the metrics datastreams except for endpoint security metrics and filebeat input metrics. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7214
 - version: "1.10.1"

--- a/packages/elastic_agent/data_stream/apm_server_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.apm_server
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent Auditbeat Metrics
 dataset: elastic_agent.auditbeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.cloudbeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.elastic_agent
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
@@ -3,6 +3,7 @@ dataset: elastic_agent.filebeat_input
 type: metrics
 release: beta
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: true

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/manifest.yml
@@ -3,7 +3,6 @@ dataset: elastic_agent.filebeat_input
 type: metrics
 release: beta
 elasticsearch:
-  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: true

--- a/packages/elastic_agent/data_stream/filebeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.filebeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.fleet_server
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.heartbeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.metricbeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.osquerybeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/manifest.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/manifest.yml
@@ -2,6 +2,7 @@ title: Elastic Agent
 dataset: elastic_agent.packetbeat
 type: metrics
 elasticsearch:
+  index_mode: "time_series"
   index_template:
     mappings:
       dynamic: false

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.10.1
+version: 1.11.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## What does this PR do?

Enable TSDB by default for all metrics data streams, except for:

- Endpoint security metrics: it never receives any data.
- Filebeat input metrics: the migration is failing with
  ```
  Error: error running package asset tests: could not complete test run: can't install the package: can't install the package: could not install package; API status code = 500; response body = {"statusCode":500,"error":"Internal Server Error","message":"invalid_index_template_exception\n\tRoot causes:\n\t\tinvalid_index_template_exception: index_template [metrics-elastic_agent.filebeat_input] invalid, cause [Validation Failed: 1: [index.mode=time_series] requires a non-empty [index.routing_path];]"}
  ```
  However, `agent.id` is set as dimension and it is always present for all documents. I cannot find the reason for why this is happening, so I am removing this data stream migration from this PR.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6938.