### PR TITLE
lastpass: allow users to specify time zone for event_report events

### DIFF
--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Allow user to specify timezone for event report events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7386
+    - description: Fix event.type for authorization events.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7386
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/lastpass/data_stream/event_report/_dev/test/pipeline/test-event-report.log-expected.json
+++ b/packages/lastpass/data_stream/event_report/_dev/test/pipeline/test-event-report.log-expected.json
@@ -13,6 +13,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login Verification Email Sent\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -68,6 +69,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Multifactor Enabled\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -123,6 +125,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Enterprise API Secret regenerated\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -178,6 +181,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Master Password Changed\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -233,8 +237,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"SAML Login\",\"Data\":\"authorizationserver.oidc\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -292,6 +297,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Delete Policy\",\"Data\":\"Require passwordless verification via LastPass Authenticator\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -350,6 +356,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add Policy\",\"Data\":\"Require passwordless verification via LastPass Authenticator New value: 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -405,6 +412,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Reporting\",\"Data\":\"Initiated by API\"}",
                 "outcome": "unknown",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -460,6 +468,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Get User Data\",\"Data\":\"Initiated by API\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -515,6 +524,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Get Shared Folder Data\",\"Data\":\"Initiated by API\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -573,8 +583,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Log in\",\"Data\":\"lastpass.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -632,8 +643,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Failed Login Attempt\",\"Data\":\"lastpass.com\"}",
                 "outcome": "failure",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -691,8 +703,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Log in\",\"Data\":\"1.1.1.1:1234/example\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -750,8 +763,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login to Admin Console\",\"Data\":\"user1@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -811,6 +825,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee Account Created\",\"Data\":\"user2@example.com,user3@example.com,user4@example.com,user5@example.com,user6@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -883,6 +898,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee Invited\",\"Data\":\"user2@example.com,user3@example.com,user4@example.com,user5@example.com,user6@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -958,6 +974,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Make Admin\",\"Data\":\"user4@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "admin"
                 ]
@@ -1019,8 +1036,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login to Admin Console\",\"Data\":\"user1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -1077,6 +1095,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Make Admin\",\"Data\":\"user4\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "admin"
                 ]
@@ -1132,6 +1151,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Site Added\",\"Data\":\"example.com/ServiceLogin\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1188,6 +1208,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted Sites\",\"Data\":\"example.com/ServiceLogin\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -1246,6 +1267,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Site Added\",\"Data\":\"example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1302,6 +1324,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted Sites\",\"Data\":\"example1.com,example2.com,example3.com,example4.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -1363,6 +1386,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Created Shared Folder\",\"Data\":\"temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1419,6 +1443,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted Shared Folder\",\"Data\":\"temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -1475,6 +1500,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add Secure Note\",\"Data\":\"Secure Note (Address) from temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1532,8 +1558,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Open Secure Note\",\"Data\":\"Secure Note (Address)\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -1588,8 +1615,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Open Secure Note\",\"Data\":\"Secure Note (Address) from temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -1645,6 +1673,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add to Shared Folder\",\"Data\":\"'temp-1' 'user1@example.com'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1707,6 +1736,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Create Group\",\"Data\":\"'temp-group'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "group",
                     "creation"
@@ -1770,6 +1800,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Adding User to Group\",\"Data\":\"user1@example.com - temp-group\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "group",
                     "creation"
