### PR TITLE
[Cisco ASA] Fix the handling of spaces in 113005 messages

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.20.1"
+  changes:
+    - description: Fix the handling of spaces in 113005 messages.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7216
 - version: "2.20.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log
@@ -17,5 +17,5 @@ Jul 14 01:45:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr et
 Jul 15 12:18:51 81.2.69.192 %ASA-6-113039: Group <novpn> User <nt\minsk> IP <216.160.83.56> AnyConnect parent session started.
 Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group <Group_VPN> User <support\column> IP <81.2.69.192> AnyConnect parent session started.
 Jun 14 01:22:47 81.2.69.142 %ASA-5-304001: 192.168.14.22 Accessed URL mirror:http://mirror.example.com/path/to/resource
-Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112
-Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128
+Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112
+Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1541,25 +1541,47 @@
         },
         {
             "@timestamp": "2023-07-01T09:27:13.000Z",
-            "cisco": {
-                "asa": {
-                    "message_id": "",
-                    "security": {}
-                }
+            "destination": {
+                "address": "81.2.69.142",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.142"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "original": "Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112",
-                "severity": 7,
-                "timezone": "UTC"
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113005",
+                "kind": "event",
+                "original": "Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
             },
             "host": {
                 "hostname": "216.160.83.56"
             },
             "log": {
-                "level": "debug"
+                "level": "informational"
             },
             "observer": {
                 "hostname": "216.160.83.56",
@@ -1570,7 +1592,39 @@
             "related": {
                 "hosts": [
                     "216.160.83.56"
+                ],
+                "ip": [
+                    "89.160.20.112",
+                    "81.2.69.142"
+                ],
+                "user": [
+                    "123"
                 ]
+            },
+            "source": {
+                "address": "89.160.20.112",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112",
+                "user": {
+                    "name": "123"
+                }
             },
             "tags": [
                 "preserve_original_event"
@@ -1578,25 +1632,47 @@
         },
         {
             "@timestamp": "2023-07-01T09:27:13.000Z",
-            "cisco": {
-                "asa": {
-                    "message_id": "",
-                    "security": {}
-                }
+            "destination": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "original": "Jul  1 09:27:13 216.160.83.56 : AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128",
-                "severity": 7,
-                "timezone": "UTC"
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113005",
+                "kind": "event",
+                "original": "Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = Account has been disabled : server = 81.2.69.144 : user = alice : user IP = 89.160.20.128",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
             },
             "host": {
                 "hostname": "216.160.83.56"
             },
             "log": {
-                "level": "debug"
+                "level": "informational"
             },
             "observer": {
                 "hostname": "216.160.83.56",
@@ -1607,7 +1683,39 @@
             "related": {
                 "hosts": [
                     "216.160.83.56"
+                ],
+                "ip": [
+                    "89.160.20.128",
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "alice"
                 ]
+            },
+            "source": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "user": {
+                    "name": "alice"
+                }
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -453,7 +453,7 @@ processors:
       description: "113005"
       field: "message"
       patterns: 
-      - "AAA user authentication Rejected: reason = %{REASON}: server = %{IP:destination.address} : user = ?%{CISCO_USER:source.user.name}: user IP = %{IP:source.address}"
+      - "AAA user authentication Rejected(%{SPACE})?: reason = %{REASON}(%{SPACE})?: server = %{IP:destination.address}(%{SPACE})?: user = ?%{CISCO_USER:source.user.name}(%{SPACE})?: user IP = %{IP:source.address}"
       pattern_definitions:
         REASON: (AAA failure|Account has been disabled)
         CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.20.0"
+version: "2.20.1"
 license: basic
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

It fixes the parsing of a 113005 Cisco ASA message as follows:

```
Jul  1 09:27:13 216.160.83.56 : %ASA-6-113005: AAA user authentication Rejected : reason = AAA failure : server = 81.2.69.142 : user = 123 : user IP = 89.160.20.112
```

The `grok` processor failed because of an unexpected space after `AAA user authentication Rejected`. This can potentially happen with every field so now the pattern expects that every value can be followed by spaces.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

