### PR TITLE
[Cloud Security] Backport v1.2 PR 7185

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.2.14"
   changes:
-    - description: Backport: Added ingest processor to copy cluster_id to orchestrator.cluster.id
+    - description: Backport - Added ingest processor to copy cluster_id to orchestrator.cluster.id
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7185
 - version: "1.2.13"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.14"
+  changes:
+    - description: Backport: Added ingest processor to copy cluster_id to orchestrator.cluster.id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7185
 - version: "1.2.13"
   changes:
     - description: "Fixed multiple for input streams"

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
     value: 'kspm'
     description: 'Backward compatibility cloudbeat version < 8.7'
     if: ctx.rule?.benchmark?.posture_type == null
+- set:
+    field: orchestrator.cluster.id
+    copy_from: cluster_id
+    description: 'Backward compatibility cloudbeat version < 8.8'
+    if: ctx.orchestrator?.cluster?.id == null
 on_failure:
 - set:
     field: error.message

--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -114,6 +114,8 @@
   external: ecs
 - name: event.type
   external: ecs
+- name: orchestrator.cluster.id
+  external: ecs
 - name: orchestrator.cluster.name
   external: ecs
 - name: cloud.account.id

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.2.13"
+version: "1.2.14"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## What does this PR do?

Adds backwards compatibility for the migration from cluster_id -> orchestrator.cluster.id ECS field for cloudbeat agents pre 8.8.0

Original PR: https://github.com/elastic/integrations/pull/7185

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues
- https://github.com/elastic/kibana/issues/155463