### PR TITLE
[cisco_meraki] Address the changes in Firmware MX18.101

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Fix flows pipeline according to new Firmware MX18.101.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7391
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log
@@ -11,3 +11,7 @@
 <134>1 1674604848.429996761 MX84 flows src=10.10.10.11 dst=172.16.12.23 mac=9C:7B:EF:A9:6C:D8 protocol=udp sport=64138 dport=3289 pattern: deny (src 10.10.0.0/16)
 <134>1 1674604848.429996761 MX84 flows src=10.241.192.11 dst=10.8.2.6 mac=9C:7B:EF:A5:9C:9B protocol=tcp sport=54791 dport=80 pattern: deny all
 <134>1 1674604848.429996761 MX84 flows src=192.168.201.81 dst=10.8.2.4 mac=B4:6B:FC:6A:E0:5A protocol=udp sport=60288 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log
@@ -11,7 +11,7 @@
 <134>1 1674604848.429996761 MX84 flows src=10.10.10.11 dst=172.16.12.23 mac=9C:7B:EF:A9:6C:D8 protocol=udp sport=64138 dport=3289 pattern: deny (src 10.10.0.0/16)
 <134>1 1674604848.429996761 MX84 flows src=10.241.192.11 dst=10.8.2.6 mac=9C:7B:EF:A5:9C:9B protocol=tcp sport=54791 dport=80 pattern: deny all
 <134>1 1674604848.429996761 MX84 flows src=192.168.201.81 dst=10.8.2.4 mac=B4:6B:FC:6A:E0:5A protocol=udp sport=60288 dport=53 pattern: allow all
