### PR TITLE
[Airflow] Revert metrics field definition to the format used before i…

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Revert metrics field definition to the format used before introducing metric_type.
+      type: enhancement
+      link: tba
 - version: "0.2.0"
   changes:
     - description: Add metric_type mapping for the fields of `statsd` datastream.

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Revert metrics field definition to the format used before introducing metric_type.
       type: enhancement
-      link: tba
+      link: https://github.com/elastic/integrations/pull/7469
 - version: "0.2.0"
   changes:
     - description: Add metric_type mapping for the fields of `statsd` datastream.

--- a/packages/airflow/data_stream/statsd/fields/fields.yml
+++ b/packages/airflow/data_stream/statsd/fields/fields.yml
@@ -2,7 +2,9 @@
   type: group
   fields:
     - name: '*.count'
-      type: double
+      type: object
+      object_type: double
+      object_type_mapping_type: "*"
       metric_type: counter
       description: Airflow counters
     - name: '*.max'
@@ -36,7 +38,9 @@
       object_type_mapping_type: "*"
       description: Airflow standard deviation timers metric
     - name: '*.value'
-      type: double
+      type: object
+      object_type: double
+      object_type_mapping_type: "*"
       metric_type: gauge
       description: Airflow gauges
     - name: 'dag_file'

--- a/packages/airflow/docs/README.md
+++ b/packages/airflow/docs/README.md
@@ -29,14 +29,14 @@ statsd_prefix =
 |---|---|---|---|
 | @timestamp | Event timestamp. | date |  |
 | agent.id |  | keyword |  |
-| airflow.\*.count | Airflow counters | double | counter |
+| airflow.\*.count | Airflow counters | object | counter |
 | airflow.\*.max | Airflow max timers metric | object |  |
 | airflow.\*.mean | Airflow mean timers metric | object |  |
 | airflow.\*.mean_rate | Airflow mean rate timers metric | object |  |
 | airflow.\*.median | Airflow median timers metric | object |  |
 | airflow.\*.min | Airflow min timers metric | object |  |
 | airflow.\*.stddev | Airflow standard deviation timers metric | object |  |
-| airflow.\*.value | Airflow gauges | double | gauge |
+| airflow.\*.value | Airflow gauges | object | gauge |
 | airflow.dag_file | Airflow dag file metadata | keyword |  |
 | airflow.dag_id | Airflow dag id metadata | keyword |  |
 | airflow.job_name | Airflow job name metadata | keyword |  |

--- a/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
+++ b/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
@@ -435,7 +435,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Scheduler Heartbeat",
-                                                    "operationType": "sum",
+                                                    "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.2.0"
+version: "0.3.0"
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Revert airflow metrics field definition to the format used before introducing metric_type.
This is done because of this [issue](https://github.com/elastic/kibana/issues/155004#issuecomment-1668190898.).
Although, Airflow remained unaffected by this issue. However, with the fix now accessible and the necessary changes present in the elastic-package, it's good to revert to the original format.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




## Related issues


- Relates #6729 

## Screenshots

<img width="1697" alt="Screenshot 2023-08-22 at 12 07 30 PM" src="https://github.com/elastic/integrations/assets/102972658/832331d6-5232-4cbe-a589-bfae00847db3">

<img width="1685" alt="Screenshot 2023-08-21 at 2 10 11 PM" src="https://github.com/elastic/integrations/assets/102972658/c306adfe-05e6-425f-ac50-0bd0f6e761a6">
<img width="493" alt="Screenshot 2023-08-21 at 2 04 12 PM" src="https://github.com/elastic/integrations/assets/102972658/d92d750b-57fe-4c62-b810-95686e903220">
<img width="565" alt="Screenshot 2023-08-21 at 2 04 02 PM" src="https://github.com/elastic/integrations/assets/102972658/17af4498-1747-45e6-aa66-4829095db4f5">


