### PR TITLE
[ti_abusech] - update package-spec to 2.9.0

### DIFF
--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.17.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7315
 - version: "1.17.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_abusech/data_stream/malware/_dev/test/pipeline/test-malware-ndjson.log-expected.json
+++ b/packages/ti_abusech/data_stream/malware/_dev/test/pipeline/test-malware-ndjson.log-expected.json
@@ -5,10 +5,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"7871286a8f1f68a14b18ae475683f724\",\"sha256_hash\":\"48a6aee18bcfe9058b35b1018832aef1c9efd8f50ac822f49abb484a5e2a4b1f\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:14:05\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/48a6aee18bcfe9058b35b1018832aef1c9efd8f50ac822f49abb484a5e2a4b1f/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JG5:X5DpBw/KViMTB1MnEWk0115JW\",\"tlsh\":\"1344D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -47,10 +51,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"7b4c77dc293347b467fb860e34515163\",\"sha256_hash\":\"ec59538e8de8525b1674b3b8fe0c180ac822145350bcce054ad3fc6b95b1b5a4\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:11:41\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/ec59538e8de8525b1674b3b8fe0c180ac822145350bcce054ad3fc6b95b1b5a4/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGY:X5DpBw/KViMTB1MnEWk0115Jr\",\"tlsh\":\"4E44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -98,10 +106,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"373d34874d7bc89fd4cefa6272ee80bf\",\"sha256_hash\":\"b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:11:22\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7/\",\"virustotal\":{\"result\":\"25 / 66\",\"percent\":\"37.88\",\"link\":\"https://www.virustotal.com/gui/file/b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7/detection/f-b0e914d\"},\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGG:X5DpBw/KViMTB1MnEWk0115Jd\",\"tlsh\":\"7544D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -140,10 +152,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"e2e02aae857488dbdbe6631c29abf3f8\",\"sha256_hash\":\"7483e834a73fb6817769596fe4c0fa01d28639f52bbbdc2b8a56c36d466dd7f8\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":null,\"firstseen\":\"2021-01-14 06:11:21\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/7483e834a73fb6817769596fe4c0fa01d28639f52bbbdc2b8a56c36d466dd7f8/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJ9:0h3eZgRQCcw+MN54dEq7kqRtoLZH\",\"tlsh\":\"5554CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -182,10 +198,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"3e988e32b0c3c230d534e286665b89a5\",\"sha256_hash\":\"760e729426fb115b967a41e5a6f2f42d7a52a5cee74ed99065a6dc39bf89f59b\",\"file_type\":\"unknown\",\"file_size\":\"352\",\"signature\":null,\"firstseen\":\"2021-01-14 06:08:02\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/760e729426fb115b967a41e5a6f2f42d7a52a5cee74ed99065a6dc39bf89f59b/\",\"virustotal\":null,\"imphash\":null,\"ssdeep\":\"6:TE6ll8uXi0jIAv6BHvPuA7RKTmOQamsQMGvMQgTYbtsWsQ72hCqPZG/:TTll8uTo5uA7RKtQamsS0QJfsQ7mCR\",\"tlsh\":\"3CE0C002AB26C036500D154C221655B3B871911503CA14E6A6824BEA765D4A3290D190\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -229,10 +249,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"dcc20d534cdf29eab03d8148bf728857\",\"sha256_hash\":\"86655c0bcf9b21b5efc682f58eb80f42811042ba152358e1bfbbb867315a60ac\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:08:02\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/86655c0bcf9b21b5efc682f58eb80f42811042ba152358e1bfbbb867315a60ac/\",\"virustotal\":{\"result\":\"27 / 69\",\"percent\":\"39.13\",\"link\":\"https://www.virustotal.com/gui/file/86655c0bcf9b21b5efc682f58eb80f42811042ba152358e1bfbbb867315a60ac/detection/f-86655c0\"},\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGI:X5DpBw/KViMTB1MnEWk0115JH\",\"tlsh\":\"0D44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -271,10 +295,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"f6facbf7a90b9e67a6de9f6634eb40ba\",\"sha256_hash\":\"e91c9e11d3ce4f55fabd7196279367482d2fabfa32df81e614b15fc53b4e26be\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:53\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/e91c9e11d3ce4f55fabd7196279367482d2fabfa32df81e614b15fc53b4e26be/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJ1:0h3eZgRQCcw+MN54dEq7kqRtoLZL\",\"tlsh\":\"2554CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -313,10 +341,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"44325fd5bdda2e2cdea07c3a39953bb1\",\"sha256_hash\":\"beedbbcacfc34b5edd8c68e3e4acf364992ebbcd989548e09e38fa03c5659bac\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:41\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/beedbbcacfc34b5edd8c68e3e4acf364992ebbcd989548e09e38fa03c5659bac/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JG/:X5DpBw/KViMTB1MnEWk0115Jg\",\"tlsh\":\"A044D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -360,10 +392,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"4c549051950522a3f1b0814aa9b1f6d1\",\"sha256_hash\":\"7cba55da723c0e020267a02e6ffc83e03a83701757fc4ec65ea398618ad881cf\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":\"Heodo\",\"firstseen\":\"2021-01-14 06:07:31\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/7cba55da723c0e020267a02e6ffc83e03a83701757fc4ec65ea398618ad881cf/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JG4:X5DpBw/KViMTB1MnEWk0115Jv\",\"tlsh\":\"4544D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -402,10 +438,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"d7333113098d88b6a5dd5b8eb24f9b87\",\"sha256_hash\":\"426be5e085e6bbad8430223dc89d8d3ced497133f8d478fd00005bcbb73399d4\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:07\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/426be5e085e6bbad8430223dc89d8d3ced497133f8d478fd00005bcbb73399d4/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJw:0h3eZgRQCcw+MN54dEq7kqRtoLZW\",\"tlsh\":\"9454CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -444,10 +484,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"c8dbb261c1f450534c3693da2f4b479f\",\"sha256_hash\":\"25093afdaeb3ea000743ab843360a6b64f58c0a1ab950072ba6528056735deb9\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:07\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/25093afdaeb3ea000743ab843360a6b64f58c0a1ab950072ba6528056735deb9/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGe:X5DpBw/KViMTB1MnEWk0115JR\",\"tlsh\":\"F344D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -486,10 +530,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"714953f1d0031a4bb2f0c44afd015931\",\"sha256_hash\":\"b3327a96280365e441057f490df6261c9a2400fd63719eb9a7a0c9db95beecc5\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:06\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/b3327a96280365e441057f490df6261c9a2400fd63719eb9a7a0c9db95beecc5/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGc:X5DpBw/KViMTB1MnEWk0115J7\",\"tlsh\":\"F644D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -528,10 +576,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"20fd22742500d4cec123398afc3d3672\",\"sha256_hash\":\"e92b54904391c171238863b584355197ba4508f73320a8e89afbb5425fc2dc4b\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:07:00\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/e92b54904391c171238863b584355197ba4508f73320a8e89afbb5425fc2dc4b/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGc:X5DpBw/KViMTB1MnEWk0115JP\",\"tlsh\":\"BE44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -570,10 +622,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"aa81ceea053797a6f8c38a0f2f9b80b0\",\"sha256_hash\":\"dd15e74b3cd3a4fdb5f47adefd6f90e27d5a20e01316cc791711f6dce7c0f52e\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:06:36\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/dd15e74b3cd3a4fdb5f47adefd6f90e27d5a20e01316cc791711f6dce7c0f52e/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGf:X5DpBw/KViMTB1MnEWk0115Jo\",\"tlsh\":\"CC44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -617,10 +673,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"a2ce6795664c0fa93b07fa54ba868991\",\"sha256_hash\":\"0fae1eeabc4f5e07bd16f7851aec5ab6032d407c7ff0270f2b6e85c2a3efebd1\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":\"Heodo\",\"firstseen\":\"2021-01-14 06:06:13\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/0fae1eeabc4f5e07bd16f7851aec5ab6032d407c7ff0270f2b6e85c2a3efebd1/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGD:X5DpBw/KViMTB1MnEWk0115JY\",\"tlsh\":\"8C44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -659,10 +719,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"9b9bac158dacb9c2f5511e9c464a7de4\",\"sha256_hash\":\"07a9d84c0b2c8cf1fd90ab409b9399d06920ab4b6efb647b5a3b9bef1045ee7e\",\"file_type\":\"dll\",\"file_size\":\"280064\",\"signature\":null,\"firstseen\":\"2021-01-14 06:05:52\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/07a9d84c0b2c8cf1fd90ab409b9399d06920ab4b6efb647b5a3b9bef1045ee7e/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:WlLMUG2gFWLDFO9vNa11y3NPcJufFFTXNZrjJTKk:W5MT4WNaHy9P1FjbrjlKk\",\"tlsh\":\"6B54CF217A53C826F5E800FCA6E9878914167F346F44A4C773D40F6AA8759E2EF2B317\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -701,10 +765,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"e48e3fa5e0f7b21c1ecf1efc81ff91e8\",\"sha256_hash\":\"708c0193aec6354af6877f314d4b0e3864552bac77258bee9ee5bf886a116df5\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:05:51\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/708c0193aec6354af6877f314d4b0e3864552bac77258bee9ee5bf886a116df5/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGo:X5DpBw/KViMTB1MnEWk0115Jj\",\"tlsh\":\"6644D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -748,10 +816,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"8957f5347633ab4b10c2ae4fb92c8572\",\"sha256_hash\":\"f70a3c016fe791eb30959961f0bcaa08ba7b738491b9ae61cb4a667cd1de8b37\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":\"Heodo\",\"firstseen\":\"2021-01-14 06:05:50\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/f70a3c016fe791eb30959961f0bcaa08ba7b738491b9ae61cb4a667cd1de8b37/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJy:0h3eZgRQCcw+MN54dEq7kqRtoLZM\",\"tlsh\":\"0754CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -790,10 +862,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"09cc76b7077b4d5704e46e864575ff03\",\"sha256_hash\":\"94ca186561b13fa9b1bf15f7e66118debc686b40d2a62a5cf4b3c6ca6ee1c7a1\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:05:36\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/94ca186561b13fa9b1bf15f7e66118debc686b40d2a62a5cf4b3c6ca6ee1c7a1/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JG/:X5DpBw/KViMTB1MnEWk0115Js\",\"tlsh\":\"BB44D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -832,10 +908,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"98a1cdf7de4232363f1d1e0f33dbfd99\",\"sha256_hash\":\"909f890dbc5748845cf06d0fb0b73a5c0cb17761f37e9cd4810eea0d0eb8627f\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":null,\"firstseen\":\"2021-01-14 06:05:16\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/909f890dbc5748845cf06d0fb0b73a5c0cb17761f37e9cd4810eea0d0eb8627f/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJQ:0h3eZgRQCcw+MN54dEq7kqRtoLZ+\",\"tlsh\":\"C554CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -879,10 +959,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"8a51830c1662513ba6bd44e2f7849547\",\"sha256_hash\":\"d1fa76346bef5bc8adaa615e109894a7c30f0bef07ab6272409c4056ea8d52aa\",\"file_type\":\"dll\",\"file_size\":\"284672\",\"signature\":\"Heodo\",\"firstseen\":\"2021-01-14 06:05:15\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/d1fa76346bef5bc8adaa615e109894a7c30f0bef07ab6272409c4056ea8d52aa/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:0hlBeZgR9LqvgFcwNAwhGV52n5Dv4JdEqvQykqRqYdBx8pRA7OZJh:0h3eZgRQCcw+MN54dEq7kqRtoLZ/\",\"tlsh\":\"1654CF22E642C926F1E900FCB2A98B4451257E355F40F4D777C40FABA835AE2AF27717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -921,10 +1005,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"ae21d742a8118d6b86674aa5370bd6a7\",\"sha256_hash\":\"3b9698b6c18bcba15ee33378440dd3f42509730e6b1d2d5832c71a74b1920e51\",\"file_type\":\"dll\",\"file_size\":\"280064\",\"signature\":null,\"firstseen\":\"2021-01-14 06:05:12\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/3b9698b6c18bcba15ee33378440dd3f42509730e6b1d2d5832c71a74b1920e51/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:WlLMUG2gFWLDFO9vNa11y3NPcJufFFTXNZrjJTKS:W5MT4WNaHy9P1FjbrjlKS\",\"tlsh\":\"5454CF217A53C826F5E800FCA6E9878925167F346F44A4C373D40F6AA8759E2DF2B317\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -963,10 +1051,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"78c9d88d24ed1d982a83216eed1590f6\",\"sha256_hash\":\"d11edc90f0e879a175abc6e2ce5c94a263aa2a01cd3b6e8b9fdf93a51235ae99\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:04:38\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/d11edc90f0e879a175abc6e2ce5c94a263aa2a01cd3b6e8b9fdf93a51235ae99/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JG8:X5DpBw/KViMTB1MnEWk0115Jr\",\"tlsh\":\"6044D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -1005,10 +1097,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"236577d5d83e2a8d08623a7a7f724188\",\"sha256_hash\":\"8cd28fed7ebdcd79ea2509dca84f0a727ca28d4eaaed5a92cd10b1279ff16afa\",\"file_type\":\"dll\",\"file_size\":\"241664\",\"signature\":null,\"firstseen\":\"2021-01-14 06:04:26\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/8cd28fed7ebdcd79ea2509dca84f0a727ca28d4eaaed5a92cd10b1279ff16afa/\",\"virustotal\":null,\"imphash\":\"ed2860c18f5483e3b5388bad75169dc1\",\"ssdeep\":\"6144:X1G3WVIOY6Bdjehj+qudd96ou/6mv5wdC:X1GmSafShjYdd96z/6cwdC\",\"tlsh\":\"8D34BE41B28B8B4BD163163C2976D1F8953CFC909761CE693B64B22F0F739D0892E7A5\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -1047,10 +1143,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"md5_hash\":\"ff60107d82dcda7e6726d214528758e7\",\"sha256_hash\":\"fb25d13188a5d0913bbcf5aeff6c7e3208ad92a7d10ab6bed2735f4d43310a27\",\"file_type\":\"dll\",\"file_size\":\"277504\",\"signature\":null,\"firstseen\":\"2021-01-14 06:04:20\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/fb25d13188a5d0913bbcf5aeff6c7e3208ad92a7d10ab6bed2735f4d43310a27/\",\"virustotal\":null,\"imphash\":\"68aea345b134d576ccdef7f06db86088\",\"ssdeep\":\"6144:+60EDP6uCLfGw/GpxXinM1BCo1PlumGx2mx2tXd0t115JGz:X5DpBw/KViMTB1MnEWk0115JU\",\"tlsh\":\"9244D022AD13DD37E1F400FCA6A58F8561626E381F00A89777D41F8A98356F1BB2B717\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -1089,10 +1189,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"file_size\":90117,\"file_type\":\"exe\",\"firstseen\":\"2023-07-21 08:00:05\",\"imphash\":\"\",\"md5_hash\":\"f501a0aafcdd6f67f8956385237b8709\",\"sha256_hash\":\"a385cb241d6c1b03ffe25dbd62beb4d8fe4d38d17b568428079291c256245401\",\"signature\":null,\"ssdeep\":\"1536:rTQEs1uI5PRfnDtUZ6FWEP2qZ2tAd3tFNgi4enBw:rMj1XbtLtUtAUb\",\"tlsh\":\"T1B2939D3172D0C072C46366305574D7A26FBEB83213B9A5CB5B682A396FB07D067783\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/a385cb241d6c1b03ffe25dbd62beb4d8fe4d38d17b568428079291c256245401/\",\"virustotal\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [

--- a/packages/ti_abusech/data_stream/malware/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_abusech/data_stream/malware/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #

--- a/packages/ti_abusech/data_stream/malware/sample_event.json
+++ b/packages/ti_abusech/data_stream/malware/sample_event.json
@@ -1,14 +1,11 @@
 {
-    "@timestamp": "2022-08-06T00:06:27.079Z",
-    "abusech": {
-        "malware": {}
-    },
+    "@timestamp": "2023-08-08T18:14:46.428Z",
     "agent": {
-        "ephemeral_id": "1760e1ca-6974-4a32-80c6-0e7e58a6d573",
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "ephemeral_id": "307223ed-6fad-46c5-8694-1911ce83f68b",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "ti_abusech.malware",
@@ -19,19 +16,23 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-06T00:06:27.079Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:14:46.428Z",
         "dataset": "ti_abusech.malware",
-        "ingested": "2022-08-06T00:06:30Z",
+        "ingested": "2023-08-08T18:14:49Z",
         "kind": "enrichment",
         "original": "{\"file_size\":\"1563\",\"file_type\":\"unknown\",\"firstseen\":\"2021-10-05 04:17:02\",\"imphash\":null,\"md5_hash\":\"9cd5a4f0231a47823c4adba7c8ef370f\",\"sha256_hash\":\"7c0852d514df7faf8fdbfa4f358cc235dd1b1a2d843cc65495d03b502e4099f2\",\"signature\":null,\"ssdeep\":\"48:yazkS7neW+mfe4CJjNXcq5Co4Fr1PpsHn:yrmGNt5mbP2n\",\"tlsh\":\"T109314C5E7822CA70B91AD69300C22D8C2F53EAF229E6686C3BDD4C86FA1344208CF1\",\"urlhaus_download\":\"https://urlhaus-api.abuse.ch/v1/download/7c0852d514df7faf8fdbfa4f358cc235dd1b1a2d843cc65495d03b502e4099f2/\",\"virustotal\":null}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"
@@ -58,7 +59,6 @@
                     "ssdeep": "48:yazkS7neW+mfe4CJjNXcq5Co4Fr1PpsHn:yrmGNt5mbP2n",
                     "tlsh": "T109314C5E7822CA70B91AD69300C22D8C2F53EAF229E6686C3BDD4C86FA1344208CF1"
                 },
-                "pe": {},
                 "size": 1563,
                 "type": "unknown"
             },