-<134>1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
-<134>1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
-<134>1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
-<134>1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all
+<134>1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
@@ -3,41 +3,26 @@
         {
             "@timestamp": "2022-03-17T01:03:08.289Z",
             "cisco_meraki": {
-                "event_subtype": "flow_allowed",
-                "event_type": "flows",
-                "flows": {
-                    "op": "allow"
-                }
-            },
-            "destination": {
-                "ip": "10.0.0.34",
-                "port": 15600
+                "event_subtype": "ip_session_initiated",
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "layer3-firewall-allowed-flow",
+                "action": "ip-session-initiated",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1647478988.289402144 MX84_4 flows allow src=10.0.2.170 dst=10.0.0.34 mac=00:7C:2D:BD:76:F2 protocol=udp sport=54841 dport=15600",
                 "type": [
                     "info",
-                    "connection",
+                    "access",
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "udp"
-            },
             "observer": {
                 "hostname": "MX84_4"
-            },
-            "source": {
-                "ip": "10.0.2.170",
-                "mac": "00-7C-2D-BD-76-F2",
-                "port": 54841
             },
             "tags": [
                 "forwarded",
@@ -48,29 +33,7 @@
             "@timestamp": "2022-03-17T01:03:08.476Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "pattern": "1 all"
-                }
-            },
-            "destination": {
-                "as": {
-                    "number": 209
-                },
-                "geo": {
-                    "city_name": "Milton",
-                    "continent_name": "North America",
-                    "country_iso_code": "US",
-                    "country_name": "United States",
-                    "location": {
-                        "lat": 47.2513,
-                        "lon": -122.3149
-                    },
-                    "region_iso_code": "US-WA",
-                    "region_name": "Washington"
-                },
-                "ip": "216.160.83.61",
-                "port": 44210
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -87,30 +50,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "tcp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "as": {
-                    "number": 209
-                },
-                "geo": {
-                    "city_name": "Milton",
-                    "continent_name": "North America",
-                    "country_iso_code": "US",
-                    "country_name": "United States",
-                    "location": {
-                        "lat": 47.2513,
-                        "lon": -122.3149
-                    },
-                    "region_iso_code": "US-WA",
-                    "region_name": "Washington"
-                },
-                "ip": "216.160.83.57",
-                "port": 54445
             },
             "tags": [
                 "forwarded",
@@ -120,41 +61,26 @@
         {
             "@timestamp": "2022-03-17T01:03:08.596Z",
             "cisco_meraki": {
-                "event_subtype": "flow_allowed",
-                "event_type": "flows",
-                "flows": {
-                    "op": "allow"
-                }
-            },
-            "destination": {
-                "ip": "10.0.0.234",
-                "port": 15500
+                "event_subtype": "ip_session_initiated",
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "layer3-firewall-allowed-flow",
+                "action": "ip-session-initiated",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1647478988.596151424 MX84_7 flows allow src=10.0.0.34 dst=10.0.0.234 mac=64:1C:B0:BA:F0:EC protocol=tcp sport=49761 dport=15500",
                 "type": [
                     "info",
-                    "connection",
+                    "access",
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "tcp"
-            },
             "observer": {
                 "hostname": "MX84_7"
-            },
-            "source": {
-                "ip": "10.0.0.34",
-                "mac": "64-1C-B0-BA-F0-EC",
-                "port": 49761
             },
             "tags": [
                 "forwarded",
@@ -164,39 +90,26 @@
         {
             "@timestamp": "2022-09-28T16:34:39.496Z",
             "cisco_meraki": {
-                "event_subtype": "flow_allowed",
-                "event_type": "flows",
-                "flows": {
-                    "op": "allow"
-                }
-            },
-            "destination": {
-                "ip": "ff02::1:ffb6:a227"
+                "event_subtype": "ip_session_initiated",
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "layer3-firewall-allowed-flow",
+                "action": "ip-session-initiated",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664382879.496990921 AP_XXXX flows allow src=fe80::1021:83ca:b68:4cd8 dst=ff02::1:ffb6:a227 mac=28:FF:3C:AB:DB:AA protocol=icmp6 type=135",
                 "type": [
                     "info",
-                    "connection",
+                    "access",
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "icmp6"
-            },
             "observer": {
                 "hostname": "AP_XXXX"
-            },
-            "source": {
-                "ip": "fe80::1021:83ca:b68:4cd8",
-                "mac": "28-FF-3C-AB-DB-AA"
             },
             "tags": [
                 "forwarded",
@@ -206,39 +119,26 @@
         {
             "@timestamp": "2022-09-28T17:17:32.707Z",
             "cisco_meraki": {
-                "event_subtype": "flow_allowed",
-                "event_type": "flows",
-                "flows": {
-                    "op": "allow"
-                }
-            },
-            "destination": {
-                "ip": "224.0.0.2"
+                "event_subtype": "ip_session_initiated",
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "layer3-firewall-allowed-flow",
+                "action": "ip-session-initiated",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664385452.707589827 AP_XXXX flows allow src=172.16.12.23 dst=224.0.0.2 mac=4C:AB:4F:0D:3D:AA protocol=2",
                 "type": [
                     "info",
-                    "connection",
+                    "access",
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "2"
-            },
             "observer": {
                 "hostname": "AP_XXXX"
-            },
-            "source": {
-                "ip": "172.16.12.23",
-                "mac": "4C-AB-4F-0D-3D-AA"
             },
             "tags": [
                 "forwarded",
@@ -248,51 +148,26 @@
         {
             "@timestamp": "2022-09-28T17:17:33.129Z",
             "cisco_meraki": {
-                "event_subtype": "flow_allowed",
-                "event_type": "flows",
-                "flows": {
-                    "op": "allow"
-                }
-            },
-            "destination": {
-                "geo": {
-                    "city_name": "London",
-                    "continent_name": "Europe",
-                    "country_iso_code": "GB",
-                    "country_name": "United Kingdom",
-                    "location": {
-                        "lat": 51.5142,
-                        "lon": -0.0931
-                    },
-                    "region_iso_code": "GB-ENG",
-                    "region_name": "England"
-                },
-                "ip": "81.2.69.144"
+                "event_subtype": "ip_session_initiated",
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "layer3-firewall-allowed-flow",
+                "action": "ip-session-initiated",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664385453.129104346 AP_XXXX flows allow src=172.16.10.14 dst=81.2.69.144 mac=EC:63:D7:0F:6B:AA protocol=icmp type=8",
                 "type": [
                     "info",
-                    "connection",
+                    "access",
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "icmp"
-            },
             "observer": {
                 "hostname": "AP_XXXX"
-            },
-            "source": {
-                "ip": "172.16.10.14",
-                "mac": "EC-63-D7-0F-6B-AA"
             },
             "tags": [
                 "forwarded",
@@ -303,15 +178,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "allow",
-                    "rule": "(dst 10.0.0.0/8) \u0026\u0026 (src 10.241.0.0/16)"
-                }
-            },
-            "destination": {
-                "ip": "10.241.77.255",
-                "port": 138
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -328,16 +195,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "udp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "10.241.77.11",
-                "mac": "24-2F-FA-1E-B7-E6",
-                "port": 138
             },
             "tags": [
                 "forwarded",
@@ -348,29 +207,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "pattern": "Group Policy Allow"
-                }
-            },
-            "destination": {
-                "as": {
-                    "number": 209
-                },
-                "geo": {
-                    "city_name": "Milton",
-                    "continent_name": "North America",
-                    "country_iso_code": "US",
-                    "country_name": "United States",
-                    "location": {
-                        "lat": 47.2513,
-                        "lon": -122.3149
-                    },
-                    "region_iso_code": "US-WA",
-                    "region_name": "Washington"
-                },
-                "ip": "216.160.83.57",
-                "port": 9998
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -387,16 +224,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "tcp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "192.168.222.3",
-                "mac": "00-17-55-76-EC-12",
-                "port": 61403
             },
             "tags": [
                 "forwarded",
@@ -407,14 +236,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "allow",
-                    "rule": "all"
-                }
-            },
-            "destination": {
-                "ip": "172.28.1.14"
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -431,14 +253,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "icmp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "10.8.6.10"
             },
             "tags": [
                 "forwarded",
@@ -449,30 +265,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "allow",
-                    "rule": "udp"
-                }
-            },
-            "destination": {
-                "as": {
-                    "number": 209
-                },
-                "geo": {
-                    "city_name": "Milton",
-                    "continent_name": "North America",
-                    "country_iso_code": "US",
-                    "country_name": "United States",
-                    "location": {
-                        "lat": 47.2513,
-                        "lon": -122.3149
-                    },
-                    "region_iso_code": "US-WA",
-                    "region_name": "Washington"
-                },
-                "ip": "216.160.83.61",
-                "port": 53
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -489,16 +282,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "udp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "172.28.1.9",
-                "mac": "98-18-88-7C-45-BF",
-                "port": 45713
             },
             "tags": [
                 "forwarded",
@@ -509,15 +294,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "deny",
-                    "rule": "(src 10.10.0.0/16)"
-                }
-            },
-            "destination": {
-                "ip": "172.16.12.23",
-                "port": 3289
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -534,16 +311,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "udp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "10.10.10.11",
-                "mac": "9C-7B-EF-A9-6C-D8",
-                "port": 64138
             },
             "tags": [
                 "forwarded",
@@ -554,15 +323,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "deny",
-                    "rule": "all"
-                }
-            },
-            "destination": {
-                "ip": "10.8.2.6",
-                "port": 80
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -579,16 +340,8 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "tcp"
-            },
             "observer": {
                 "hostname": "MX84"
-            },
-            "source": {
-                "ip": "10.241.192.11",
-                "mac": "9C-7B-EF-A5-9C-9B",
-                "port": 54791
             },
             "tags": [
                 "forwarded",
@@ -599,15 +352,7 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows",
-                "firewall": {
-                    "action": "allow",
-                    "rule": "all"
-                }
-            },
-            "destination": {
-                "ip": "10.8.2.4",
-                "port": 53
+                "event_type": "flows"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -624,16 +369,124 @@
                     "start"
                 ]
             },
-            "network": {
-                "protocol": "udp"
-            },
             "observer": {
                 "hostname": "MX84"
             },
-            "source": {
-                "ip": "192.168.201.81",
-                "mac": "B4-6B-FC-6A-E0-5A",
-                "port": 60288
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2000-01-17T19:14:46.721Z",
+            "cisco_meraki": {
+                "event_subtype": "ip_session_initiated",
+                "event_type": "firewall"
+            },
+            "ecs": {
+                "version": "8.9.0"
+            },
+            "event": {
+                "action": "ip-session-initiated",
+                "category": [
+                    "network"
+                ],
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "type": [
+                    "info",
+                    "access",
+                    "start"
+                ]
+            },
+            "observer": {
+                "hostname": "MX60"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2000-01-17T19:14:46.721Z",
+            "cisco_meraki": {
+                "event_subtype": "ip_session_initiated",
+                "event_type": "vpn_firewall"
+            },
+            "ecs": {
+                "version": "8.9.0"
+            },
+            "event": {
+                "action": "ip-session-initiated",
+                "category": [
+                    "network"
+                ],
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "type": [
+                    "info",
+                    "access",
+                    "start"
+                ]
+            },
+            "observer": {
+                "hostname": "MX60"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2000-01-17T19:14:46.721Z",
+            "cisco_meraki": {
+                "event_subtype": "ip_session_initiated",
+                "event_type": "cellular_firewall"
+            },
+            "ecs": {
+                "version": "8.9.0"
+            },
+            "event": {
+                "action": "ip-session-initiated",
+                "category": [
+                    "network"
+                ],
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "type": [
+                    "info",
+                    "access",
+                    "start"
+                ]
+            },
+            "observer": {
+                "hostname": "MX60"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2000-01-17T19:14:46.721Z",
+            "cisco_meraki": {
+                "event_subtype": "ip_session_initiated",
+                "event_type": "bridge_anyconnect_client_vpn_firewall"
+            },
+            "ecs": {
+                "version": "8.9.0"
+            },
+            "event": {
+                "action": "ip-session-initiated",
+                "category": [
+                    "network"
+                ],
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "type": [
+                    "info",
+                    "access",
+                    "start"
+                ]
+            },
+            "observer": {
+                "hostname": "MX60"
             },
             "tags": [
                 "forwarded",

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
@@ -3,26 +3,41 @@
         {
             "@timestamp": "2022-03-17T01:03:08.289Z",
             "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_subtype": "flow_allowed",
+                "event_type": "flows",
+                "flows": {
+                    "op": "allow"
+                }
+            },
+            "destination": {
+                "ip": "10.0.0.34",
+                "port": 15600
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "ip-session-initiated",
+                "action": "layer3-firewall-allowed-flow",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1647478988.289402144 MX84_4 flows allow src=10.0.2.170 dst=10.0.0.34 mac=00:7C:2D:BD:76:F2 protocol=udp sport=54841 dport=15600",
                 "type": [
                     "info",
-                    "access",
+                    "connection",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX84_4"
+            },
+            "source": {
+                "ip": "10.0.2.170",
+                "mac": "00-7C-2D-BD-76-F2",
+                "port": 54841
             },
             "tags": [
                 "forwarded",
@@ -33,7 +48,29 @@
             "@timestamp": "2022-03-17T01:03:08.476Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "pattern": "1 all"
+                }
+            },
+            "destination": {
+                "as": {
+                    "number": 209
+                },
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.61",
+                "port": 44210
             },
             "ecs": {
                 "version": "8.9.0"
@@ -50,8 +87,30 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "tcp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "as": {
+                    "number": 209
+                },
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.57",
+                "port": 54445
             },
             "tags": [
                 "forwarded",
@@ -61,26 +120,41 @@
         {
             "@timestamp": "2022-03-17T01:03:08.596Z",
             "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_subtype": "flow_allowed",
+                "event_type": "flows",
+                "flows": {
+                    "op": "allow"
+                }
+            },
+            "destination": {
+                "ip": "10.0.0.234",
+                "port": 15500
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "ip-session-initiated",
+                "action": "layer3-firewall-allowed-flow",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1647478988.596151424 MX84_7 flows allow src=10.0.0.34 dst=10.0.0.234 mac=64:1C:B0:BA:F0:EC protocol=tcp sport=49761 dport=15500",
                 "type": [
                     "info",
-                    "access",
+                    "connection",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "tcp"
+            },
             "observer": {
                 "hostname": "MX84_7"
+            },
+            "source": {
+                "ip": "10.0.0.34",
+                "mac": "64-1C-B0-BA-F0-EC",
+                "port": 49761
             },
             "tags": [
                 "forwarded",
@@ -90,26 +164,39 @@
         {
             "@timestamp": "2022-09-28T16:34:39.496Z",
             "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_subtype": "flow_allowed",
+                "event_type": "flows",
+                "flows": {
+                    "op": "allow"
+                }
+            },
+            "destination": {
+                "ip": "ff02::1:ffb6:a227"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "ip-session-initiated",
+                "action": "layer3-firewall-allowed-flow",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664382879.496990921 AP_XXXX flows allow src=fe80::1021:83ca:b68:4cd8 dst=ff02::1:ffb6:a227 mac=28:FF:3C:AB:DB:AA protocol=icmp6 type=135",
                 "type": [
                     "info",
-                    "access",
+                    "connection",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "icmp6"
+            },
             "observer": {
                 "hostname": "AP_XXXX"
+            },
+            "source": {
+                "ip": "fe80::1021:83ca:b68:4cd8",
+                "mac": "28-FF-3C-AB-DB-AA"
             },
             "tags": [
                 "forwarded",
@@ -119,26 +206,39 @@
         {
             "@timestamp": "2022-09-28T17:17:32.707Z",
             "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_subtype": "flow_allowed",
+                "event_type": "flows",
+                "flows": {
+                    "op": "allow"
+                }
+            },
+            "destination": {
+                "ip": "224.0.0.2"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "ip-session-initiated",
+                "action": "layer3-firewall-allowed-flow",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664385452.707589827 AP_XXXX flows allow src=172.16.12.23 dst=224.0.0.2 mac=4C:AB:4F:0D:3D:AA protocol=2",
                 "type": [
                     "info",
-                    "access",
+                    "connection",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "2"
+            },
             "observer": {
                 "hostname": "AP_XXXX"
+            },
+            "source": {
+                "ip": "172.16.12.23",
+                "mac": "4C-AB-4F-0D-3D-AA"
             },
             "tags": [
                 "forwarded",
@@ -148,26 +248,51 @@
         {
             "@timestamp": "2022-09-28T17:17:33.129Z",
             "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_subtype": "flow_allowed",
+                "event_type": "flows",
+                "flows": {
+                    "op": "allow"
+                }
+            },
+            "destination": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144"
             },
             "ecs": {
                 "version": "8.9.0"
             },
             "event": {
-                "action": "ip-session-initiated",
+                "action": "layer3-firewall-allowed-flow",
                 "category": [
                     "network"
                 ],
                 "original": "\u003c134\u003e1 1664385453.129104346 AP_XXXX flows allow src=172.16.10.14 dst=81.2.69.144 mac=EC:63:D7:0F:6B:AA protocol=icmp type=8",
                 "type": [
                     "info",
-                    "access",
+                    "connection",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "icmp"
+            },
             "observer": {
                 "hostname": "AP_XXXX"
+            },
+            "source": {
+                "ip": "172.16.10.14",
+                "mac": "EC-63-D7-0F-6B-AA"
             },
             "tags": [
                 "forwarded",
@@ -178,7 +303,15 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "(dst 10.0.0.0/8) \u0026\u0026 (src 10.241.0.0/16)"
+                }
+            },
+            "destination": {
+                "ip": "10.241.77.255",
+                "port": 138
             },
             "ecs": {
                 "version": "8.9.0"
@@ -195,8 +328,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "10.241.77.11",
+                "mac": "24-2F-FA-1E-B7-E6",
+                "port": 138
             },
             "tags": [
                 "forwarded",
@@ -207,7 +348,29 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "pattern": "Group Policy Allow"
+                }
+            },
+            "destination": {
+                "as": {
+                    "number": 209
+                },
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.57",
+                "port": 9998
             },
             "ecs": {
                 "version": "8.9.0"
@@ -224,8 +387,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "tcp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "192.168.222.3",
+                "mac": "00-17-55-76-EC-12",
+                "port": 61403
             },
             "tags": [
                 "forwarded",
@@ -236,7 +407,14 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "172.28.1.14"
             },
             "ecs": {
                 "version": "8.9.0"
@@ -253,8 +431,14 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "icmp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "10.8.6.10"
             },
             "tags": [
                 "forwarded",
@@ -265,7 +449,30 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "udp"
+                }
+            },
+            "destination": {
+                "as": {
+                    "number": 209
+                },
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.61",
+                "port": 53
             },
             "ecs": {
                 "version": "8.9.0"
@@ -282,8 +489,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "172.28.1.9",
+                "mac": "98-18-88-7C-45-BF",
+                "port": 45713
             },
             "tags": [
                 "forwarded",
@@ -294,7 +509,15 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "deny",
+                    "rule": "(src 10.10.0.0/16)"
+                }
+            },
+            "destination": {
+                "ip": "172.16.12.23",
+                "port": 3289
             },
             "ecs": {
                 "version": "8.9.0"
@@ -311,8 +534,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "10.10.10.11",
+                "mac": "9C-7B-EF-A9-6C-D8",
+                "port": 64138
             },
             "tags": [
                 "forwarded",
@@ -323,7 +554,15 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "deny",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.8.2.6",
+                "port": 80
             },
             "ecs": {
                 "version": "8.9.0"
@@ -340,8 +579,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "tcp"
+            },
             "observer": {
                 "hostname": "MX84"
+            },
+            "source": {
+                "ip": "10.241.192.11",
+                "mac": "9C-7B-EF-A5-9C-9B",
+                "port": 54791
             },
             "tags": [
                 "forwarded",
@@ -352,7 +599,15 @@
             "@timestamp": "2023-01-25T00:00:48.429Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "flows"
+                "event_type": "flows",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.8.2.4",
+                "port": 53
             },
             "ecs": {
                 "version": "8.9.0"
@@ -369,37 +624,16 @@
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX84"
             },
-            "tags": [
-                "forwarded",
-                "preserve_original_event"
-            ]
-        },
-        {
-            "@timestamp": "2000-01-17T19:14:46.721Z",
-            "cisco_meraki": {
-                "event_subtype": "ip_session_initiated",
-                "event_type": "firewall"
-            },
-            "ecs": {
-                "version": "8.9.0"
-            },
-            "event": {
-                "action": "ip-session-initiated",
-                "category": [
-                    "network"
-                ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
-                "type": [
-                    "info",
-                    "access",
-                    "start"
-                ]
-            },
-            "observer": {
-                "hostname": "MX60"
+            "source": {
+                "ip": "192.168.201.81",
+                "mac": "B4-6B-FC-6A-E0-5A",
+                "port": 60288
             },
             "tags": [
                 "forwarded",
@@ -410,7 +644,15 @@
             "@timestamp": "2000-01-17T19:14:46.721Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "vpn_firewall"
+                "event_type": "firewall",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.241.77.255",
+                "port": 53
             },
             "ecs": {
                 "version": "8.9.0"
@@ -420,15 +662,23 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX60"
+            },
+            "source": {
+                "ip": "10.10.10.11",
+                "mac": "24-2F-FA-1E-B7-E6",
+                "port": 9562
             },
             "tags": [
                 "forwarded",
@@ -439,7 +689,15 @@
             "@timestamp": "2000-01-17T19:14:46.721Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "cellular_firewall"
+                "event_type": "vpn_firewall",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.241.77.255",
+                "port": 53
             },
             "ecs": {
                 "version": "8.9.0"
@@ -449,15 +707,23 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX60"
+            },
+            "source": {
+                "ip": "10.241.192.1",
+                "mac": "24-2F-FA-1E-B7-E6",
+                "port": 9562
             },
             "tags": [
                 "forwarded",
@@ -468,7 +734,15 @@
             "@timestamp": "2000-01-17T19:14:46.721Z",
             "cisco_meraki": {
                 "event_subtype": "ip_session_initiated",
-                "event_type": "bridge_anyconnect_client_vpn_firewall"
+                "event_type": "cellular_firewall",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.241.77.255",
+                "port": 53
             },
             "ecs": {
                 "version": "8.9.0"
@@ -478,15 +752,68 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=00:18:0A:XX:XX:XX protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
                     "start"
                 ]
             },
+            "network": {
+                "protocol": "udp"
+            },
             "observer": {
                 "hostname": "MX60"
+            },
+            "source": {
+                "ip": "10.10.10.11",
+                "mac": "24-2F-FA-1E-B7-E6",
+                "port": 9562
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2000-01-17T19:14:46.721Z",
+            "cisco_meraki": {
+                "event_subtype": "ip_session_initiated",
+                "event_type": "bridge_anyconnect_client_vpn_firewall",
+                "firewall": {
+                    "action": "allow",
+                    "rule": "all"
+                }
+            },
+            "destination": {
+                "ip": "10.241.77.255",
+                "port": 53
+            },
+            "ecs": {
+                "version": "8.9.0"
+            },
+            "event": {
+                "action": "ip-session-initiated",
+                "category": [
+                    "network"
+                ],
+                "original": "\u003c134\u003e1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
+                "type": [
+                    "info",
+                    "access",
+                    "start"
+                ]
+            },
+            "network": {
+                "protocol": "udp"
+            },
+            "observer": {
+                "hostname": "MX60"
+            },
+            "source": {
+                "ip": "10.241.192.1",
+                "mac": "24-2F-FA-1E-B7-E6",
+                "port": 9562
             },
             "tags": [
                 "forwarded",

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -32,7 +32,7 @@ processors:
           value: 'failed to parse time field ({{{ _temp.ts_nano }}}): {{{ _ingest.on_failure_message }}}'
 - pipeline:
     name: '{{ IngestPipeline "flows" }}'
-    if: ctx.cisco_meraki.event_type == 'flows'
+    if: ctx.cisco_meraki.event_type == 'flows' || ctx.cisco_meraki.event_type == 'firewall' || ctx.cisco_meraki.event_type == 'vpn_firewall' || ctx.cisco_meraki.event_type == 'cellular_firewall' || ctx.cisco_meraki.event_type == 'bridge_anyconnect_client_vpn_firewall'
 - pipeline:
     name: '{{ IngestPipeline "ipflows" }}'
     if: ctx.cisco_meraki.event_type == 'ip_flow_start' || ctx.cisco_meraki.event_type == 'ip_flow_end'

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -32,7 +32,7 @@ processors:
           value: 'failed to parse time field ({{{ _temp.ts_nano }}}): {{{ _ingest.on_failure_message }}}'
 - pipeline:
     name: '{{ IngestPipeline "flows" }}'
-    if: ctx.cisco_meraki.event_type == 'flows' || ctx.cisco_meraki.event_type == 'firewall' || ctx.cisco_meraki.event_type == 'vpn_firewall' || ctx.cisco_meraki.event_type == 'cellular_firewall' || ctx.cisco_meraki.event_type == 'bridge_anyconnect_client_vpn_firewall'
+    if: "['flows', 'firewall', 'vpn_firewall', 'cellular_firewall', 'bridge_anyconnect_client_vpn_firewall'].contains(ctx.cisco_meraki.event_type)"
 - pipeline:
     name: '{{ IngestPipeline "ipflows" }}'
     if: ctx.cisco_meraki.event_type == 'ip_flow_start' || ctx.cisco_meraki.event_type == 'ip_flow_end'

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/flows.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/flows.yml
@@ -4,7 +4,9 @@ processors:
 - grok:
     field: event.original
     patterns:
-      - "flows|firewall|vpn_firewall|cellular_firewall|bridge_anyconnect_client_vpn_firewall( %{NOTSPACE:cisco_meraki.flows.op})? src=%{IP:source.ip:ip} dst=%{IP:destination.ip:ip}( mac=%{MAC:source.mac})? protocol=%{NOTSPACE:network.protocol}( type=%{NOTSPACE})?( sport=%{NONNEGINT:source.port:long})?( dport=%{NONNEGINT:destination.port:long})?( pattern: %{GREEDYDATA:cisco_meraki.firewall.pattern})?"
+      - "%{TYPE}( %{NOTSPACE:cisco_meraki.flows.op})? src=%{IP:source.ip:ip} dst=%{IP:destination.ip:ip}( mac=%{MAC:source.mac})? protocol=%{NOTSPACE:network.protocol}( type=%{NOTSPACE})?( sport=%{NONNEGINT:source.port:long})?( dport=%{NONNEGINT:destination.port:long})?( pattern: %{GREEDYDATA:cisco_meraki.firewall.pattern})?"
+    pattern_definitions:
+      TYPE: 'flows|firewall|vpn_firewall|cellular_firewall|bridge_anyconnect_client_vpn_firewall'
 - grok:
     field: cisco_meraki.firewall.pattern
     patterns:

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/flows.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/flows.yml
@@ -4,7 +4,7 @@ processors:
 - grok:
     field: event.original
     patterns:
-      - "flows( %{NOTSPACE:cisco_meraki.flows.op})? src=%{IP:source.ip:ip} dst=%{IP:destination.ip:ip}( mac=%{MAC:source.mac})? protocol=%{NOTSPACE:network.protocol}( type=%{NOTSPACE})?( sport=%{NONNEGINT:source.port:long})?( dport=%{NONNEGINT:destination.port:long})?( pattern: %{GREEDYDATA:cisco_meraki.firewall.pattern})?"
+      - "flows|firewall|vpn_firewall|cellular_firewall|bridge_anyconnect_client_vpn_firewall( %{NOTSPACE:cisco_meraki.flows.op})? src=%{IP:source.ip:ip} dst=%{IP:destination.ip:ip}( mac=%{MAC:source.mac})? protocol=%{NOTSPACE:network.protocol}( type=%{NOTSPACE})?( sport=%{NONNEGINT:source.port:long})?( dport=%{NONNEGINT:destination.port:long})?( pattern: %{GREEDYDATA:cisco_meraki.firewall.pattern})?"
 - grok:
     field: cisco_meraki.firewall.pattern
     patterns:

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Cisco has changed the event_type for flow/ruleset logs, from flows to multiple other types. See the info box in the "Flows" paragraph in [documentation](https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Server_Overview_and_Configuration), and the list of [event_types](https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/Syslog_Event_Types_and_Log_Samples) This causes the logs-cisco_meraki.log pipeline to skip the logs-cisco_meraki.log-flows pipeline.

The flows pipeline also needs updating to correctly parse the new event types.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #7387 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
