### PR TITLE
[O11y][GCP] Migrate GCP Load Balancing L3 Overview dashboard to lens

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Migrate GCP Load Balancing L3 Overview dashboard to lens.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
+      link: https://github.com/elastic/integrations/pull/7461
 - version: "2.27.0"
   changes:
     - description: Add GCP CloudSQL MySQL, SQL Server and PostgreSQL dashboards.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.28.0"
+  changes:
+    - description: Migrate GCP Load Balancing L3 Overview dashboard to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 # FIXME Replace with the real PR link
 - version: "2.27.0"
   changes:
     - description: Add GCP CloudSQL MySQL, SQL Server and PostgreSQL dashboards.

--- a/packages/gcp/kibana/dashboard/gcp-8f9c6cc0-909d-11ea-8180-7b0dacd9df87.json
+++ b/packages/gcp/kibana/dashboard/gcp-8f9c6cc0-909d-11ea-8180-7b0dacd9df87.json
@@ -1,14 +1,12 @@
 {
-    "id": "gcp-8f9c6cc0-909d-11ea-8180-7b0dacd9df87",
-    "type": "dashboard",
-    "namespaces": [
-        "default"
-    ],
-    "updated_at": "2022-09-14T09:47:20.533Z",
-    "version": "WzcxOCwxXQ==",
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"19b17b1a-02e7-425b-bdaf-789f36fb52b8\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"19b17b1a-02e7-425b-bdaf-789f36fb52b8\",\"fieldName\":\"gcp.labels.resource.backend_name\",\"title\":\"Backend Name\",\"enhancements\":{}}},\"682e20de-617f-479c-9f35-1282a76f0834\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"682e20de-617f-479c-9f35-1282a76f0834\",\"fieldName\":\"gcp.labels.metrics.client_zone\",\"title\":\"Client Zone\",\"enhancements\":{}}},\"519ec7d3-cef1-40ff-99a0-6370f278f54c\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"519ec7d3-cef1-40ff-99a0-6370f278f54c\",\"fieldName\":\"gcp.labels.metrics.client_network\",\"title\":\"Client Network\",\"enhancements\":{}}},\"e43dc646-7457-4b36-b7c3-b5acb7725a5e\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"e43dc646-7457-4b36-b7c3-b5acb7725a5e\",\"fieldName\":\"gcp.labels.metrics.client_subnetwork\",\"title\":\"Client Sub-network\",\"enhancements\":{}}}}"
+        },
         "description": "Overview of GCP Load Balancing L3 Metrics",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],
