### PR TITLE
[suricata] - update package-spec to 2.9.0

### DIFF
--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7309
 - version: "2.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/suricata/changelog.yml
+++ b/packages/suricata/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.12.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-alerts.log-expected.json
@@ -2556,19 +2556,35 @@
                     "subject": "C=US, ST=California, L=Mountain View, O=Google Inc, CN=*.google.com",
                     "x509": {
                         "issuer": {
-                            "common_name": "Google Internet Authority G2",
-                            "country": "US",
-                            "organization": "Google Inc"
+                            "common_name": [
+                                "Google Internet Authority G2"
+                            ],
+                            "country": [
+                                "US"
+                            ],
+                            "organization": [
+                                "Google Inc"
+                            ]
                         },
                         "not_after": "2024-07-16T14:52:35.000Z",
                         "not_before": "2019-07-17T14:52:35.000Z",
                         "serial_number": "001122334455667788",
                         "subject": {
-                            "common_name": "*.google.com",
-                            "country": "US,",
-                            "locality": "Mountain View,",
-                            "organization": "Google Inc,",
-                            "state_or_province": "California,"
+                            "common_name": [
+                                "*.google.com"
+                            ],
+                            "country": [
+                                "US,"
+                            ],
+                            "locality": [
+                                "Mountain View,"
+                            ],
+                            "organization": [
+                                "Google Inc,"
+                            ],
+                            "state_or_province": [
+                                "California,"
+                            ]
                         }
                     }
                 },
@@ -2688,23 +2704,47 @@
                     "subject": "C=Unknown, ST=Unknown, L=Unknown, O=Unknown, OU=Unknown, CN=Unknown",
                     "x509": {
                         "issuer": {
-                            "common_name": "Unknown",
-                            "country": "Unknown",
-                            "locality": "Unknown",
-                            "organization": "Unknown",
-                            "organizational_unit": "Unknown",
-                            "state_or_province": "Unknown"
+                            "common_name": [
+                                "Unknown"
+                            ],
+                            "country": [
+                                "Unknown"
+                            ],
+                            "locality": [
+                                "Unknown"
+                            ],
+                            "organization": [
+                                "Unknown"
+                            ],
+                            "organizational_unit": [
+                                "Unknown"
+                            ],
+                            "state_or_province": [
+                                "Unknown"
+                            ]
                         },
                         "not_after": "2026-06-25T17:36:29.000Z",
                         "not_before": "2016-06-27T17:36:29.000Z",
                         "serial_number": "72A92C51",
                         "subject": {
-                            "common_name": "Unknown",
-                            "country": "Unknown,",
-                            "locality": "Unknown,",
-                            "organization": "Unknown,",
-                            "organizational_unit": "Unknown,",
-                            "state_or_province": "Unknown,"
+                            "common_name": [
+                                "Unknown"
+                            ],
+                            "country": [
+                                "Unknown,"
+                            ],
+                            "locality": [
+                                "Unknown,"
+                            ],
+                            "organization": [
+                                "Unknown,"
+                            ],
+                            "organizational_unit": [
+                                "Unknown,"
+                            ],
+                            "state_or_province": [
+                                "Unknown,"
+                            ]
                         }
                     }
                 },

--- a/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
+++ b/packages/suricata/data_stream/eve/_dev/test/pipeline/test-eve-small.log-expected.json
@@ -682,20 +682,38 @@
                     "subject": "CN=*.icloud.com, OU=management:idms.group.506364, O=Apple Inc., ST=California, C=US",
                     "x509": {
                         "issuer": {
-                            "common_name": "Apple IST CA 2 - G1",
-                            "country": "US",
-                            "organization": "Apple Inc.",
-                            "organizational_unit": "Certification Authority"
+                            "common_name": [
+                                "Apple IST CA 2 - G1"
+                            ],
+                            "country": [
+                                "US"
+                            ],
+                            "organization": [
+                                "Apple Inc."
+                            ],
+                            "organizational_unit": [
+                                "Certification Authority"
+                            ]
                         },
                         "not_after": "2019-03-29T17:54:31.000Z",
                         "not_before": "2017-02-27T17:54:31.000Z",
                         "serial_number": "5C9CE1097887F807",
                         "subject": {
-                            "common_name": "*.icloud.com,",
-                            "country": "US",
-                            "organization": "Apple Inc.,",
-                            "organizational_unit": "management:idms.group.506364,",
-                            "state_or_province": "California,"
+                            "common_name": [
+                                "*.icloud.com,"
+                            ],
+                            "country": [
+                                "US"
+                            ],
+                            "organization": [
+                                "Apple Inc.,"
+                            ],
+                            "organizational_unit": [
+                                "management:idms.group.506364,"
+                            ],
+                            "state_or_province": [
+                                "California,"
+                            ]
                         }
                     }
                 },
