### PR TITLE
[panw] - update package-spec to 2.9.0

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.15.0"
+  changes:
+    - description: Update package-spec to ECS 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "3.14.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "3.15.0"
   changes:
-    - description: Update package-spec to ECS 2.9.0.
+    - description: Update package-spec to 2.9.0.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7294
 - version: "3.14.0"

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to ECS 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7294
 - version: "3.14.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-config-sample.log-expected.json
@@ -17,7 +17,9 @@
                 "timezone": "-04:00"
             },
             "host": {
-                "ip": "81.2.69.193"
+                "ip": [
+                    "81.2.69.193"
+                ]
             },
             "message": "81.2.69.193,,set,admin,Web,Succeeded, config shared log-settings iptag match-list  ip-tag,,\"iptag { match-list { ip-tag  { send-syslog [ SYSLOG-1 ]; filter \"\"All Logs\"\"; } } } \",1234567890,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {
@@ -74,7 +76,9 @@
                 "timezone": "-04:00"
             },
             "host": {
-                "ip": "81.2.69.193"
+                "ip": [
+                    "81.2.69.193"
+                ]
             },
             "message": "81.2.69.193,,set,admin,Web,Succeeded, config shared log-settings globalprotect match-list  globalProtect,,\"globalprotect { match-list { globalProtect  { send-syslog [ SYSLOG-1 ]; filter \"\"All Logs\"\"; } } } \",1234567890,0x0,0,0,0,0,,PA-VM,0,",
             "observer": {

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
@@ -190,10 +190,14 @@
             },
             "x509": {
                 "issuer": {
-                    "common_name": "com.example.com"
+                    "common_name": [
+                        "com.example.com"
+                    ]
                 },
                 "subject": {
-                    "common_name": "com.example.com"
+                    "common_name": [
+                        "com.example.com"
+                    ]
                 }
             }
         },
