### PR TITLE
[Azure][container_service] Add missing azure dimensions to the kube_pod_status_phase and kube_pod_status_ready metrics

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add missing azure dimensions to the kube_pod_status_phase and kube_pod_status_ready metrics
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7127
+      link: https://github.com/elastic/integrations/pull/7245
 - version: "1.0.17"
   changes:
     - description: Add dimension and metric_type metadata to the container_instance datastream

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.18"
+  changes:
+    - description: Add missing azure dimensions to the kube_pod_status_phase and kube_pod_status_ready metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7127
 - version: "1.0.17"
   changes:
     - description: Add dimension and metric_type metadata to the container_instance datastream

--- a/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
@@ -43,13 +43,28 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
-              value: "*"        
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
+              value: "*"
     {{/each}}
 {{/if}}
 {{#if resource_ids}}
@@ -71,12 +86,27 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
               value: "*"
     {{/each}}
 {{/if}}
@@ -105,12 +135,27 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
-              value: "*"          
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
+              value: "*"
     {{/unless}}
 {{/unless}}

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.17
+version: 1.0.18
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add missing dimensions to the `kube_pod_status_phase` and `kube_pod_status_ready` metrics

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/7161

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
