### PR TITLE
nagios_xi: add support for http request trace logging

### DIFF
--- a/packages/nagios_xi/changelog.yml
+++ b/packages/nagios_xi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Add support for HTTP request trace logging.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7342
 - version: "1.0.0"
   changes:
     - description: Make Nagios XI GA

--- a/packages/nagios_xi/data_stream/events/agent/stream/stream.yml.hbs
+++ b/packages/nagios_xi/data_stream/events/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.method: GET
 request.url: {{hostname}}/nagiosxi/api/v1/objects/logentries?apikey={{api_key}}&orderby=entry_time:a
 {{#if proxy_url }}

--- a/packages/nagios_xi/data_stream/host/agent/stream/stream.yml.hbs
+++ b/packages/nagios_xi/data_stream/host/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.method: GET
 request.url: {{hostname}}/nagiosxi/api/v1/objects/hoststatus?apikey={{api_key}}
 {{#if proxy_url }}

--- a/packages/nagios_xi/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/nagios_xi/data_stream/service/agent/stream/stream.yml.hbs
@@ -1,5 +1,8 @@
 config_version: 2
 interval: {{interval}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.method: GET
 request.url: {{hostname}}/nagiosxi/api/v1/objects/servicestatus?apikey={{api_key}}
 {{#if proxy_url }}

--- a/packages/nagios_xi/manifest.yml
+++ b/packages/nagios_xi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: nagios_xi
 title: "Nagios XI"
-version: "1.0.0"
+version: "1.1.0"
 license: basic
 description: Collect Logs and Metrics from Nagios XI with Elastic Agent.
 type: integration
@@ -97,6 +97,13 @@ policy_templates:
               #    yvgJ38BRsFOtkRuAGSf6ZUwTO8JJRRIFnpUzXflAnGivK9M13D5GEQMmIl6U9Pvk
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
+          - name: enable_request_tracer
+            type: bool
+            title: Enable request tracing
+            multi: false
+            required: false
+            show_user: false
+            description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.
         title: Collect Nagios XI Metrics via API
         description: Collect Nagios XI Host metrics, Service metrics and System events.
 owner:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Add support for HTTP request trace logging.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7228

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