@@ -20,419 +18,804 @@
         },
         "optionsJSON": {
             "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
             {
-                "version": "7.17.0",
-                "type": "visualization",
-                "gridData": {
-                    "h": 6,
-                    "i": "8b86e712-4709-458a-b8e9-40e79305b1aa",
-                    "w": 48,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "8b86e712-4709-458a-b8e9-40e79305b1aa",
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Load Balancing L3 Filters [Metrics GCP]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "gcp.labels.resource.backend_name",
-                                    "id": "1588881306802",
-                                    "indexPatternRefName": "control_0_index_pattern",
-                                    "label": "Backend Name",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                },
-                                {
-                                    "fieldName": "gcp.labels.metrics.client_zone",
-                                    "id": "1588881320708",
-                                    "indexPatternRefName": "control_1_index_pattern",
-                                    "label": "Client Zone",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                },
-                                {
-                                    "fieldName": "gcp.labels.metrics.client_network",
-                                    "id": "1588881383318",
-                                    "indexPatternRefName": "control_2_index_pattern",
-                                    "label": "Client Network",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                },
-                                {
-                                    "fieldName": "gcp.labels.metrics.client_subnetwork",
-                                    "id": "1588881498842",
-                                    "indexPatternRefName": "control_3_index_pattern",
-                                    "label": "Client Sub-network",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
                                 }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": false,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Filters"
-            },
-            {
-                "version": "7.17.0",
-                "type": "visualization",
-                "gridData": {
-                    "h": 15,
-                    "i": "44d18a84-d060-4149-825d-eacc61f946f3",
-                    "w": 24,
-                    "x": 24,
-                    "y": 6
-                },
-                "panelIndex": "44d18a84-d060-4149-825d-eacc61f946f3",
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Load Balancing L3 Egress Packets [Metrics GCP]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "gcp.loadbalancing_metrics.l3.internal.egress_packets.count : * "
                             },
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "metrics-*",
-                            "interval": "1m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": "0",
-                                    "formatter": "bytes",
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "gcp.loadbalancing_metrics.l3.internal.egress_packets.count",
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "avg"
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "205dc823-a3a8-4703-b44a-065f57cadda7": {
+                                            "columnOrder": [
+                                                "bd6c80c0-b05f-447b-af97-5558546f69dc",
+                                                "bc5a2ed6-a226-4b9c-9653-ac17abfb954f",
+                                                "9efe475f-1479-47ef-b4b6-8191b4ab7717"
+                                            ],
+                                            "columns": {
+                                                "9efe475f-1479-47ef-b4b6-8191b4ab7717": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of gcp.loadbalancing_metrics.l3.internal.egress.bytes",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "gcp.loadbalancing_metrics.l3.internal.egress.bytes"
+                                                },
+                                                "bc5a2ed6-a226-4b9c-9653-ac17abfb954f": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "1m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "bd6c80c0-b05f-447b-af97-5558546f69dc": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of gcp.labels.resource.backend_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "9efe475f-1479-47ef-b4b6-8191b4ab7717",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gcp.labels.resource.backend_name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
                                         }
-                                    ],
-                                    "point_size": "3",
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "gcp.labels.resource.backend_name",
-                                    "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                    "type": "timeseries"
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-205dc823-a3a8-4703-b44a-065f57cadda7",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "9efe475f-1479-47ef-b4b6-8191b4ab7717"
+                                        ],
+                                        "layerId": "205dc823-a3a8-4703-b44a-065f57cadda7",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "bd6c80c0-b05f-447b-af97-5558546f69dc",
+                                        "xAccessor": "bc5a2ed6-a226-4b9c-9653-ac17abfb954f",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "9efe475f-1479-47ef-b4b6-8191b4ab7717"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
-                "title": "Egress Packets"
-            },
-            {
-                "version": "7.17.0",
-                "type": "visualization",
                 "gridData": {
                     "h": 15,
                     "i": "c38aeaae-69a7-4a6c-a35a-4bf5c8f70e86",
                     "w": 24,
                     "x": 0,
-                    "y": 6
+                    "y": 0
                 },
                 "panelIndex": "c38aeaae-69a7-4a6c-a35a-4bf5c8f70e86",
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Load Balancing L3 Egress Bytes [Metrics GCP]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "gcp.loadbalancing_metrics.l3.internal.egress.bytes : * "
-                            },
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "metrics-*",
-                            "interval": "1m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": "0",
-                                    "formatter": "bytes",
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "gcp.loadbalancing_metrics.l3.internal.egress.bytes",
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": "3",
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "gcp.labels.resource.backend_name",
-                                    "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                    "type": "timeseries"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Egress Bytes"
+                "title": "Egress Bytes",
+                "type": "lens",
+                "version": "8.7.1"
             },
             {
-                "version": "7.17.0",
-                "type": "visualization",
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9ea6939b-acf8-4012-a7b2-cf0aa66d7d9b": {
+                                            "columnOrder": [
+                                                "f2f02443-fc69-4615-aefd-52af51be76db",
+                                                "95e5d4bb-3927-4868-8ec2-fef69824aa24",
+                                                "3db8370a-da10-4da8-9021-8abf693a3bcd"
+                                            ],
+                                            "columns": {
+                                                "3db8370a-da10-4da8-9021-8abf693a3bcd": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of gcp.loadbalancing_metrics.l3.internal.egress_packets.count",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "gcp.loadbalancing_metrics.l3.internal.egress_packets.count"
+                                                },
+                                                "95e5d4bb-3927-4868-8ec2-fef69824aa24": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "1m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "f2f02443-fc69-4615-aefd-52af51be76db": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of gcp.labels.resource.backend_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "3db8370a-da10-4da8-9021-8abf693a3bcd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gcp.labels.resource.backend_name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-9ea6939b-acf8-4012-a7b2-cf0aa66d7d9b",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "3db8370a-da10-4da8-9021-8abf693a3bcd"
+                                        ],
+                                        "layerId": "9ea6939b-acf8-4012-a7b2-cf0aa66d7d9b",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "f2f02443-fc69-4615-aefd-52af51be76db",
+                                        "xAccessor": "95e5d4bb-3927-4868-8ec2-fef69824aa24",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "3db8370a-da10-4da8-9021-8abf693a3bcd"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
-                    "i": "c5782327-dc55-466d-97d8-b79618f0b47a",
+                    "i": "44d18a84-d060-4149-825d-eacc61f946f3",
                     "w": 24,
                     "x": 24,
