### PR TITLE
[ti_cif3] - update package-spec to 2.9.0

### DIFF
--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.0"
+  changes:
+    - description: Update package-spec to 2.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.9.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7316
 - version: "1.3.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_cif3/data_stream/feed/_dev/test/pipeline/test-cif3-no-preserve-ndjson.log-expected.json
+++ b/packages/ti_cif3/data_stream/feed/_dev/test/pipeline/test-cif3-no-preserve-ndjson.log-expected.json
@@ -10,9 +10,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "ip": [

--- a/packages/ti_cif3/data_stream/feed/_dev/test/pipeline/test-cif3-sample-ndjson.log-expected.json
+++ b/packages/ti_cif3/data_stream/feed/_dev/test/pipeline/test-cif3-sample-ndjson.log-expected.json
@@ -10,10 +10,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"indicator\":\"89.160.20.156\",\"itype\":\"ipv4\",\"tlp\":\"white\",\"provider\":\"threatfox.abuse.ch\",\"group\":[\"everyone\"],\"count\":1,\"tags\":[\"agenttesla\",\"botnet\",\"hunter\"],\"confidence\":8.0,\"description\":\"agent tesla\",\"uuid\":\"3fbdd654-b2b0-498c-8e20-ef87bce73672\",\"reference\":\"https://threatfox.abuse.ch/ioc/838651/\",\"rdata\":\"http://208.67.106.111/theme/inc/e26dbe0dcc481e.php\",\"firsttime\":\"2022-07-19T07:40:41.000000Z\",\"lasttime\":\"2022-07-19T08:35:05.971696Z\",\"reporttime\":\"2022-07-19T08:35:05.971696Z\",\"indicator_ipv4\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "related": {
                 "ip": [

--- a/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #

--- a/packages/ti_cif3/data_stream/feed/fields/ecs.yml
+++ b/packages/ti_cif3/data_stream/feed/fields/ecs.yml
@@ -95,8 +95,6 @@
 - external: ecs
   name: threat.indicator.geo.country_iso_code
 - external: ecs
-  name: threat.indicator.geo.location
-- external: ecs
   name: threat.indicator.geo.region_name
 - external: ecs
   name: threat.indicator.geo.timezone

--- a/packages/ti_cif3/data_stream/feed/sample_event.json
+++ b/packages/ti_cif3/data_stream/feed/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-07-25T02:59:05.404Z",
+    "@timestamp": "2023-08-08T18:44:20.288Z",
     "agent": {
-        "ephemeral_id": "6d30ac65-9d55-4014-9a2a-2fbcf8816fff",
-        "id": "f599fd51-b36d-45b4-a90f-4d63240b8477",
+        "ephemeral_id": "01cfb0f6-6879-48c3-a90f-2f8c5274de1f",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.9.0"
     },
     "cif3": {
         "itype": "ipv4",
@@ -21,19 +21,23 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "f599fd51-b36d-45b4-a90f-4d63240b8477",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-07-25T02:59:05.404Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:44:20.288Z",
         "dataset": "ti_cif3.feed",
-        "ingested": "2022-07-25T02:59:08Z",
+        "ingested": "2023-08-08T18:44:23Z",
         "kind": "enrichment",
         "original": "{\"application\":\"https\",\"asn\":8075,\"asn_desc\":\"microsoft-corp-msn-as-block\",\"cc\":\"br\",\"city\":\"campinas\",\"confidence\":10,\"count\":1,\"firsttime\":\"2022-07-20T20:25:53.000000Z\",\"group\":[\"everyone\"],\"indicator\":\"20.206.75.106\",\"indicator_ipv4\":\"20.206.75.106\",\"itype\":\"ipv4\",\"lasttime\":\"2022-07-20T20:25:53.000000Z\",\"latitude\":-22.9035,\"location\":[-47.0565,-22.9035],\"longitude\":-47.0565,\"portlist\":\"443\",\"protocol\":\"tcp\",\"provider\":\"sslbl.abuse.ch\",\"reference\":\"https://sslbl.abuse.ch/blacklist/sslipblacklist.csv\",\"region\":\"sao paulo\",\"reporttime\":\"2022-07-21T20:33:26.585967Z\",\"tags\":[\"botnet\"],\"timezone\":\"america/sao_paulo\",\"tlp\":\"white\",\"uuid\":\"ac240898-1443-4d7e-a98a-1daed220c162\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_cif3/docs/README.md
+++ b/packages/ti_cif3/docs/README.md
@@ -120,13 +120,13 @@ An example event for `feed` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-07-25T02:59:05.404Z",
+    "@timestamp": "2023-08-08T18:44:20.288Z",
     "agent": {
-        "ephemeral_id": "6d30ac65-9d55-4014-9a2a-2fbcf8816fff",
-        "id": "f599fd51-b36d-45b4-a90f-4d63240b8477",
+        "ephemeral_id": "01cfb0f6-6879-48c3-a90f-2f8c5274de1f",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.9.0"
     },
     "cif3": {
         "itype": "ipv4",
@@ -142,19 +142,23 @@ An example event for `feed` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "f599fd51-b36d-45b4-a90f-4d63240b8477",
+        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.9.0"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-07-25T02:59:05.404Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-08T18:44:20.288Z",
         "dataset": "ti_cif3.feed",
-        "ingested": "2022-07-25T02:59:08Z",
+        "ingested": "2023-08-08T18:44:23Z",
         "kind": "enrichment",
         "original": "{\"application\":\"https\",\"asn\":8075,\"asn_desc\":\"microsoft-corp-msn-as-block\",\"cc\":\"br\",\"city\":\"campinas\",\"confidence\":10,\"count\":1,\"firsttime\":\"2022-07-20T20:25:53.000000Z\",\"group\":[\"everyone\"],\"indicator\":\"20.206.75.106\",\"indicator_ipv4\":\"20.206.75.106\",\"itype\":\"ipv4\",\"lasttime\":\"2022-07-20T20:25:53.000000Z\",\"latitude\":-22.9035,\"location\":[-47.0565,-22.9035],\"longitude\":-47.0565,\"portlist\":\"443\",\"protocol\":\"tcp\",\"provider\":\"sslbl.abuse.ch\",\"reference\":\"https://sslbl.abuse.ch/blacklist/sslipblacklist.csv\",\"region\":\"sao paulo\",\"reporttime\":\"2022-07-21T20:33:26.585967Z\",\"tags\":[\"botnet\"],\"timezone\":\"america/sao_paulo\",\"tlp\":\"white\",\"uuid\":\"ac240898-1443-4d7e-a98a-1daed220c162\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,8 +1,7 @@
-format_version: 1.0.0
+format_version: 2.9.0
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.3.0"
-license: basic
+version: "1.4.0"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.9.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.9.0 packages/ti_cif3
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870