### PR TITLE
[pulse_connect_secure] - update package-spec to 2.9.0

### DIFF
--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7298
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-admin.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-admin.log-expected.json
@@ -39,7 +39,9 @@
             },
             "message": "Connection from IP 89.160.20.156 not authenticated yet (URL=/dana-na/auth/welcome.cgi?p=forced-off)",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -99,7 +101,9 @@
             },
             "message": "Connection from IP 89.160.20.156 not authenticated yet (URL=/dana-na/auth/url_o2d6zvh39ac6C92s/welcome.cgi?p=forced-off)",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -159,7 +163,9 @@
             },
             "message": "Source IP realm restrictions successfully passed for admin/ADMIN_REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -237,7 +243,9 @@
             },
             "message": "User Limit realm restrictions successfully passed for admin/ADMIN_REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -317,7 +325,9 @@
             },
             "message": "Login failed. Reason: Wrong Password",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -395,7 +405,9 @@
             },
             "message": "Primary authentication failed for admin/Administrators from 89.160.20.156",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -475,7 +487,9 @@
             },
             "message": "Login failed using auth server Administrators (Local Authentication). Reason: Failed",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -553,7 +567,9 @@
             },
             "message": "Source IP realm restrictions successfully passed for admin/ADMIN_REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -631,7 +647,9 @@
             },
             "message": "User Limit realm restrictions successfully passed for admin/ADMIN_REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -709,7 +727,9 @@
             },
             "message": "Primary authentication successful for admin/Administrators fr",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-syslog.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-syslog.log-expected.json
@@ -41,7 +41,9 @@
             },
             "message": "Primary authentication successful for username/REALM from 89.160.20.156",
             "observer": {
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "pcs-name",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -121,7 +123,9 @@
             },
             "message": "Host Checker policy 'HC_POLICY' passed on host '89.160.20.156' address '2D-FF-88-AA-BB-DC' for user 'username'.",
             "observer": {
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "pcs-name",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -201,7 +205,9 @@
             },
             "message": "Syslog server 81.2.69.144 (facility LOCAL5, filter Standard, type UDP, interface Global) removed from Events logs",
             "observer": {
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "pcs-name",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -263,7 +269,9 @@
             },
             "message": "The current virus signature list imported successfully.",
             "observer": {
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "pcs-name",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -307,7 +315,9 @@
             },
             "message": "The current virus signature list downloaded successfully from 'https://download.pulsesecure.net/software/av/uac/epupdate_hist.xml'",
             "observer": {
-                "ip": "89.160.20.112",
+                "ip": [
+                    "89.160.20.112"
+                ],
                 "name": "pcs-name",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-system.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-system.log-expected.json
@@ -21,7 +21,9 @@
             },
             "message": "No new virus signature list available from 'https://download.pulsesecure.net/software/av/uac/epupdate_hist.xml'.",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node0",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -81,7 +83,9 @@
             },
             "message": "User Limit realm restrictions successfully passed for /REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -141,7 +145,9 @@
             },
             "message": "Integrity Checker Tool: Periodic Scan Started!",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node0",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -183,7 +189,9 @@
             },
             "message": "Integrity Scan Completed: Integrity Scan Results : Matched Files 18773, Newly Detected Files 0, Mismatched Files 0",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node0",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -225,7 +233,9 @@
             },
             "message": "Integrity Checker Tool: Periodic Scan Finished!",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node0",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -285,7 +295,9 @@
             },
             "message": "User user.name denied access as the client version '9.1.11.6725' is lower than the minimum client version configured",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",

--- a/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-vpn.log-expected.json
+++ b/packages/pulse_connect_secure/data_stream/log/_dev/test/pipeline/test-log-vpn.log-expected.json
@@ -39,7 +39,9 @@
             },
             "message": "Primary authentication successful for user.name/REALM from 89.160.20.156",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -118,7 +120,9 @@
             },
             "message": "Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -223,7 +227,9 @@
                 "type": "ipv4"
             },
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -307,7 +313,9 @@
             },
             "message": "VPN Tunneling: User with IP 172.22.27.209 connected with SSL transport mode.",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -385,7 +393,9 @@
             },
             "message": "User Limit realm restrictions successfully passed for user.name/REALM",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -465,7 +475,9 @@
             },
             "message": "Login failed. Reason: Wrong Password",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -543,7 +555,9 @@
             },
             "message": "Primary authentication failed for user.name/sign-in-page from 89.160.20.156",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -623,7 +637,9 @@
             },
             "message": "Login failed using auth server AuthServer (Local Authentication). Reason: Failed",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -701,7 +717,9 @@
             },
             "message": "Closed connection to TUN-VPN port 443 after 9 seconds, with 1308 bytes read (in 1 chunks) and 1131 bytes written (in 1 chunks) (session:sid085594569c49f5da11e483b49eaaabfc6fede5ce4a227da4)",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -793,7 +811,9 @@
                 "type": "ipv4"
             },
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -877,7 +897,9 @@
             },
             "message": "Logout from 89.160.20.156 (session:sid085594569c49f5da11e483b49eaaabfc6fede5ce4a227da4)",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -958,7 +980,9 @@
             },
             "message": "Session resumed from user agent 'Pulse-Secure/9.1.11.6725 (Windows 10) Pulse/9.1.11.6725' (session:sid9734dc3a195205ddb89cc05a9261a271201b4687ab468240).",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "pcs-node1",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",
