### PR TITLE
windows: retain winlog.event_data.Details

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.33.0"
+  changes:
+    - description: Retain `event_data.Details` in sysmon_operational datastream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7396
 - version: "1.32.0"
   changes:
     - description: Add Windows AppLocker Packaged app-Execution data stream
@@ -11,7 +16,7 @@
       link: https://github.com/elastic/integrations/pull/7393
 - version: "1.30.0"
   changes:
-    - description: Add Windows AppLocker MSI and Script data stream, update AppLocker Dashboard
+    - description: Add Windows AppLocker MSI and Script data stream, update AppLocker Dashboard.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7279
 - version: "1.29.0"
@@ -141,7 +146,7 @@
       link: https://github.com/elastic/integrations/pull/3707
 - version: "1.13.0"
   changes:
-    - description: Added Processors for service datatstream.
+    - description: Added Processors for service datastream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/3618
 - version: "1.12.4"

--- a/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
+++ b/packages/windows/data_stream/forwarded/_dev/test/pipeline/test-sysmon-operational-events.json-expected.json
@@ -675,6 +675,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "DWORD (0x00000004)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -2081,6 +2082,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -2355,6 +2357,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "QWORD (0x00000000-0x00000005)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -2421,6 +2424,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -22364,6 +22368,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/sysmon_operational.yml
@@ -1240,7 +1240,6 @@ processors:
         - winlog.event_data.Hash
         - winlog.event_data.Hashes
         - winlog.event_data.TargetObject
-        - winlog.event_data.Details
         - winlog.time_created
         - winlog.level
       ignore_failure: true

--- a/packages/windows/data_stream/forwarded/fields/winlog.yml
+++ b/packages/windows/data_stream/forwarded/fields/winlog.yml
@@ -140,7 +140,7 @@
           type: keyword
         - name: Description
           type: keyword
-        - name: Detail
+        - name: Details
           type: keyword
         - name: DeviceName
           type: keyword

--- a/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
+++ b/packages/windows/data_stream/sysmon_operational/_dev/test/pipeline/test-events.json-expected.json
@@ -517,6 +517,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "DWORD (0x00000004)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -1859,6 +1860,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -2118,6 +2120,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "QWORD (0x00000000-0x00000005)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -2185,6 +2188,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -21277,6 +21281,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -21767,6 +21772,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "QWORD (0x00000000-0x1234fabd)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -21850,6 +21856,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "abcd",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -21933,6 +21940,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "DWORD (0x12349abc)",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -22016,6 +22024,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -22099,6 +22108,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "Binary Data",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",
@@ -22182,6 +22192,7 @@
                 "channel": "Microsoft-Windows-Sysmon/Operational",
                 "computer_name": "vagrant",
                 "event_data": {
+                    "Details": "*.dll expanded",
                     "EventType": "SetValue"
                 },
                 "event_id": "13",

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -1343,7 +1343,6 @@ processors:
         - winlog.event_data.Hash
         - winlog.event_data.Hashes
         - winlog.event_data.TargetObject
-        - winlog.event_data.Details
         - winlog.time_created
         - winlog.level
       ignore_failure: true

--- a/packages/windows/data_stream/sysmon_operational/fields/winlog.yml
+++ b/packages/windows/data_stream/sysmon_operational/fields/winlog.yml
@@ -63,7 +63,7 @@
           type: keyword
         - name: Description
           type: keyword
-        - name: Detail
+        - name: Details
           type: keyword
         - name: DeviceName
           type: keyword

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -2599,7 +2599,7 @@ An example event for `sysmon_operational` looks as following:
 | winlog.event_data.CorruptionActionState |  | keyword |
 | winlog.event_data.CreationUtcTime |  | keyword |
 | winlog.event_data.Description |  | keyword |
-| winlog.event_data.Detail |  | keyword |
+| winlog.event_data.Details |  | keyword |
 | winlog.event_data.DeviceName |  | keyword |
 | winlog.event_data.DeviceNameLength |  | keyword |
 | winlog.event_data.DeviceTime |  | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.32.0
+version: 1.33.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

See title. The field is retained because it may contain information that is useful.

The `winlog.event_data.Detail` field is dropped from the definitions as it is not used and is likely there as a typo of `….Details`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #7310

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
