### PR TITLE
CODEOWNERS: split ownership of gcp between cloud monitoring and security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,6 +98,11 @@
 /packages/fortinet_fortimail @elastic/security-external-integrations
 /packages/fortinet_fortimanager @elastic/security-external-integrations
 /packages/gcp @elastic/security-external-integrations @elastic/obs-cloud-monitoring
+/packages/gcp/data_stream @elastic/obs-cloud-monitoring
+/packages/gcp/data_stream/audit @elastic/security-external-integrations
+/packages/gcp/data_stream/dns @elastic/security-external-integrations
+/packages/gcp/data_stream/firewall @elastic/security-external-integrations
+/packages/gcp/data_stream/vpcflow @elastic/security-external-integrations
 /packages/gcp_metrics @elastic/obs-cloud-monitoring
 /packages/gcp_pubsub @elastic/security-external-integrations
 /packages/github @elastic/security-external-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Makes code ownership more fine grained in the system package.

The manifest and changelog are co-owned by both teams and the two primarily security focused data streams are assigned to security external integrations. Rather than enumerating all data streams, assign data streams to cloud monitoring by default and carve out security data streams.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7023

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
