### PR TITLE
cel: fix location of http request trace log destination

### DIFF
--- a/packages/cel/agent/input/input.yml.hbs
+++ b/packages/cel/agent/input/input.yml.hbs
@@ -117,7 +117,7 @@ resource.rate_limit.burst: {{resource_rate_limit_burst}}
 {{/if}}
 
 {{#if enable_request_tracer}}
-resource.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
 {{/if}}
 
 {{#if tags}}

--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.1"
+  changes:
+    - description: Fix location of request trace log destination.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7335
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -3,7 +3,7 @@ name: cel
 title: CEL Custom API
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.2.0"
+version: "1.2.1"
 categories:
   - custom
 conditions:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Write HTTP request trace logs unders logs/cel/ rather than logs/httpjson/

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
