### PR TITLE
trellix_epo_cloud: add support for http request trace logging

### DIFF
--- a/packages/trellix_epo_cloud/changelog.yml
+++ b/packages/trellix_epo_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add support for HTTP request trace logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7334
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/trellix_epo_cloud/data_stream/device/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/device/agent/stream/input.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+{{/if}}
 {{#if proxy_url}}
 resource.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/trellix_epo_cloud/data_stream/device/manifest.yml
+++ b/packages/trellix_epo_cloud/data_stream/device/manifest.yml
@@ -63,3 +63,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.

--- a/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/event/agent/stream/input.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+{{/if}}
 {{#if proxy_url}}
 resource.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/trellix_epo_cloud/data_stream/event/manifest.yml
+++ b/packages/trellix_epo_cloud/data_stream/event/manifest.yml
@@ -71,3 +71,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.

--- a/packages/trellix_epo_cloud/data_stream/group/agent/stream/input.yml.hbs
+++ b/packages/trellix_epo_cloud/data_stream/group/agent/stream/input.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+{{/if}}
 {{#if proxy_url}}
 resource.proxy_url: {{proxy_url}}
 {{/if}}

--- a/packages/trellix_epo_cloud/data_stream/group/manifest.yml
+++ b/packages/trellix_epo_cloud/data_stream/group/manifest.yml
@@ -63,3 +63,11 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.

--- a/packages/trellix_epo_cloud/manifest.yml
+++ b/packages/trellix_epo_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.6.0
 name: trellix_epo_cloud
 title: Trellix ePO Cloud
-version: "1.2.0"
+version: "1.3.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Trellix ePO Cloud with Elastic Agent.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Adds support for CEL input-based HTTP request trace logging.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7228

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
