### PR TITLE
[cisco_secure_email_gateway] Match both Unix and Windows-style paths

### DIFF
--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Match both Unix and Windows-style paths
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7452
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,7 +12,7 @@ processors:
       field: _tmp.filepath
       if: ctx.log?.file?.path != null
       patterns:
-        - "^%{DATA}/%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"
+        - "^%{DATA}[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"
   - rename:
       field: message
       target_field: event.original

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.11.0"
+version: "1.11.1"
 license: basic
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Adjust a Grok pattern applied to `log.file.path` so that it matches Windows-style paths like `V:\\DATA\\mail_logs.@20230817T054656.s` as well as Unix-style paths like `/data/mail_logs.@20230817T054656.s`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Doesn't break existing tests:
```
cd packages/cisco_secure_email_gateway
elastic-package test
```

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/3729