### PR TITLE
bitdefender: add support for http request trace logging

### DIFF
--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Add support for HTTP request trace logging.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7339
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/bitdefender/data_stream/push_configuration/agent/stream/httpjson.yml.hbs
+++ b/packages/bitdefender/data_stream/push_configuration/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.url: {{url}}
 request.method: POST
 {{#if proxy_url }}

--- a/packages/bitdefender/data_stream/push_statistics/agent/stream/httpjson.yml.hbs
+++ b/packages/bitdefender/data_stream/push_statistics/agent/stream/httpjson.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.url: {{url}}
 request.method: POST
 {{#if proxy_url }}

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bitdefender
 title: "BitDefender"
-version: "1.2.0"
+version: "1.3.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"
@@ -72,5 +72,12 @@ policy_templates:
             title: BitDefender GravityZone API Key
             show_user: true
             required: true
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
 owner:
   github: elastic/security-external-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Add support for HTTP request trace logging.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7228

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
