### PR TITLE
[System] Validate ClientAddress IP for Windows Security events

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.38.2"
+  changes:
+    - description: Validate ClientAddress IP for events 4778 and 4779
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7237
 - version: "1.38.1"
   changes:
     - description: Remove duplicated fields in diskio datastream

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2012-4779.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2012-4779.json
@@ -35,7 +35,64 @@
                     "LogonID": "0x60d1ccb",
                     "SessionName": "RDP-Tcp#116",
                     "ClientName": "EQP01777",
-                    "ClientAddress": "10.100.150.17",
+                    "ClientAddress": "LOCAL",
+                    "AccountName": "at_adm"
+                },
+                "event_id": 4779,
+                "record_id": 5069070,
+                "computer_name": "DC_TEST2k12.TEST.SAAS",
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "outcome": "success",
+                "process": {
+                    "pid": 496,
+                    "thread": {
+                        "id": 3852
+                    }
+                }
+            },
+            "event": {
+                "kind": "event",
+                "code": 4779,
+                "provider": "Microsoft-Windows-Security-Auditing",
+                "outcome": "success"
+            }
+        },
+        {
+            "@timestamp": "2021-04-15T19:03:22.673Z",
+            "log": {
+                "level": "information",
+                "file": {
+                    "path": "/Users/leehinman/src/beats/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.xml"
+                }
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "name": "DC_TEST2k12.TEST.SAAS"
+            },
+            "agent": {
+                "ephemeral_id": "d9d93a3d-3242-4f55-a4de-4ded8ae26301",
+                "id": "3cdc1e10-ded0-4f5d-8434-ede1d1120b17",
+                "name": "Lees-MBP.localdomain",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "winlog": {
+                "channel": "Security",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "opcode": "Info",
+                "time_created": "2020-04-03T10:18:01.882Z",
+                "level": "information",
+                "event_data": {
+                    "AccountDomain": "TEST",
+                    "LogonID": "0x60d1ccb",
+                    "SessionName": "RDP-Tcp#116",
+                    "ClientName": "EQP01777",
+                    "ClientAddress": "Unknown",
                     "AccountName": "at_adm"
                 },
                 "event_id": 4779,

--- a/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
+++ b/packages/system/data_stream/security/_dev/test/pipeline/test-security-windows2012-4779.json-expected.json
@@ -37,7 +37,7 @@
             },
             "related": {
                 "ip": [
-                    "10.100.150.17"
+                    "127.0.0.1"
                 ],
                 "user": [
                     "at_adm"
@@ -45,7 +45,7 @@
             },
             "source": {
                 "domain": "EQP01777",
-                "ip": "10.100.150.17"
+                "ip": "127.0.0.1"
             },
             "user": {
                 "domain": "TEST",
@@ -57,7 +57,87 @@
                 "event_data": {
                     "AccountDomain": "TEST",
                     "AccountName": "at_adm",
-                    "ClientAddress": "10.100.150.17",
+                    "ClientAddress": "127.0.0.1",
+                    "ClientName": "EQP01777",
+                    "LogonID": "0x60d1ccb",
+                    "SessionName": "RDP-Tcp#116"
+                },
+                "event_id": "4779",
+                "keywords": [
+                    "Audit Success"
+                ],
+                "level": "information",
+                "logon": {
+                    "id": "0x60d1ccb"
+                },
+                "opcode": "Info",
+                "outcome": "success",
+                "process": {
+                    "pid": 496,
+                    "thread": {
+                        "id": 3852
+                    }
+                },
+                "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+                "provider_name": "Microsoft-Windows-Security-Auditing",
+                "record_id": "5069070",
+                "time_created": "2020-04-03T10:18:01.882Z"
+            }
+        },
+        {
+            "@timestamp": "2020-04-03T10:18:01.882Z",
+            "agent": {
+                "ephemeral_id": "d9d93a3d-3242-4f55-a4de-4ded8ae26301",
+                "id": "3cdc1e10-ded0-4f5d-8434-ede1d1120b17",
+                "name": "Lees-MBP.localdomain",
+                "type": "filebeat",
+                "version": "8.0.0"
+            },
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event": {
+                "action": "session-disconnected",
+                "category": [
+                    "authentication",
+                    "session"
+                ],
+                "code": "4779",
+                "kind": "event",
+                "outcome": "success",
+                "provider": "Microsoft-Windows-Security-Auditing",
+                "type": [
+                    "end"
+                ]
+            },
+            "host": {
+                "name": "DC_TEST2k12.TEST.SAAS"
+            },
+            "log": {
+                "file": {
+                    "path": "/Users/leehinman/src/beats/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.xml"
+                },
+                "level": "information"
+            },
+            "related": {
+                "user": [
+                    "at_adm"
+                ]
+            },
+            "source": {
+                "domain": "EQP01777"
+            },
+            "user": {
+                "domain": "TEST",
+                "name": "at_adm"
+            },
+            "winlog": {
+                "channel": "Security",
+                "computer_name": "DC_TEST2k12.TEST.SAAS",
+                "event_data": {
+                    "AccountDomain": "TEST",
+                    "AccountName": "at_adm",
+                    "ClientAddress": "Unknown",
                     "ClientName": "EQP01777",
                     "LogonID": "0x60d1ccb",
                     "SessionName": "RDP-Tcp#116"

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -2427,7 +2427,12 @@ processors:
 
         //ClientAddress to source.ip and related.ip
         if (ctx.winlog?.event_data?.ClientAddress != null &&
-            ctx.winlog.event_data.ClientAddress != "-") {
+            ctx.winlog.event_data.ClientAddress != "-" &&
+            ctx.winlog.event_data.ClientAddress != "Unknown") {
+          // Correct invalid IP address "LOCAL"
+          if (ctx.winlog.event_data.ClientAddress == "LOCAL") {
+            ctx.winlog.event_data.ClientAddress = "127.0.0.1";
+          }
           if (ctx.source == null) {
             HashMap hm = new HashMap();
             ctx.put("source", hm);
@@ -2919,7 +2924,12 @@ processors:
           ctx.winlog.event_data.remove("WorkstationName");
         }
         if (ctx.winlog?.event_data?.ClientAddress != null &&
-            ctx.winlog.event_data.ClientAddress != "-") {
+            ctx.winlog.event_data.ClientAddress != "-" &&
+            ctx.winlog.event_data.ClientAddress != "Unknown") {
+          // Correct invalid IP address "LOCAL"
+          if (ctx.winlog.event_data.ClientAddress == "LOCAL") {
+            ctx.winlog.event_data.ClientAddress = "127.0.0.1";
+          }
           if (ctx.related == null) {
             HashMap hm = new HashMap();
             ctx.put("related", hm);

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: system
 title: System
-version: 1.38.1
+version: 1.38.2
 license: basic
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

It fixes a constraint error with the `source.ip` and `related.ip` fields when populated from `winlog.event_data.ClientAddress` that may contain invalid IP values, in particular `LOCAL` and `Unknown`, leading to this error:
```
[0] unexpected pipeline error: ['LOCAL' is not an IP string literal.]
```

This has been already fixed in Winlogbeat at https://github.com/elastic/beats/pull/34295 but doesn't affect the winlog input and this ingest pipeline.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Added pipeline tests to validate that `ClientAddress` is handled properly.