--- a/packages/ti_abusech/data_stream/malwarebazaar/_dev/test/pipeline/test-malwarebazaar-ndjson.log-expected.json
+++ b/packages/ti_abusech/data_stream/malwarebazaar/_dev/test/pipeline/test-malwarebazaar-ndjson.log-expected.json
@@ -17,10 +17,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"5bce7d528c1363104a93fbb5a7fa9bdd991ce929cc09cc7fb29052a68d4fd24b\",\"sha3_384_hash\":\"3b454eb6421d17d093f19292b64d30bf918cb91e9322d0e2d2512857997f574ea2ca5b005133c16f6c33c7cee9c1bd0e\",\"sha1_hash\":\"a71fd0504821092e003f350080a6bcc5fa6a972e\",\"md5_hash\":\"0af07660056a692b7cb82fa329221ddd\",\"first_seen\":\"2021-04-06 20:34:58\",\"last_seen\":null,\"file_name\":\"SALM0BRU.exe\",\"file_size\":399872,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"exe\",\"reporter\":\"James_inthe_box\",\"origin_country\":\"US\",\"anonymous\":0,\"signature\":null,\"imphash\":\"f34d5f2d4577ed6d9ceec516c1f5a744\",\"tlsh\":\"F9848B24AF932F9BC6CCC1FE50C2D165C9A9F85DD2B1251A73B6CB89FE00544ED2C686\",\"telfhash\":null,\"ssdeep\":\"3072:DsPPK3p+8r5igrL1Tq50cVBDmDJhE9yV4veedHrP6FXK7:D+PL8bronBDmDJ69JeedHriFG\",\"tags\":[\"exe\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"15\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -78,10 +82,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"83d0429a2c5f1b611ebc30391eeeb75bebb51212ee1af51dbcf2624b48f9d27f\",\"sha3_384_hash\":\"0a1536add280715320040d5ac5340d3b205d90045ff5c90993b8e909edb9b3e9338b3ffbb3febcaf82584d00d516e8c7\",\"sha1_hash\":\"c454be4eb0892d61a4ad6bac16f97724e73cd795\",\"md5_hash\":\"296aad7075596d21516b30bfbc17fcac\",\"first_seen\":\"2021-04-06 20:32:25\",\"last_seen\":null,\"file_name\":\"PO_NO.ENQUIRY-210604.zip\",\"file_size\":476768,\"file_type_mime\":\"application/zip\",\"file_type\":\"zip\",\"reporter\":\"GovCERT_CH\",\"origin_country\":\"US\",\"anonymous\":0,\"signature\":null,\"imphash\":null,\"tlsh\":\"74A4233B9A6D5CA02B224AA69F37537D13A8406300944EAEFD375CA431583056B9F6FF\",\"telfhash\":null,\"ssdeep\":\"12288:j++y4mulTPaYJSaHwvJblQpLGwYeHU9vPpNGd+Zr:j3HPaMtQxblje01pNHZr\",\"tags\":null,\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"11\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -138,10 +146,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"f4910ea08d14eeb634084de47cf590d4dc5e554552f111da20d22ae71d7b425b\",\"sha3_384_hash\":\"ee7586cb085fde3c14c9c1bea4635ccb30b1af2020f64e87a9983e61b05026ec9b35255670a3d9ecaab436c4ba302dcc\",\"sha1_hash\":\"bf103996196df8255881127dee103c22fc12bef3\",\"md5_hash\":\"a4838dd31c672122441bebcbf7e9d277\",\"first_seen\":\"2021-04-06 20:12:29\",\"last_seen\":null,\"file_name\":\"DropDll.dat\",\"file_size\":435926,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"dll\",\"reporter\":\"DmitriyMelikov\",\"origin_country\":\"DE\",\"anonymous\":0,\"signature\":\"Hancitor\",\"imphash\":\"0b5a952a025c2783c3126cdb9bef2844\",\"tlsh\":\"0C947D11BA96C473E572163008399F6A17BE7A900B704BDBE3CC097E4E755C24B36BA7\",\"telfhash\":null,\"ssdeep\":\"12288:L2X/txpFDEVkUNglTovKfoLy+hqK/cEUMMlGOG:RzglgLm/9lGOG\",\"tags\":[\"Hancitor\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"30\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -184,7 +196,9 @@
                     "type": "file"
                 },
                 "software": {
-                    "alias": "Hancitor"
+                    "alias": [
+                        "Hancitor"
+                    ]
                 }
             }
         },
@@ -206,10 +220,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"e45ffc61a85c2f5c0cbe9376ff215cad324bf14f925bf52ec0d2949f7d235a00\",\"sha3_384_hash\":\"788f61cf45bbc8cad5775de18d0d5f42c4e028af0aaa34c570645efc96af8ebc3d7fe330aaf22ef34d35360bbd4a708c\",\"sha1_hash\":\"a68ca1b41cb93fe2879bb3baeb8e19990758f099\",\"md5_hash\":\"8d7c8b55ac49d241fb7f75a27a5ef8d5\",\"first_seen\":\"2021-04-06 20:07:59\",\"last_seen\":null,\"file_name\":\"vabsheche.py\",\"file_size\":11717,\"file_type_mime\":\"text/x-script.python\",\"file_type\":\"unknown\",\"reporter\":\"ArkbirdDevil\",\"origin_country\":\"FR\",\"anonymous\":0,\"signature\":null,\"imphash\":null,\"tlsh\":\"AE3222515C6A881A03B3C66F7992B844FB588303C7116607F6FC86782F79568CAF1BBD\",\"telfhash\":null,\"ssdeep\":\"192:z7X/yHo/yz/yBKiSOINLyhQMYd+LiTfq6LTf3ZoTta3Grj6rg2:z7CIKnNNLwufPfAPq7\",\"tags\":[\"backdoor\",\"python\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"27\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -266,10 +284,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"42f5f5474431738f91f612d9765b3fc9b85a547274ea64aa034298ad97ad28f4\",\"sha3_384_hash\":\"752e5d56a166227d06f8cbd40cd3f693f543f9c3f798c673c1430957bb7e149a12d9158138fa449479105f472e70f68f\",\"sha1_hash\":\"e8378aede9f26f09b7d503d79a05d67612be15f6\",\"md5_hash\":\"fe185f106730583156f39233f77f8019\",\"first_seen\":\"2021-04-06 20:00:48\",\"last_seen\":null,\"file_name\":\"42f5f5474431738f91f612d9765b3fc9b85a547274ea64aa034298ad97ad28f4.bin\",\"file_size\":7929856,\"file_type_mime\":\"application/msword\",\"file_type\":\"docx\",\"reporter\":\"ArkbirdDevil\",\"origin_country\":\"FR\",\"anonymous\":0,\"signature\":null,\"imphash\":null,\"tlsh\":\"13863341B085EE2EE2CA41BA0DA9C2BD43B63D131E054F677269B72D3EB76E0E7D4144\",\"telfhash\":null,\"ssdeep\":\"196608:KQaeKLOiBEp+uc+iuYmbMdHmN1Rwyd2jecXeaH1pHE+2:oeIOTp+p+iNJC1ChjhXZ1pHz2\",\"tags\":[\"maldoc\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"21\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -327,10 +349,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"2d705f0b76f24a18e08163db2f187140ee9f03e43697a9ea0d840c829692d43c\",\"sha3_384_hash\":\"c82132559381b7b3b184b4ce8c7a58c301a46001621f346b637139f5987dee968ae2ef009a17b2388852b2db15a45b58\",\"sha1_hash\":\"b2da45913353bfc66d189455f9ad80ef26968143\",\"md5_hash\":\"70da6872b6b2da9ddc94d14b02302917\",\"first_seen\":\"2021-04-06 19:58:50\",\"last_seen\":null,\"file_name\":\"winlog.wll\",\"file_size\":131584,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"dll\",\"reporter\":\"ArkbirdDevil\",\"origin_country\":\"FR\",\"anonymous\":0,\"signature\":null,\"imphash\":\"6476b7c4dd55eafbdf922a7ba1e2d5f9\",\"tlsh\":\"A2D38C067790C071DAAF013908799E624B7F7D70DDB49D8B77841A8E69342D0AF3AB27\",\"telfhash\":null,\"ssdeep\":\"1536:2NVi7z0r0lJRn6I8+YDgr1fnWG5Ff0+adgBYlCtMiQMX1c0E4JsWjcdonPv870E1:YM7zh8+Cofnp5eRm6riQ6OZoPv870E\",\"tags\":[\"apt\",\"tonto\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"30\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -388,10 +414,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"30787f32adc487311d764b19d4504fdeab08c0d385e2fa065bd8d5836c031606\",\"sha3_384_hash\":\"a3ec981ed158fe08cc2cd97303807cfbed147e59ccfd92fcaa9395c5718b4d9b892d6e9fa6337f5976dc1bd042562fe4\",\"sha1_hash\":\"3d613d5678e43faeea1c636185a0b4c3ec80e742\",\"md5_hash\":\"de80e1d7d9f5b1c64ec9f8d4f5063989\",\"first_seen\":\"2021-04-06 19:58:44\",\"last_seen\":null,\"file_name\":\"30787f32adc487311d764b19d4504fdeab08c0d385e2fa065bd8d5836c031606.bin.sample\",\"file_size\":1088000,\"file_type_mime\":\"application/msword\",\"file_type\":\"docx\",\"reporter\":\"DmitriyMelikov\",\"origin_country\":\"DE\",\"anonymous\":0,\"signature\":null,\"imphash\":null,\"tlsh\":\"8635D001BA82C573D5621A35083ADBAA177E7D604F704ADBB3C83B2E5D355C14B32BA7\",\"telfhash\":null,\"ssdeep\":\"24576:WKEiZxl3A4yJJG2dPQQCthXzglgLm/9lGO:WKEGByvGOQQC/XElga/9lGO\",\"tags\":null,\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"32\",\"uploads\":\"1\",\"mail\":null}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -452,10 +482,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"84f983067868de50e5b1553782c056c1f5b5118bb2084473ca4b6908f221cd3b\",\"sha3_384_hash\":\"138dc28a74d15c1f9797ce732e99097c8c6db4549cb17cb7b20c1c6738a170328e45aea2d4c3b593912f14a97f521c1d\",\"sha1_hash\":\"00b52e8ca1785d5086703ad8cff1d28fc3354934\",\"md5_hash\":\"2759c73c986c6a757bf9d25621c5595a\",\"first_seen\":\"2021-04-06 19:52:32\",\"last_seen\":null,\"file_name\":\"Purchase Order.8000.scan.pdf...exe\",\"file_size\":752128,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"exe\",\"reporter\":\"James_inthe_box\",\"origin_country\":\"FR\",\"anonymous\":0,\"signature\":\"SnakeKeylogger\",\"imphash\":\"f34d5f2d4577ed6d9ceec516c1f5a744\",\"tlsh\":\"23F4AE212684C9C0D93E67B4D43584F003BABD16D631F69F6E887C693EB32D2D63B646\",\"telfhash\":null,\"ssdeep\":\"12288:8t11ulRZRLZNh4YeX6f6XmwNShqE73YXy7moh:S11gZpZNmBX06WmAcy7m0\",\"tags\":[\"exe\",\"SnakeKeylogger\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"38\",\"uploads\":\"1\",\"mail\":{\"Generic\":\"low\"}}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -498,7 +532,9 @@
                     "type": "file"
                 },
                 "software": {
-                    "alias": "SnakeKeylogger"
+                    "alias": [
+                        "SnakeKeylogger"
+                    ]
                 }
             }
         },
@@ -523,10 +559,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"0661d87116f44cbd5b5c6bec7fb06c4e5cd5b6ecbc5455d959e65f1ee46c54c8\",\"sha3_384_hash\":\"ed5d03454121d81adf65a01ba90af81b1a7cea052709c22bb9170508069d17242861f85e5546b2cc3efb07c10926368c\",\"sha1_hash\":\"a34fd5e57d75d17bc2d84055ca4752e5ee2e92f5\",\"md5_hash\":\"596b3dbf07a287dcf76860b5e54762c3\",\"first_seen\":\"2021-04-06 19:47:13\",\"last_seen\":null,\"file_name\":\"New Order PO#121012020_____PDF_______.exe\",\"file_size\":836096,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"exe\",\"reporter\":\"James_inthe_box\",\"origin_country\":\"FR\",\"anonymous\":0,\"signature\":\"AgentTesla\",\"imphash\":\"f34d5f2d4577ed6d9ceec516c1f5a744\",\"tlsh\":\"A505CF712694C9A4FABD53B80434403007F5FE42E232FA9A6FD17C993E72782DA3B655\",\"telfhash\":null,\"ssdeep\":\"12288:qRedcNeqimzAEmN03VgdZfBOMx+RVBM7pdWje9ppB5nAZGNY2:ZaNeqikqN0udZfBFUYp55nFN\",\"tags\":[\"AgentTesla\",\"exe\"],\"code_sign\":[],\"intelligence\":{\"clamav\":null,\"downloads\":\"40\",\"uploads\":\"1\",\"mail\":{\"Generic\":\"low\"}}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -569,7 +609,9 @@
                     "type": "file"
                 },
                 "software": {
-                    "alias": "AgentTesla"
+                    "alias": [
+                        "AgentTesla"
+                    ]
                 }
             }
         },
@@ -602,10 +644,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"sha256_hash\":\"4fccd38f504290cf5c70e7336071a90a064303c7fdf5c17f7c38001768bce115\",\"sha3_384_hash\":null,\"sha1_hash\":\"3a83bb68be29e1f18fc9d328d952fd228abfae2a\",\"md5_hash\":\"e614a69d706913376ab2bb20a703dcf5\",\"first_seen\":\"2022-08-30 22:36:54\",\"last_seen\":null,\"file_name\":\"4fccd38f504290cf5c70e7336071a90a064303c7fdf5c17f7c38001768bce115\",\"file_size\":246816,\"file_type_mime\":\"application/x-dosexec\",\"file_type\":\"exe\",\"reporter\":\"OSimao\",\"anonymous\":0,\"signature\":\"Dridex\",\"imphash\":\"53654c59ffb323a249342d35a6b65745\",\"tlsh\":\"T17034B0A0F196C8DAF85765B54C5FE9201012AAAED4B1D51E20EB3B39E8F33531077A4F\",\"telfhash\":null,\"gimphash\":null,\"ssdeep\":\"3072:KWiPOo14wwI606CzpJEPlp+K2b1WvAUQdk5m84D2KQdXtvkDqW0TrHbed2rT2pN8:KWdEj6rapJEPr11AXdQm84Dr0OOPSR4\",\"dhash_icon\":\"79e4e4ccccc4c4c0\",\"tags\":[\"Dridex\",\"exe\",\"signed\"],\"code_sign\":[{\"subject_cn\":\"\\\"VERONIKA 2\\\" OOO\",\"issuer_cn\":\"Sectigo RSA Code Signing CA\",\"algorithm\":\"sha256WithRSAEncryption\",\"valid_from\":\"2019-07-15T00:00:00Z\",\"valid_to\":\"2020-06-27T23:59:59Z\",\"serial_number\":\"e573d9c8b403c41bd59ffa0a8efd4168\",\"thumbprint_algorithm\":\"SHA256\",\"thumbprint\":\"a9ab2be0ea677c6c6ed67b23cfee0fa44bfb346a4bb720f10a3f02a78b8f5c82\",\"cscb_listed\":false,\"cscb_reason\":\"\"}]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [
@@ -671,7 +717,9 @@
                     "type": "file"
                 },
                 "software": {
-                    "alias": "Dridex"
+                    "alias": [
+                        "Dridex"
+                    ]
                 }
             }
         },
