### PR TITLE
[CockroachDB] Revert metrics field definition to the format used befo…

### DIFF
--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Revert metrics field definition to the format used before introducing metric_type.
       type: enhancement
-      link: tba
+      link: https://github.com/elastic/integrations/pull/7429
 - version: "1.5.0"
   changes:
     - description: Add `metric_type` mapping for the fields of `status` datastream.

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.5.1"
+  changes:
+    - description: Revert metrics field definition to the format used before introducing metric_type.
+      type: enhancement
+      link: tba
 - version: "1.5.0"
   changes:
     - description: Add `metric_type` mapping for the fields of `status` datastream.

--- a/packages/cockroachdb/data_stream/status/fields/fields.yml
+++ b/packages/cockroachdb/data_stream/status/fields/fields.yml
@@ -1,17 +1,23 @@
 - name: cockroachdb.status.*.value
-  type: double
+  type: object
+  object_type: double
+  object_type_mapping_type: "*"
   metric_type: gauge
   description: >
     Prometheus gauge metric
 
 - name: cockroachdb.status.*.counter
-  type: double
+  type: object
+  object_type: double
+  object_type_mapping_type: "*"
   metric_type: counter
   description: >
     Prometheus counter metric
 
 - name: cockroachdb.status.*.rate
-  type: double
+  type: object
+  object_type: double
+  object_type_mapping_type: "*"
   metric_type: counter
   description: >
     Prometheus rated counter metric

--- a/packages/cockroachdb/docs/README.md
+++ b/packages/cockroachdb/docs/README.md
@@ -26,10 +26,10 @@ exposing metrics in Prometheus format.
 | cloud.project.id | Name of the project in Google Cloud. | keyword |  |
 | cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
 | cloud.region | Region in which this host is running. | keyword |  |
-| cockroachdb.status.\*.counter | Prometheus counter metric | double | counter |
+| cockroachdb.status.\*.counter | Prometheus counter metric | object | counter |
 | cockroachdb.status.\*.histogram | Prometheus histogram metric | object |  |
-| cockroachdb.status.\*.rate | Prometheus rated counter metric | double | counter |
-| cockroachdb.status.\*.value | Prometheus gauge metric | double | gauge |
+| cockroachdb.status.\*.rate | Prometheus rated counter metric | object | counter |
+| cockroachdb.status.\*.value | Prometheus gauge metric | object | gauge |
 | cockroachdb.status.labels.advertise_addr | The IP address/hostname and port to tell other nodes to use. | keyword |  |
 | cockroachdb.status.labels.go_version | The version of Go in which the source code is written. | keyword |  |
 | cockroachdb.status.labels.http_addr | The IP address/hostname and port to listen on for DB Console HTTP requests. | keyword |  |

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: "1.5.0"
+version: "1.5.1"
 release: ga
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Revert cockroachDB metrics field definition to the format used before introducing metric_type.
This is done because of this [issue](https://github.com/elastic/kibana/issues/155004#issuecomment-1668190898).
Although, CockroachDB remained unaffected by this issue. However, with the fix now accessible and the necessary changes present in the elastic-package, it's good to revert to the original format.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues


- Relates #6728 

## Screenshots

<img width="1720" alt="Screenshot 2023-08-22 at 12 17 47 PM" src="https://github.com/elastic/integrations/assets/102972658/2bda3f5f-f74c-4640-9b0a-26b934f39bb3">

<img width="1012" alt="Screenshot 2023-08-21 at 2 44 39 PM" src="https://github.com/elastic/integrations/assets/102972658/b6ba344a-e270-4544-8510-8f0db56bb9e9">

<img width="538" alt="Screenshot 2023-08-21 at 2 45 13 PM" src="https://github.com/elastic/integrations/assets/102972658/63358f71-febe-4b94-a39b-68d03b1d9fea">


