### PR TITLE
[Cloud Security] Add a CloudShell url param

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -4,6 +4,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.5.0-preview29"
+  changes:
+    - description: Add a cloudshell url for the GCP CSPM integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xx
 - version: "1.5.0-preview28"
   changes:
     - description: Added ingest processor to copy cluster_id to orchestrator.cluster.id

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Add a cloudshell url for the GCP CSPM integration
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xx
+      link: https://github.com/elastic/integrations/pull/7235
 - version: "1.5.0-preview28"
   changes:
     - description: Added ingest processor to copy cluster_id to orchestrator.cluster.id

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -127,7 +127,7 @@ streams:
         type: text
         title: Project Id
         multi: false
-        required: true
+        required: false
         show_user: true
         default: SET_PROJECT_NAME
       - name: credentials_file

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview28"
+version: "1.5.0-preview29"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -117,6 +117,15 @@ policy_templates:
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations
+        vars:
+          - name: cloud_shell_url
+            type: text
+            title: CloudShell URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to CloudShell for creating a new deployment
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.10&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
       - type: cloudbeat/cis_azure
         title: Azure
         description: CIS Benchmark for Microsoft Azure Foundations


### PR DESCRIPTION
## What does this PR do?
1. Make the project_id param optional as the user will not provide it in the CN deployment mode.
Will be required by the UI component in the manual setup.
2. Add a new input var for storing the Cloudshell URL that will be used to redirect the client.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes: https://github.com/elastic/integrations/issues/7233
- Related: https://github.com/elastic/cloudbeat/issues/1121