@@ -692,10 +740,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"anonymous\":1,\"code_sign\":[],\"dhash_icon\":null,\"file_name\":\"4da57027ffe7e32c891334d6834923bc17e4174c53ace4ff69de6410c24d84cb\",\"file_size\":2560,\"file_type\":\"exe\",\"file_type_mime\":\"application/x-dosexec\",\"first_seen\":\"2023-07-21 17:06:27\",\"gimphash\":null,\"imphash\":\"\",\"intelligence\":{\"clamav\":null,\"downloads\":\"227\",\"mail\":null,\"uploads\":\"1\"},\"last_seen\":null,\"md5_hash\":\"4f744666d2a2dc95419208c61e42f163\",\"origin_country\":\"US\",\"reporter\":\"anonymous\",\"sha1_hash\":\"34712624aadd053f43703af860fe90e545bf1f0a\",\"sha256_hash\":\"4da57027ffe7e32c891334d6834923bc17e4174c53ace4ff69de6410c24d84cb\",\"sha3_384_hash\":\"40753109b922a577de0f9252e89bc80b8eba54c08aba7f6a59e836714a21ffd1b3ec58ff69d902469d4fcff73eabc5ba\",\"signature\":null,\"ssdeep\":\"24:ev1GSxthEcf5K1a1I8Q3nB8+gxtkcPnRuV4MPgic:qjBK1GQXGxLRuqS\",\"tags\":[\"exe\"],\"telfhash\":null,\"tlsh\":\"T164511E8783A88896D219037D425BC9387737B3202B9F0B5B7F5C52BF3F0124298A3D50\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "hash": [

--- a/packages/ti_abusech/data_stream/malwarebazaar/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_abusech/data_stream/malwarebazaar/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #
@@ -75,6 +75,10 @@ processors:
       field: abusech.malwarebazaar.signature
       target_field: threat.software.alias
       ignore_missing: true
+  - set:
+      field: threat.software.alias
+      value: ['{{{threat.software.alias}}}']
+      if: ctx.threat?.software?.alias instanceof String
   - rename:
       field: abusech.malwarebazaar.file_size
       target_field: threat.indicator.file.size