-                    "y": 21
+                    "y": 0
                 },
-                "panelIndex": "c5782327-dc55-466d-97d8-b79618f0b47a",
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Load Balancing L3 Ingress Packets [Metrics GCP]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "gcp.loadbalancing_metrics.l3.internal.ingress_packets.count : * "
-                            },
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "metrics-*",
-                            "interval": "1m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": "0",
-                                    "formatter": "bytes",
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "gcp.loadbalancing_metrics.l3.internal.ingress_packets.count",
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": "3",
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "gcp.labels.resource.backend_name",
-                                    "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                    "type": "timeseries"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Ingress Packets"
+                "panelIndex": "44d18a84-d060-4149-825d-eacc61f946f3",
+                "title": "Egress Packets",
+                "type": "lens",
+                "version": "8.7.1"
             },
             {
-                "version": "7.17.0",
-                "type": "visualization",
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "fe5b16c4-9ed6-4f46-a83f-e74df7076900": {
+                                            "columnOrder": [
+                                                "996b126b-dc05-41ef-a883-f993f47f57a8",
+                                                "aa2732dc-1da0-4e7f-92a0-f5c1de9a847f",
+                                                "82c464f8-722e-4d6e-af93-e2f0df674cac"
+                                            ],
+                                            "columns": {
+                                                "82c464f8-722e-4d6e-af93-e2f0df674cac": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of gcp.loadbalancing_metrics.l3.internal.ingress.bytes",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "gcp.loadbalancing_metrics.l3.internal.ingress.bytes"
+                                                },
+                                                "996b126b-dc05-41ef-a883-f993f47f57a8": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of gcp.labels.resource.backend_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "82c464f8-722e-4d6e-af93-e2f0df674cac",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gcp.labels.resource.backend_name"
+                                                },
+                                                "aa2732dc-1da0-4e7f-92a0-f5c1de9a847f": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "1m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-fe5b16c4-9ed6-4f46-a83f-e74df7076900",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "82c464f8-722e-4d6e-af93-e2f0df674cac"
+                                        ],
+                                        "layerId": "fe5b16c4-9ed6-4f46-a83f-e74df7076900",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "996b126b-dc05-41ef-a883-f993f47f57a8",
+                                        "xAccessor": "aa2732dc-1da0-4e7f-92a0-f5c1de9a847f",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "82c464f8-722e-4d6e-af93-e2f0df674cac"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "beaf5f45-5217-4aed-b663-69e5e9ca35c3",
                     "w": 24,
                     "x": 0,
-                    "y": 21
+                    "y": 15
                 },
                 "panelIndex": "beaf5f45-5217-4aed-b663-69e5e9ca35c3",