@@ -1836,6 +1867,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Created LastPass Account\",\"Data\":\"user1@example.com-Shared-temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -1895,6 +1927,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Update Folder Permissions\",\"Data\":\"'temp-1' 'user1@example.com' 'Read only:no Admin:no Hide PW:no'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -1962,6 +1995,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Master Password Reset by Super Admin\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2023,6 +2057,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee Account Deleted\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -2086,6 +2121,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Require Password Change\",\"Data\":\"user3@example.com\"}",
                 "outcome": "unknown",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -2147,6 +2183,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Remove Admin\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -2205,6 +2242,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Edit Secure Note\",\"Data\":\"Secure Note (Wifi renamed)\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2261,6 +2299,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Renamed Shared Folder\",\"Data\":\"'test1' 'test2'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2318,6 +2357,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move to Shared Folder\",\"Data\":\"example.com to Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2375,6 +2415,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move to Shared Folder\",\"Data\":\" to Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2431,6 +2472,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from Shared Folder\",\"Data\":\"example.com from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2488,6 +2530,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from Shared Folder\",\"Data\":\" from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2544,6 +2587,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Limit Shared Folder\",\"Data\":\"shared folder test@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2601,6 +2645,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Removed From Shared Folder\",\"Data\":\"'test1' 'test@example.com'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -2658,6 +2703,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Delete Shared Sites\",\"Data\":\"example.com from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -2715,6 +2761,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from Shared Folder\",\"Data\":\" from INVALID SHARED FOLDER\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2773,6 +2820,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login verification email sent\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -2828,6 +2876,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Multifactor enabled\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -2883,6 +2932,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Enterprise API secret regenerated\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2938,6 +2988,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Master password changed\",\"Data\":\"\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -2993,8 +3044,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"SAML login\",\"Data\":\"authorizationserver.oidc\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3052,6 +3104,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Delete policy\",\"Data\":\"Require passwordless verification via LastPass Authenticator\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -3110,6 +3163,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add policy\",\"Data\":\"Require passwordless verification via LastPass Authenticator New value: 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -3165,6 +3219,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Reporting\",\"Data\":\"Initiated by API\"}",
                 "outcome": "unknown",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -3220,6 +3275,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Get user data\",\"Data\":\"Initiated by API\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -3275,6 +3331,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Get shared folder data\",\"Data\":\"Initiated by API\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -3333,8 +3390,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Log in\",\"Data\":\"lastpass.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3392,8 +3450,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Failed login attempt\",\"Data\":\"lastpass.com\"}",
                 "outcome": "failure",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3451,8 +3510,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Log in\",\"Data\":\"1.1.1.1:1234/example\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3510,8 +3570,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login to admin console\",\"Data\":\"user1@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3571,6 +3632,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee account created\",\"Data\":\"user2@example.com,user3@example.com,user4@example.com,user5@example.com,user6@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -3643,6 +3705,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee invited\",\"Data\":\"user2@example.com,user3@example.com,user4@example.com,user5@example.com,user6@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -3718,6 +3781,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Make admin\",\"Data\":\"user4@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "admin"
                 ]
@@ -3779,8 +3843,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Login to admin console\",\"Data\":\"user1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -3837,6 +3902,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Make admin\",\"Data\":\"user4\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "admin"
                 ]
@@ -3892,6 +3958,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Site added\",\"Data\":\"example.com/ServiceLogin\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -3948,6 +4015,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted sites\",\"Data\":\"example.com/ServiceLogin\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -4006,6 +4074,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Site added\",\"Data\":\"example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -4062,6 +4131,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted sites\",\"Data\":\"example1.com,example2.com,example3.com,example4.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -4123,6 +4193,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Created shared folder\",\"Data\":\"temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -4179,6 +4250,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Deleted shared folder\",\"Data\":\"temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -4235,6 +4307,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add secure note\",\"Data\":\"Secure Note (Address) from temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -4292,8 +4365,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Open secure note\",\"Data\":\"Secure Note (Address)\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -4348,8 +4422,9 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Open secure note\",\"Data\":\"Secure Note (Address) from temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "lastpass": {
@@ -4405,6 +4480,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Add to shared folder\",\"Data\":\"'temp-1' 'user1@example.com'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -4467,6 +4543,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Create group\",\"Data\":\"'temp-group'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "group",
                     "creation"
@@ -4530,6 +4607,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Adding user to group\",\"Data\":\"user1@example.com - temp-group\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "group",
                     "creation"
@@ -4596,6 +4674,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Created LastPass account\",\"Data\":\"user1@example.com-Shared-temp-1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "creation"
                 ]
@@ -4655,6 +4734,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Update folder permissions\",\"Data\":\"'temp-1' 'user1@example.com' 'Read only:no Admin:no Hide PW:no'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -4722,6 +4802,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Master password reset by super admin\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -4783,6 +4864,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Employee account deleted\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -4846,6 +4928,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Require password change\",\"Data\":\"user3@example.com\"}",
                 "outcome": "unknown",
+                "timezone": "US/Eastern",
                 "type": [
                     "info"
                 ]