@@ -922,20 +940,38 @@
                     "subject": "C=US, ST=New York, L=New York City, O=Acme U.S.A., INC., CN=update.acme.com",
                     "x509": {
                         "issuer": {
-                            "common_name": "GeoTrust RSA CA 2018",
-                            "country": "US",
-                            "organization": "DigiCert Inc",
-                            "organizational_unit": "www.digicert.com"
+                            "common_name": [
+                                "GeoTrust RSA CA 2018"
+                            ],
+                            "country": [
+                                "US"
+                            ],
+                            "organization": [
+                                "DigiCert Inc"
+                            ],
+                            "organizational_unit": [
+                                "www.digicert.com"
+                            ]
                         },
                         "not_after": "2021-12-25T23:59:59.000Z",
                         "not_before": "2020-11-24T00:00:00.000Z",
                         "serial_number": "0DCEDCBCAF9256B4C5414071265B1D53",
                         "subject": {
-                            "common_name": "update.acme.com",
-                            "country": "US,",
-                            "locality": "New York City,",
-                            "organization": "Acme U.S.A., INC.,",
-                            "state_or_province": "New York,"
+                            "common_name": [
+                                "update.acme.com"
+                            ],
+                            "country": [
+                                "US,"
+                            ],
+                            "locality": [
+                                "New York City,"
+                            ],
+                            "organization": [
+                                "Acme U.S.A., INC.,"
+                            ],
+                            "state_or_province": [
+                                "New York,"
+                            ]
                         }
                     }
                 },

--- a/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
+++ b/packages/suricata/data_stream/eve/elasticsearch/ingest_pipeline/tls.yml
@@ -35,26 +35,50 @@ processors:
       field: suricata.eve.tls.kv_subject.C
       target_field: tls.server.x509.subject.country
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.country
+      value: ['{{{tls.server.x509.subject.country}}}']
+      if: ctx.tls?.server?.x509?.subject?.country instanceof String
   - rename:
       field: suricata.eve.tls.kv_subject.CN
       target_field: tls.server.x509.subject.common_name
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.common_name
+      value: ['{{{tls.server.x509.subject.common_name}}}']
+      if: ctx.tls?.server?.x509?.subject?.common_name instanceof String
   - rename:
       field: suricata.eve.tls.kv_subject.L
       target_field: tls.server.x509.subject.locality
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.locality
+      value: ['{{{tls.server.x509.subject.locality}}}']
+      if: ctx.tls?.server?.x509?.subject?.locality instanceof String
   - rename:
       field: suricata.eve.tls.kv_subject.O
       target_field: tls.server.x509.subject.organization
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.organization
+      value: ['{{{tls.server.x509.subject.organization}}}']
+      if: ctx.tls?.server?.x509?.subject?.organization instanceof String
   - rename:
       field: suricata.eve.tls.kv_subject.OU
       target_field: tls.server.x509.subject.organizational_unit
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.organizational_unit
+      value: ['{{{tls.server.x509.subject.organizational_unit}}}']
+      if: ctx.tls?.server?.x509?.subject?.organizational_unit instanceof String
   - rename:
       field: suricata.eve.tls.kv_subject.ST
       target_field: tls.server.x509.subject.state_or_province
       ignore_missing: true
+  - set:
+      field: tls.server.x509.subject.state_or_province
+      value: ['{{{tls.server.x509.subject.state_or_province}}}']
+      if: ctx.tls?.server?.x509?.subject?.state_or_province instanceof String
   # Issuer
   - set:
       field: tls.server.issuer