@@ -387,10 +391,14 @@
             },
             "x509": {
                 "issuer": {
-                    "common_name": "com.example.com"
+                    "common_name": [
+                        "com.example.com"
+                    ]
                 },
                 "subject": {
-                    "common_name": "com.example.com"
+                    "common_name": [
+                        "com.example.com"
+                    ]
                 }
             }
         }

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-globalprotect-sample.log-expected.json
@@ -19,7 +19,9 @@
             },
             "host": {
                 "id": "09300aaa-23-4900-8aa9-32695452aa",
-                "ip": "81.2.69.193",
+                "ip": [
+                    "81.2.69.193"
+                ],
                 "os": {
                     "family": "OS",
                     "full": "OS 10 Pro , 64-bit"
@@ -100,7 +102,9 @@
             },
             "host": {
                 "id": "e0957c11-93-437a-9e23-9f0c24059898",
-                "ip": "10.20.13.217",
+                "ip": [
+                    "10.20.13.217"
+                ],
                 "name": "cp935",
                 "os": {
                     "family": "OS",
@@ -200,7 +204,9 @@
             },
             "host": {
                 "id": "523e8b-7efa-4397-a4d5-824dfa4d8a",
-                "ip": "67.43.156.14",
+                "ip": [
+                    "67.43.156.14"
+                ],
                 "name": "host82878"
             },
             "message": "vsys1,gateway-hip-check,host-info,,,domain\\user1,,HOST82878,1.128.3.4,0.0.0.0,67.43.156.14,0.0.0.0,523e8b-7efa-4397-a4d5-824dfa4d8a,F1SM2,5.2.4,,\"\",1,,,\"HIP report is not needed\",success,,0,,0,GlobalProtect_GW,6920071768563516860,0x0",
@@ -290,7 +296,9 @@
             },
             "host": {
                 "id": "7d01b5-f538-4fa3-a2a2-83980d1325",
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "host73486",
                 "os": {
                     "family": "OS",
@@ -390,7 +398,9 @@
             },
             "host": {
                 "id": "2ba9f01-b83b-4902-a1fb-1748c0365",
-                "ip": "0.0.0.0",
+                "ip": [
+                    "0.0.0.0"
+                ],
                 "name": "hostp92413"
             },
             "message": "vsys1,gateway-tunnel-latency,tunnel,,,,userlterso,HOSTP92413,81.2.69.143,0.0.0.0,0.0.0.0,0.0.0.0,2ba9f01-b83b-4902-a1fb-1748c0365,GJG98Y2,5.2.4,,\"\",1,,,\"Pre-tunnel latency: 67ms, Post-tunnel latency: 47ms\",success,,0,,0,GlobalProtect_GW,6920071768563516847,0x0",
@@ -470,7 +480,9 @@
             },
             "host": {
                 "id": "985e865f-7da3-43b4-89a9-299b1bb0c975",
-                "ip": "0.0.0.0",
+                "ip": [
+                    "0.0.0.0"
+                ],
                 "name": "pc1234",
                 "os": {
                     "family": "OS",
@@ -557,7 +569,9 @@
             },
             "host": {
                 "id": "96c43d47-8bb5-4f78-8dfc-413a189a29e0",
-                "ip": "10.20.30.40",
+                "ip": [
+                    "10.20.30.40"
+                ],
                 "name": "rechner123",
                 "os": {
                     "family": "OS",
@@ -655,7 +669,9 @@
             },
             "host": {
                 "id": "0183d851-7ea2-4a0d-80de-fde1e04ce12f",
-                "ip": "0.0.0.0",
+                "ip": [
+                    "0.0.0.0"
+                ],
                 "os": {
                     "family": "OS",
                     "full": "OS 10 Enterprise, 64-bit"
@@ -737,7 +753,9 @@
             },
             "host": {
                 "id": "8cbc136b-e262-4cf8-912c-95ea132d9fef",
-                "ip": "0.0.0.0",
+                "ip": [
+                    "0.0.0.0"
+                ],
                 "name": "pc12345",
                 "os": {
                     "family": "OS",
@@ -826,7 +844,9 @@
             },
             "host": {
                 "id": "8cbc136b-e262-4cf8-912c-95ea132d9fef",
-                "ip": "10.2.2.2",
+                "ip": [
+                    "10.2.2.2"
+                ],
                 "name": "hostname"
             },
             "message": "vsys1,gateway-hip-check,host-info,,,host\\\\user,,HOSTNAME,10.1.1.1,,10.2.2.2,fc00::1,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.6,,,1,,,HIP report is not needed,success,,0,,0,GlobalProtect_External_Gateway,1305925,true",
@@ -904,7 +924,9 @@
             },
             "host": {
                 "id": "8cbc136b-e262-4cf8-912c-95ea132d9fef",
-                "ip": "10.4.4.4",
+                "ip": [
+                    "10.4.4.4"
+                ],
                 "name": "hostname"
             },
             "message": "vsys1,gateway-tunnel-latency,tunnel,,,user,,HOSTNAME,10.3.3.3,,10.4.4.4,,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.8,,,1,,,\"Pre-tunnel latency: 35ms, Post-tunnel latency: 16ms\",success,,0,,0,GlobalProtect_External_Gateway,1041590,true",
@@ -980,7 +1002,9 @@
             },
             "host": {
                 "id": "8cbc136b-e262-4cf8-912c-95ea132d9fef",
-                "ip": "fc00::abcd",
+                "ip": [
+                    "fc00::abcd"
+                ],
                 "name": "hostname"
             },
             "message": "vsys1,gateway-tunnel-latency,tunnel,,,user,,HOSTNAME,,fc00::1234,,fc00::abcd,8cbc136b-e262-4cf8-912c-95ea132d9fef,SERIALNR,5.2.8,,,1,,,\"Pre-tunnel latency: 35ms, Post-tunnel latency: 16ms\",success,,0,,0,GlobalProtect_External_Gateway,1041590,true",

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-other-sample.log-expected.json
@@ -17,7 +17,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,set,admin,Web,Succeeded, config shared local-user-database user  badguy,0,0x0",
             "observer": {
@@ -65,7 +67,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,set,admin,Web,Succeeded, config mgt-config users  badguy,0,0x0",
             "observer": {
@@ -113,7 +117,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
             "observer": {
@@ -320,7 +326,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,edit,badguy,Web,Succeeded, vsys  vsys1 profiles url-filtering  monzyspolicy,0,0x0",
             "observer": {
@@ -368,7 +376,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,commit,badguy,Web,Submitted,,0,0x0",
             "observer": {
@@ -1175,7 +1185,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,commit,admin,Web,Submitted,,0,0x0",
             "observer": {
@@ -1222,7 +1234,9 @@
                 "timezone": "+05:45"
             },
             "host": {
-                "ip": "192.168.0.2"
+                "ip": [
+                    "192.168.0.2"
+                ]
             },
             "message": "192.168.0.2,,edit,admin,Web,Succeeded, vsys  vsys1 profiles data-objects  PII,0,0x0",
             "observer": {

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-traffic.json-expected.json
@@ -213,7 +213,9 @@
                 ]
             },
             "host": {
-                "ip": "127.0.0.1"
+                "ip": [
+                    "127.0.0.1"
+                ]
             },
             "labels": {
                 "captive_portal": true

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
@@ -243,9 +243,17 @@ processors:
       copy_from: panw.panos.subject_common_name.value
       ignore_failure: true
   - set:
+      field: x509.subject.common_name
+      value: ['{{{x509.subject.common_name}}}']
+      if: ctx.x509?.subject?.common_name instanceof String
+  - set:
       field: x509.issuer.common_name
       copy_from: panw.panos.issuer_common_name.value
       ignore_failure: true
+  - set:
+      field: x509.issuer.common_name
+      value: [ '{{{x509.issuer.common_name}}}' ]
+      if: ctx.x509?.issuer?.common_name instanceof String
   - set:
       field: rule.uuid
       copy_from: panw.panos.rule_uuid

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -382,6 +382,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+  - set:
+      field: host.ip
+      value: ['{{{host.ip}}}']
+      if: ctx.host?.ip instanceof String
   - convert:
       field: network.forwarded_ip
       type: ip

--- a/packages/panw/data_stream/panos/sample_event.json
+++ b/packages/panw/data_stream/panos/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "db66df65-23a5-4f27-9018-6f9258e37285",
-        "id": "dc5749af-742c-4ef4-9092-7bdc1f1dfcac",
+        "ephemeral_id": "14270b7f-dcde-4dce-a132-6579ebe118a0",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.7.1"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -34,9 +34,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "dc5749af-742c-4ef4-9092-7bdc1f1dfcac",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.7.1"
+        "version": "8.9.0"
     },
     "event": {
         "action": "url_filtering",
@@ -48,7 +48,7 @@
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2023-05-12T09:06:49Z",
+        "ingested": "2023-08-07T14:52:26Z",
         "kind": "alert",
         "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -68,7 +68,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.21.0.4:42732"
+            "address": "192.168.176.4:41606"
         },
         "syslog": {
             "facility": {

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -34,11 +34,11 @@ An example event for `panos` looks as following:
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "db66df65-23a5-4f27-9018-6f9258e37285",
-        "id": "dc5749af-742c-4ef4-9092-7bdc1f1dfcac",
+        "ephemeral_id": "14270b7f-dcde-4dce-a132-6579ebe118a0",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.7.1"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -67,9 +67,9 @@ An example event for `panos` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "dc5749af-742c-4ef4-9092-7bdc1f1dfcac",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.7.1"
+        "version": "8.9.0"
     },
     "event": {
         "action": "url_filtering",
@@ -81,7 +81,7 @@ An example event for `panos` looks as following:
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2023-05-12T09:06:49Z",
+        "ingested": "2023-08-07T14:52:26Z",
         "kind": "alert",
         "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -101,7 +101,7 @@ An example event for `panos` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.21.0.4:42732"
+            "address": "192.168.176.4:41606"
         },
         "syslog": {
             "facility": {

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,11 +1,9 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.14.0"
-release: ga
+version: "3.15.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: [security, network]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.9.0
- Ensure host.ip is an array
- Ensure x509.subject.common_name and x509.issuer.common_name are arrays

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.9.0 packages/panw
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870