@@ -4907,6 +4990,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Remove admin\",\"Data\":\"user3@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -4965,6 +5049,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Edit secure note\",\"Data\":\"Secure Note (Wifi renamed)\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5021,6 +5106,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Renamed shared folder\",\"Data\":\"'test1' 'test2'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5078,6 +5164,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move to shared folder\",\"Data\":\"example.com to Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5135,6 +5222,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move to shared folder\",\"Data\":\" to Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5191,6 +5279,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from shared folder\",\"Data\":\"example.com from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5248,6 +5337,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from shared folder\",\"Data\":\" from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5304,6 +5394,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Limit shared folder\",\"Data\":\"shared folder test@example.com\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]
@@ -5361,6 +5452,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Removed from shared folder\",\"Data\":\"'test1' 'test@example.com'\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -5418,6 +5510,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Delete shared sites\",\"Data\":\"example.com from Shared Folder 1\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "deletion"
                 ]
@@ -5475,6 +5568,7 @@
                 "kind": "event",
                 "original": "{\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"test@example.com\",\"IP_Address\":\"67.43.156.0\",\"Action\":\"Move from shared folder\",\"Data\":\" from INVALID SHARED FOLDER\"}",
                 "outcome": "success",
+                "timezone": "US/Eastern",
                 "type": [
                     "change"
                 ]

--- a/packages/lastpass/data_stream/event_report/_dev/test/system/test-default-config.yml
+++ b/packages/lastpass/data_stream/event_report/_dev/test/system/test-default-config.yml
@@ -7,5 +7,6 @@ vars:
   enable_request_tracer: true
 data_stream:
   vars:
+    tz_offset: UTC
     preserve_original_event: true
     preserve_duplicate_custom_fields: true

