### PR TITLE
[AWS] Disable TSDB on AWS Billing

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.53.1"
+  changes:
+    - description: Disable TSDB on AWS Billing.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7151
 - version: "1.53.0"
   changes:
     - description: Add AWS API Gateway custom acccess logging fields.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable TSDB on AWS Billing.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7151
+      link: https://github.com/elastic/integrations/pull/7435
 - version: "1.53.0"
   changes:
     - description: Add AWS API Gateway custom acccess logging fields.

--- a/packages/aws/data_stream/billing/manifest.yml
+++ b/packages/aws/data_stream/billing/manifest.yml
@@ -1,7 +1,5 @@
 title: AWS Billing Metrics
 type: metrics
-elasticsearch:
-  index_mode: "time_series"
 streams:
   - input: aws/metrics
     vars:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.53.0
+version: 1.53.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Disables TSDB on AWS Billing.

The reason for this decision is explained [in this issue](https://github.com/elastic/integrations/issues/7345).


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).