@@ -1053,7 +1077,9 @@
             },
             "message": "WebRequest completed, GET to https://some.web.ch:443//sss/sessionPing?unique=0.10846163950738053 from 81.2.69.144 result=200 sent=60 received=4 in 1 seconds",
             "observer": {
-                "ip": "10.5.2.3",
+                "ip": [
+                    "10.5.2.3"
+                ],
                 "name": "sslvpn02",
                 "product": "Pulse Secure Connect",
                 "type": "vpn",

--- a/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pulse_connect_secure/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -116,9 +116,11 @@ processors:
   - set:
       field: source
       copy_from: client
+  - set:
+      field: observer.ip
+      value: ['{{{observer.ip}}}']
+      if: ctx.observer?.ip instanceof String
 
-
-      
   - remove:
       field:
         - _tmp

--- a/packages/pulse_connect_secure/data_stream/log/sample_event.json
+++ b/packages/pulse_connect_secure/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-10-19T09:10:35.000+02:00",
     "agent": {
-        "ephemeral_id": "48b94170-8de9-42a4-8608-50484a347a6a",
-        "id": "584f3aea-648c-4e58-aba4-32b8f88d4396",
+        "ephemeral_id": "dbefdcf7-8da3-42ce-a1dd-919d2f3e0611",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.9.0"
     },
     "client": {
         "address": "89.160.20.156",
@@ -38,18 +38,18 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "584f3aea-648c-4e58-aba4-32b8f88d4396",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "network",
         "created": "2021-10-19T09:10:35.000+02:00",
         "dataset": "pulse_connect_secure.log",
-        "ingested": "2022-02-03T09:39:02Z",
+        "ingested": "2023-08-07T18:48:45Z",
         "kind": "event",
-        "original": "Oct 19 09:10:35 pcs-node1 1 2021-10-19T09:10:35+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 09:10:35 - pcs-node1 - [89.160.20.156] user.name(REALM)[REALM_ROLES] - Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.\n",
+        "original": "Oct 19 09:10:35 pcs-node1 1 2021-10-19T09:10:35+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 09:10:35 - pcs-node1 - [89.160.20.156] user.name(REALM)[REALM_ROLES] - Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.",
         "outcome": "success",
         "timezone": "+02:00"
     },
@@ -57,16 +57,18 @@
         "hostname": "pcs-node1"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "172.19.0.7:51695"
+            "address": "192.168.176.4:55846"
         }
     },
     "message": "Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.",
     "observer": {
-        "ip": "10.5.2.3",
+        "ip": [
+            "10.5.2.3"
+        ],
         "name": "pcs-node1",
         "product": "Pulse Secure Connect",
         "type": "vpn",

--- a/packages/pulse_connect_secure/docs/README.md
+++ b/packages/pulse_connect_secure/docs/README.md
@@ -10,11 +10,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2021-10-19T09:10:35.000+02:00",
     "agent": {
-        "ephemeral_id": "48b94170-8de9-42a4-8608-50484a347a6a",
-        "id": "584f3aea-648c-4e58-aba4-32b8f88d4396",
+        "ephemeral_id": "dbefdcf7-8da3-42ce-a1dd-919d2f3e0611",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.0.0-beta1"
+        "version": "8.9.0"
     },
     "client": {
         "address": "89.160.20.156",
@@ -47,18 +47,18 @@ An example event for `log` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "584f3aea-648c-4e58-aba4-32b8f88d4396",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.0.0-beta1"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": "network",
         "created": "2021-10-19T09:10:35.000+02:00",
         "dataset": "pulse_connect_secure.log",
-        "ingested": "2022-02-03T09:39:02Z",
+        "ingested": "2023-08-07T18:48:45Z",
         "kind": "event",
-        "original": "Oct 19 09:10:35 pcs-node1 1 2021-10-19T09:10:35+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 09:10:35 - pcs-node1 - [89.160.20.156] user.name(REALM)[REALM_ROLES] - Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.\n",
+        "original": "Oct 19 09:10:35 pcs-node1 1 2021-10-19T09:10:35+02:00 10.5.2.3 PulseSecure: - - - 2021-10-19 09:10:35 - pcs-node1 - [89.160.20.156] user.name(REALM)[REALM_ROLES] - Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.",
         "outcome": "success",
         "timezone": "+02:00"
     },
@@ -66,16 +66,18 @@ An example event for `log` looks as following:
         "hostname": "pcs-node1"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "source": {
-            "address": "172.19.0.7:51695"
+            "address": "192.168.176.4:55846"
         }
     },
     "message": "Agent login succeeded for user.name/REALM (session:sid74fa8e00ca601280318287f67dfaee7cc6da40db0be6ac75) from 89.160.20.156 with Pulse-Secure/9.1.13.11723 (Windows 10) Pulse/9.1.13.11723.",
     "observer": {
-        "ip": "10.5.2.3",
+        "ip": [
+            "10.5.2.3"
+        ],
         "name": "pcs-node1",
         "product": "Pulse Secure Connect",
         "type": "vpn",

--- a/packages/pulse_connect_secure/manifest.yml
+++ b/packages/pulse_connect_secure/manifest.yml
@@ -1,7 +1,6 @@
 name: pulse_connect_secure
 title: Pulse Connect Secure
-version: "1.11.0"
-release: ga
+version: "1.12.0"
 description: Collect logs from Pulse Connect Secure with Elastic Agent.
 type: integration
 icons:
@@ -9,8 +8,7 @@ icons:
     title: pulse_connect_secure
     size: 300x70
     type: image/svg+xml
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: [vpn_security, security]
 conditions:
   kibana.version: "^7.16.0 || ^8.0.0"


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.9.0
- Ensure that observer.ip is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.9.0 packages/pulse_connect_secure
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870