### PR TITLE
[Azure][compute_vm] Add dimensions, metric_type to the compute_vm datastream; remove dupl…

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.0.19"
+  changes:
+    - description: Add dimension and metric_type metadata to the compute_vm datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7245
 - version: "1.0.18"
   changes:
     - description: Add missing azure dimensions to the kube_pod_status_phase and kube_pod_status_ready metrics

--- a/packages/azure_metrics/data_stream/compute_vm/fields/agent.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/fields/agent.yml
@@ -22,6 +22,7 @@
     - name: instance.id
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Instance ID of the host machine.
       example: i-1234567890abcdef0
@@ -45,6 +46,7 @@
     - name: region
       level: extended
       type: keyword
+      dimension: true
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
@@ -62,26 +64,11 @@
     These fields help correlate data based containers from any runtime.'
   type: group
   fields:
-    - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
-    - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
     - name: labels
       level: extended
       type: object
       object_type: keyword
       description: Image labels.
-    - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
 - name: host
   title: Host
   group: 2

--- a/packages/azure_metrics/data_stream/compute_vm/fields/ecs.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/fields/ecs.yml
@@ -15,3 +15,6 @@
   external: ecs
 - name: host
   external: ecs
+- name: agent.id
+  external: ecs
+  dimension: true

--- a/packages/azure_metrics/data_stream/compute_vm/fields/fields.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/fields/fields.yml
@@ -1,6 +1,7 @@
 - name: azure.compute_vm.*.*
   type: object
+  metric_type: gauge
   object_type: float
   object_type_mapping_type: "*"
   description: >-
-    compute_vm
+    Returned compute_vm metrics

--- a/packages/azure_metrics/data_stream/compute_vm/fields/package-fields.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/fields/package-fields.yml
@@ -3,6 +3,7 @@
   description: ""
   fields:
     - name: timegrain
+      dimension: true
       type: keyword
       description: >
         The Azure metric timegrain
@@ -25,6 +26,7 @@
 
         - name: id
           type: keyword
+          dimension: true
           description: >
             The id of the resource
 
@@ -41,6 +43,7 @@
             Azure resource tags.
 
     - name: namespace
+      dimension: true
       type: keyword
       description: >
         The namespace selected
@@ -55,17 +58,26 @@
       description: >
         The application ID
 
-    - name: dimensions.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Azure metric dimensions.
-
-    - name: metrics.*.*
-      type: object
-      object_type: float
-      object_type_mapping_type: "*"
-      description: >
-        Metrics returned.
-
+    - name: dimensions
+      type: group
+      fields:
+        - name: device
+          type: keyword
+          dimension: true
+          description: Name of the device of the linux instance, eg. sda2
+        - name: host
+          type: keyword
+          dimension: true
+          description: Name of the linux host
+        - name: name
+          type: keyword
+          dimension: true
+          description: Name of the device of the linux instance
+        - name: interface
+          type: keyword
+          dimension: true
+          description: Name of the network interface on the linux instance
+        - name: cpu
+          type: keyword
+          dimension: true
+          description: Cpu core on the linux instance

--- a/packages/azure_metrics/docs/README.md
+++ b/packages/azure_metrics/docs/README.md
@@ -120,62 +120,66 @@ so the `period` for `compute_vm` should be `300s` or multiples of `300s`.
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| azure.application_id | The application ID | keyword |
-| azure.compute_vm.\*.\* | compute_vm | object |
-| azure.dimensions.\* | Azure metric dimensions. | object |
-| azure.metrics.\*.\* | Metrics returned. | object |
-| azure.namespace | The namespace selected | keyword |
-| azure.resource.group | The resource group | keyword |
-| azure.resource.id | The id of the resource | keyword |
-| azure.resource.name | The name of the resource | keyword |
-| azure.resource.tags.\* | Azure resource tags. | object |
-| azure.resource.type | The type of the resource | keyword |
-| azure.subscription_id | The subscription ID | keyword |
-| azure.timegrain | The Azure metric timegrain | keyword |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| container.runtime | Runtime managing this container. | keyword |
-| data_stream.dataset | Data stream dataset name. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.address | Service address | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
+| azure.application_id | The application ID | keyword |  |
+| azure.compute_vm.\*.\* | Returned compute_vm metrics | object | gauge |
+| azure.dimensions.cpu | Cpu core on the linux instance | keyword |  |
+| azure.dimensions.device | Name of the device of the linux instance, eg. sda2 | keyword |  |
+| azure.dimensions.host | Name of the linux host | keyword |  |
+| azure.dimensions.interface | Name of the network interface on the linux instance | keyword |  |
+| azure.dimensions.name | Name of the device of the linux instance | keyword |  |
+| azure.namespace | The namespace selected | keyword |  |
+| azure.resource.group | The resource group | keyword |  |
+| azure.resource.id | The id of the resource | keyword |  |
+| azure.resource.name | The name of the resource | keyword |  |
+| azure.resource.tags.\* | Azure resource tags. | object |  |
+| azure.resource.type | The type of the resource | keyword |  |
+| azure.subscription_id | The subscription ID | keyword |  |
+| azure.timegrain | The Azure metric timegrain | keyword |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Runtime managing this container. | keyword |  |
+| data_stream.dataset | Data stream dataset name. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| dataset.name | Dataset name. | constant_keyword |  |
+| dataset.namespace | Dataset namespace. | constant_keyword |  |
+| dataset.type | Dataset type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 `compute_vm_scaleset`

