### PR TITLE
[Cloud Security] Update GCP's policy manifest

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -4,6 +4,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.5.0-preview32"
+  changes:
+    - description: Remove default value for project id
+      type: bug
+      link: https://github.com/elastic/integrations/pull/7379
 - version: "1.5.0-preview31"
   changes:
     - description: Ensure event.kind is correctly set for pipeline errors.

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -7,7 +7,7 @@
 - version: "1.5.0-preview32"
   changes:
     - description: Remove default value for project id
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/7379
 - version: "1.5.0-preview31"
   changes:

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -129,7 +129,6 @@ streams:
         multi: false
         required: false
         show_user: true
-        default: SET_PROJECT_NAME
       - name: credentials_file
         type: text
         title: Credentials File

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview31"
+version: "1.5.0-preview32"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## What does this PR do?
We want the project id to be missing in case of a cloudshell deployment. 
When deploying the agent through GCP Cloud Shell, the Project ID is not provided, Cloudbeat detects this and  takes action by retrieving the Project ID from the associated service account of the instance. This ensures that the necessary Project ID is acquired and utilized.

Fix the following error:
```
[elastic_agent.cloudbeat][error] Exiting: launcher could not run Beater: could not create beater: failed to get GCP identity: unable to get project with id 'projects/SET_PROJECT_NAME': googleapi: Error 400: Fail to resolve resource 'projects/SET_PROJECT_NAME', badRequest
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