+                "title": "Ingress Bytes",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Load Balancing L3 Ingress Bytes [Metrics GCP]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 1,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "gcp.loadbalancing_metrics.l3.internal.ingress.bytes : * "
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
                             },
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "metrics-*",
-                            "interval": "1m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": "0",
-                                    "formatter": "bytes",
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "",
-                                    "line_width": "2",
-                                    "metrics": [
-                                        {
-                                            "field": "gcp.loadbalancing_metrics.l3.internal.ingress.bytes",
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "avg"
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ce05284e-1e46-4eaa-8619-6805f3fb3d62": {
+                                            "columnOrder": [
+                                                "bb83411b-9f22-4265-85ea-3c147c7236d9",
+                                                "cdcccb10-fd37-4a36-be85-7dcfcd9cf346",
+                                                "faf901e9-16d2-4609-beb9-b75e38381e31"
+                                            ],
+                                            "columns": {
+                                                "bb83411b-9f22-4265-85ea-3c147c7236d9": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of gcp.labels.resource.backend_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "faf901e9-16d2-4609-beb9-b75e38381e31",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "gcp.labels.resource.backend_name"
+                                                },
+                                                "cdcccb10-fd37-4a36-be85-7dcfcd9cf346": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "1m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "faf901e9-16d2-4609-beb9-b75e38381e31": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average of gcp.loadbalancing_metrics.l3.internal.ingress_packets.count",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 1
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "gcp.loadbalancing_metrics.l3.internal.ingress_packets.count"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
                                         }
-                                    ],
-                                    "point_size": "3",
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "gcp.labels.resource.backend_name",
-                                    "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                    "type": "timeseries"
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-ce05284e-1e46-4eaa-8619-6805f3fb3d62",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "faf901e9-16d2-4609-beb9-b75e38381e31"
+                                        ],
+                                        "layerId": "ce05284e-1e46-4eaa-8619-6805f3fb3d62",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "bb83411b-9f22-4265-85ea-3c147c7236d9",
+                                        "xAccessor": "cdcccb10-fd37-4a36-be85-7dcfcd9cf346",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#68BC00",
+                                                "forAccessor": "faf901e9-16d2-4609-beb9-b75e38381e31"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
-                "title": "Ingress Bytes"
+                "gridData": {
+                    "h": 15,
+                    "i": "c5782327-dc55-466d-97d8-b79618f0b47a",
+                    "w": 24,
+                    "x": 24,
+                    "y": 15
+                },
+                "panelIndex": "c5782327-dc55-466d-97d8-b79618f0b47a",
+                "title": "Ingress Packets",
+                "type": "lens",
+                "version": "8.7.1"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics GCP] Load Balancing L3 Overview",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.1",
+    "created_at": "2023-08-18T06:53:59.299Z",
+    "id": "gcp-8f9c6cc0-909d-11ea-8180-7b0dacd9df87",
+    "migrationVersion": {
+        "dashboard": "8.7.0"
+    },
     "references": [
         {
-            "type": "index-pattern",
-            "name": "8b86e712-4709-458a-b8e9-40e79305b1aa:control_0_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_19b17b1a-02e7-425b-bdaf-789f36fb52b8:optionsListDataView",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "8b86e712-4709-458a-b8e9-40e79305b1aa:control_1_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_682e20de-617f-479c-9f35-1282a76f0834:optionsListDataView",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "8b86e712-4709-458a-b8e9-40e79305b1aa:control_2_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_519ec7d3-cef1-40ff-99a0-6370f278f54c:optionsListDataView",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "8b86e712-4709-458a-b8e9-40e79305b1aa:control_3_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_e43dc646-7457-4b36-b7c3-b5acb7725a5e:optionsListDataView",
+            "type": "index-pattern"
         }
     ],
-    "migrationVersion": {
-        "dashboard": "7.17.3"
-    },
-    "coreMigrationVersion": "7.17.6"
+    "type": "dashboard"
 }

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.27.0"
+version: "2.28.0"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

### Urgency
- High

### Activity Type
- Enhancement

## What does this PR do?
- Manually migrate `GCP Load Balancing L3` visualizations to the lens in the current Kibana version `8.7.1` itself. 

- Statistics for `GCP Load Balancing TCP L3` Lens migration:
## Migration stats
<html>
<body>


  | Before Migration |   |   | After Migration |   |  
-- | -- | -- | -- | -- | -- | --
  | Lens | Vizualization | Old Control panels | Lens | Vizualization | New Input controls
[Metrics GCP] Load Balancing L3 Overview | 0 | 4 | 1 | 4 | 0 | 1

</div></div><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>


## Checklist

- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that panels are populated with data.
- [X] I have verified that panels are not distorted after being migrated to the lens.
- [x] I have updated screenshots of the dashboard.
- [X] I have verified that the data counts are matching and panel aggregations are the same as before.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Migrated panels should be removed from visualization folder.
- [X] Migrated visualizations are populating in current Kibana version 8.7.1 itself.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7256

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

## Screenshots

## Before migration
![image](https://github.com/elastic/integrations/assets/89848966/547dd1cb-5a92-4f43-98a8-c6dd6644f0f7)

## After migration
![image](https://github.com/elastic/integrations/assets/89848966/b977212c-b748-4a65-941a-70f96fee1fed)

