### PR TITLE
[Netflow] Missing ECS Field Mappings

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.18"
+  changes:
+    - description: Add missing azure dimensions to the kube_pod_status_phase and kube_pod_status_ready metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7245
 - version: "1.0.17"
   changes:
     - description: Add dimension and metric_type metadata to the container_instance datastream

--- a/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
+++ b/packages/azure_metrics/data_stream/container_service/agent/stream/stream.yml.hbs
@@ -43,13 +43,28 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
-              value: "*"        
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
+              value: "*"
     {{/each}}
 {{/if}}
 {{#if resource_ids}}
@@ -71,12 +86,27 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
               value: "*"
     {{/each}}
 {{/if}}
@@ -105,12 +135,27 @@ resources:
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
-          - name: ["kube_pod_status_ready", "kube_pod_status_phase"]
+          - name: ["kube_pod_status_ready"]
             namespace: "Microsoft.ContainerService/managedClusters"
             ignore_unsupported: true
             timegrain: "PT5M"
             dimensions:
             - name: "pod"
-              value: "*"          
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "condition"
+              value: "*"
+          - name: ["kube_pod_status_phase"]
+            namespace: "Microsoft.ContainerService/managedClusters"
+            ignore_unsupported: true
+            timegrain: "PT5M"
+            dimensions:
+            - name: "pod"
+              value: "*"
+            - name: "namespace"
+              value: "*"
+            - name: "phase"
+              value: "*"
     {{/unless}}
 {{/unless}}

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.17
+version: 1.0.18
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration

--- a/packages/netflow/data_stream/log/fields/ecs.yml
+++ b/packages/netflow/data_stream/log/fields/ecs.yml
@@ -27,6 +27,8 @@
 - external: ecs
   name: client.geo.city_name
 - external: ecs
+  name: client.geo.continent_code
+- external: ecs
   name: client.geo.continent_name
 - external: ecs
   name: client.geo.country_iso_code
@@ -37,9 +39,13 @@
 - external: ecs
   name: client.geo.name
 - external: ecs
+  name: client.geo.postal_code
+- external: ecs
   name: client.geo.region_iso_code
 - external: ecs
   name: client.geo.region_name
+- external: ecs
+  name: client.geo.timezone
 - external: ecs
   name: client.ip
 - external: ecs
@@ -105,6 +111,8 @@
 - external: ecs
   name: destination.geo.city_name
 - external: ecs
+  name: destination.geo.continent_code
+- external: ecs
   name: destination.geo.continent_name
 - external: ecs
   name: destination.geo.country_iso_code
@@ -115,9 +123,13 @@
 - external: ecs
   name: destination.geo.name
 - external: ecs
+  name: destination.geo.postal_code
+- external: ecs
   name: destination.geo.region_iso_code
 - external: ecs
   name: destination.geo.region_name
+- external: ecs
+  name: destination.geo.timezone
 - external: ecs
   name: destination.ip
 - external: ecs
@@ -319,6 +331,8 @@
 - external: ecs
   name: host.geo.city_name
 - external: ecs
+  name: host.geo.continent_code
+- external: ecs
   name: host.geo.continent_name
 - external: ecs
   name: host.geo.country_iso_code
@@ -329,9 +343,13 @@
 - external: ecs
   name: host.geo.name
 - external: ecs
+  name: host.geo.postal_code
+- external: ecs
   name: host.geo.region_iso_code
 - external: ecs
   name: host.geo.region_name
+- external: ecs
+  name: host.geo.timezone
 - external: ecs
   name: host.hostname
 - external: ecs
@@ -421,6 +439,8 @@
 - external: ecs
   name: observer.geo.city_name
 - external: ecs
+  name: observer.geo.continent_code
+- external: ecs
   name: observer.geo.continent_name
 - external: ecs
   name: observer.geo.country_iso_code
@@ -431,9 +451,13 @@
 - external: ecs
   name: observer.geo.name
 - external: ecs
+  name: observer.geo.postal_code
+- external: ecs
   name: observer.geo.region_iso_code
 - external: ecs
   name: observer.geo.region_name
+- external: ecs
+  name: observer.geo.timezone
 - external: ecs
   name: observer.hostname
 - external: ecs
@@ -547,6 +571,8 @@
 - external: ecs
   name: server.geo.city_name
 - external: ecs
+  name: server.geo.continent_code
+- external: ecs
   name: server.geo.continent_name
 - external: ecs
   name: server.geo.country_iso_code
@@ -557,9 +583,13 @@
 - external: ecs
   name: server.geo.name
 - external: ecs
+  name: server.geo.postal_code
+- external: ecs
   name: server.geo.region_iso_code
 - external: ecs
   name: server.geo.region_name
+- external: ecs
+  name: server.geo.timezone
 - external: ecs
   name: server.ip
 - external: ecs
@@ -621,6 +651,8 @@
 - external: ecs
   name: source.geo.city_name
 - external: ecs
+  name: source.geo.continent_code
+- external: ecs
   name: source.geo.continent_name
 - external: ecs
   name: source.geo.country_iso_code
@@ -631,9 +663,13 @@
 - external: ecs
   name: source.geo.name
 - external: ecs
+  name: source.geo.postal_code
+- external: ecs
   name: source.geo.region_iso_code
 - external: ecs
   name: source.geo.region_name
+- external: ecs
+  name: source.geo.timezone
 - external: ecs
   name: source.ip
 - external: ecs


### PR DESCRIPTION
Type of change

- Bug

## What does this PR do?

This PR adds missing mappings `source.*` and `destination.*` fields to prevent field mapping conflicts in the `logs-*` Data View. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have incremented the version in my package's `manifest.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #7270

## Screenshots

![netflow_conflict](https://github.com/elastic/integrations/assets/26614684/9404df32-fa8e-4ec7-9f0a-90a9f162b334)