### PR TITLE
[AWS] Remove duplicated `number_of_workers` settings from the custom logs integration

### DIFF
--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -62,9 +62,6 @@ api_sleep: {{ api_sleep }}
 {{#if latency }}
 latency: {{ latency }}
 {{/if}}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
 
 {{#if credential_profile_name}}
 credential_profile_name: {{credential_profile_name}}

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -16,7 +16,7 @@ queue_url: {{ queue_url }}
 {{/unless}}
 {{! end SQS queue }}
 
-{{#unless queue_url}}{{! start S3 bucket }}
+{{#unless queue_url}}{{! start S3 bucket polling }}
 
 {{!
 When using an S3 bucket, you can specify only one of the following options:
@@ -24,7 +24,7 @@ When using an S3 bucket, you can specify only one of the following options:
 - A non-AWS bucket name
 }}
 
-{{! shared S3 options }}
+{{! shared S3 bucket polling options }}
 {{#if number_of_workers }}
 number_of_workers: {{ number_of_workers }}
 {{/if}}
@@ -51,7 +51,7 @@ non_aws_bucket_name: {{ non_aws_bucket_name }}
 {{/if}}
 {{/unless}}
 
-{{/unless}}{{! end S3 bucket }}
+{{/unless}}{{! end S3 bucket polling }}
 
 {{#if buffer_size }}
 buffer_size: {{ buffer_size }}

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -4,6 +4,9 @@ data_stream:
 pipeline: {{pipeline}}
 {{/if}}
 
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
+
+{{! start SQS queue }}
 {{#unless bucket_arn}}
 {{#unless non_aws_bucket_name}}
 {{#if queue_url }}
@@ -11,50 +14,44 @@ queue_url: {{ queue_url }}
 {{/if}}
 {{/unless}}
 {{/unless}}
+{{! end SQS queue }}
 
-{{#unless queue_url}}
+{{#unless queue_url}}{{! start S3 bucket }}
+
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{! shared S3 options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
+{{/if}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
+{{/if}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
+{{/if}}
+
+{{! AWS S3 bucket ARN options }}
 {{#unless non_aws_bucket_name}}
 {{#if bucket_arn }}
 bucket_arn: {{ bucket_arn }}
 {{/if}}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-{{#if bucket_list_interval }}
-bucket_list_interval: {{ bucket_list_interval }}
-{{/if}}
-{{/unless}}
 {{/unless}}
 
+{{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#unless queue_url}}
 {{#if non_aws_bucket_name }}
 non_aws_bucket_name: {{ non_aws_bucket_name }}
 {{/if}}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-{{#if bucket_list_interval }}
-bucket_list_interval: {{ bucket_list_interval }}
-{{/if}}
-{{/unless}}
 {{/unless}}
 
-{{#unless queue_url}}
-{{#unless non_aws_bucket_name}}
-{{#unless bucket_arn }}
-{{#if bucket_list_prefix }}
-bucket_list_prefix: {{ bucket_list_prefix }}
-{{/if}}
-{{#if number_of_workers }}
-number_of_workers: {{ number_of_workers }}
-{{/if}}
-{{#if bucket_list_interval }}
-bucket_list_interval: {{ bucket_list_interval }}
-{{/if}}
-{{/unless}}
-{{/unless}}
-{{/unless}}
+{{/unless}}{{! end S3 bucket }}
 
 {{#if buffer_size }}
 buffer_size: {{ buffer_size }}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -41,7 +41,7 @@ streams:
         default: 1
         required: false
         show_user: false
-        description: Number of workers that will process the log groups with the given log_group_name_prefix. Default value is 1.
+        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: log_streams
         type: text
         title: Log Streams
@@ -95,12 +95,6 @@ streams:
         required: false
         show_user: false
         description: "The amount of time required for the logs to be available to CloudWatch Logs. Sample values, `1m` or `5m` — see Golang [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for more details. Latency translates the query's time range to consider the CloudWatch Logs latency. Example: `5m` means that the integration will query CloudWatch to search for logs available 5 minutes ago."
-      - name: number_of_workers
-        type: integer
-        title: Number of workers
-        required: false
-        show_user: false
-        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: tags
         type: text
         title: Tags

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -41,7 +41,7 @@ streams:
         default: 1
         required: false
         show_user: false
-        description: The number of workers assigned to reading from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
+        description: The number of workers assigned to read from log groups. Each worker will read log events from one of the log groups matching `log_group_name_prefix`. For example, if `log_group_name_prefix` matches five log groups, then `number_of_workers` should be set to `5`. The default value is `1`.
       - name: log_streams
         type: text
         title: Log Streams


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Addresses two distinct problems happening to the CloudWatch and S3 integrations.

### CloudWatch integration

In a previous [PR](https://github.com/elastic/integrations/pull/5794/), I added an extra `number_of_workers` advanced configuration setting by mistake while adding it to a group of CloudWatch-based integrations missing it.

This change applies to following changes:

- Removes the extra definition.
- Reuse the later setting description because it contains more details.

### S3 integration

If we set the "Bucket List Prefix" option, the `number_of_workers` is defined twice creating the "duplicated mapping key" error.

This PR re-groups the S3 settings to avoid defining the `number_of_workers` setting multiple times.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
## Author's Checklist

Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

TBA

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
## Related issues

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-

-->

<!-- Optional
## Screenshots

Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
