### PR TITLE
[Okta] Add field for okta.debug_context.debug_data.dt_hash

### DIFF
--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.0"
+  changes:
+    - description: Retain `okta.debug_context.debug_data.dt_hash` field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7330
 - version: "1.27.0"
   changes:
     - description: Update package-spec 2.9.0.

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
@@ -2242,6 +2242,7 @@
                 },
                 "debug_context": {
                     "debug_data": {
+                        "dt_hash": "751b157a5a24ed83129433243e8d42307434b047120c32d7a7f5a5d2d91726fa",
                         "flattened": {
                             "authnRequestId": "Y5elHFMngoYoVKvakwnp2wAAAKo",
                             "behaviors": {
@@ -2602,6 +2603,7 @@
                 "debug_context": {
                     "debug_data": {
                         "device_fingerprint": "id",
+                        "dt_hash": "hash",
                         "factor": "FIDO_WEBAUTHN",
                         "flattened": {
                             "authnRequestId": "id",
@@ -2787,6 +2789,7 @@
                 "debug_context": {
                     "debug_data": {
                         "device_fingerprint": "id",
+                        "dt_hash": "hash",
                         "factor": "FIDO_WEBAUTHN",
                         "flattened": {
                             "authnRequestId": "id",
@@ -2988,6 +2991,7 @@
                 },
                 "debug_context": {
                     "debug_data": {
+                        "dt_hash": "veqflnui3t7ql7k6v0nptw9lipilzybr",
                         "flattened": {
                             "dtHash": "veqflnui3t7ql7k6v0nptw9lipilzybr",
                             "requestId": "3bsdgs8tyatf74aufwsvkt7lv1i9x0o9",
@@ -3516,6 +3520,7 @@
                 },
                 "debug_context": {
                     "debug_data": {
+                        "dt_hash": "abc123456abc",
                         "factor": "SIGNED_NONCE",
                         "flattened": {
                             "dtHash": "abc123456abc",

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -374,6 +374,11 @@ processors:
       target_field: okta.debug_context.debug_data.url
       ignore_missing: true
       ignore_failure: true
+  - rename:
+      field: json.debugContext.debugData.dtHash
+      target_field: okta.debug_context.debug_data.dt_hash
+      ignore_missing: true
+      ignore_failure: true
   - set:
       field: okta.debug_context.debug_data.risk_level
       value: "{{{okta.debug_context.debug_data.flattened.logOnlySecurityData.risk.level}}}"

--- a/packages/okta/data_stream/system/fields/fields.yml
+++ b/packages/okta/data_stream/system/fields/fields.yml
@@ -179,6 +179,10 @@
           type: keyword
           description: |
             The fingerprint of the device.
+        - name: dt_hash
+          type: keyword
+          description: |
+            The device token token hash
         - name: factor
           type: keyword
           description: |

--- a/packages/okta/data_stream/system/fields/fields.yml
+++ b/packages/okta/data_stream/system/fields/fields.yml
@@ -182,7 +182,7 @@
         - name: dt_hash
           type: keyword
           description: |
-            The device token token hash
+            The device token hash
         - name: factor
           type: keyword
           description: |

--- a/packages/okta/data_stream/system/sample_event.json
+++ b/packages/okta/data_stream/system/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "8eaa9775-8007-4ee9-98fa-697aece3176b",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "3f42021e-4a96-4f9e-a171-f1270261873e",
+        "id": "12fae7e9-e1d1-4d7d-935d-77da8e90f576",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -33,7 +33,7 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "12fae7e9-e1d1-4d7d-935d-77da8e90f576",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -44,10 +44,10 @@
             "authentication",
             "session"
         ],
-        "created": "2023-08-07T13:21:29.152Z",
+        "created": "2023-08-09T18:07:16.315Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2023-08-07T13:21:30Z",
+        "ingested": "2023-08-09T18:07:17Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",

--- a/packages/okta/docs/README.md
+++ b/packages/okta/docs/README.md
@@ -14,8 +14,8 @@ An example event for `system` looks as following:
 {
     "@timestamp": "2020-02-14T20:18:57.718Z",
     "agent": {
-        "ephemeral_id": "8eaa9775-8007-4ee9-98fa-697aece3176b",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "3f42021e-4a96-4f9e-a171-f1270261873e",
+        "id": "12fae7e9-e1d1-4d7d-935d-77da8e90f576",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -46,7 +46,7 @@ An example event for `system` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "12fae7e9-e1d1-4d7d-935d-77da8e90f576",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -57,10 +57,10 @@ An example event for `system` looks as following:
             "authentication",
             "session"
         ],
-        "created": "2023-08-07T13:21:29.152Z",
+        "created": "2023-08-09T18:07:16.315Z",
         "dataset": "okta.system",
         "id": "3aeede38-4f67-11ea-abd3-1f5d113f2546",
-        "ingested": "2023-08-07T13:21:30Z",
+        "ingested": "2023-08-09T18:07:17Z",
         "kind": "event",
         "original": "{\"actor\":{\"alternateId\":\"xxxxxx@elastic.co\",\"detailEntry\":null,\"displayName\":\"xxxxxx\",\"id\":\"00u1abvz4pYqdM8ms4x6\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"102bZDNFfWaQSyEZQuDgWt-uQ\",\"interface\":null,\"issuer\":null},\"client\":{\"device\":\"Computer\",\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"id\":null,\"ipAddress\":\"108.255.197.247\",\"userAgent\":{\"browser\":\"FIREFOX\",\"os\":\"Mac OS X\",\"rawUserAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:72.0) Gecko/20100101 Firefox/72.0\"},\"zone\":\"null\"},\"debugContext\":{\"debugData\":{\"deviceFingerprint\":\"541daf91d15bef64a7e08c946fd9a9d0\",\"requestId\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"requestUri\":\"/api/v1/authn\",\"threatSuspected\":\"false\",\"url\":\"/api/v1/authn?\"}},\"displayMessage\":\"User login to Okta\",\"eventType\":\"user.session.start\",\"legacyEventType\":\"core.user_auth.login_success\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2020-02-14T20:18:57.718Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Dublin\",\"country\":\"United States\",\"geolocation\":{\"lat\":37.7201,\"lon\":-121.919},\"postalCode\":\"94568\",\"state\":\"California\"},\"ip\":\"108.255.197.247\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":null,\"asOrg\":null,\"domain\":null,\"isProxy\":null,\"isp\":null},\"severity\":\"INFO\",\"target\":null,\"transaction\":{\"detail\":{},\"id\":\"XkcAsWb8WjwDP76xh@1v8wAABp0\",\"type\":\"WEB\"},\"uuid\":\"3aeede38-4f67-11ea-abd3-1f5d113f2546\",\"version\":\"0\"}",
         "outcome": "success",
@@ -281,6 +281,7 @@ An example event for `system` looks as following:
 | okta.client.user_agent.raw_user_agent | The raw informaton of the user agent. | keyword |
 | okta.client.zone | The zone information of the client. | keyword |
 | okta.debug_context.debug_data.device_fingerprint | The fingerprint of the device. | keyword |
+| okta.debug_context.debug_data.dt_hash | The device token token hash | keyword |
 | okta.debug_context.debug_data.factor | The factor used for authentication. | keyword |
 | okta.debug_context.debug_data.flattened | The complete debug_data object. | flattened |
 | okta.debug_context.debug_data.request_id | The identifier of the request. | keyword |

--- a/packages/okta/docs/README.md
+++ b/packages/okta/docs/README.md
@@ -281,7 +281,7 @@ An example event for `system` looks as following:
 | okta.client.user_agent.raw_user_agent | The raw informaton of the user agent. | keyword |
 | okta.client.zone | The zone information of the client. | keyword |
 | okta.debug_context.debug_data.device_fingerprint | The fingerprint of the device. | keyword |
-| okta.debug_context.debug_data.dt_hash | The device token token hash | keyword |
+| okta.debug_context.debug_data.dt_hash | The device token hash | keyword |
 | okta.debug_context.debug_data.factor | The factor used for authentication. | keyword |
 | okta.debug_context.debug_data.flattened | The complete debug_data object. | flattened |
 | okta.debug_context.debug_data.request_id | The identifier of the request. | keyword |

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "1.27.0"
+version: "1.28.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: 2.9.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Sets the value of the field `okta.debug_context.debug_data.dt_hash`.
<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #7329 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