--- a/packages/ti_abusech/data_stream/malwarebazaar/sample_event.json
+++ b/packages/ti_abusech/data_stream/malwarebazaar/sample_event.json
@@ -1,9 +1,8 @@
 {
-    "@timestamp": "2022-08-06T00:08:33.562Z",
+    "@timestamp": "2023-08-08T18:15:38.506Z",
     "abusech": {
         "malwarebazaar": {
             "anonymous": 0,
-            "code_sign": [],
             "intelligence": {
                 "downloads": 11,
                 "uploads": 1
@@ -15,11 +14,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "7d65c47e-ccda-4f97-9896-6118ffb92a61",
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "ephemeral_id": "7c243d3c-4b26-4228-81c7-9f222533ed9f",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "ti_abusech.malwarebazaar",
@@ -30,30 +29,36 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-06T00:08:33.562Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:15:38.506Z",
         "dataset": "ti_abusech.malwarebazaar",
-        "ingested": "2022-08-06T00:08:36Z",
+        "ingested": "2023-08-08T18:15:41Z",
         "kind": "enrichment",
         "original": "{\"anonymous\":0,\"code_sign\":[],\"dhash_icon\":null,\"file_name\":\"7a6c03013a2f2ab8b9e8e7e5d226ea89e75da72c1519e.exe\",\"file_size\":432640,\"file_type\":\"exe\",\"file_type_mime\":\"application/x-dosexec\",\"first_seen\":\"2021-10-05 14:02:45\",\"imphash\":\"f34d5f2d4577ed6d9ceec516c1f5a744\",\"intelligence\":{\"clamav\":null,\"downloads\":\"11\",\"mail\":null,\"uploads\":\"1\"},\"last_seen\":null,\"md5_hash\":\"1fc1c2997c8f55ac10496b88e23f5320\",\"origin_country\":\"FR\",\"reporter\":\"abuse_ch\",\"sha1_hash\":\"42c7153680d7402e56fe022d1024aab49a9901a0\",\"sha256_hash\":\"7a6c03013a2f2ab8b9e8e7e5d226ea89e75da72c1519e78fd28b2253ea755c28\",\"sha3_384_hash\":\"d63e73b68973bc73ab559549aeee2141a48b8a3724aabc0d81fb14603c163a098a5a10be9f6d33b888602906c0d89955\",\"signature\":\"RedLineStealer\",\"ssdeep\":\"12288:jhhl1Eo+iEXvpb1C7drqAd1uUaJvzXGyO2F5V3bS1jsTacr:7lL\",\"tags\":[\"exe\",\"RedLineStealer\"],\"telfhash\":null,\"tlsh\":\"T13794242864BFC05994E3EEA12DDCA8FBD99A55E3640C743301B4633B8B52B84DE4F479\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"
     },
     "related": {
         "hash": [
-            "1fc1c2997c8f55ac10496b88e23f5320",
+            "42c7153680d7402e56fe022d1024aab49a9901a0",
+            "d63e73b68973bc73ab559549aeee2141a48b8a3724aabc0d81fb14603c163a098a5a10be9f6d33b888602906c0d89955",
             "7a6c03013a2f2ab8b9e8e7e5d226ea89e75da72c1519e78fd28b2253ea755c28",
+            "T13794242864BFC05994E3EEA12DDCA8FBD99A55E3640C743301B4633B8B52B84DE4F479",
             "12288:jhhl1Eo+iEXvpb1C7drqAd1uUaJvzXGyO2F5V3bS1jsTacr:7lL",
-            "f34d5f2d4577ed6d9ceec516c1f5a744",
-            "T13794242864BFC05994E3EEA12DDCA8FBD99A55E3640C743301B4633B8B52B84DE4F479"
+            "1fc1c2997c8f55ac10496b88e23f5320",
+            "f34d5f2d4577ed6d9ceec516c1f5a744"
         ]
     },
     "tags": [
@@ -64,7 +69,6 @@
     "threat": {
         "indicator": {
             "file": {
-                "elf": {},
                 "extension": "exe",
                 "hash": {
                     "md5": "1fc1c2997c8f55ac10496b88e23f5320",
@@ -89,7 +93,9 @@
             "type": "file"
         },
         "software": {
-            "alias": "RedLineStealer"
+            "alias": [
+                "RedLineStealer"
+            ]
         }
     }
 }

--- a/packages/ti_abusech/data_stream/threatfox/_dev/test/pipeline/test-threatfox-ndjson.log-expected.json
+++ b/packages/ti_abusech/data_stream/threatfox/_dev/test/pipeline/test-threatfox-ndjson.log-expected.json
@@ -16,11 +16,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841508",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841508\",\"ioc\":\"2a02:cf40:1::5:40669\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 11:40:15 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -58,11 +62,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841507",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841507\",\"ioc\":\"http://malaikahlowry33.top\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.hydra\",\"malware_printable\":\"Hydra\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.hydra\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 11:36:10 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"apk\",\"Hydra\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -102,11 +110,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841506",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841506\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 11:25:24 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -143,11 +155,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841505",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841505\",\"ioc\":\"81.2.69.142:8808\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.asyncrat\",\"malware_printable\":\"AsyncRAT\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.asyncrat\",\"confidence_level\":75,\"first_seen\":\"2022-08-05 11:10:13 UTC\",\"last_seen\":null,\"reference\":\"https://bazaar.abuse.ch/sample/45e87ee0b025a7e4a783a6786564982e7735c8c50d0b3d84a3d5dd90ce735cfe/\",\"reporter\":\"abuse_ch\",\"tags\":[\"asyncrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -185,11 +201,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841504",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841504\",\"ioc\":\"81.2.69.142:6606\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.asyncrat\",\"malware_printable\":\"AsyncRAT\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.asyncrat\",\"confidence_level\":75,\"first_seen\":\"2022-08-05 11:10:12 UTC\",\"last_seen\":null,\"reference\":\"https://bazaar.abuse.ch/sample/45e87ee0b025a7e4a783a6786564982e7735c8c50d0b3d84a3d5dd90ce735cfe/\",\"reporter\":\"abuse_ch\",\"tags\":[\"asyncrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -228,11 +248,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841503",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841503\",\"ioc\":\"81.2.69.142:7707\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.asyncrat\",\"malware_printable\":\"AsyncRAT\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.asyncrat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 11:05:33 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"asyncrat\",\"RAT\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -269,11 +293,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841502",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841502\",\"ioc\":\"81.2.69.142:38241\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"elf.mirai\",\"malware_printable\":\"Mirai\",\"malware_alias\":\"Katana\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/elf.mirai\",\"confidence_level\":75,\"first_seen\":\"2022-08-05 10:40:07 UTC\",\"last_seen\":null,\"reference\":\"https://bazaar.abuse.ch/sample/2373eac488f89172263c8ea1d996d74d90803c54762cedf5808f05b9d6d341f1/\",\"reporter\":\"abuse_ch\",\"tags\":[\"Mirai\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -314,11 +342,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841501",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841501\",\"ioc\":\"81.2.69.142:5552\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.njrat\",\"malware_printable\":\"NjRAT\",\"malware_alias\":\"Bladabindi\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.njrat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:35:24 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"njrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -358,11 +390,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841500",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841500\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:28:53 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -405,11 +441,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841499",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841499\",\"ioc\":\"http://72.11.148.153/jquery-3.3.1.min.js\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:28:52 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -458,11 +498,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841498",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841498\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:25:47 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -506,11 +550,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841497",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841497\",\"ioc\":\"http://104.21.75.114/cx\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:25:45 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -558,11 +606,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841496",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841496\",\"ioc\":\"http://172.67.222.204/ca\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:25:44 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -609,11 +661,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841495",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841495\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:24:47 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -656,11 +712,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841494",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841494\",\"ioc\":\"https://62.182.86.225/jquery-3.3.1.min.js\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:24:46 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -709,11 +769,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841493",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841493\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:24:40 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"SERVER4-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -757,11 +821,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841491",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841491\",\"ioc\":\"https://muwokok.com/us\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:24:31 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"Digital Energy Technologies Ltd.\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -809,11 +877,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841492",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841492\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:24:31 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"Digital Energy Technologies Ltd.\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -856,11 +928,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841490",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841490\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:23:31 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -903,11 +979,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841489",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841489\",\"ioc\":\"https://39.105.193.50/jquery-3.3.1.min.js\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:23:30 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -956,11 +1036,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841488",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841488\",\"ioc\":\"http://hasanhaberlerdengelenlerden.co.vu/\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:31 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1005,11 +1089,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841487",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841487\",\"ioc\":\"http://where9smym8nd.com\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:30 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1053,11 +1141,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841486",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841486\",\"ioc\":\"http://nothingandnothin31.com\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:27 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1101,11 +1193,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841485",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841485\",\"ioc\":\"http://baggshdyfsdp.shop\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:25 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1149,11 +1245,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841484",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841484\",\"ioc\":\"http://152.228.162.150\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:23 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1197,11 +1297,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841483",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841483\",\"ioc\":\"http://5.161.62.171\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:20 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1245,11 +1349,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841482",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841482\",\"ioc\":\"http://45.83.122.2\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.alien\",\"malware_printable\":\"Alien\",\"malware_alias\":\"AlienBot\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.alien\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:21:02 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"Alien\",\"apk\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1293,11 +1401,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841481",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841481\",\"ioc\":\"http://50.17.77.39:4444/fwlink\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:17:36 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"AMAZON-AES\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1345,11 +1457,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841480",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841480\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:17:19 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1392,11 +1508,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841479",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841479\",\"ioc\":\"http://1.13.248.119/articles/189948/text.php\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:17:18 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1445,11 +1565,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841478",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841478\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:17:07 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1493,11 +1617,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841477",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841477\",\"ioc\":\"http://47.104.88.25/IE9CompatViewList.xml\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:17:06 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1546,11 +1674,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841476",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841476\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:16:58 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"LINODE-AP Linode LLC\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1594,11 +1726,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841475",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841475\",\"ioc\":\"https://45.79.127.214/j.ad\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:16:57 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"LINODE-AP Linode LLC\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1647,11 +1783,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841474",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841474\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:16:14 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"TENCENT-NET-AP-CN Tencent Building Kejizhongyi Avenue\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1695,11 +1835,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841473",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841473\",\"ioc\":\"http://service-akilm85g-1311240945.gz.apigw.tencentcs.com/api/x\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:16:10 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"TENCENT-NET-AP-CN Tencent Building Kejizhongyi Avenue\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1747,11 +1891,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841472",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841472\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:15:47 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1795,11 +1943,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841471",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841471\",\"ioc\":\"https://39.101.184.39/visit.js\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:15:46 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"ALIBABA-CN-NET Hangzhou Alibaba Advertising Co.Ltd.\",\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1848,11 +2000,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841470",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841470\",\"ioc\":\"http://lexdavid22.top\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"apk.hydra\",\"malware_printable\":\"Hydra\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/apk.hydra\",\"confidence_level\":80,\"first_seen\":\"2022-08-05 10:13:36 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"myonium1\",\"tags\":[\"apk\",\"Hydra\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1893,11 +2049,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841469",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841469\",\"ioc\":\"81.2.69.142:5552\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.limerat\",\"malware_printable\":\"LimeRAT\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.limerat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:10:26 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"LimeRAT\",\"RAT\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1935,11 +2095,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841468",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841468\",\"ioc\":\"81.2.69.142:7171\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.nanocore\",\"malware_printable\":\"Nanocore RAT\",\"malware_alias\":\"Nancrat,NanoCore\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.nanocore\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 10:10:23 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"NanoCore\",\"RAT\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1980,11 +2144,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841467",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841467\",\"ioc\":\"81.2.69.142:21330\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 09:55:22 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2022,11 +2190,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841466",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841466\",\"ioc\":\"81.2.69.142:22027\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.nanocore\",\"malware_printable\":\"Nanocore RAT\",\"malware_alias\":\"Nancrat,NanoCore\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.nanocore\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 09:35:25 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"NanoCore\",\"RAT\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2067,11 +2239,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841465",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841465\",\"ioc\":\"81.2.69.142:3398\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.remcos\",\"malware_printable\":\"Remcos\",\"malware_alias\":\"RemcosRAT,Remvio,Socmer\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.remcos\",\"confidence_level\":75,\"first_seen\":\"2022-08-05 09:35:12 UTC\",\"last_seen\":null,\"reference\":\"https://bazaar.abuse.ch/sample/42638e51cd3eff415ce751e700d233596988fd51ffba584b18dd2e78ec07bc2b/\",\"reporter\":\"abuse_ch\",\"tags\":[\"remcos\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2111,11 +2287,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841464",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841464\",\"ioc\":\"ffa22c40ac69750b229654c54919a480b33bc41f68c128f5e3b5967d442728fb\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha256_hash\",\"ioc_type_desc\":\"SHA256 hash of a malware sample (payload)\",\"malware\":\"win.woody\",\"malware_printable\":\"woody\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.woody\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 09:04:23 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/JAMESWT_MHT/status/1555479791821791232\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2156,11 +2336,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841463",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841463\",\"ioc\":\"81.2.69.142:35565\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.njrat\",\"malware_printable\":\"NjRAT\",\"malware_alias\":\"Bladabindi\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.njrat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 08:30:21 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"njrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2200,11 +2384,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841462",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841462\",\"ioc\":\"http://124.221.206.154:1443/submit.php\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":75,\"first_seen\":\"2022-08-05 07:55:06 UTC\",\"last_seen\":null,\"reference\":\"https://bazaar.abuse.ch/sample/eb94cd39cde6a5270181d6e6788c69a2a90ab2b27f9236c8382e810e4dfead1d/\",\"reporter\":\"abuse_ch\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2254,11 +2442,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841461",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841461\",\"ioc\":\"81.2.69.142:5050\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.njrat\",\"malware_printable\":\"NjRAT\",\"malware_alias\":\"Bladabindi\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.njrat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 07:35:17 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"njrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2295,11 +2487,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841460",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841460\",\"ioc\":\"c31b17eb7e69da771f0ee2230922622a94e1d27cfea1ff556615e4f27104340a\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha256_hash\",\"ioc_type_desc\":\"SHA256 hash of a malware sample (payload)\",\"malware\":\"osx.xloader\",\"malware_printable\":\"Xloader\",\"malware_alias\":\"Formbook\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/osx.xloader\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 07:04:11 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/JAMESWT_MHT/status/1555445680797270016\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2343,11 +2539,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841459",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841459\",\"ioc\":\"81.2.69.142:14009\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 06:40:18 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2381,11 +2581,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841458",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841458\",\"ioc\":\"http://115.55.81.211:33294/Mozi.m\",\"threat_type\":\"payload_delivery\",\"threat_type_desc\":\"Indicator that identifies a malware distribution server (payload delivery)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that delivers a malware payload\",\"malware\":\"elf.mozi\",\"malware_printable\":\"Mozi\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/elf.mozi\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 06:40:03 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"sicehice\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2428,11 +2632,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841457",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841457\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 06:30:17 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2469,11 +2677,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841456",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841456\",\"ioc\":\"81.2.69.142:46278\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.redline_stealer\",\"malware_printable\":\"RedLine Stealer\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 06:25:18 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"RedLineStealer\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2510,11 +2722,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841455",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841455\",\"ioc\":\"http://213.170.133.189/\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.recordbreaker\",\"malware_printable\":\"RecordBreaker\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.recordbreaker\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 06:20:17 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"abuse_ch\",\"tags\":[\"recordbreaker\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2552,11 +2768,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841454",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841454\",\"ioc\":\"a695ab311e3449cacf5a2611dffac5bd\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"md5_hash\",\"ioc_type_desc\":\"MD5 hash of a malware sample (payload)\",\"malware\":\"win.kutaki\",\"malware_printable\":\"Kutaki\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.kutaki\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 06:16:32 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/pollo290987/status/1555437557298651136\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2594,11 +2814,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841453",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841453\",\"ioc\":\"7768d132668a2eb1a86a04b249fab7e5b0790b6a61927ae6db283950f4cc7d59\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha256_hash\",\"ioc_type_desc\":\"SHA256 hash of a malware sample (payload)\",\"malware\":\"win.isfb\",\"malware_printable\":\"ISFB\",\"malware_alias\":\"Gozi ISFB,IAP,Pandemyia\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.isfb\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 05:25:21 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/StopMalvertisin/status/1555424657037475840\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2641,11 +2865,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841452",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841452\",\"ioc\":\"b92e9e2c758e32857506f9472cc51aec4b499afa6f703f7c40218e4e4258da86\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha256_hash\",\"ioc_type_desc\":\"SHA256 hash of a malware sample (payload)\",\"malware\":\"win.isfb\",\"malware_printable\":\"ISFB\",\"malware_alias\":\"Gozi ISFB,IAP,Pandemyia\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.isfb\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 05:25:19 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/StopMalvertisin/status/1555424657037475840\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2688,11 +2916,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841451",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841451\",\"ioc\":\"0989361dd7c8739827009be27579080b37430dbbb35ac9673b5e33f61505fdff\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha256_hash\",\"ioc_type_desc\":\"SHA256 hash of a malware sample (payload)\",\"malware\":\"win.isfb\",\"malware_printable\":\"ISFB\",\"malware_alias\":\"Gozi ISFB,IAP,Pandemyia\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.isfb\",\"confidence_level\":50,\"first_seen\":\"2022-08-05 05:25:18 UTC\",\"last_seen\":null,\"reference\":\"https://twitter.com/StopMalvertisin/status/1555424657037475840\",\"reporter\":\"Virus_Deck\",\"tags\":null}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2739,11 +2971,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841450",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841450\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:26:51 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"GIR-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2786,11 +3022,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841449",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841449\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:26:30 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2833,11 +3073,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841448",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841448\",\"ioc\":\"https://119.45.94.71/activity\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:26:29 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2885,11 +3129,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841447",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841447\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:25:51 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"GIR-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2933,11 +3181,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841446",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841446\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:25:14 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"MICROSOFT-CORP-MSN-AS-BLOCK\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2981,11 +3233,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841445",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841445\",\"ioc\":\"http://20.239.66.2/match\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:25:13 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"MICROSOFT-CORP-MSN-AS-BLOCK\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3033,11 +3289,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841444",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841444\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:34 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"TENCENT-NET-AP-CN Tencent Building Kejizhongyi Avenue\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3081,11 +3341,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841443",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841443\",\"ioc\":\"https://43.155.60.197/dot.gif\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:33 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"TENCENT-NET-AP-CN Tencent Building Kejizhongyi Avenue\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3133,11 +3397,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841441",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841441\",\"ioc\":\"http://service-da5heloj-1312757872.sh.apigw.tencentcs.com/include/template/isx.php\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:18 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3185,11 +3453,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841442",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841442\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:18 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3232,11 +3504,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841440",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841440\",\"ioc\":\"81.2.69.142:80\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:11 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3279,11 +3555,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841439",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841439\",\"ioc\":\"http://43.138.129.56/cm\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:24:10 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3331,11 +3611,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841438",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841438\",\"ioc\":\"81.2.69.142:443\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"ip:port\",\"ioc_type_desc\":\"ip:port combination that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:23:36 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"STARK-INDUSTRIES-SOLUTIONS-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3379,11 +3663,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841437",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841437\",\"ioc\":\"https://194.87.216.182/push\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:23:35 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"STARK-INDUSTRIES-SOLUTIONS-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3431,11 +3719,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841436",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841436\",\"ioc\":\"https://77.91.102.151/push\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"url\",\"ioc_type_desc\":\"URL that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.cobalt_strike\",\"malware_printable\":\"Cobalt Strike\",\"malware_alias\":\"Agentemis,BEACON,CobaltStrike,cobeacon\",\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 03:23:33 UTC\",\"last_seen\":null,\"reference\":null,\"reporter\":\"drb_ra\",\"tags\":[\"CobaltStrike\",\"STARK-INDUSTRIES-SOLUTIONS-AS\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3482,11 +3774,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "841537",
                 "kind": "enrichment",
                 "original": "{\"id\":\"841537\",\"ioc\":\"wizzy.hopto.org\",\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\u0026control server (C\u0026C)\",\"ioc_type\":\"domain\",\"ioc_type_desc\":\"Domain that is used for botnet Command\u0026control (C\u0026C)\",\"malware\":\"win.asyncrat\",\"malware_printable\":\"AsyncRAT\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.asyncrat\",\"confidence_level\":100,\"first_seen\":\"2022-08-05 19:43:08 UTC\",\"last_seen\":null,\"reference\":\"https://tria.ge/220805-w57pxsgae2\",\"reporter\":\"AndreGironda\",\"tags\":[\"asyncrat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3525,11 +3821,15 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "id": "839586",
                 "kind": "enrichment",
                 "original": "{\"id\":\"839586\",\"ioc\":\"872ff530d50579ae6bdc7cb4d658324b1d0e7a3e\",\"threat_type\":\"payload\",\"threat_type_desc\":\"Indicator that identifies a malware sample (payload)\",\"ioc_type\":\"sha1_hash\",\"ioc_type_desc\":\"SHA1 hash of a malware sample (payload)\",\"malware\":\"win.vidar\",\"malware_printable\":\"Vidar\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.vidar\",\"confidence_level\":75,\"first_seen\":\"2022-07-25 22:27:09 UTC\",\"last_seen\":null,\"reference\":\"\",\"reporter\":\"crep1x\",\"tags\":[\"Vidar\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/ti_abusech/data_stream/threatfox/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_abusech/data_stream/threatfox/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #

--- a/packages/ti_abusech/data_stream/threatfox/sample_event.json
+++ b/packages/ti_abusech/data_stream/threatfox/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-08-06T00:10:26.114Z",
+    "@timestamp": "2023-08-08T18:16:34.498Z",
     "abusech": {
         "threatfox": {
             "confidence_level": 100,
@@ -12,11 +12,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "c8fde031-e301-47e0-b688-4e36b951789c",
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "ephemeral_id": "988b1377-fd66-4604-9472-2d396c8ad3e5",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "ti_abusech.threatfox",
@@ -27,20 +27,24 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-06T00:10:26.114Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:16:34.498Z",
         "dataset": "ti_abusech.threatfox",
         "id": "841537",
-        "ingested": "2022-08-06T00:10:29Z",
+        "ingested": "2023-08-08T18:16:37Z",
         "kind": "enrichment",
         "original": "{\"confidence_level\":100,\"first_seen\":\"2022-08-05 19:43:08 UTC\",\"id\":\"841537\",\"ioc\":\"wizzy.hopto.org\",\"ioc_type\":\"domain\",\"ioc_type_desc\":\"Domain that is used for botnet Command\\u0026control (C\\u0026C)\",\"last_seen\":null,\"malware\":\"win.asyncrat\",\"malware_alias\":null,\"malware_malpedia\":\"https://malpedia.caad.fkie.fraunhofer.de/details/win.asyncrat\",\"malware_printable\":\"AsyncRAT\",\"reference\":\"https://tria.ge/220805-w57pxsgae2\",\"reporter\":\"AndreGironda\",\"tags\":[\"asyncrat\"],\"threat_type\":\"botnet_cc\",\"threat_type_desc\":\"Indicator that identifies a botnet command\\u0026control server (C\\u0026C)\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_abusech/data_stream/url/_dev/test/pipeline/test-abusechurl-ndjson.log-expected.json
+++ b/packages/ti_abusech/data_stream/url/_dev/test/pipeline/test-abusechurl-ndjson.log-expected.json
@@ -21,10 +21,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961548\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961548/\",\"url\":\"http://89.160.20.156:34613/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:19:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -69,10 +73,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961546\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961546/\",\"url\":\"http://89.160.20.156:44941/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -117,10 +125,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961547\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961547/\",\"url\":\"http://89.160.20.156:37173/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -165,10 +177,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961545\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961545/\",\"url\":\"http://89.160.20.156:47545/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -213,10 +229,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961544\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961544/\",\"url\":\"http://89.160.20.156:44782/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -261,10 +281,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961543\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961543/\",\"url\":\"http://89.160.20.156:44359/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -309,10 +333,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961540\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961540/\",\"url\":\"http://89.160.20.156:56507/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -357,10 +385,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961541\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961541/\",\"url\":\"http://89.160.20.156:57562/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -405,10 +437,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961542\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961542/\",\"url\":\"http://89.160.20.156:48845/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -453,10 +489,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961539\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961539/\",\"url\":\"http://89.160.20.156:58245/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -501,10 +541,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961538\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961538/\",\"url\":\"http://89.160.20.156:37198/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -549,10 +593,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961537\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961537/\",\"url\":\"http://89.160.20.156:33524/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -597,10 +645,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961531\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961531/\",\"url\":\"http://89.160.20.156:48261/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -645,10 +697,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961532\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961532/\",\"url\":\"http://89.160.20.156:34478/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -693,10 +749,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961533\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961533/\",\"url\":\"http://89.160.20.156:35703/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -741,10 +801,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961534\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961534/\",\"url\":\"http://89.160.20.156:48666/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -789,10 +853,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961535\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961535/\",\"url\":\"http://89.160.20.156:53923/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -837,10 +905,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961536\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961536/\",\"url\":\"http://89.160.20.156:52794/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -885,10 +957,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961530\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961530/\",\"url\":\"http://89.160.20.156:49312/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:34 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -933,10 +1009,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961525\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961525/\",\"url\":\"http://89.160.20.156:38961/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -981,10 +1061,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961526\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961526/\",\"url\":\"http://89.160.20.156:50420/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1029,10 +1113,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961527\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961527/\",\"url\":\"http://89.160.20.156:55007/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1077,10 +1165,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961528\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961528/\",\"url\":\"http://89.160.20.156:51143/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1125,10 +1217,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961529\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961529/\",\"url\":\"http://89.160.20.156:41003/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1172,10 +1268,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961524\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961524/\",\"url\":\"http://89.160.20.156:35739/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:38 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1219,10 +1319,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961523\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961523/\",\"url\":\"http://89.160.20.156:45653/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:36 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1266,10 +1370,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961520\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961520/\",\"url\":\"http://89.160.20.156:41349/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1313,10 +1421,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961521\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961521/\",\"url\":\"http://89.160.20.156:48586/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1360,10 +1472,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961522\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961522/\",\"url\":\"http://89.160.20.156:38111/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1407,10 +1523,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961518\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961518/\",\"url\":\"http://89.160.20.156:34556/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1455,10 +1575,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961519\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961519/\",\"url\":\"http://89.160.20.156:59815/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1504,10 +1628,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961516\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961516/\",\"url\":\"http://89.160.20.156:50587/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1552,10 +1680,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961517\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961517/\",\"url\":\"http://89.160.20.156:48322/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1599,10 +1731,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961515\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961515/\",\"url\":\"http://89.160.20.156:33317/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1646,10 +1782,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961513\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961513/\",\"url\":\"http://89.160.20.156:41516/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1693,10 +1833,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961514\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961514/\",\"url\":\"http://89.160.20.156:57798/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1740,10 +1884,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961509\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961509/\",\"url\":\"http://89.160.20.156:47671/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1787,10 +1935,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961510\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961510/\",\"url\":\"http://89.160.20.156:57690/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1836,10 +1988,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961511\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961511/\",\"url\":\"http://89.160.20.156:50611/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1882,10 +2038,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961512\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961512/\",\"url\":\"http://89.160.20.156:34141/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 21:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1930,10 +2090,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961507\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961507/\",\"url\":\"http://89.160.20.156:44399/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -1978,10 +2142,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961508\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961508/\",\"url\":\"http://89.160.20.156:49120/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2026,10 +2194,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961506\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961506/\",\"url\":\"http://89.160.20.156:51136/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2074,10 +2246,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961504\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961504/\",\"url\":\"http://89.160.20.156:45773/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2122,10 +2298,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961505\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961505/\",\"url\":\"http://89.160.20.156:56528/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2170,10 +2350,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961500\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961500/\",\"url\":\"http://89.160.20.156:44427/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2218,10 +2402,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961501\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961501/\",\"url\":\"http://89.160.20.156:36134/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2266,10 +2454,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961502\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961502/\",\"url\":\"http://89.160.20.156:43973/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2314,10 +2506,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961503\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961503/\",\"url\":\"http://89.160.20.156:41319/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2362,10 +2558,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961496\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961496/\",\"url\":\"http://89.160.20.156:51847/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2410,10 +2610,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961497\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961497/\",\"url\":\"http://89.160.20.156:54469/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2458,10 +2662,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961498\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961498/\",\"url\":\"http://89.160.20.156:34547/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2506,10 +2714,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961499\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961499/\",\"url\":\"http://89.160.20.156:33932/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2553,10 +2765,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961494\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961494/\",\"url\":\"https://univirtek.com/viro/02478080035/blank.jpg\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:51:47 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2598,10 +2814,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961495\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961495/\",\"url\":\"https://univirtek.com/viro/FRRNDR77C25D325O/map.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:51:47 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2643,10 +2863,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961492\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961492/\",\"url\":\"https://ladiesincode.com/ladi/CNNSRG83H04F158R/blank.jpg\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:51:45 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2688,10 +2912,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961493\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961493/\",\"url\":\"https://letonguesc.com/leto/02328510512/logo.css\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:51:45 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2733,10 +2961,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961490\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961490/\",\"url\":\"https://cxminute.com/minu/MLILSN74B21E507L/uk.png\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:51:44 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2778,10 +3010,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961491\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961491/\",\"url\":\"https://cxminute.com/minu/12875710159/blank.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:51:44 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2823,10 +3059,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961489\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961489/\",\"url\":\"https://cxminute.com/minu/CPNLNZ65M20A200N/maps.gif\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:51:41 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2868,10 +3108,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961488\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961488/\",\"url\":\"https://belfetproduction.com/bella/DLPCMN64D02D789E/logo.png\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:51:40 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2913,10 +3157,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961487\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961487/\",\"url\":\"https://belfetproduction.com/bella/01844510469/1x1.jpg\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:51:17 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -2958,10 +3206,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961485\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961485/\",\"url\":\"https://ladiesincode.com/ladi/FRRDNI52M71E522D/logo.css\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:51:16 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3003,10 +3255,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961486\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961486/\",\"url\":\"https://letonguesc.com/leto/CPPMRC65E04H980Q/it.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:51:16 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3048,10 +3304,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961482\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961482/\",\"url\":\"https://univirtek.com/viro/06389650018/it.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:51:15 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3093,10 +3353,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961483\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961483/\",\"url\":\"https://belfetproduction.com/bella/CRSRRT61E15H501H/logo.png\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:51:15 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3138,10 +3402,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961484\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961484/\",\"url\":\"https://cxminute.com/minu/SMPMSM67P05F205U/it.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:51:15 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3183,10 +3451,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961480\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961480/\",\"url\":\"https://univirtek.com/viro/SBNPQL78A24A783E/uk.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:51:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3228,10 +3500,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961481\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961481/\",\"url\":\"https://cxminute.com/minu/15578761007/maps.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:51:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3273,10 +3549,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961478\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961478/\",\"url\":\"https://univirtek.com/viro/03079590133/1x1.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:51:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3318,10 +3598,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961479\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961479/\",\"url\":\"https://ladiesincode.com/ladi/BNCLNR77T56M082U/it.gif\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:51:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3363,10 +3647,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961476\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961476/\",\"url\":\"https://cxminute.com/minu/JNKMTJ64B29L424O/uk.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:45 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3408,10 +3696,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961477\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961477/\",\"url\":\"https://belfetproduction.com/bella/PGNMRA64S22I608Z/en.png\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:50:45 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3453,10 +3745,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961470\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961470/\",\"url\":\"https://cxminute.com/minu/RZKDRD77T23Z229T/logo.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3498,10 +3794,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961471\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961471/\",\"url\":\"https://fhivelifestyle.online/nhbrwvdffsgt/adf/maps.jpg\",\"url_status\":\"offline\",\"host\":\"fhivelifestyle.online\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3543,10 +3843,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961472\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961472/\",\"url\":\"https://belfetproduction.com/bella/05739900487/1x1.css\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3588,10 +3892,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961473\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961473/\",\"url\":\"https://belfetproduction.com/bella/01767180597/map.css\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3633,10 +3941,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961474\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961474/\",\"url\":\"https://belfetproduction.com/bella/BRNGRG55D21F394K/map.css\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3678,10 +3990,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961475\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961475/\",\"url\":\"https://cxminute.com/minu/DLLTZN67L20L157J/1x1.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:43 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3723,10 +4039,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961468\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961468/\",\"url\":\"https://cxminute.com/minu/08035410722/logo.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:38 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3768,10 +4088,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961469\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961469/\",\"url\":\"https://univirtek.com/viro/GRNZEI60M13G346L/en.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:50:38 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3813,10 +4137,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961467\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961467/\",\"url\":\"https://letonguesc.com/leto/03253350239/1x1.png\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:50:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3858,10 +4186,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961464\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961464/\",\"url\":\"https://ladiesincode.com/ladi/10582470158/uk.css\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:50:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3903,10 +4235,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961465\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961465/\",\"url\":\"https://ladiesincode.com/ladi/BTTLNZ68A56D325C/map.css\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:50:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3948,10 +4284,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961466\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961466/\",\"url\":\"https://letonguesc.com/leto/NNTLRT68P28A717L/en.jpg\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:50:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -3993,10 +4333,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961461\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961461/\",\"url\":\"https://univirtek.com/viro/CTTNDR89A19B149W/maps.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4038,10 +4382,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961462\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961462/\",\"url\":\"https://cxminute.com/minu/DRSNTN77B16I197U/logo.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4083,10 +4431,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961463\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961463/\",\"url\":\"https://univirtek.com/viro/02941830735/uk.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4128,10 +4480,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961458\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961458/\",\"url\":\"https://belfetproduction.com/bella/MNSGCM91A04G240K/it.css\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:50:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4173,10 +4529,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961459\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961459/\",\"url\":\"https://ladiesincode.com/ladi/03108100615/it.jpg\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:50:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4218,10 +4578,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961460\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961460/\",\"url\":\"https://cxminute.com/minu/PTACSM56A31F604X/en.png\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:50:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4263,10 +4627,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961455\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961455/\",\"url\":\"https://univirtek.com/viro/00183050368/en.gif\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:39 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4308,10 +4676,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961456\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961456/\",\"url\":\"https://cxminute.com/minu/TSNLSN58H30G912H/uk.gif\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:49:39 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4353,10 +4725,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961457\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961457/\",\"url\":\"https://letonguesc.com/leto/08658331007/blank.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:39 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4398,10 +4774,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961450\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961450/\",\"url\":\"https://cxminute.com/minu/01098910324/blank.png\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:49:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4443,10 +4823,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961451\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961451/\",\"url\":\"https://univirtek.com/viro/02794390233/uk.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4488,10 +4872,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961452\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961452/\",\"url\":\"https://univirtek.com/viro/CSTDNT69D63F754D/en.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4533,10 +4921,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961453\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961453/\",\"url\":\"https://univirtek.com/viro/GSTGNE91B06L219W/1x1.jpg\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4578,10 +4970,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961454\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961454/\",\"url\":\"https://univirtek.com/viro/03610140125/map.jpg\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4623,10 +5019,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961448\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961448/\",\"url\":\"https://belfetproduction.com/bella/CRRLRD74E09A462T/blank.png\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:49:36 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4668,10 +5068,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961449\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961449/\",\"url\":\"https://univirtek.com/viro/RSTFRZ57T05G337C/maps.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:36 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4713,10 +5117,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961447\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961447/\",\"url\":\"https://letonguesc.com/leto/LBRFNC56S10D952D/map.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4758,10 +5166,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961444\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961444/\",\"url\":\"https://univirtek.com/viro/01669890194/it.gif\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:49:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4803,10 +5215,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961445\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961445/\",\"url\":\"https://letonguesc.com/leto/GTNNTN60P12H632S/maps.css\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4848,10 +5264,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961446\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961446/\",\"url\":\"https://cxminute.com/minu/ZHOXBN72B06Z210N/en.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:49:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4893,10 +5313,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961442\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961442/\",\"url\":\"https://letonguesc.com/leto/KHNGGR61S21Z112Y/uk.css\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4938,10 +5362,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961443\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961443/\",\"url\":\"https://ladiesincode.com/ladi/MNRMNL75A12I531F/uk.jpg\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:49:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -4983,10 +5411,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961438\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961438/\",\"url\":\"https://ladiesincode.com/ladi/RBGMNL67A02L675L/uk.css\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5028,10 +5460,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961439\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961439/\",\"url\":\"https://letonguesc.com/leto/RSSPPL67P15G535L/map.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5073,10 +5509,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961440\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961440/\",\"url\":\"https://fhivelifestyle.online/nhbrwvdffsgt/adf/uk.css\",\"url_status\":\"offline\",\"host\":\"fhivelifestyle.online\",\"date_added\":\"2021-01-14 20:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5118,10 +5558,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961441\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961441/\",\"url\":\"https://letonguesc.com/leto/BNTLGU67R11L706R/blank.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5163,10 +5607,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961437\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961437/\",\"url\":\"https://cxminute.com/minu/03713610651/map.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:48:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5208,10 +5656,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961436\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961436/\",\"url\":\"https://univirtek.com/viro/01312580507/uk.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:36 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5253,10 +5705,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961431\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961431/\",\"url\":\"https://cxminute.com/minu/FRNRST34B11F843P/blank.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:48:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5298,10 +5754,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961432\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961432/\",\"url\":\"https://univirtek.com/viro/RCUNDA90D24Z100H/1x1.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5343,10 +5803,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961433\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961433/\",\"url\":\"https://univirtek.com/viro/GTTGRI72H19A952D/map.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5388,10 +5852,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961434\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961434/\",\"url\":\"https://univirtek.com/viro/00385010103/map.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5433,10 +5901,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961435\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961435/\",\"url\":\"https://ladiesincode.com/ladi/04263990162/map.css\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:48:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5478,10 +5950,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961428\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961428/\",\"url\":\"https://univirtek.com/viro/BNNSFN74A13G674O/logo.png\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:34 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5523,10 +5999,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961429\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961429/\",\"url\":\"https://univirtek.com/viro/RZZCRS93B15G224O/it.gif\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:34 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5568,10 +6048,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961430\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961430/\",\"url\":\"https://cxminute.com/minu/01495100032/maps.gif\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:48:34 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5613,10 +6097,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961427\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961427/\",\"url\":\"https://letonguesc.com/leto/CMPDVD69C11G693Z/map.gif\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:48:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5658,10 +6146,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961426\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961426/\",\"url\":\"https://cxminute.com/minu/LLLMRC84B29A944R/it.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:48:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5703,10 +6195,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961421\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961421/\",\"url\":\"https://cxminute.com/minu/PRSSFN72L18C573S/map.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:48:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5748,10 +6244,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961422\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961422/\",\"url\":\"https://ladiesincode.com/ladi/00814870150/1x1.png\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:48:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5793,10 +6293,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961423\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961423/\",\"url\":\"https://ladiesincode.com/ladi/03635540234/it.gif\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:48:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5838,10 +6342,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961424\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961424/\",\"url\":\"https://univirtek.com/viro/PLCSFN62B11D548Q/map.gif\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5883,10 +6391,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961425\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961425/\",\"url\":\"https://univirtek.com/viro/03294650167/maps.jpg\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5928,10 +6440,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961418\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961418/\",\"url\":\"https://univirtek.com/viro/GGLSCR73D17C627Q/blank.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -5973,10 +6489,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961419\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961419/\",\"url\":\"https://univirtek.com/viro/CRRLRA68A70H501X/maps.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:48:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6018,10 +6538,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961420\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961420/\",\"url\":\"https://ladiesincode.com/ladi/CRSNLD59R12L840V/blank.jpg\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:48:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6063,10 +6587,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961416\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961416/\",\"url\":\"https://belfetproduction.com/bella/RTTCRL58M29A794D/logo.css\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:47:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6108,10 +6636,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961417\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961417/\",\"url\":\"https://letonguesc.com/leto/04138120169/en.jpg\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:47:35 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6153,10 +6685,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961408\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961408/\",\"url\":\"https://letonguesc.com/leto/SPGMRC73H13A475I/it.jpg\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6198,10 +6734,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961409\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961409/\",\"url\":\"https://letonguesc.com/leto/80007070552/it.png\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6243,10 +6783,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961410\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961410/\",\"url\":\"https://letonguesc.com/leto/02482130271/logo.png\",\"url_status\":\"offline\",\"host\":\"letonguesc.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6288,10 +6832,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961411\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961411/\",\"url\":\"https://univirtek.com/viro/15730201009/uk.gif\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6333,10 +6881,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961412\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961412/\",\"url\":\"https://univirtek.com/viro/01074480250/maps.css\",\"url_status\":\"offline\",\"host\":\"univirtek.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6378,10 +6930,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961413\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961413/\",\"url\":\"https://cxminute.com/minu/SCHRKE77C47G224W/1x1.jpg\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6423,10 +6979,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961414\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961414/\",\"url\":\"https://cxminute.com/minu/04281560377/en.css\",\"url_status\":\"offline\",\"host\":\"cxminute.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6468,10 +7028,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961415\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961415/\",\"url\":\"https://ladiesincode.com/ladi/02613440060/maps.png\",\"url_status\":\"offline\",\"host\":\"ladiesincode.com\",\"date_added\":\"2021-01-14 20:47:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6513,10 +7077,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961406\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961406/\",\"url\":\"https://nowyouknowent.com/werdona/PLLRRT83A05H501O/it.gif\",\"url_status\":\"offline\",\"host\":\"nowyouknowent.com\",\"date_added\":\"2021-01-14 20:47:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6558,10 +7126,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961407\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961407/\",\"url\":\"https://hoagtechhydroponics.com/teco/LGTCDC74T45F205G/logo.png\",\"url_status\":\"offline\",\"host\":\"hoagtechhydroponics.com\",\"date_added\":\"2021-01-14 20:47:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6603,10 +7175,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961404\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961404/\",\"url\":\"https://belfetproduction.com/bella/00160060349/uk.jpg\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:42:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6648,10 +7224,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961405\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961405/\",\"url\":\"https://belfetproduction.com/bella/01288650243/1x1.jpg\",\"url_status\":\"offline\",\"host\":\"belfetproduction.com\",\"date_added\":\"2021-01-14 20:42:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Cryptolaemus1\",\"larted\":\"false\",\"tags\":[\"sLoad\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6695,10 +7275,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961403\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961403/\",\"url\":\"http://89.160.20.156:50611/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:39:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6743,10 +7327,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961402\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961402/\",\"url\":\"http://89.160.20.156:45371/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:14 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6791,10 +7379,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961400\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961400/\",\"url\":\"http://89.160.20.156:50093/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6839,10 +7431,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961401\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961401/\",\"url\":\"http://89.160.20.156:36652/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6887,10 +7483,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961397\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961397/\",\"url\":\"http://89.160.20.156:54182/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6935,10 +7535,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961398\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961398/\",\"url\":\"http://89.160.20.156:46048/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -6983,10 +7587,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961399\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961399/\",\"url\":\"http://89.160.20.156:33953/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:36:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7031,10 +7639,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961393\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961393/\",\"url\":\"http://89.160.20.156:36447/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7079,10 +7691,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961394\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961394/\",\"url\":\"http://89.160.20.156:36828/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7127,10 +7743,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961395\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961395/\",\"url\":\"http://89.160.20.156:55281/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7175,10 +7795,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961396\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961396/\",\"url\":\"http://89.160.20.156:49772/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7223,10 +7847,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961391\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961391/\",\"url\":\"http://89.160.20.156:50229/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7271,10 +7899,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961392\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961392/\",\"url\":\"http://89.160.20.156:39996/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7319,10 +7951,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961387\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961387/\",\"url\":\"http://89.160.20.156:50195/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7367,10 +8003,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961388\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961388/\",\"url\":\"http://89.160.20.156:52447/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7415,10 +8055,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961389\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961389/\",\"url\":\"http://89.160.20.156:56321/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7463,10 +8107,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961390\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961390/\",\"url\":\"http://89.160.20.156:54620/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7511,10 +8159,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961386\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961386/\",\"url\":\"http://89.160.20.156:52064/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:23:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7559,10 +8211,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961385\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961385/\",\"url\":\"http://89.160.20.156:47401/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7607,10 +8263,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961382\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961382/\",\"url\":\"http://89.160.20.156:46527/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7655,10 +8315,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961383\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961383/\",\"url\":\"http://89.160.20.156:38132/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7703,10 +8367,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961384\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961384/\",\"url\":\"http://89.160.20.156:59015/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7751,10 +8419,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961379\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961379/\",\"url\":\"http://89.160.20.156:59454/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7799,10 +8471,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961380\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961380/\",\"url\":\"http://89.160.20.156:37883/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7847,10 +8523,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961381\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961381/\",\"url\":\"http://89.160.20.156:55209/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7895,10 +8575,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961378\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961378/\",\"url\":\"http://89.160.20.156:41062/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:21:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7944,10 +8628,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961377\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961377/\",\"url\":\"http://89.160.20.156:60380/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -7991,10 +8679,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961375\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961375/\",\"url\":\"http://89.160.20.156:54796/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8039,10 +8731,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961376\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961376/\",\"url\":\"http://89.160.20.156:35251/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8087,10 +8783,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961373\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961373/\",\"url\":\"http://89.160.20.156:50562/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8135,10 +8835,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961374\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961374/\",\"url\":\"http://89.160.20.156:33445/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8183,10 +8887,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961370\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961370/\",\"url\":\"http://89.160.20.156:60280/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8231,10 +8939,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961371\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961371/\",\"url\":\"http://89.160.20.156:46386/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8279,10 +8991,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961372\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961372/\",\"url\":\"http://89.160.20.156:60288/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8327,10 +9043,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961368\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961368/\",\"url\":\"http://89.160.20.156:49731/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8375,10 +9095,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961369\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961369/\",\"url\":\"http://89.160.20.156:38837/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8423,10 +9147,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961366\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961366/\",\"url\":\"http://89.160.20.156:37814/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8471,10 +9199,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961367\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961367/\",\"url\":\"http://89.160.20.156:47507/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8520,10 +9252,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961365\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961365/\",\"url\":\"http://89.160.20.156:47140/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:18:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8567,10 +9303,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961363\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961363/\",\"url\":\"http://89.160.20.156:41514/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:11 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8615,10 +9355,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961364\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961364/\",\"url\":\"http://89.160.20.156:58748/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:11 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8663,10 +9407,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961362\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961362/\",\"url\":\"http://89.160.20.156:51183/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8711,10 +9459,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961361\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961361/\",\"url\":\"http://89.160.20.156:42104/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8759,10 +9511,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961354\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961354/\",\"url\":\"http://89.160.20.156:53130/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8807,10 +9563,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961355\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961355/\",\"url\":\"http://89.160.20.156:57768/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8855,10 +9615,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961356\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961356/\",\"url\":\"http://89.160.20.156:34541/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8903,10 +9667,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961357\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961357/\",\"url\":\"http://89.160.20.156:51344/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8951,10 +9719,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961358\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961358/\",\"url\":\"http://89.160.20.156:40084/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -8999,10 +9771,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961359\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961359/\",\"url\":\"http://89.160.20.156:60457/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9047,10 +9823,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961360\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961360/\",\"url\":\"http://89.160.20.156:34906/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9095,10 +9875,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961353\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961353/\",\"url\":\"http://89.160.20.156:59847/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:10:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9143,10 +9927,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961352\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961352/\",\"url\":\"http://89.160.20.156:47873/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:09:00 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9191,10 +9979,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961349\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961349/\",\"url\":\"http://89.160.20.156:48645/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9239,10 +10031,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961350\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961350/\",\"url\":\"http://89.160.20.156:36524/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9287,10 +10083,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961351\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961351/\",\"url\":\"http://89.160.20.156:38726/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9335,10 +10135,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961345\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961345/\",\"url\":\"http://89.160.20.156:41149/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9383,10 +10187,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961346\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961346/\",\"url\":\"http://89.160.20.156:46993/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9431,10 +10239,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961347\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961347/\",\"url\":\"http://89.160.20.156:39190/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9479,10 +10291,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961348\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961348/\",\"url\":\"http://89.160.20.156:48344/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:05:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9528,10 +10344,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961344\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961344/\",\"url\":\"http://89.160.20.156:58427/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:04:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9577,10 +10397,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961343\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961343/\",\"url\":\"http://89.160.20.156:41921/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 20:02:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9625,10 +10449,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961342\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961342/\",\"url\":\"http://89.160.20.156:47140/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:55:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9673,10 +10501,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961341\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961341/\",\"url\":\"http://89.160.20.156:34789/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:52:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9721,10 +10553,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961340\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961340/\",\"url\":\"http://89.160.20.156:37634/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9769,10 +10605,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961339\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961339/\",\"url\":\"http://89.160.20.156:41636/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9817,10 +10657,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961338\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961338/\",\"url\":\"http://89.160.20.156:32907/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9865,10 +10709,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961336\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961336/\",\"url\":\"http://89.160.20.156:57568/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9913,10 +10761,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961337\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961337/\",\"url\":\"http://89.160.20.156:40740/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -9961,10 +10813,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961331\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961331/\",\"url\":\"http://89.160.20.156:35927/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10009,10 +10865,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961332\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961332/\",\"url\":\"http://89.160.20.156:55558/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10057,10 +10917,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961333\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961333/\",\"url\":\"http://89.160.20.156:60558/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10105,10 +10969,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961334\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961334/\",\"url\":\"http://89.160.20.156:59624/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10153,10 +11021,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961335\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961335/\",\"url\":\"http://89.160.20.156:39386/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10201,10 +11073,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961322\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961322/\",\"url\":\"http://89.160.20.156:46289/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10249,10 +11125,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961323\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961323/\",\"url\":\"http://89.160.20.156:34951/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10297,10 +11177,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961324\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961324/\",\"url\":\"http://89.160.20.156:47594/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10345,10 +11229,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961325\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961325/\",\"url\":\"http://89.160.20.156:55792/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10393,10 +11281,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961326\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961326/\",\"url\":\"http://89.160.20.156:35271/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10441,10 +11333,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961327\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961327/\",\"url\":\"http://89.160.20.156:36300/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10489,10 +11385,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961328\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961328/\",\"url\":\"http://89.160.20.156:60680/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10537,10 +11437,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961329\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961329/\",\"url\":\"http://89.160.20.156:51132/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10585,10 +11489,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961330\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961330/\",\"url\":\"http://89.160.20.156:39049/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10633,10 +11541,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961321\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961321/\",\"url\":\"http://89.160.20.156:57455/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:49:12 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10681,10 +11593,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961320\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961320/\",\"url\":\"http://89.160.20.156:32823/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:49:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10729,10 +11645,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961318\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961318/\",\"url\":\"http://89.160.20.156:44103/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10777,10 +11697,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961319\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961319/\",\"url\":\"http://89.160.20.156:36257/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10826,10 +11750,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961317\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961317/\",\"url\":\"http://89.160.20.156:41921/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:45:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10875,10 +11803,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961316\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961316/\",\"url\":\"http://89.160.20.156:50971/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:44:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10922,10 +11854,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961315\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961315/\",\"url\":\"http://89.160.20.156:56339/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -10970,10 +11906,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961314\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961314/\",\"url\":\"http://89.160.20.156:52551/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11018,10 +11958,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961312\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961312/\",\"url\":\"http://89.160.20.156:35942/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11066,10 +12010,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961313\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961313/\",\"url\":\"http://89.160.20.156:39636/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11114,10 +12062,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961310\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961310/\",\"url\":\"http://89.160.20.156:53548/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11162,10 +12114,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961311\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961311/\",\"url\":\"http://89.160.20.156:40967/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11210,10 +12166,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961309\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961309/\",\"url\":\"http://89.160.20.156:49471/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11258,10 +12218,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961302\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961302/\",\"url\":\"http://89.160.20.156:43937/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11306,10 +12270,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961303\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961303/\",\"url\":\"http://89.160.20.156:57992/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11354,10 +12322,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961304\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961304/\",\"url\":\"http://89.160.20.156:43603/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11402,10 +12374,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961305\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961305/\",\"url\":\"http://89.160.20.156:37157/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11450,10 +12426,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961306\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961306/\",\"url\":\"http://89.160.20.156:37229/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11498,10 +12478,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961307\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961307/\",\"url\":\"http://89.160.20.156:49104/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11546,10 +12530,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961308\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961308/\",\"url\":\"http://89.160.20.156:49575/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11594,10 +12582,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961299\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961299/\",\"url\":\"http://89.160.20.156:50000/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11642,10 +12634,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961300\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961300/\",\"url\":\"http://89.160.20.156:36251/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11690,10 +12686,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961301\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961301/\",\"url\":\"http://89.160.20.156:51932/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11738,10 +12738,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961297\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961297/\",\"url\":\"http://89.160.20.156:45660/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11786,10 +12790,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961298\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961298/\",\"url\":\"http://89.160.20.156:42478/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11834,10 +12842,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961296\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961296/\",\"url\":\"http://89.160.20.156:50726/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11883,10 +12895,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961295\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961295/\",\"url\":\"http://89.160.20.156:40256/i\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:33:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11931,10 +12947,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961294\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961294/\",\"url\":\"http://89.160.20.156:50971/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:29:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -11979,10 +12999,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961293\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961293/\",\"url\":\"https://realestatederivatives.com.ng/zx/janomo_hfWUGQvSPn0.bin\",\"url_status\":\"online\",\"host\":\"realestatederivatives.com.ng\",\"date_added\":\"2021-01-14 19:24:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"encrypted\",\"GuLoader\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12025,10 +13049,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961291\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961291/\",\"url\":\"http://89.160.20.156:33946/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12073,10 +13101,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961292\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961292/\",\"url\":\"http://89.160.20.156:39990/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12121,10 +13153,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961288\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961288/\",\"url\":\"http://89.160.20.156:60558/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12169,10 +13205,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961289\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961289/\",\"url\":\"http://89.160.20.156:32989/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12217,10 +13257,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961290\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961290/\",\"url\":\"http://89.160.20.156:52458/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12265,10 +13309,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961286\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961286/\",\"url\":\"http://89.160.20.156:60735/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12313,10 +13361,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961287\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961287/\",\"url\":\"http://89.160.20.156:34755/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12361,10 +13413,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961285\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961285/\",\"url\":\"http://89.160.20.156:39290/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12409,10 +13465,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961279\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961279/\",\"url\":\"http://89.160.20.156:56141/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12457,10 +13517,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961280\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961280/\",\"url\":\"http://89.160.20.156:40247/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12506,10 +13570,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961281\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961281/\",\"url\":\"http://89.160.20.156:36619/i\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12553,10 +13621,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961282\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961282/\",\"url\":\"http://89.160.20.156:43673/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12601,10 +13673,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961283\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961283/\",\"url\":\"http://89.160.20.156:55726/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12649,10 +13725,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961284\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961284/\",\"url\":\"http://89.160.20.156:59668/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12697,10 +13777,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961278\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961278/\",\"url\":\"http://89.160.20.156:34391/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12745,10 +13829,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961277\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961277/\",\"url\":\"http://89.160.20.156:49478/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12793,10 +13881,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961276\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961276/\",\"url\":\"http://89.160.20.156:54670/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12841,10 +13933,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961270\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961270/\",\"url\":\"http://89.160.20.156:59599/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12889,10 +13985,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961271\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961271/\",\"url\":\"http://89.160.20.156:45189/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12937,10 +14037,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961272\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961272/\",\"url\":\"http://89.160.20.156:60805/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -12985,10 +14089,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961273\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961273/\",\"url\":\"http://89.160.20.156:38888/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13033,10 +14141,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961274\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961274/\",\"url\":\"http://89.160.20.156:47869/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13081,10 +14193,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961275\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961275/\",\"url\":\"http://89.160.20.156:57478/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13130,10 +14246,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961269\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961269/\",\"url\":\"http://89.160.20.156:40256/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:10:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13178,10 +14298,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961268\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961268/\",\"url\":\"http://89.160.20.156:49035/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13226,10 +14350,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961266\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961266/\",\"url\":\"http://89.160.20.156:41531/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13274,10 +14402,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961267\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961267/\",\"url\":\"http://89.160.20.156:49596/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13322,10 +14454,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961265\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961265/\",\"url\":\"http://89.160.20.156:43584/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:07:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13370,10 +14506,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961264\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961264/\",\"url\":\"http://89.160.20.156:44976/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13418,10 +14558,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961259\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961259/\",\"url\":\"http://89.160.20.156:51107/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13466,10 +14610,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961260\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961260/\",\"url\":\"http://89.160.20.156:33790/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13514,10 +14662,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961261\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961261/\",\"url\":\"http://89.160.20.156:58919/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13562,10 +14714,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961262\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961262/\",\"url\":\"http://89.160.20.156:40395/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13610,10 +14766,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961263\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961263/\",\"url\":\"http://89.160.20.156:53510/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13658,10 +14818,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961258\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961258/\",\"url\":\"http://89.160.20.156:39115/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:12 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13706,10 +14870,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961257\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961257/\",\"url\":\"http://89.160.20.156:40713/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:11 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13754,10 +14922,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961256\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961256/\",\"url\":\"http://89.160.20.156:54811/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13802,10 +14974,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961255\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961255/\",\"url\":\"http://89.160.20.156:58269/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13850,10 +15026,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961251\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961251/\",\"url\":\"http://89.160.20.156:47985/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13898,10 +15078,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961252\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961252/\",\"url\":\"http://89.160.20.156:38107/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13946,10 +15130,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961253\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961253/\",\"url\":\"http://89.160.20.156:50354/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -13994,10 +15182,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961254\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961254/\",\"url\":\"http://89.160.20.156:44987/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14042,10 +15234,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961249\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961249/\",\"url\":\"http://89.160.20.156:44681/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14090,10 +15286,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961250\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961250/\",\"url\":\"http://89.160.20.156:58391/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14138,10 +15338,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961248\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961248/\",\"url\":\"http://89.160.20.156:48540/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14186,10 +15390,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961246\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961246/\",\"url\":\"http://89.160.20.156:42755/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14234,10 +15442,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961247\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961247/\",\"url\":\"http://89.160.20.156:52688/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14282,10 +15494,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961244\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961244/\",\"url\":\"http://89.160.20.156:33782/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14330,10 +15546,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961245\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961245/\",\"url\":\"http://89.160.20.156:50381/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14378,10 +15598,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961243\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961243/\",\"url\":\"http://89.160.20.156:44219/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14427,10 +15651,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961242\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961242/\",\"url\":\"http://89.160.20.156:36619/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 19:01:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14476,10 +15704,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961241\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961241/\",\"url\":\"http://89.160.20.156:59976/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:56:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14523,10 +15755,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961239\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961239/\",\"url\":\"http://89.160.20.156:48688/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14571,10 +15807,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961240\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961240/\",\"url\":\"http://89.160.20.156:45682/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14619,10 +15859,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961238\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961238/\",\"url\":\"http://89.160.20.156:34922/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14667,10 +15911,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961233\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961233/\",\"url\":\"http://89.160.20.156:37489/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14715,10 +15963,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961234\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961234/\",\"url\":\"http://89.160.20.156:51940/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14763,10 +16015,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961235\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961235/\",\"url\":\"http://89.160.20.156:49599/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14811,10 +16067,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961236\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961236/\",\"url\":\"http://89.160.20.156:53436/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14859,10 +16119,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961237\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961237/\",\"url\":\"http://89.160.20.156:57237/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14907,10 +16171,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961232\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961232/\",\"url\":\"http://89.160.20.156:50907/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -14955,10 +16223,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961231\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961231/\",\"url\":\"http://89.160.20.156:41910/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:14 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15003,10 +16275,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961229\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961229/\",\"url\":\"http://89.160.20.156:57217/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15051,10 +16327,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961230\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961230/\",\"url\":\"http://89.160.20.156:47632/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15099,10 +16379,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961227\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961227/\",\"url\":\"http://89.160.20.156:46654/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15147,10 +16431,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961228\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961228/\",\"url\":\"http://89.160.20.156:59073/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15195,10 +16483,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961221\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961221/\",\"url\":\"http://89.160.20.156:37958/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15243,10 +16535,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961222\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961222/\",\"url\":\"http://89.160.20.156:53943/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15291,10 +16587,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961223\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961223/\",\"url\":\"http://89.160.20.156:40404/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15339,10 +16639,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961224\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961224/\",\"url\":\"http://89.160.20.156:46738/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15387,10 +16691,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961225\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961225/\",\"url\":\"http://89.160.20.156:58234/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15435,10 +16743,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961226\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961226/\",\"url\":\"http://89.160.20.156:36911/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15483,10 +16795,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961220\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961220/\",\"url\":\"http://89.160.20.156:35028/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:49:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15532,10 +16848,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961219\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961219/\",\"url\":\"http://allanabolicsteam.net/nedfr_.exe\",\"url_status\":\"offline\",\"host\":\"allanabolicsteam.net\",\"date_added\":\"2021-01-14 18:47:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"Myrtus0x0\",\"larted\":\"true\",\"tags\":[\"c2\",\"hancitor\",\"payload\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15577,10 +16897,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961217\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961217/\",\"url\":\"https://intranetstc.micromart.com.br/fined.php\",\"url_status\":\"offline\",\"host\":\"intranetstc.micromart.com.br\",\"date_added\":\"2021-01-14 18:47:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"0x49736b\",\"larted\":\"false\",\"tags\":[\"Dridex\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15624,10 +16948,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961218\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961218/\",\"url\":\"http://allanabolicsteam.net/1301s.bin\",\"url_status\":\"online\",\"host\":\"allanabolicsteam.net\",\"date_added\":\"2021-01-14 18:47:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"Myrtus0x0\",\"larted\":\"true\",\"tags\":[\"c2\",\"hancitor\",\"payload\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15671,10 +16999,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961216\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961216/\",\"url\":\"http://89.160.20.156:43741/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:44:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15719,10 +17051,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961215\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961215/\",\"url\":\"http://89.160.20.156:45803/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:41:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"false\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15767,10 +17103,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961214\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961214/\",\"url\":\"http://89.160.20.156:38611/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"false\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15815,10 +17155,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961213\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961213/\",\"url\":\"http://89.160.20.156:35185/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:12 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15863,10 +17207,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961212\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961212/\",\"url\":\"http://89.160.20.156:35054/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15911,10 +17259,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961207\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961207/\",\"url\":\"http://89.160.20.156:60038/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -15959,10 +17311,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961208\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961208/\",\"url\":\"http://89.160.20.156:52253/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16007,10 +17363,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961209\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961209/\",\"url\":\"http://89.160.20.156:43125/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16055,10 +17415,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961210\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961210/\",\"url\":\"http://89.160.20.156:52650/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16103,10 +17467,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961211\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961211/\",\"url\":\"http://89.160.20.156:59273/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16151,10 +17519,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961206\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961206/\",\"url\":\"http://89.160.20.156:40346/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16199,10 +17571,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961204\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961204/\",\"url\":\"http://89.160.20.156:44242/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16247,10 +17623,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961205\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961205/\",\"url\":\"http://89.160.20.156:40624/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16295,10 +17675,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961202\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961202/\",\"url\":\"http://89.160.20.156:41245/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16343,10 +17727,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961203\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961203/\",\"url\":\"http://89.160.20.156:48866/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16391,10 +17779,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961198\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961198/\",\"url\":\"http://89.160.20.156:58258/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16439,10 +17831,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961199\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961199/\",\"url\":\"http://89.160.20.156:34516/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16487,10 +17883,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961200\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961200/\",\"url\":\"http://89.160.20.156:47851/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16535,10 +17935,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961201\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961201/\",\"url\":\"http://89.160.20.156:49226/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16584,10 +17988,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961197\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961197/\",\"url\":\"http://89.160.20.156:36957/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:34:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16632,10 +18040,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961196\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961196/\",\"url\":\"http://89.160.20.156:53089/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:34:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16680,10 +18092,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961193\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961193/\",\"url\":\"http://89.160.20.156:57114/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16728,10 +18144,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961194\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961194/\",\"url\":\"http://89.160.20.156:33163/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16776,10 +18196,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961195\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961195/\",\"url\":\"http://89.160.20.156:48557/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16825,10 +18249,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961192\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961192/\",\"url\":\"http://89.160.20.156:59976/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:31:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16874,10 +18302,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961191\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961191/\",\"url\":\"http://89.160.20.156:48291/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16921,10 +18353,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961190\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961190/\",\"url\":\"http://89.160.20.156:45797/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:21:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -16970,10 +18406,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961186\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961186/\",\"url\":\"http://89.160.20.156:43741/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17018,10 +18458,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961187\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961187/\",\"url\":\"http://89.160.20.156:35446/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17066,10 +18510,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961188\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961188/\",\"url\":\"http://89.160.20.156:35720/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17114,10 +18562,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961189\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961189/\",\"url\":\"http://89.160.20.156:50501/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:21:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17162,10 +18614,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961185\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961185/\",\"url\":\"http://89.160.20.156:55796/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17210,10 +18666,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961183\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961183/\",\"url\":\"http://89.160.20.156:52308/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17258,10 +18718,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961184\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961184/\",\"url\":\"http://89.160.20.156:59154/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17306,10 +18770,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961177\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961177/\",\"url\":\"http://89.160.20.156:57950/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17354,10 +18822,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961178\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961178/\",\"url\":\"http://89.160.20.156:33520/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17402,10 +18874,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961179\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961179/\",\"url\":\"http://89.160.20.156:45525/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17450,10 +18926,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961180\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961180/\",\"url\":\"http://89.160.20.156:38430/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17498,10 +18978,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961181\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961181/\",\"url\":\"http://89.160.20.156:4096/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17546,10 +19030,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961182\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961182/\",\"url\":\"http://89.160.20.156:50631/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17594,10 +19082,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961176\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961176/\",\"url\":\"http://89.160.20.156:37989/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17642,10 +19134,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961175\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961175/\",\"url\":\"http://89.160.20.156:54078/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:20:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17691,10 +19187,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961173\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961173/\",\"url\":\"http://89.160.20.156:34201/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17738,10 +19238,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961174\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961174/\",\"url\":\"http://89.160.20.156:56573/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17787,10 +19291,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961172\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961172/\",\"url\":\"http://89.160.20.156:48291/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:08:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17835,10 +19343,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961170\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961170/\",\"url\":\"http://89.160.20.156:60102/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17883,10 +19395,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961171\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961171/\",\"url\":\"http://89.160.20.156:52225/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17931,10 +19447,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961167\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961167/\",\"url\":\"http://89.160.20.156:56733/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -17979,10 +19499,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961168\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961168/\",\"url\":\"http://89.160.20.156:57042/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18027,10 +19551,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961169\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961169/\",\"url\":\"http://89.160.20.156:38035/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18075,10 +19603,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961165\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961165/\",\"url\":\"http://89.160.20.156:33540/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18123,10 +19655,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961166\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961166/\",\"url\":\"http://89.160.20.156:51947/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18171,10 +19707,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961164\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961164/\",\"url\":\"http://89.160.20.156:36915/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18219,10 +19759,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961163\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961163/\",\"url\":\"http://89.160.20.156:38865/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:05:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18266,10 +19810,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961162\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961162/\",\"url\":\"http://89.160.20.156:55480/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:37 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18313,10 +19861,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961161\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961161/\",\"url\":\"http://89.160.20.156:51996/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:36 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18360,10 +19912,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961160\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961160/\",\"url\":\"http://89.160.20.156:36042/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:34 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18407,10 +19963,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961158\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961158/\",\"url\":\"http://89.160.20.156:34350/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18454,10 +20014,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961159\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961159/\",\"url\":\"http://89.160.20.156:53587/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:33 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18501,10 +20065,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961157\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961157/\",\"url\":\"http://89.160.20.156:53444/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18549,10 +20117,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961155\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961155/\",\"url\":\"http://89.160.20.156:58653/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18596,10 +20168,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961156\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961156/\",\"url\":\"http://89.160.20.156:50579/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18643,10 +20219,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961152\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961152/\",\"url\":\"http://89.160.20.156:3553/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18691,10 +20271,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961153\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961153/\",\"url\":\"http://89.160.20.156:35288/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18738,10 +20322,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961154\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961154/\",\"url\":\"http://89.160.20.156:46429/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18785,10 +20373,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961151\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961151/\",\"url\":\"http://89.160.20.156:44575/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18833,10 +20425,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961149\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961149/\",\"url\":\"http://89.160.20.156:43245/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18880,10 +20476,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961150\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961150/\",\"url\":\"http://89.160.20.156:50444/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18927,10 +20527,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961144\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961144/\",\"url\":\"http://89.160.20.156:51318/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"true\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -18975,10 +20579,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961145\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961145/\",\"url\":\"http://89.160.20.156:46221/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19023,10 +20631,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961146\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961146/\",\"url\":\"http://89.160.20.156:51430/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19071,10 +20683,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961147\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961147/\",\"url\":\"http://89.160.20.156:52028/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19119,10 +20735,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961148\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961148/\",\"url\":\"http://89.160.20.156:48291/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19166,10 +20786,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961143\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961143/\",\"url\":\"http://89.160.20.156:39613/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 18:04:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"Gandylyan1\",\"larted\":\"false\",\"tags\":[\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19215,10 +20839,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961142\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961142/\",\"url\":\"http://89.160.20.156:34201/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:56:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19263,10 +20891,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961141\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961141/\",\"url\":\"http://89.160.20.156:47095/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19311,10 +20943,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961136\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961136/\",\"url\":\"http://89.160.20.156:42004/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19359,10 +20995,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961137\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961137/\",\"url\":\"http://89.160.20.156:52058/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19407,10 +21047,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961138\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961138/\",\"url\":\"http://89.160.20.156:45432/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19455,10 +21099,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961139\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961139/\",\"url\":\"http://89.160.20.156:49891/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19503,10 +21151,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961140\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961140/\",\"url\":\"http://89.160.20.156:34334/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:53:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19551,10 +21203,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961135\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961135/\",\"url\":\"http://89.160.20.156:42886/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19599,10 +21255,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961134\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961134/\",\"url\":\"http://89.160.20.156:47096/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19647,10 +21307,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961132\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961132/\",\"url\":\"http://89.160.20.156:48214/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19695,10 +21359,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961133\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961133/\",\"url\":\"http://89.160.20.156:40478/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19743,10 +21411,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961130\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961130/\",\"url\":\"http://89.160.20.156:37771/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19791,10 +21463,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961131\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961131/\",\"url\":\"http://89.160.20.156:35513/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19839,10 +21515,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961129\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961129/\",\"url\":\"http://89.160.20.156:53382/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:51:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19887,10 +21567,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961128\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961128/\",\"url\":\"http://89.160.20.156:50336/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:17 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19935,10 +21619,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961124\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961124/\",\"url\":\"http://89.160.20.156:34233/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -19983,10 +21671,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961125\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961125/\",\"url\":\"http://89.160.20.156:38392/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20031,10 +21723,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961126\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961126/\",\"url\":\"http://89.160.20.156:52654/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20079,10 +21775,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961127\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961127/\",\"url\":\"http://89.160.20.156:60203/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20127,10 +21827,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961123\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961123/\",\"url\":\"http://89.160.20.156:48091/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20175,10 +21879,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961122\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961122/\",\"url\":\"http://89.160.20.156:40783/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:49:41 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20223,10 +21931,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961121\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961121/\",\"url\":\"http://89.160.20.156:52015/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:49:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20271,10 +21983,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961118\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961118/\",\"url\":\"http://89.160.20.156:42987/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20319,10 +22035,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961119\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961119/\",\"url\":\"http://89.160.20.156:53388/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20367,10 +22087,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961120\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961120/\",\"url\":\"http://89.160.20.156:44124/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20415,10 +22139,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961115\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961115/\",\"url\":\"http://89.160.20.156:33802/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20463,10 +22191,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961116\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961116/\",\"url\":\"http://89.160.20.156:43806/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20511,10 +22243,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961117\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961117/\",\"url\":\"http://89.160.20.156:52278/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20559,10 +22295,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961114\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961114/\",\"url\":\"http://89.160.20.156:41202/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20607,10 +22347,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961113\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961113/\",\"url\":\"http://89.160.20.156:35756/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:36:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20655,10 +22399,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961112\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961112/\",\"url\":\"http://89.160.20.156:40569/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20703,10 +22451,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961111\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961111/\",\"url\":\"http://89.160.20.156:47645/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:36:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20751,10 +22503,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961110\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961110/\",\"url\":\"http://89.160.20.156:40023/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20799,10 +22555,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961109\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961109/\",\"url\":\"http://89.160.20.156:53402/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:34:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20848,10 +22608,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961108\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961108/\",\"url\":\"http://89.160.20.156:36316/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:29:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20897,10 +22661,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961107\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961107/\",\"url\":\"http://89.160.20.156:48105/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:28:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20945,10 +22713,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961103\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961103/\",\"url\":\"http://89.160.20.156:40017/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -20993,10 +22765,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961104\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961104/\",\"url\":\"http://89.160.20.156:41906/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21041,10 +22817,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961105\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961105/\",\"url\":\"http://89.160.20.156:38607/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21089,10 +22869,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961106\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961106/\",\"url\":\"http://89.160.20.156:59331/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21137,10 +22921,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961102\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961102/\",\"url\":\"http://89.160.20.156:53932/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:24 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21185,10 +22973,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961101\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961101/\",\"url\":\"http://89.160.20.156:58385/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21233,10 +23025,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961099\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961099/\",\"url\":\"http://89.160.20.156:57010/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21281,10 +23077,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961100\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961100/\",\"url\":\"http://89.160.20.156:59715/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21329,10 +23129,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961094\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961094/\",\"url\":\"http://89.160.20.156:57052/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21377,10 +23181,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961095\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961095/\",\"url\":\"http://89.160.20.156:60550/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21425,10 +23233,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961096\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961096/\",\"url\":\"http://89.160.20.156:39684/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21473,10 +23285,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961097\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961097/\",\"url\":\"http://89.160.20.156:43593/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21521,10 +23337,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961098\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961098/\",\"url\":\"http://89.160.20.156:36066/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:20:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21569,10 +23389,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961093\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961093/\",\"url\":\"http://89.160.20.156:35006/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21617,10 +23441,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961091\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961091/\",\"url\":\"http://89.160.20.156:38184/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21665,10 +23493,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961092\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961092/\",\"url\":\"http://89.160.20.156:59027/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21713,10 +23545,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961090\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961090/\",\"url\":\"http://89.160.20.156:50639/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21761,10 +23597,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961086\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961086/\",\"url\":\"http://89.160.20.156:33534/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21809,10 +23649,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961087\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961087/\",\"url\":\"http://89.160.20.156:36316/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21857,10 +23701,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961088\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961088/\",\"url\":\"http://89.160.20.156:47120/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21905,10 +23753,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961089\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961089/\",\"url\":\"http://89.160.20.156:46287/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:19:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -21954,10 +23806,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961085\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961085/\",\"url\":\"http://89.160.20.156:39536/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:14:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22002,10 +23858,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961083\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961083/\",\"url\":\"http://89.160.20.156:40689/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22050,10 +23910,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961084\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961084/\",\"url\":\"http://89.160.20.156:51123/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22098,10 +23962,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961082\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961082/\",\"url\":\"http://89.160.20.156:52540/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22146,10 +24014,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961081\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961081/\",\"url\":\"http://89.160.20.156:56964/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22194,10 +24066,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961078\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961078/\",\"url\":\"http://89.160.20.156:57120/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22242,10 +24118,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961079\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961079/\",\"url\":\"http://89.160.20.156:44518/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22290,10 +24170,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961080\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961080/\",\"url\":\"http://89.160.20.156:50389/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22338,10 +24222,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961077\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961077/\",\"url\":\"http://89.160.20.156:34335/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22386,10 +24274,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961069\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961069/\",\"url\":\"http://89.160.20.156:54865/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22434,10 +24326,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961070\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961070/\",\"url\":\"http://89.160.20.156:50773/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22482,10 +24378,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961071\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961071/\",\"url\":\"http://89.160.20.156:52005/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22530,10 +24430,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961072\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961072/\",\"url\":\"http://89.160.20.156:56066/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22578,10 +24482,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961073\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961073/\",\"url\":\"http://89.160.20.156:32915/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22626,10 +24534,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961074\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961074/\",\"url\":\"http://89.160.20.156:43462/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22674,10 +24586,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961075\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961075/\",\"url\":\"http://89.160.20.156:33291/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22722,10 +24638,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961076\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961076/\",\"url\":\"http://89.160.20.156:1440/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22770,10 +24690,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961068\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961068/\",\"url\":\"http://89.160.20.156:55907/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22818,10 +24742,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961066\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961066/\",\"url\":\"http://89.160.20.156:33181/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22866,10 +24794,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961067\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961067/\",\"url\":\"http://89.160.20.156:44691/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22914,10 +24846,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961059\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961059/\",\"url\":\"http://89.160.20.156:55254/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -22962,10 +24898,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961060\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961060/\",\"url\":\"http://89.160.20.156:43010/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23010,10 +24950,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961061\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961061/\",\"url\":\"http://89.160.20.156:37886/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23058,10 +25002,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961062\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961062/\",\"url\":\"http://89.160.20.156:40153/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23106,10 +25054,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961063\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961063/\",\"url\":\"http://89.160.20.156:34305/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23154,10 +25106,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961064\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961064/\",\"url\":\"http://89.160.20.156:35653/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23202,10 +25158,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961065\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961065/\",\"url\":\"http://89.160.20.156:48908/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23250,10 +25210,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961058\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961058/\",\"url\":\"http://89.160.20.156:40035/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:04:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23298,10 +25262,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961055\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961055/\",\"url\":\"http://89.160.20.156:54461/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23346,10 +25314,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961056\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961056/\",\"url\":\"http://89.160.20.156:51991/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23395,10 +25367,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961057\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961057/\",\"url\":\"http://89.160.20.156:41143/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23443,10 +25419,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961054\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961054/\",\"url\":\"http://89.160.20.156:51095/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 17:02:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23490,10 +25470,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961053\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961053/\",\"url\":\"http://89.160.20.156:36558/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23538,10 +25522,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961050\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961050/\",\"url\":\"http://89.160.20.156:47548/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23586,10 +25574,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961051\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961051/\",\"url\":\"http://89.160.20.156:35796/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23634,10 +25626,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961052\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961052/\",\"url\":\"http://89.160.20.156:42765/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23682,10 +25678,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961048\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961048/\",\"url\":\"http://89.160.20.156:37388/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:51:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23730,10 +25730,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961049\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961049/\",\"url\":\"http://89.160.20.156:56849/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:51:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23778,10 +25782,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961047\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961047/\",\"url\":\"http://89.160.20.156:35574/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23826,10 +25834,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961046\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961046/\",\"url\":\"http://89.160.20.156:46947/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23874,10 +25886,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961043\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961043/\",\"url\":\"http://89.160.20.156:34452/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23922,10 +25938,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961044\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961044/\",\"url\":\"http://89.160.20.156:33017/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -23970,10 +25990,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961045\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961045/\",\"url\":\"http://89.160.20.156:55061/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24018,10 +26042,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961040\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961040/\",\"url\":\"http://89.160.20.156:50046/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24066,10 +26094,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961041\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961041/\",\"url\":\"http://89.160.20.156:51960/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24114,10 +26146,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961042\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961042/\",\"url\":\"http://89.160.20.156:42372/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24162,10 +26198,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961039\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961039/\",\"url\":\"http://89.160.20.156:51592/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:49:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24210,10 +26250,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961038\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961038/\",\"url\":\"http://89.160.20.156:35585/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:49:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24258,10 +26302,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961035\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961035/\",\"url\":\"http://89.160.20.156:38398/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:49:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24306,10 +26354,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961036\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961036/\",\"url\":\"http://89.160.20.156:59880/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:49:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24354,10 +26406,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961037\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961037/\",\"url\":\"http://89.160.20.156:39138/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:49:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24403,10 +26459,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961033\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961033/\",\"url\":\"http://89.160.20.156:51095/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:40:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24452,10 +26512,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961034\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961034/\",\"url\":\"http://89.160.20.156:45117/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:40:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24499,10 +26563,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961032\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961032/\",\"url\":\"http://89.160.20.156:50204/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24547,10 +26615,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961029\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961029/\",\"url\":\"http://89.160.20.156:45079/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24595,10 +26667,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961030\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961030/\",\"url\":\"http://89.160.20.156:52238/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24643,10 +26719,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961031\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961031/\",\"url\":\"http://89.160.20.156:40312/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24691,10 +26771,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961026\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961026/\",\"url\":\"http://89.160.20.156:39002/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24739,10 +26823,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961027\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961027/\",\"url\":\"http://89.160.20.156:50773/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24787,10 +26875,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961028\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961028/\",\"url\":\"http://89.160.20.156:50050/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24835,10 +26927,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961024\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961024/\",\"url\":\"http://89.160.20.156:60081/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24883,10 +26979,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961025\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961025/\",\"url\":\"http://89.160.20.156:58177/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24931,10 +27031,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961023\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961023/\",\"url\":\"http://89.160.20.156:38589/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:36:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -24979,10 +27083,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961022\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961022/\",\"url\":\"http://89.160.20.156:39229/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:35:25 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25027,10 +27135,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961021\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961021/\",\"url\":\"http://89.160.20.156:53595/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25075,10 +27187,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961018\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961018/\",\"url\":\"http://89.160.20.156:57279/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25123,10 +27239,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961019\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961019/\",\"url\":\"http://89.160.20.156:49019/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25171,10 +27291,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961020\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961020/\",\"url\":\"http://89.160.20.156:48558/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25219,10 +27343,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961017\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961017/\",\"url\":\"http://89.160.20.156:58913/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:25 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25267,10 +27395,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961016\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961016/\",\"url\":\"http://89.160.20.156:49608/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25316,10 +27448,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961013\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961013/\",\"url\":\"http://89.160.20.156:41143/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25364,10 +27500,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961014\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961014/\",\"url\":\"http://89.160.20.156:42129/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25412,10 +27552,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961015\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961015/\",\"url\":\"http://89.160.20.156:47403/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25460,10 +27604,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961011\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961011/\",\"url\":\"http://89.160.20.156:60187/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25508,10 +27656,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961012\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961012/\",\"url\":\"http://89.160.20.156:46097/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:34:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25557,10 +27709,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961010\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961010/\",\"url\":\"http://89.160.20.156:50771/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:31:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25604,10 +27760,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961009\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961009/\",\"url\":\"https://pastebin.com/raw/00aUJCLx\",\"url_status\":\"offline\",\"host\":\"pastebin.com\",\"date_added\":\"2021-01-14 16:29:03 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"pmelson\",\"larted\":\"false\",\"tags\":[\"ASPXShell\",\"webshell\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25650,10 +27810,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961008\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961008/\",\"url\":\"http://89.160.20.156:45117/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:25:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25698,10 +27862,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961007\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961007/\",\"url\":\"http://89.160.20.156:41485/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:16 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25746,10 +27914,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961006\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961006/\",\"url\":\"http://89.160.20.156:43851/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:15 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25794,10 +27966,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961005\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961005/\",\"url\":\"http://89.160.20.156:37095/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25842,10 +28018,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961004\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961004/\",\"url\":\"http://89.160.20.156:59275/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25890,10 +28070,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961002\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961002/\",\"url\":\"http://89.160.20.156:46131/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25938,10 +28122,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961003\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961003/\",\"url\":\"http://89.160.20.156:40129/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -25986,10 +28174,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961000\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961000/\",\"url\":\"http://89.160.20.156:43924/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26035,10 +28227,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"961001\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/961001/\",\"url\":\"http://89.160.20.156:38851/i\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26082,10 +28278,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960996\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960996/\",\"url\":\"http://89.160.20.156:33008/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26130,10 +28330,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960997\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960997/\",\"url\":\"http://89.160.20.156:60201/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26178,10 +28382,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960998\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960998/\",\"url\":\"http://89.160.20.156:41479/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26226,10 +28434,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960999\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960999/\",\"url\":\"http://89.160.20.156:52003/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:21:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26274,10 +28486,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960995\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960995/\",\"url\":\"http://89.160.20.156:39500/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:16 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26322,10 +28538,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960994\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960994/\",\"url\":\"http://89.160.20.156:36966/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26370,10 +28590,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960991\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960991/\",\"url\":\"http://89.160.20.156:59875/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26418,10 +28642,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960992\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960992/\",\"url\":\"http://89.160.20.156:44123/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26466,10 +28694,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960993\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960993/\",\"url\":\"http://89.160.20.156:45224/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26514,10 +28746,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960990\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960990/\",\"url\":\"http://89.160.20.156:43105/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26562,10 +28798,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960984\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960984/\",\"url\":\"http://89.160.20.156:46011/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26610,10 +28850,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960985\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960985/\",\"url\":\"http://89.160.20.156:51170/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26658,10 +28902,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960986\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960986/\",\"url\":\"http://89.160.20.156:38025/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26706,10 +28954,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960987\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960987/\",\"url\":\"http://89.160.20.156:54132/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26754,10 +29006,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960988\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960988/\",\"url\":\"http://89.160.20.156:57705/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26802,10 +29058,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960989\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960989/\",\"url\":\"http://89.160.20.156:32983/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:20:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26850,10 +29110,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960983\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960983/\",\"url\":\"http://89.160.20.156:47908/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26898,10 +29162,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960982\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960982/\",\"url\":\"http://89.160.20.156:35116/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26946,10 +29214,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960978\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960978/\",\"url\":\"http://89.160.20.156:38070/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -26994,10 +29266,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960979\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960979/\",\"url\":\"http://89.160.20.156:53399/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27042,10 +29318,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960980\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960980/\",\"url\":\"http://89.160.20.156:39529/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27090,10 +29370,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960981\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960981/\",\"url\":\"http://89.160.20.156:33465/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:19:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27138,10 +29422,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960977\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960977/\",\"url\":\"http://89.160.20.156:59085/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:16:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"07ac0n\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27187,10 +29475,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960976\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960976/\",\"url\":\"http://89.160.20.156:33799/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:09:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27234,10 +29526,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960972\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960972/\",\"url\":\"http://89.160.20.156:40430/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27282,10 +29578,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960973\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960973/\",\"url\":\"http://89.160.20.156:43006/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27330,10 +29630,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960974\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960974/\",\"url\":\"http://89.160.20.156:33385/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27378,10 +29682,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960975\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960975/\",\"url\":\"http://89.160.20.156:56649/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27426,10 +29734,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960971\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960971/\",\"url\":\"http://89.160.20.156:55457/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27474,10 +29786,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960968\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960968/\",\"url\":\"http://89.160.20.156:52314/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27522,10 +29838,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960969\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960969/\",\"url\":\"http://89.160.20.156:41985/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27571,10 +29891,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960970\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960970/\",\"url\":\"http://89.160.20.156:53197/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:07:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27618,10 +29942,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960967\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960967/\",\"url\":\"http://89.160.20.156:54472/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27666,10 +29994,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960966\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960966/\",\"url\":\"http://89.160.20.156:38100/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27714,10 +30046,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960964\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960964/\",\"url\":\"http://89.160.20.156:33121/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27762,10 +30098,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960965\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960965/\",\"url\":\"http://89.160.20.156:39363/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27810,10 +30150,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960961\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960961/\",\"url\":\"http://89.160.20.156:42844/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27858,10 +30202,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960962\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960962/\",\"url\":\"http://89.160.20.156:45789/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27906,10 +30254,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960963\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960963/\",\"url\":\"http://89.160.20.156:34080/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:06:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -27954,10 +30306,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960960\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960960/\",\"url\":\"http://89.160.20.156:56067/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:11 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28002,10 +30358,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960959\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960959/\",\"url\":\"http://89.160.20.156:34205/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28050,10 +30410,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960957\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960957/\",\"url\":\"http://89.160.20.156:53239/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28098,10 +30462,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960958\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960958/\",\"url\":\"http://89.160.20.156:53868/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28146,10 +30514,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960955\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960955/\",\"url\":\"http://89.160.20.156:39724/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28194,10 +30566,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960956\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960956/\",\"url\":\"http://89.160.20.156:60804/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28242,10 +30618,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960953\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960953/\",\"url\":\"http://89.160.20.156:51949/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28290,10 +30670,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960954\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960954/\",\"url\":\"http://89.160.20.156:48224/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:05:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28338,10 +30722,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960952\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960952/\",\"url\":\"http://89.160.20.156:37716/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:10 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28386,10 +30774,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960951\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960951/\",\"url\":\"http://89.160.20.156:60524/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28435,10 +30827,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960946\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960946/\",\"url\":\"http://urlfrance.fr/code/dd.txt\",\"url_status\":\"offline\",\"host\":\"urlfrance.fr\",\"date_added\":\"2021-01-14 16:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"Encoded\",\"njRAT\",\"rat\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28482,10 +30878,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960947\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960947/\",\"url\":\"http://89.160.20.156:49988/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28530,10 +30930,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960948\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960948/\",\"url\":\"http://89.160.20.156:42857/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28579,10 +30983,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960949\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960949/\",\"url\":\"http://89.160.20.156:44751/bin.sh\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28627,10 +31035,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960950\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960950/\",\"url\":\"http://89.160.20.156:47719/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 16:04:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28675,10 +31087,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960945\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960945/\",\"url\":\"http://89.160.20.156:38133/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:59:12 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"07ac0n\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28723,10 +31139,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960944\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960944/\",\"url\":\"http://www.sowetoson.com/new/Host_yjwloaz52.bin\",\"url_status\":\"online\",\"host\":\"www.sowetoson.com\",\"date_added\":\"2021-01-14 15:57:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"encrypted\",\"GuLoader\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28769,10 +31189,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960942\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960942/\",\"url\":\"https://www.agamagroup.com.ng/zxc/janomo_uGdNtpvRY170.bin\",\"url_status\":\"online\",\"host\":\"www.agamagroup.com.ng\",\"date_added\":\"2021-01-14 15:57:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"abused_legit_malware\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"encrypted\",\"GuLoader\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28815,10 +31239,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960943\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960943/\",\"url\":\"https://onedrive.live.com/download?cid=8FE9EB3F9398B325\u0026resid=8FE9EB3F9398B325%21126\u0026authkey=AOzL9FiDhEYRkm8\",\"url_status\":\"online\",\"host\":\"onedrive.live.com\",\"date_added\":\"2021-01-14 15:57:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"encrypted\",\"GuLoader\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28861,10 +31289,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960941\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960941/\",\"url\":\"http://89.160.20.156:46462/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28909,10 +31341,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960940\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960940/\",\"url\":\"http://89.160.20.156:39046/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -28957,10 +31393,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960934\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960934/\",\"url\":\"http://89.160.20.156:47418/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29005,10 +31445,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960935\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960935/\",\"url\":\"http://89.160.20.156:42287/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29053,10 +31497,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960936\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960936/\",\"url\":\"http://89.160.20.156:49596/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29101,10 +31549,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960937\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960937/\",\"url\":\"http://89.160.20.156:39815/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29149,10 +31601,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960938\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960938/\",\"url\":\"http://89.160.20.156:36568/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29197,10 +31653,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960939\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960939/\",\"url\":\"http://89.160.20.156:32954/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:52:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29245,10 +31705,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960933\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960933/\",\"url\":\"http://89.160.20.156:57752/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:51:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29293,10 +31757,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960932\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960932/\",\"url\":\"http://89.160.20.156:52221/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:51:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29341,10 +31809,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960931\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960931/\",\"url\":\"http://89.160.20.156:58493/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:40 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29389,10 +31861,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960930\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960930/\",\"url\":\"http://89.160.20.156:57603/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:14 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29437,10 +31913,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960929\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960929/\",\"url\":\"http://89.160.20.156:45439/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:13 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29485,10 +31965,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960928\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960928/\",\"url\":\"http://89.160.20.156:58291/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:08 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29533,10 +32017,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960927\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960927/\",\"url\":\"http://89.160.20.156:52785/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29581,10 +32069,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960924\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960924/\",\"url\":\"http://89.160.20.156:38582/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29629,10 +32121,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960925\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960925/\",\"url\":\"http://89.160.20.156:39503/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29677,10 +32173,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960926\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960926/\",\"url\":\"http://89.160.20.156:53018/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29725,10 +32225,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960923\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960923/\",\"url\":\"http://89.160.20.156:40698/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:50:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29773,10 +32277,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960922\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960922/\",\"url\":\"http://89.160.20.156:50060/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:49:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29821,10 +32329,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960921\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960921/\",\"url\":\"http://89.160.20.156:47874/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:49:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29870,10 +32382,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960919\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960919/\",\"url\":\"http://perezluzwsdycafeyzmn.dns.navy/perdoc/regasm.exe\",\"url_status\":\"online\",\"host\":\"perezluzwsdycafeyzmn.dns.navy\",\"date_added\":\"2021-01-14 15:46:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"exe\",\"Loki\",\"opendir\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29917,10 +32433,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960920\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960920/\",\"url\":\"http://89.160.20.156:33799/bin.sh\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:46:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"arm\",\"elf\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -29965,10 +32485,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960918\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960918/\",\"url\":\"http://kalamikwsdyonlinedws.dns.navy/kaladoc/vbc.exe\",\"url_status\":\"online\",\"host\":\"kalamikwsdyonlinedws.dns.navy\",\"date_added\":\"2021-01-14 15:45:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"AgentTesla\",\"exe\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30011,10 +32535,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960917\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960917/\",\"url\":\"http://89.160.20.156/js/js/lokkk.jpg\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:45:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"abuse_ch\",\"larted\":\"true\",\"tags\":[\"exe\",\"Loki\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30058,10 +32586,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960916\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960916/\",\"url\":\"http://89.160.20.156:33201/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30106,10 +32638,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960914\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960914/\",\"url\":\"http://89.160.20.156:53926/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30154,10 +32690,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960915\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960915/\",\"url\":\"http://89.160.20.156:43917/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30202,10 +32742,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960911\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960911/\",\"url\":\"http://89.160.20.156:42053/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30250,10 +32794,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960912\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960912/\",\"url\":\"http://89.160.20.156:57875/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30298,10 +32846,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960913\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960913/\",\"url\":\"http://89.160.20.156:35523/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30347,10 +32899,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960910\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960910/\",\"url\":\"http://89.160.20.156:47418/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:38:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30394,10 +32950,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960908\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960908/\",\"url\":\"http://89.160.20.156:53007/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30442,10 +33002,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960909\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960909/\",\"url\":\"http://89.160.20.156:38089/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30490,10 +33054,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960904\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960904/\",\"url\":\"http://89.160.20.156:35243/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30538,10 +33106,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960905\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960905/\",\"url\":\"http://89.160.20.156:50589/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30586,10 +33158,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960906\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960906/\",\"url\":\"http://89.160.20.156:42479/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30634,10 +33210,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960907\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960907/\",\"url\":\"http://89.160.20.156:43425/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:37:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30682,10 +33262,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960903\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960903/\",\"url\":\"http://89.160.20.156:35013/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:36:28 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30730,10 +33314,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960902\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960902/\",\"url\":\"http://89.160.20.156:35298/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:11 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30778,10 +33366,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960900\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960900/\",\"url\":\"http://89.160.20.156:54174/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30826,10 +33418,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960901\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960901/\",\"url\":\"http://89.160.20.156:42768/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:09 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30874,10 +33470,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960898\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960898/\",\"url\":\"http://89.160.20.156:59110/Mozi.a\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30922,10 +33522,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960899\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960899/\",\"url\":\"http://89.160.20.156:51476/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -30970,10 +33574,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960897\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960897/\",\"url\":\"http://89.160.20.156:58839/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31018,10 +33626,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960894\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960894/\",\"url\":\"http://89.160.20.156:50249/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31066,10 +33678,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960895\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960895/\",\"url\":\"http://89.160.20.156:46173/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31114,10 +33730,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960896\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960896/\",\"url\":\"http://89.160.20.156:43785/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:35:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31162,10 +33782,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960893\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960893/\",\"url\":\"http://89.160.20.156:46924/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:34:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31210,10 +33834,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960892\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960892/\",\"url\":\"http://89.160.20.156:59734/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:34:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31258,10 +33886,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960889\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960889/\",\"url\":\"http://89.160.20.156:51620/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31306,10 +33938,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960890\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960890/\",\"url\":\"http://89.160.20.156:42585/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31354,10 +33990,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960891\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960891/\",\"url\":\"http://89.160.20.156:57941/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:34:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31403,10 +34043,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960888\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960888/\",\"url\":\"http://89.160.20.156:38308/i\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:32:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"geenensp\",\"larted\":\"true\",\"tags\":[\"32-bit\",\"elf\",\"mips\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31450,10 +34094,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960887\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960887/\",\"url\":\"http://89.160.20.156:55281/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:44 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31498,10 +34146,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960886\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960886/\",\"url\":\"http://89.160.20.156:57662/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:07 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31546,10 +34198,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960885\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960885/\",\"url\":\"http://89.160.20.156:40738/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:06 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31594,10 +34250,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960884\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960884/\",\"url\":\"http://89.160.20.156:59018/Mozi.m\",\"url_status\":\"offline\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:05 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31642,10 +34302,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960880\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960880/\",\"url\":\"http://89.160.20.156:60279/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31690,10 +34354,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960881\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960881/\",\"url\":\"http://89.160.20.156:52738/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31738,10 +34406,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960882\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960882/\",\"url\":\"http://89.160.20.156:37394/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31786,10 +34458,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960883\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960883/\",\"url\":\"http://89.160.20.156:56491/Mozi.m\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:22:04 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -31834,10 +34510,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"id\":\"960879\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/960879/\",\"url\":\"http://89.160.20.156:46067/Mozi.a\",\"url_status\":\"online\",\"host\":\"89.160.20.156\",\"date_added\":\"2021-01-14 15:20:19 UTC\",\"threat\":\"malware_download\",\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"reporter\":\"lrz_urlhaus\",\"larted\":\"true\",\"tags\":[\"elf\",\"Mozi\"]}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/ti_abusech/data_stream/url/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_abusech/data_stream/url/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #

--- a/packages/ti_abusech/data_stream/url/sample_event.json
+++ b/packages/ti_abusech/data_stream/url/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2022-08-06T00:12:22.693Z",
+    "@timestamp": "2023-08-08T18:17:29.562Z",
     "abusech": {
         "url": {
             "blacklists": {
@@ -13,11 +13,11 @@
         }
     },
     "agent": {
-        "ephemeral_id": "2945b255-2667-4bac-8930-70eb987c8fef",
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "ephemeral_id": "d6e60fca-c7da-4d62-852d-bece09c6efc6",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "data_stream": {
         "dataset": "ti_abusech.url",
@@ -28,19 +28,23 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "87d4d8f8-b034-42ba-a5bb-33ff670e619e",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.0"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-06T00:12:22.693Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:17:29.562Z",
         "dataset": "ti_abusech.url",
-        "ingested": "2022-08-06T00:12:26Z",
+        "ingested": "2023-08-08T18:17:32Z",
         "kind": "enrichment",
         "original": "{\"blacklists\":{\"spamhaus_dbl\":\"not listed\",\"surbl\":\"not listed\"},\"date_added\":\"2021-10-05 13:57:05 UTC\",\"host\":\"120.85.169.98\",\"id\":\"1656008\",\"larted\":\"true\",\"reporter\":\"tammeto\",\"tags\":null,\"threat\":\"malware_download\",\"url\":\"http://120.85.169.98:55871/mozi.m\",\"url_status\":\"online\",\"urlhaus_reference\":\"https://urlhaus.abuse.ch/url/1656008/\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,11 +1,9 @@
 name: ti_abusech
 title: AbuseCH
-version: "1.17.0"
-release: ga
+version: "1.18.0"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.9.0
 categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.9.0
- Ensure event.type and event.category are arrays
- Ensure threat.software.alias is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.9.0 packages/ti_abusech
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870