### PR TITLE
hadoop: add support for http request trace logging

### DIFF
--- a/packages/hadoop/changelog.yml
+++ b/packages/hadoop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.9.0"
+  changes:
+    - description: Add support for HTTP request trace logging in application data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7343
 - version: "0.8.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
+++ b/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
@@ -1,6 +1,9 @@
 config_version: 2
 type: httpjson
 interval: {{period}}
+{{#if enable_request_tracer}}
+request.tracer.filename: "../../logs/httpjson/http-request-trace-*.ndjson"
+{{/if}}
 request.method: GET
 request.url: {{hostname}}/ws/v1/cluster/apps
 {{#if ssl}}

--- a/packages/hadoop/data_stream/application/manifest.yml
+++ b/packages/hadoop/data_stream/application/manifest.yml
@@ -50,4 +50,10 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
-
+      - name: enable_request_tracer
+        type: bool
+        title: Enable request tracing
+        multi: false
+        required: false
+        show_user: false
+        description: The request tracer logs requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#_request_tracer_filename) for details.

--- a/packages/hadoop/manifest.yml
+++ b/packages/hadoop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: hadoop
 title: Hadoop
-version: "0.8.0"
+version: "0.9.0"
 license: basic
 description: Collect metrics from Apache Hadoop with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Add support for HTTP request trace logging.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7228

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
