### PR TITLE
[Kubernetes/Kind] Update k8s and kind version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -14,8 +14,8 @@ pipeline {
     AWS_ACCOUNT_SECRET = "secret/observability-team/ci/elastic-observability-aws-account-auth"
     HOME = "${env.WORKSPACE}"
     DOCKER_COMPOSE_VERSION = "v2.17.2"
-    KIND_VERSION = "v0.17.0"
-    K8S_VERSION = "v1.26.0"
+    KIND_VERSION = "v0.20.0"
+    K8S_VERSION = "v1.27.3"
     JOB_GCS_BUCKET = 'fleet-ci-temp'
     JOB_GCS_BUCKET_INTERNAL = 'fleet-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'fleet-ci-gcs-plugin'

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -91,7 +91,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.23.x - 1.26.x] versions
+The Kubernetes package is tested with Kubernetes [1.25.x - 1.27.x] versions
 
 ## Dashboard
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -91,7 +91,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.23.x - 1.26.x] versions
+The Kubernetes package is tested with Kubernetes [1.25.x - 1.27.x] versions
 
 ## Dashboard
 


### PR DESCRIPTION
## What does this PR do?

Add support for Kubernetes latest version 1.27.


## Related issues

https://github.com/elastic/observability-dev/issues/2531
