### PR TITLE
[Cloud Security] Update CSPM url

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -4,7 +4,7 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.5.0-preview32"
+- version: "1.5.0-preview33"
   changes:
     - description: Remove default value for project id
       type: bugfix

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.5.0-preview32"
+version: "1.5.0-preview33"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -113,7 +113,7 @@ policy_templates:
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.10.0-2023-08-09-10-10-44.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.10.0-2023-08-14-15-06-59.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations


### PR DESCRIPTION
## What does this PR do?

Adds more organization-level read permissions

This will future-proof our CloudFormation template for future changes like https://github.com/elastic/cloudbeat/issues/1177 and https://github.com/elastic/cloudbeat/issues/1214 that will require more permissions in the organization level. After merging those, newer CloudFormation templates can trim down the required permissions again.


## Related issues

- Relates https://github.com/elastic/cloudbeat/pull/1226