@@ -75,26 +99,50 @@ processors:
       field: suricata.eve.tls.kv_issuerdn.C
       target_field: tls.server.x509.issuer.country
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.country
+      value: ['{{{tls.server.x509.issuer.country}}}']
+      if: ctx.tls?.server?.x509?.issuer?.country instanceof String
   - rename:
       field: suricata.eve.tls.kv_issuerdn.CN
       target_field: tls.server.x509.issuer.common_name
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.common_name
+      value: ['{{{tls.server.x509.issuer.common_name}}}']
+      if: ctx.tls?.server?.x509?.issuer?.common_name instanceof String
   - rename:
       field: suricata.eve.tls.kv_issuerdn.L
       target_field: tls.server.x509.issuer.locality
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.locality
+      value: ['{{{tls.server.x509.issuer.locality}}}']
+      if: ctx.tls?.server?.x509?.issuer?.locality instanceof String
   - rename:
       field: suricata.eve.tls.kv_issuerdn.O
       target_field: tls.server.x509.issuer.organization
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.organization
+      value: ['{{{tls.server.x509.issuer.organization}}}']
+      if: ctx.tls?.server?.x509?.issuer?.organization instanceof String
   - rename:
       field: suricata.eve.tls.kv_issuerdn.OU
       target_field: tls.server.x509.issuer.organizational_unit
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.organizational_unit
+      value: ['{{{tls.server.x509.issuer.organizational_unit}}}']
+      if: ctx.tls?.server?.x509?.issuer?.organizational_unit instanceof String
   - rename:
       field: suricata.eve.tls.kv_issuerdn.ST
       target_field: tls.server.x509.issuer.state_or_province
       ignore_missing: true
+  - set:
+      field: tls.server.x509.issuer.state_or_province
+      value: ['{{{tls.server.x509.issuer.state_or_province}}}']
+      if: ctx.tls?.server?.x509?.issuer?.state_or_province instanceof String
 
   - convert:
       field: suricata.eve.tls.session_resumed

--- a/packages/suricata/data_stream/eve/sample_event.json
+++ b/packages/suricata/data_stream/eve/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-07-05T19:01:09.820Z",
     "agent": {
-        "ephemeral_id": "1766b03e-b9fd-4e5b-9c37-bb972c55d7c5",
-        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
+        "ephemeral_id": "58adcb6e-5d0e-4822-98a4-8d93557f8f2e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.3"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "suricata.eve",
@@ -21,18 +21,18 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.2.3"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "created": "2022-07-08T01:02:15.499Z",
+        "created": "2023-08-08T15:09:13.171Z",
         "dataset": "suricata.eve",
-        "ingested": "2022-07-08T01:02:16Z",
+        "ingested": "2023-08-08T15:09:14Z",
         "kind": "event",
         "type": [
             "protocol"

--- a/packages/suricata/docs/README.md
+++ b/packages/suricata/docs/README.md
@@ -17,11 +17,11 @@ An example event for `eve` looks as following:
 {
     "@timestamp": "2018-07-05T19:01:09.820Z",
     "agent": {
-        "ephemeral_id": "1766b03e-b9fd-4e5b-9c37-bb972c55d7c5",
-        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
+        "ephemeral_id": "58adcb6e-5d0e-4822-98a4-8d93557f8f2e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.2.3"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "suricata.eve",
@@ -37,18 +37,18 @@ An example event for `eve` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "543eeec2-6585-484f-9f7b-34db47abcd9c",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.2.3"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
         "category": [
             "network"
         ],
-        "created": "2022-07-08T01:02:15.499Z",
+        "created": "2023-08-08T15:09:13.171Z",
         "dataset": "suricata.eve",
-        "ingested": "2022-07-08T01:02:16Z",
+        "ingested": "2023-08-08T15:09:14Z",
         "kind": "event",
         "type": [
             "protocol"

--- a/packages/suricata/manifest.yml
+++ b/packages/suricata/manifest.yml
@@ -1,7 +1,6 @@
 name: suricata
 title: Suricata
-version: "2.11.0"
-release: ga
+version: "2.12.0"
 description: Collect logs from Suricata with Elastic Agent.
 type: integration
 icons:
@@ -9,8 +8,7 @@ icons:
     title: suricata
     size: 309x309
     type: image/svg+xml
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: [network, security, ids_ips]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.9.0
- Ensure x509 subject and issuer fields are arrays

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.9.0 packages/suricata
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870