### PR TITLE
[Atlassian Confluence] Add `condition` support to Confluence Log File Integration

### DIFF
--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Add ability to set condition for logfile logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7370
 - version: "1.15.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/atlassian_confluence/data_stream/audit/agent/stream/stream.yml.hbs
+++ b/packages/atlassian_confluence/data_stream/audit/agent/stream/stream.yml.hbs
@@ -17,3 +17,6 @@ exclude_files: [".gz$"]
 processors:
 {{processors}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -38,6 +38,13 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: condition
+        title: Condition
+        description: Condition to filter when to collect this input
+        type: text
+        multi: false
+        required: false
+        show_user: false
 
   - input: httpjson
     title: Confluence audit logs via Confluence audit API

--- a/packages/atlassian_confluence/data_stream/audit/manifest.yml
+++ b/packages/atlassian_confluence/data_stream/audit/manifest.yml
@@ -40,7 +40,7 @@ streams:
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
       - name: condition
         title: Condition
-        description: Condition to filter when to collect this input
+        description: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
         type: text
         multi: false
         required: false

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.15.0"
+version: "1.16.0"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Enhancement - Adds support for setting [`condition`](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) to Atlassian Confluence Log File integration. This allows for defining this integration in a policy, but only having it run on during specific condition.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Install new version, confirm that condition field is available and can be set.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->


![image](https://github.com/elastic/integrations/assets/8277432/57777172-9dd8-4439-b2ee-32912d92e066)
