### PR TITLE
[Cloud Security] Backport v1.0 pr 7185

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.0.11"
   changes:
-    - description: Backport: Added ingest processor to copy cluster_id to orchestrator.cluster.id
+    - description: Backport - Added ingest processor to copy cluster_id to orchestrator.cluster.id
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7185
 - version: "1.0.10"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.11"
+  changes:
+    - description: Backport: Added ingest processor to copy cluster_id to orchestrator.cluster.id
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7185
 - version: "1.0.10"
   changes:
     - description: Documentation update - backport documentation update for Kibana 8.5.

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -4,6 +4,11 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
+- set:
+    field: orchestrator.cluster.id
+    copy_from: cluster_id
+    description: 'Backward compatibility cloudbeat version < 8.8'
+    if: ctx.orchestrator?.cluster?.id == null
 on_failure:
 - set:
     field: error.message

--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -199,6 +199,9 @@
 - name: event.type
   external: ecs
   type: keyword
+- name: orchestrator.cluster.id
+  external: ecs
+  type: keyword
 - name: orchestrator.cluster.name
   external: ecs
   type: keyword

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cloud_security_posture
 title: "Kubernetes Security Posture Management"
-version: 1.0.10
+version: 1.0.11
 release: ga
 license: basic
 description: "Check Kubernetes cluster compliance with the Kubernetes CIS benchmark."


### PR DESCRIPTION
## What does this PR do?

Backports the cluster_id -> orchestrator.cluster.id processor + mapping to the 1.0 series of the CSP package.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related

- https://github.com/elastic/integrations/pull/7185 <-- original PR
- https://github.com/elastic/kibana/issues/155463 <-- issue