--- a/packages/azure_metrics/docs/compute_vm.md
+++ b/packages/azure_metrics/docs/compute_vm.md
@@ -72,59 +72,63 @@ Authentication: Dedicated authentication token will be created and updated regul
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| azure.application_id | The application ID | keyword |
-| azure.compute_vm.\*.\* | compute_vm | object |
-| azure.dimensions.\* | Azure metric dimensions. | object |
-| azure.metrics.\*.\* | Metrics returned. | object |
-| azure.namespace | The namespace selected | keyword |
-| azure.resource.group | The resource group | keyword |
-| azure.resource.id | The id of the resource | keyword |
-| azure.resource.name | The name of the resource | keyword |
-| azure.resource.tags.\* | Azure resource tags. | object |
-| azure.resource.type | The type of the resource | keyword |
-| azure.subscription_id | The subscription ID | keyword |
-| azure.timegrain | The Azure metric timegrain | keyword |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| container.runtime | Runtime managing this container. | keyword |
-| data_stream.dataset | Data stream dataset name. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| dataset.name | Dataset name. | constant_keyword |
-| dataset.namespace | Dataset namespace. | constant_keyword |
-| dataset.type | Dataset type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.address | Service address | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
+| azure.application_id | The application ID | keyword |  |
+| azure.compute_vm.\*.\* | Returned compute_vm metrics | object | gauge |
+| azure.dimensions.cpu | Cpu core on the linux instance | keyword |  |
+| azure.dimensions.device | Name of the device of the linux instance, eg. sda2 | keyword |  |
+| azure.dimensions.host | Name of the linux host | keyword |  |
+| azure.dimensions.interface | Name of the network interface on the linux instance | keyword |  |
+| azure.dimensions.name | Name of the device of the linux instance | keyword |  |
+| azure.namespace | The namespace selected | keyword |  |
+| azure.resource.group | The resource group | keyword |  |
+| azure.resource.id | The id of the resource | keyword |  |
+| azure.resource.name | The name of the resource | keyword |  |
+| azure.resource.tags.\* | Azure resource tags. | object |  |
+| azure.resource.type | The type of the resource | keyword |  |
+| azure.subscription_id | The subscription ID | keyword |  |
+| azure.timegrain | The Azure metric timegrain | keyword |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| container.runtime | Runtime managing this container. | keyword |  |
+| data_stream.dataset | Data stream dataset name. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| dataset.name | Dataset name. | constant_keyword |  |
+| dataset.namespace | Dataset namespace. | constant_keyword |  |
+| dataset.type | Dataset type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| host | A host is defined as a general computing instance. ECS host.\* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes. | group |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.address | Service address | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.0.18
+version: 1.0.19
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
…icated fields; extend azure.dimensions.* field with exact fields

## What does this PR do?

- Add dimensions fields:
`agent.id`
`azure.dimensions.*`
`azure.namespace` - there might be multiple sources of metrics - for example for the same windows instance there can be available `Microsoft.Compute/virtualMachines` and `Azure.VM.Windows.GuestMetrics` metrics, both does not have `dimensions`
`cloud.region`
`cloud.instance.id` - this is mainly added to follow the same rules as for aws/gcp, `azure.resource.id` should be unique enough
`azure.resource.id` 
`azure.timegrain`
- remove duplicated fields
- add `agent.id` field

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