--- a/packages/lastpass/data_stream/event_report/agent/stream/httpjson.yml.hbs
+++ b/packages/lastpass/data_stream/event_report/agent/stream/httpjson.yml.hbs
@@ -71,3 +71,9 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+fields_under_root: true
+fields:
+  _conf:
+{{#if tz_offset}}
+    tz_offset: "{{tz_offset}}"
+{{/if}}

--- a/packages/lastpass/data_stream/event_report/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/lastpass/data_stream/event_report/elasticsearch/ingest_pipeline/default.yml
@@ -49,7 +49,7 @@ processors:
   - set:
       field: event.type
       if: ctx.event?.action?.contains('log in') || ctx.event?.action?.contains('login to admin console') || ctx.event?.action?.contains('saml login') || ctx.event?.action?.contains('open secure note') || ctx.event?.action?.contains('failed login attempt')
-      value: [access]
+      value: [start]
   - set:
       field: event.type
       if: ctx.event?.action?.contains('make admin')
@@ -86,11 +86,22 @@ processors:
       field: event.outcome
       if: ctx.event?.action?.contains('require password change') || ctx.event?.action?.contains('reporting')
       value: unknown
+  # Set timezone based on config or locale. Defaults to US/Eastern due to
+  # https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/api_event_reporting.html&_LANG=enus.
+  - rename:
+      field: _conf.tz_offset
+      target_field: event.timezone
+      if: ctx._conf?.tz_offset != null
+      ignore_failure: true
+  - set:
+      field: event.timezone
+      value: US/Eastern
+      override: false
   - date:
       field: json.Time
-      if: ctx.json?.Time != null && ctx.json.Time != ''
+      if: ctx.json?.Time != null && ctx.json.Time != '' && ctx.event?.timezone != null
       target_field: lastpass.event_report.time
-      timezone: "US/Eastern"
+      timezone: '{{{event.timezone}}}'
       formats:
         - ISO8601
         - yyyy-MM-dd HH:mm:ss

--- a/packages/lastpass/data_stream/event_report/manifest.yml
+++ b/packages/lastpass/data_stream/event_report/manifest.yml
@@ -39,6 +39,14 @@ streams:
         default:
           - forwarded
           - lastpass-event_report
+      - name: tz_offset
+        type: text
+        title: Timezone
+        multi: false
+        required: false
+        show_user: false
+        default: US/Eastern
+        description: IANA time zone or time offset (e.g. `America/Denver` or `-06:00`) to use when LastPass timestamps without a time zone.
       - name: preserve_original_event
         required: true
         show_user: true

--- a/packages/lastpass/data_stream/event_report/sample_event.json
+++ b/packages/lastpass/data_stream/event_report/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2015-07-17T09:51:51.000-04:00",
+    "@timestamp": "2015-07-17T09:51:51.000Z",
     "agent": {
-        "ephemeral_id": "4e6d75f4-e465-474d-a8d1-0b01f2ac927d",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "9ece9bbd-9d6c-4204-bd9f-3182e1a55f27",
+        "id": "02365282-f602-4b79-beec-adb210ac6467",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.7.1"
     },
     "data_stream": {
         "dataset": "lastpass.event_report",
@@ -16,9 +16,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "02365282-f602-4b79-beec-adb210ac6467",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.7.1"
     },
     "event": {
         "action": "failed login attempt",
@@ -26,14 +26,15 @@
         "category": [
             "authentication"
         ],
-        "created": "2023-07-24T13:39:48.616Z",
+        "created": "2023-08-14T22:51:42.186Z",
         "dataset": "lastpass.event_report",
-        "ingested": "2023-07-24T13:39:49Z",
+        "ingested": "2023-08-14T22:51:43Z",
         "kind": "event",
         "original": "{\"Action\":\"Failed Login Attempt\",\"Data\":\"\",\"IP_Address\":\"10.16.21.21\",\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"j.user@example.com\",\"id\":\"Event1\"}",
         "outcome": "failure",
+        "timezone": "UTC",
         "type": [
-            "access"
+            "start"
         ]
     },
     "input": {
@@ -43,7 +44,7 @@
         "event_report": {
             "action": "Failed Login Attempt",
             "ip": "10.16.21.21",
-            "time": "2015-07-17T09:51:51.000-04:00",
+            "time": "2015-07-17T09:51:51.000Z",
             "user_name": "j.user@example.com"
         }
     },

--- a/packages/lastpass/docs/README.md
+++ b/packages/lastpass/docs/README.md
@@ -195,13 +195,13 @@ An example event for `event_report` looks as following:
 
 ```json
 {
-    "@timestamp": "2015-07-17T09:51:51.000-04:00",
+    "@timestamp": "2015-07-17T09:51:51.000Z",
     "agent": {
-        "ephemeral_id": "4e6d75f4-e465-474d-a8d1-0b01f2ac927d",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "9ece9bbd-9d6c-4204-bd9f-3182e1a55f27",
+        "id": "02365282-f602-4b79-beec-adb210ac6467",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.7.1"
     },
     "data_stream": {
         "dataset": "lastpass.event_report",
@@ -212,9 +212,9 @@ An example event for `event_report` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "02365282-f602-4b79-beec-adb210ac6467",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.7.1"
     },
     "event": {
         "action": "failed login attempt",
@@ -222,14 +222,15 @@ An example event for `event_report` looks as following:
         "category": [
             "authentication"
         ],
-        "created": "2023-07-24T13:39:48.616Z",
+        "created": "2023-08-14T22:51:42.186Z",
         "dataset": "lastpass.event_report",
-        "ingested": "2023-07-24T13:39:49Z",
+        "ingested": "2023-08-14T22:51:43Z",
         "kind": "event",
         "original": "{\"Action\":\"Failed Login Attempt\",\"Data\":\"\",\"IP_Address\":\"10.16.21.21\",\"Time\":\"2015-07-17 09:51:51\",\"Username\":\"j.user@example.com\",\"id\":\"Event1\"}",
         "outcome": "failure",
+        "timezone": "UTC",
         "type": [
-            "access"
+            "start"
         ]
     },
     "input": {
@@ -239,7 +240,7 @@ An example event for `event_report` looks as following:
         "event_report": {
             "action": "Failed Login Attempt",
             "ip": "10.16.21.21",
-            "time": "2015-07-17T09:51:51.000-04:00",
+            "time": "2015-07-17T09:51:51.000Z",
             "user_name": "j.user@example.com"
         }
     },

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: lastpass
 title: LastPass
-version: "1.7.0"
+version: "1.8.0"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

The LastPass documentation states that the timezone for events will be US/Eastern, but we have user reports of events with other timezones, so allow user configuration.

Also fix `event.type` value for authentication which was not one of the acceptable values.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
