### PR TITLE
[Kibana] Add missing "basepath" variable in Kibana integration settings

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.6"
+  changes:
+    - description: Add basepath to kibana manifest
+      type: bugfix
+      link: https://github.com/elastic/integrations/issues/7359
 - version: "2.3.5"
   changes:
     - description: Add background task utilization metric

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.3.5
+version: 2.3.6
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:
@@ -43,6 +43,12 @@ policy_templates:
             show_user: true
             default:
               - http://localhost:5601
+          - name: basepath
+            type: text
+            title: Base path
+            multi: false
+            required: false
+            show_user: false
           - name: username
             type: text
             title: Username
@@ -80,6 +86,12 @@ policy_templates:
             show_user: true
             default:
               - http://localhost:5601
+          - name: basepath
+            type: text
+            title: Base path
+            multi: false
+            required: false
+            show_user: false
           - name: username
             type: text
             title: Username


### PR DESCRIPTION
## What does this PR do?

This PR adds the `basepath` setting inside the Kibana integration

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Go to `integrations/packages/kibana`
- Follow [this test guide](https://github.com/elastic/elastic-package/blob/main/docs/howto/install_package.md#kibana--870)
- Open kibana integration installation page and check for basepath (https://127.0.0.1:5601/app/fleet/integrations/kibana-2.3.6/add-integration)

## Related issues

- Closes [#7359](https://github.com/elastic/integrations/issues/7359)

## Screenshots

![Screenshot 2023-08-11 at 16-53-33 Add integration - Kibana - Integrations - Elastic](https://github.com/elastic/integrations/assets/14139027/3bce1396-c347-4d40-9f00-7c3a617f82a4)
