### PR TITLE
[Elastic Agent] adding 8.10 dashboard resources

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Adding some missing dashboard resources and changing min version due to 8.9/8.10 incompatibility
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7471
 - version: "1.11.1"
   changes:
     - description: Fix agent health dashboard links to work when installed in other spaces.

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding some missing dashboard resources and changing min version due to 8.9/8.10 incompatibility
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7471
+      link: https://github.com/elastic/integrations/pull/7474
 - version: "1.11.1"
   changes:
     - description: Fix agent health dashboard links to work when installed in other spaces.

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n**[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)**  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboards shows more detailed health information specifically related to running Elastic Agent instances.\n\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n**[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)**  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboards shows more detailed health information specifically related to running Elastic Agent instances.\n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "10f18ea6-0bc4-4a96-ae2d-da7ed34c3c1a",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -203,7 +203,7 @@
                 "panelIndex": "36dd783f-4b32-41db-8d33-e2fb7b4d9365",
                 "title": "[Elastic Agent] Agent Versions",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -385,7 +385,7 @@
                 "panelIndex": "1fa17cb8-3a19-4fc7-9631-0f44ce8692b4",
                 "title": "[Elastic Agent] Most Active Agents",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -544,7 +544,7 @@
                 "panelIndex": "ea70f89b-accb-4972-9119-b04d1afae410",
                 "title": "[Elastic Agent] Integrations per Agent",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -780,7 +780,7 @@
                 "panelIndex": "5848c519-791c-45e2-b350-0740a12c3ace",
                 "title": "[Elastic Agent] Agents with Errors",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -797,19 +797,17 @@
                 "panelIndex": "9604578e-7da2-4575-923e-f15e51bca436",
                 "panelRefName": "panel_9604578e-7da2-4575-923e-f15e51bca436",
                 "type": "search",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Agent Info",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:54:25.234Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -877,5 +875,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -61,149 +61,7 @@
                 "panelIndex": "10f18ea6-0bc4-4a96-ae2d-da7ed34c3c1a",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "d2a77691-eb30-480e-b021-e323a1f67f07": {
-                                            "columnOrder": [
-                                                "f82bd006-d5e8-42cf-975b-8c49ed8de2fe",
-                                                "a9b13926-7e9f-4786-9372-af9a5aad1e4e"
-                                            ],
-                                            "columns": {
-                                                "a9b13926-7e9f-4786-9372-af9a5aad1e4e": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Agents",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "agent.name"
-                                                },
-                                                "f82bd006-d5e8-42cf-975b-8c49ed8de2fe": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Versions",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "a9b13926-7e9f-4786-9372-af9a5aad1e4e",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 9
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "agent.version"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
-                                        "key": "data_stream.dataset",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "apm.*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "apm.*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "categoryDisplay": "default",
-                                        "layerId": "d2a77691-eb30-480e-b021-e323a1f67f07",
-                                        "layerType": "data",
-                                        "legendDisplay": "show",
-                                        "metrics": [
-                                            "a9b13926-7e9f-4786-9372-af9a5aad1e4e"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "f82bd006-d5e8-42cf-975b-8c49ed8de2fe"
-                                        ]
-                                    }
-                                ],
-                                "shape": "donut"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "36dd783f-4b32-41db-8d33-e2fb7b4d9365",
-                    "w": 18,
-                    "x": 30,
-                    "y": 0
-                },
-                "panelIndex": "36dd783f-4b32-41db-8d33-e2fb7b4d9365",
-                "title": "[Elastic Agent] Agent Versions",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -385,166 +243,7 @@
                 "panelIndex": "1fa17cb8-3a19-4fc7-9631-0f44ce8692b4",
                 "title": "[Elastic Agent] Most Active Agents",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "5aae4230-61df-4557-972b-cf52a1c78870",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "2b14e40b-0f07-4713-b7fb-96b4df2c93aa": {
-                                            "columnOrder": [
-                                                "0af06ae8-c199-4684-a132-a1a3d42acaec",
-                                                "faf97258-224e-4050-9c05-3c4bb647a9f0"
-                                            ],
-                                            "columns": {
-                                                "0af06ae8-c199-4684-a132-a1a3d42acaec": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Agents",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "faf97258-224e-4050-9c05-3c4bb647a9f0",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "agent.name"
-                                                },
-                                                "faf97258-224e-4050-9c05-3c4bb647a9f0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Number of Integrations",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5aae4230-61df-4557-972b-cf52a1c78870",
-                                        "key": "data_stream.dataset",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "elastic_agent*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "categoryDisplay": "default",
-                                        "layerId": "2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
-                                        "layerType": "data",
-                                        "legendDisplay": "show",
-                                        "metrics": [
-                                            "faf97258-224e-4050-9c05-3c4bb647a9f0"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "0af06ae8-c199-4684-a132-a1a3d42acaec"
-                                        ]
-                                    }
-                                ],
-                                "shape": "donut"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": [
-                                {
-                                    "action": {
-                                        "config": {
-                                            "openInNewTab": false,
-                                            "useCurrentDateRange": true,
-                                            "useCurrentFilters": false
-                                        },
-                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
-                                        "name": "Integrations Dashboard"
-                                    },
-                                    "eventId": "f2edc3a8-5d50-4649-bb16-536aa103ed58",
-                                    "triggers": [
-                                        "FILTER_TRIGGER"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "ea70f89b-accb-4972-9119-b04d1afae410",
-                    "w": 18,
-                    "x": 30,
-                    "y": 14
-                },
-                "panelIndex": "ea70f89b-accb-4972-9119-b04d1afae410",
-                "title": "[Elastic Agent] Integrations per Agent",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -780,7 +479,308 @@
                 "panelIndex": "5848c519-791c-45e2-b350-0740a12c3ace",
                 "title": "[Elastic Agent] Agents with Errors",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "d2a77691-eb30-480e-b021-e323a1f67f07": {
+                                            "columnOrder": [
+                                                "f82bd006-d5e8-42cf-975b-8c49ed8de2fe",
+                                                "a9b13926-7e9f-4786-9372-af9a5aad1e4e"
+                                            ],
+                                            "columns": {
+                                                "a9b13926-7e9f-4786-9372-af9a5aad1e4e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Agents",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "agent.name"
+                                                },
+                                                "f82bd006-d5e8-42cf-975b-8c49ed8de2fe": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Versions",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "a9b13926-7e9f-4786-9372-af9a5aad1e4e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 9
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "agent.version"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "apm.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "apm.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "layerId": "d2a77691-eb30-480e-b021-e323a1f67f07",
+                                        "layerType": "data",
+                                        "legendDisplay": "show",
+                                        "metrics": [
+                                            "a9b13926-7e9f-4786-9372-af9a5aad1e4e"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "f82bd006-d5e8-42cf-975b-8c49ed8de2fe"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "36dd783f-4b32-41db-8d33-e2fb7b4d9365",
+                    "w": 18,
+                    "x": 30,
+                    "y": 0
+                },
+                "panelIndex": "36dd783f-4b32-41db-8d33-e2fb7b4d9365",
+                "title": "[Elastic Agent] Agent Versions",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "5aae4230-61df-4557-972b-cf52a1c78870",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "2b14e40b-0f07-4713-b7fb-96b4df2c93aa": {
+                                            "columnOrder": [
+                                                "0af06ae8-c199-4684-a132-a1a3d42acaec",
+                                                "faf97258-224e-4050-9c05-3c4bb647a9f0"
+                                            ],
+                                            "columns": {
+                                                "0af06ae8-c199-4684-a132-a1a3d42acaec": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Agents",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "faf97258-224e-4050-9c05-3c4bb647a9f0",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "agent.name"
+                                                },
+                                                "faf97258-224e-4050-9c05-3c4bb647a9f0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Number of Integrations",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "data_stream.dataset"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "5aae4230-61df-4557-972b-cf52a1c78870",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "layerId": "2b14e40b-0f07-4713-b7fb-96b4df2c93aa",
+                                        "layerType": "data",
+                                        "legendDisplay": "show",
+                                        "metrics": [
+                                            "faf97258-224e-4050-9c05-3c4bb647a9f0"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "0af06ae8-c199-4684-a132-a1a3d42acaec"
+                                        ]
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": false,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": false
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "Integrations Dashboard"
+                                    },
+                                    "eventId": "f2edc3a8-5d50-4649-bb16-536aa103ed58",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "ea70f89b-accb-4972-9119-b04d1afae410",
+                    "w": 18,
+                    "x": 30,
+                    "y": 14
+                },
+                "panelIndex": "ea70f89b-accb-4972-9119-b04d1afae410",
+                "title": "[Elastic Agent] Integrations per Agent",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -797,7 +797,7 @@
                 "panelIndex": "9604578e-7da2-4575-923e-f15e51bca436",
                 "panelRefName": "panel_9604578e-7da2-4575-923e-f15e51bca436",
                 "type": "search",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -805,20 +805,10 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:23.131Z",
     "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
     "managed": false,
     "references": [
-        {
-            "id": "logs-*",
-            "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
-            "type": "index-pattern"
-        },
         {
             "id": "logs-*",
             "name": "1fa17cb8-3a19-4fc7-9631-0f44ce8692b4:indexpattern-datasource-layer-299e2c43-13cd-477a-ba36-4c0f84bd32a4",
@@ -827,6 +817,26 @@
         {
             "id": "logs-*",
             "name": "1fa17cb8-3a19-4fc7-9631-0f44ce8692b4:ffe5b460-523c-4b2c-9403-4f6b7917c660",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "5848c519-791c-45e2-b350-0740a12c3ace:indexpattern-datasource-layer-501c5bb4-5af0-46bf-99c1-e08ed2c31111",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "5848c519-791c-45e2-b350-0740a12c3ace:a1c28df9-4fd0-4acb-bc12-0f510a821ed2",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:indexpattern-datasource-layer-d2a77691-eb30-480e-b021-e323a1f67f07",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "36dd783f-4b32-41db-8d33-e2fb7b4d9365:79d7f2b4-c4d9-4b9b-9e3f-5b70226aebe0",
             "type": "index-pattern"
         },
         {
@@ -843,16 +853,6 @@
             "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
             "name": "ea70f89b-accb-4972-9119-b04d1afae410:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:f2edc3a8-5d50-4649-bb16-536aa103ed58:dashboardId",
             "type": "dashboard"
-        },
-        {
-            "id": "logs-*",
-            "name": "5848c519-791c-45e2-b350-0740a12c3ace:indexpattern-datasource-layer-501c5bb4-5af0-46bf-99c1-e08ed2c31111",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "5848c519-791c-45e2-b350-0740a12c3ace:a1c28df9-4fd0-4acb-bc12-0f510a821ed2",
-            "type": "index-pattern"
         },
         {
             "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n**[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)**  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n\n**Overview**\n\nThis dashboards visualizes the statistics and overall health of all the active integrations.\n\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n**[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)**  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n\n**Overview**\n\nThis dashboards visualizes the statistics and overall health of all the active integrations.\n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -238,7 +238,7 @@
                 "panelIndex": "e2b6fbdd-506f-4b42-bd11-01a33205f6da",
                 "title": "[Elastic Agent] Events per Integration",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -450,7 +450,7 @@
                 "panelIndex": "54f07979-6f4b-4535-b97b-0552bbeb9b39",
                 "title": "[Elastic Agent] Integration Errors Table",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -466,19 +466,17 @@
                 "panelIndex": "91739766-1a6c-4e96-9ad8-c9be52c03ff6",
                 "panelRefName": "panel_91739766-1a6c-4e96-9ad8-c9be52c03ff6",
                 "type": "search",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Integrations",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:03.107Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -516,5 +514,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -61,184 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "3eae8cc8-c7dd-4928-a680-2d184923881f": {
-                                            "columnOrder": [
-                                                "fe1ea7d3-8330-4e4f-ad33-d058cfc96007",
-                                                "30a1bcb7-9331-4748-93d8-dd1a4e554d2c",
-                                                "01d61a02-d08d-4149-a1c0-02744ac2467f"
-                                            ],
-                                            "columns": {
-                                                "01d61a02-d08d-4149-a1c0-02744ac2467f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Events",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 0
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "30a1bcb7-9331-4748-93d8-dd1a4e554d2c": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "fe1ea7d3-8330-4e4f-ad33-d058cfc96007": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Datasets",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "01d61a02-d08d-4149-a1c0-02744ac2467f",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
-                                        "key": "data_stream.dataset",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "elastic_agent*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "01d61a02-d08d-4149-a1c0-02744ac2467f"
-                                        ],
-                                        "layerId": "3eae8cc8-c7dd-4928-a680-2d184923881f",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area_stacked",
-                                        "showGridlines": false,
-                                        "splitAccessor": "fe1ea7d3-8330-4e4f-ad33-d058cfc96007",
-                                        "xAccessor": "30a1bcb7-9331-4748-93d8-dd1a4e554d2c"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "e2b6fbdd-506f-4b42-bd11-01a33205f6da",
-                    "w": 29,
-                    "x": 19,
-                    "y": 0
-                },
-                "panelIndex": "e2b6fbdd-506f-4b42-bd11-01a33205f6da",
-                "title": "[Elastic Agent] Events per Integration",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -450,7 +273,184 @@
                 "panelIndex": "54f07979-6f4b-4535-b97b-0552bbeb9b39",
                 "title": "[Elastic Agent] Integration Errors Table",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "3eae8cc8-c7dd-4928-a680-2d184923881f": {
+                                            "columnOrder": [
+                                                "fe1ea7d3-8330-4e4f-ad33-d058cfc96007",
+                                                "30a1bcb7-9331-4748-93d8-dd1a4e554d2c",
+                                                "01d61a02-d08d-4149-a1c0-02744ac2467f"
+                                            ],
+                                            "columns": {
+                                                "01d61a02-d08d-4149-a1c0-02744ac2467f": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "30a1bcb7-9331-4748-93d8-dd1a4e554d2c": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fe1ea7d3-8330-4e4f-ad33-d058cfc96007": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Datasets",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "01d61a02-d08d-4149-a1c0-02744ac2467f",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "data_stream.dataset"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "970463b2-ccd3-4298-8f57-17b6e8dbaef0",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "01d61a02-d08d-4149-a1c0-02744ac2467f"
+                                        ],
+                                        "layerId": "3eae8cc8-c7dd-4928-a680-2d184923881f",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "fe1ea7d3-8330-4e4f-ad33-d058cfc96007",
+                                        "xAccessor": "30a1bcb7-9331-4748-93d8-dd1a4e554d2c"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "e2b6fbdd-506f-4b42-bd11-01a33205f6da",
+                    "w": 29,
+                    "x": 19,
+                    "y": 0
+                },
+                "panelIndex": "e2b6fbdd-506f-4b42-bd11-01a33205f6da",
+                "title": "[Elastic Agent] Events per Integration",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -466,7 +466,7 @@
                 "panelIndex": "91739766-1a6c-4e96-9ad8-c9be52c03ff6",
                 "panelRefName": "panel_91739766-1a6c-4e96-9ad8-c9be52c03ff6",
                 "type": "search",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -474,20 +474,10 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:38.144Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "managed": false,
     "references": [
-        {
-            "id": "logs-*",
-            "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:970463b2-ccd3-4298-8f57-17b6e8dbaef0",
-            "type": "index-pattern"
-        },
         {
             "id": "logs-*",
             "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:indexpattern-datasource-layer-d125ad67-b062-4e41-ae8b-1db28534246f",
@@ -496,6 +486,16 @@
         {
             "id": "logs-*",
             "name": "54f07979-6f4b-4535-b97b-0552bbeb9b39:ec330081-de01-4c31-808f-3bfa4c01193b",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:indexpattern-datasource-layer-3eae8cc8-c7dd-4928-a680-2d184923881f",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "e2b6fbdd-506f-4b42-bd11-01a33205f6da:970463b2-ccd3-4298-8f57-17b6e8dbaef0",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n**[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)**  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n\n[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n**[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)**  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -102,6 +102,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -208,7 +209,7 @@
                 "panelIndex": "684ec058-a4b7-4f52-9390-4b88816ea134",
                 "title": "[Elastic Agent] Winlog Errors Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -249,6 +250,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -355,7 +357,7 @@
                 "panelIndex": "feccd679-72d5-4e95-a31c-8328cc296d4a",
                 "title": "[Elastic Agent] Winlog Discarded Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -394,6 +396,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -511,7 +514,7 @@
                 "panelIndex": "e8beaaa7-e731-4056-9ef2-943572ba2280",
                 "title": "[Elastic Agent] Winlog Source Time Difference",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -618,7 +621,7 @@
                 "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
                 "title": "[Elastic Agent] Winlog Unique Channels",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -659,6 +662,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -731,7 +735,7 @@
                 "panelIndex": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0",
                 "title": "[Elastic Agent] Winlog Events Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -954,7 +958,7 @@
                 "panelIndex": "f7a119e0-fad5-44a7-90e3-654b8c17b8d5",
                 "title": "[Elastic Agent] Event Collection",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1200,7 +1204,7 @@
                 "panelIndex": "038cd6ac-ddfb-4c85-ae07-8cad371fac9d",
                 "title": "[Elastic Agent] Source Time Difference (In Seconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1452,7 +1456,7 @@
                 "panelIndex": "1496a918-0b43-4d9e-b604-66ebf7864528",
                 "title": "[Elastic Agent] Time Between Event Log Collections in Seconds",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1663,19 +1667,17 @@
                 "panelIndex": "7af2c1db-3a8f-485c-b37c-6c51db1a98da",
                 "title": "[Elastic Agent] Log Collection Errors",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Winlog Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:56:01.414Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1783,5 +1785,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -209,155 +209,7 @@
                 "panelIndex": "684ec058-a4b7-4f52-9390-4b88816ea134",
                 "title": "[Elastic Agent] Winlog Errors Total",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "5209f1ad-c717-4c57-af38-5d4de7428bb8",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.discarded_events_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Discarded Events Total",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.discarded_events_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "5209f1ad-c717-4c57-af38-5d4de7428bb8",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "winlog"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "winlog"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#cc5642",
-                                                "stop": null
-                                            },
-                                            {
-                                                "color": "#54B399",
-                                                "stop": 0
-                                            }
-                                        ],
-                                        "continuity": "all",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": null,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#cc5642",
-                                                "stop": 0
-                                            },
-                                            {
-                                                "color": "#54B399",
-                                                "stop": 1
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "feccd679-72d5-4e95-a31c-8328cc296d4a",
-                    "w": 8,
-                    "x": 15,
-                    "y": 0
-                },
-                "panelIndex": "feccd679-72d5-4e95-a31c-8328cc296d4a",
-                "title": "[Elastic Agent] Winlog Discarded Total",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -514,114 +366,7 @@
                 "panelIndex": "e8beaaa7-e731-4056-9ef2-943572ba2280",
                 "title": "[Elastic Agent] Winlog Source Time Difference",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "c4d4cfa5-770e-4fd2-bd05-7d3eda70f619",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.provider: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Unique Windows Channels",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.provider"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "c4d4cfa5-770e-4fd2-bd05-7d3eda70f619",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "winlog"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "winlog"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "subtitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "a29b5945-c706-40df-87be-3edea85fcfc9",
-                    "w": 8,
-                    "x": 40,
-                    "y": 0
-                },
-                "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
-                "title": "[Elastic Agent] Winlog Unique Channels",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -735,7 +480,262 @@
                 "panelIndex": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0",
                 "title": "[Elastic Agent] Winlog Events Total",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "c4d4cfa5-770e-4fd2-bd05-7d3eda70f619",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.provider: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Unique Windows Channels",
+                                                    "operationType": "unique_count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.provider"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "c4d4cfa5-770e-4fd2-bd05-7d3eda70f619",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "winlog"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "winlog"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "subtitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "a29b5945-c706-40df-87be-3edea85fcfc9",
+                    "w": 8,
+                    "x": 40,
+                    "y": 0
+                },
+                "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
+                "title": "[Elastic Agent] Winlog Unique Channels",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "5209f1ad-c717-4c57-af38-5d4de7428bb8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.discarded_events_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Discarded Events Total",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.discarded_events_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "5209f1ad-c717-4c57-af38-5d4de7428bb8",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "winlog"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "winlog"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#54B399",
+                                                "stop": 0
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": 0
+                                            },
+                                            {
+                                                "color": "#54B399",
+                                                "stop": 1
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "feccd679-72d5-4e95-a31c-8328cc296d4a",
+                    "w": 8,
+                    "x": 15,
+                    "y": 0
+                },
+                "panelIndex": "feccd679-72d5-4e95-a31c-8328cc296d4a",
+                "title": "[Elastic Agent] Winlog Discarded Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -958,7 +958,7 @@
                 "panelIndex": "f7a119e0-fad5-44a7-90e3-654b8c17b8d5",
                 "title": "[Elastic Agent] Event Collection",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1204,7 +1204,7 @@
                 "panelIndex": "038cd6ac-ddfb-4c85-ae07-8cad371fac9d",
                 "title": "[Elastic Agent] Source Time Difference (In Seconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1456,7 +1456,7 @@
                 "panelIndex": "1496a918-0b43-4d9e-b604-66ebf7864528",
                 "title": "[Elastic Agent] Time Between Event Log Collections in Seconds",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1667,7 +1667,7 @@
                 "panelIndex": "7af2c1db-3a8f-485c-b37c-6c51db1a98da",
                 "title": "[Elastic Agent] Log Collection Errors",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1675,7 +1675,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:06:28.905Z",
     "id": "elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c",
     "managed": false,
     "references": [
@@ -1691,22 +1691,22 @@
         },
         {
             "id": "metrics-*",
-            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:5209f1ad-c717-4c57-af38-5d4de7428bb8",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "e8beaaa7-e731-4056-9ef2-943572ba2280:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
             "name": "e8beaaa7-e731-4056-9ef2-943572ba2280:86854b43-58d0-4fd6-8830-435c381be89f",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0:indexpattern-datasource-layer-795ad203-ed2f-46a8-9099-05fcc0ce26da",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0:ca1d1d28-ef76-4d69-a89e-792ba9f9814b",
             "type": "index-pattern"
         },
         {
@@ -1721,12 +1721,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0:indexpattern-datasource-layer-795ad203-ed2f-46a8-9099-05fcc0ce26da",
+            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0:ca1d1d28-ef76-4d69-a89e-792ba9f9814b",
+            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:5209f1ad-c717-4c57-af38-5d4de7428bb8",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -175,114 +175,7 @@
                 "panelIndex": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0",
                 "title": "[Elastic Agent] S3 Total Documents Created",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "786554cd-2ab8-4d73-80e8-6c3a94734008",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.sqs_messages_received_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "SQS Messages Received Total",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.sqs_messages_received_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "786554cd-2ab8-4d73-80e8-6c3a94734008",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-s3"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-s3"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "a29b5945-c706-40df-87be-3edea85fcfc9",
-                    "w": 8,
-                    "x": 16,
-                    "y": 0
-                },
-                "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
-                "title": "[Elastic Agent] SQS Messages Total",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -389,441 +282,7 @@
                 "panelIndex": "d64fc6fe-b9cf-4c0d-83fb-45fcb254e364",
                 "title": "[Elastic Agent] SQS Messages Deleted Total",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "5f337898-8be3-497a-ab82-673fc44ae16a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.sqs_messages_inflight_gauge: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "SQS Messages Inflight",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.sqs_messages_inflight_gauge"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "5f337898-8be3-497a-ab82-673fc44ae16a",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-s3"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-s3"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "subtitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "e8beaaa7-e731-4056-9ef2-943572ba2280",
-                    "w": 8,
-                    "x": 40,
-                    "y": 0
-                },
-                "panelIndex": "e8beaaa7-e731-4056-9ef2-943572ba2280",
-                "title": "[Elastic Agent] SQS Messages Inflight",
-                "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-57860acd-0677-4a04-b59a-a2cc4dcf5d1b",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "cea38572-ee6f-40c1-a144-fba12971b20d",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "57860acd-0677-4a04-b59a-a2cc4dcf5d1b": {
-                                            "columnOrder": [
-                                                "1048b2b6-4c27-44f1-833a-ad7584e8c461"
-                                            ],
-                                            "columns": {
-                                                "1048b2b6-4c27-44f1-833a-ad7584e8c461": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.s3_bytes_processed_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Total Bytes Processed",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.s3_bytes_processed_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "cea38572-ee6f-40c1-a144-fba12971b20d",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-s3"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-s3"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "57860acd-0677-4a04-b59a-a2cc4dcf5d1b",
-                                "layerType": "data",
-                                "metricAccessor": "1048b2b6-4c27-44f1-833a-ad7584e8c461",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "3dfd26c0-6499-4b60-896c-868883f4e979",
-                    "w": 9,
-                    "x": 7,
-                    "y": 5
-                },
-                "panelIndex": "3dfd26c0-6499-4b60-896c-868883f4e979",
-                "title": "[Elastic Agent] S3 Total Bytes",
-                "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "0eb55a52-097d-444c-9dac-ee26a72bcd50",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.s3_objects_requested_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "S3 Objects Requested Total",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.s3_objects_requested_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "0eb55a52-097d-444c-9dac-ee26a72bcd50",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-s3"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-s3"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7",
-                    "w": 8,
-                    "x": 16,
-                    "y": 5
-                },
-                "panelIndex": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7",
-                "title": "[Elastic Agent] S3 Requested Objects Total",
-                "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "8e85c4f7-426a-448f-a7f7-cbaa86a1b4eb",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
-                                            "columnOrder": [
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
-                                            ],
-                                            "columns": {
-                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.s3_objects_acked_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "S3 Objects Acked Total (No SQS)",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.s3_objects_acked_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "8e85c4f7-426a-448f-a7f7-cbaa86a1b4eb",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-s3"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-s3"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-                                "layerType": "data",
-                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "6685bf1d-4a80-4769-898a-e9520dd360dc",
-                    "w": 8,
-                    "x": 24,
-                    "y": 5
-                },
-                "panelIndex": "6685bf1d-4a80-4769-898a-e9520dd360dc",
-                "title": "[Elastic Agent] S3 Objects Acked Total",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -964,7 +423,7 @@
                 "panelIndex": "feccd679-72d5-4e95-a31c-8328cc296d4a",
                 "title": "[Elastic Agent] SQS Messages Error Total",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -977,7 +436,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "12194fe1-bdf5-4187-9615-2486da97804b",
+                                "name": "5f337898-8be3-497a-ab82-673fc44ae16a",
                                 "type": "index-pattern"
                             }
                         ],
@@ -996,16 +455,16 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "filebeat_input.s3_objects_inflight_gauge: *"
+                                                        "query": "filebeat_input.sqs_messages_inflight_gauge: *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "S3 Objects Inflights (No SQS)",
+                                                    "label": "SQS Messages Inflight",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "filebeat_input.s3_objects_inflight_gauge"
+                                                    "sourceField": "filebeat_input.sqs_messages_inflight_gauge"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -1026,7 +485,7 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "filebeat_input.input",
-                                        "index": "12194fe1-bdf5-4187-9615-2486da97804b",
+                                        "index": "5f337898-8be3-497a-ab82-673fc44ae16a",
                                         "key": "filebeat_input.input",
                                         "negate": false,
                                         "params": {
@@ -1063,15 +522,342 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "b9c992a8-7c58-47ca-8a8a-7d8273566133",
+                    "i": "e8beaaa7-e731-4056-9ef2-943572ba2280",
                     "w": 8,
                     "x": 40,
+                    "y": 0
+                },
+                "panelIndex": "e8beaaa7-e731-4056-9ef2-943572ba2280",
+                "title": "[Elastic Agent] SQS Messages Inflight",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-57860acd-0677-4a04-b59a-a2cc4dcf5d1b",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "cea38572-ee6f-40c1-a144-fba12971b20d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "57860acd-0677-4a04-b59a-a2cc4dcf5d1b": {
+                                            "columnOrder": [
+                                                "1048b2b6-4c27-44f1-833a-ad7584e8c461"
+                                            ],
+                                            "columns": {
+                                                "1048b2b6-4c27-44f1-833a-ad7584e8c461": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.s3_bytes_processed_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Total Bytes Processed",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.s3_bytes_processed_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "cea38572-ee6f-40c1-a144-fba12971b20d",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-s3"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-s3"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "57860acd-0677-4a04-b59a-a2cc4dcf5d1b",
+                                "layerType": "data",
+                                "metricAccessor": "1048b2b6-4c27-44f1-833a-ad7584e8c461",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "3dfd26c0-6499-4b60-896c-868883f4e979",
+                    "w": 9,
+                    "x": 7,
                     "y": 5
                 },
-                "panelIndex": "b9c992a8-7c58-47ca-8a8a-7d8273566133",
-                "title": "[Elastic Agent] S3 Objects Inflight",
+                "panelIndex": "3dfd26c0-6499-4b60-896c-868883f4e979",
+                "title": "[Elastic Agent] S3 Total Bytes",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "786554cd-2ab8-4d73-80e8-6c3a94734008",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.sqs_messages_received_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "SQS Messages Received Total",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.sqs_messages_received_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "786554cd-2ab8-4d73-80e8-6c3a94734008",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-s3"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-s3"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "a29b5945-c706-40df-87be-3edea85fcfc9",
+                    "w": 8,
+                    "x": 16,
+                    "y": 0
+                },
+                "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
+                "title": "[Elastic Agent] SQS Messages Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "8e85c4f7-426a-448f-a7f7-cbaa86a1b4eb",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.s3_objects_acked_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "S3 Objects Acked Total (No SQS)",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.s3_objects_acked_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "8e85c4f7-426a-448f-a7f7-cbaa86a1b4eb",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-s3"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-s3"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "6685bf1d-4a80-4769-898a-e9520dd360dc",
+                    "w": 8,
+                    "x": 24,
+                    "y": 5
+                },
+                "panelIndex": "6685bf1d-4a80-4769-898a-e9520dd360dc",
+                "title": "[Elastic Agent] S3 Objects Acked Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1178,7 +964,221 @@
                 "panelIndex": "b23cf0ce-2b44-497c-ae36-067ab36b7643",
                 "title": "[Elastic Agent] S3 Objects Processed Total",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "12194fe1-bdf5-4187-9615-2486da97804b",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.s3_objects_inflight_gauge: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "S3 Objects Inflights (No SQS)",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.s3_objects_inflight_gauge"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "12194fe1-bdf5-4187-9615-2486da97804b",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-s3"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-s3"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "subtitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "b9c992a8-7c58-47ca-8a8a-7d8273566133",
+                    "w": 8,
+                    "x": 40,
+                    "y": 5
+                },
+                "panelIndex": "b9c992a8-7c58-47ca-8a8a-7d8273566133",
+                "title": "[Elastic Agent] S3 Objects Inflight",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "0eb55a52-097d-444c-9dac-ee26a72bcd50",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a00b86a4-2b3c-44d4-86bf-11d2c3209e83": {
+                                            "columnOrder": [
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf"
+                                            ],
+                                            "columns": {
+                                                "70c99a86-1423-4f72-a674-e40d3ebfa2bf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.s3_objects_requested_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "S3 Objects Requested Total",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.s3_objects_requested_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "0eb55a52-097d-444c-9dac-ee26a72bcd50",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-s3"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-s3"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+                                "layerType": "data",
+                                "metricAccessor": "70c99a86-1423-4f72-a674-e40d3ebfa2bf",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7",
+                    "w": 8,
+                    "x": 16,
+                    "y": 5
+                },
+                "panelIndex": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7",
+                "title": "[Elastic Agent] S3 Requested Objects Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1438,7 +1438,7 @@
                 "panelIndex": "1496a918-0b43-4d9e-b604-66ebf7864528",
                 "title": "[Elastic Agent] S3 Object Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1698,7 +1698,7 @@
                 "panelIndex": "f7a119e0-fad5-44a7-90e3-654b8c17b8d5",
                 "title": "[Elastic Agent] SQS Lag Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1958,7 +1958,7 @@
                 "panelIndex": "398d762a-a759-4026-8ced-0c29faaa0de8",
                 "title": "[Elastic Agent] SQS Message Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -2180,7 +2180,7 @@
                 "panelIndex": "17f29bce-2870-425d-b20f-15a745e0acb2",
                 "title": "[Elastic Agent] SQS Message Received",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -2327,7 +2327,7 @@
                 "panelIndex": "0b681b63-838d-47c7-b195-8c970e444545",
                 "title": "[Elastic Agent] Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -2335,7 +2335,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:06:05.628Z",
     "id": "elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2",
     "managed": false,
     "references": [
@@ -2351,22 +2351,22 @@
         },
         {
             "id": "metrics-*",
-            "name": "a29b5945-c706-40df-87be-3edea85fcfc9:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "a29b5945-c706-40df-87be-3edea85fcfc9:786554cd-2ab8-4d73-80e8-6c3a94734008",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "d64fc6fe-b9cf-4c0d-83fb-45fcb254e364:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
             "name": "d64fc6fe-b9cf-4c0d-83fb-45fcb254e364:b1568e46-269e-4c7c-9fbc-a93f5e90b5bd",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:50a234fb-2b9f-47f1-a76b-9ca23b96ea91",
             "type": "index-pattern"
         },
         {
@@ -2391,12 +2391,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+            "name": "a29b5945-c706-40df-87be-3edea85fcfc9:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7:0eb55a52-097d-444c-9dac-ee26a72bcd50",
+            "name": "a29b5945-c706-40df-87be-3edea85fcfc9:786554cd-2ab8-4d73-80e8-6c3a94734008",
             "type": "index-pattern"
         },
         {
@@ -2411,12 +2411,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+            "name": "b23cf0ce-2b44-497c-ae36-067ab36b7643:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "feccd679-72d5-4e95-a31c-8328cc296d4a:50a234fb-2b9f-47f1-a76b-9ca23b96ea91",
+            "name": "b23cf0ce-2b44-497c-ae36-067ab36b7643:6e715069-a841-45ab-8f79-9f36a605ef2f",
             "type": "index-pattern"
         },
         {
@@ -2431,12 +2431,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "b23cf0ce-2b44-497c-ae36-067ab36b7643:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
+            "name": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7:indexpattern-datasource-layer-a00b86a4-2b3c-44d4-86bf-11d2c3209e83",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "b23cf0ce-2b44-497c-ae36-067ab36b7643:6e715069-a841-45ab-8f79-9f36a605ef2f",
+            "name": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7:0eb55a52-097d-444c-9dac-ee26a72bcd50",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n**[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)**  \n[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**  \n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n\n[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n**[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)**  \n[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**  \n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -102,6 +102,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -174,7 +175,7 @@
                 "panelIndex": "8c09dfc5-6b3f-4037-8261-d3a1393e4ca0",
                 "title": "[Elastic Agent] S3 Total Documents Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -281,7 +282,7 @@
                 "panelIndex": "a29b5945-c706-40df-87be-3edea85fcfc9",
                 "title": "[Elastic Agent] SQS Messages Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -388,7 +389,7 @@
                 "panelIndex": "d64fc6fe-b9cf-4c0d-83fb-45fcb254e364",
                 "title": "[Elastic Agent] SQS Messages Deleted Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -495,7 +496,7 @@
                 "panelIndex": "e8beaaa7-e731-4056-9ef2-943572ba2280",
                 "title": "[Elastic Agent] SQS Messages Inflight",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -608,7 +609,7 @@
                 "panelIndex": "3dfd26c0-6499-4b60-896c-868883f4e979",
                 "title": "[Elastic Agent] S3 Total Bytes",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -715,7 +716,7 @@
                 "panelIndex": "cd8ee31b-3d1e-4656-b63e-10d3550cf9c7",
                 "title": "[Elastic Agent] S3 Requested Objects Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -822,7 +823,7 @@
                 "panelIndex": "6685bf1d-4a80-4769-898a-e9520dd360dc",
                 "title": "[Elastic Agent] S3 Objects Acked Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -963,7 +964,7 @@
                 "panelIndex": "feccd679-72d5-4e95-a31c-8328cc296d4a",
                 "title": "[Elastic Agent] SQS Messages Error Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1070,7 +1071,7 @@
                 "panelIndex": "b9c992a8-7c58-47ca-8a8a-7d8273566133",
                 "title": "[Elastic Agent] S3 Objects Inflight",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1177,7 +1178,7 @@
                 "panelIndex": "b23cf0ce-2b44-497c-ae36-067ab36b7643",
                 "title": "[Elastic Agent] S3 Objects Processed Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1437,7 +1438,7 @@
                 "panelIndex": "1496a918-0b43-4d9e-b604-66ebf7864528",
                 "title": "[Elastic Agent] S3 Object Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1697,7 +1698,7 @@
                 "panelIndex": "f7a119e0-fad5-44a7-90e3-654b8c17b8d5",
                 "title": "[Elastic Agent] SQS Lag Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1957,7 +1958,7 @@
                 "panelIndex": "398d762a-a759-4026-8ced-0c29faaa0de8",
                 "title": "[Elastic Agent] SQS Message Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -2179,7 +2180,7 @@
                 "panelIndex": "17f29bce-2870-425d-b20f-15a745e0acb2",
                 "title": "[Elastic Agent] SQS Message Received",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -2326,19 +2327,17 @@
                 "panelIndex": "0b681b63-838d-47c7-b195-8c970e444545",
                 "title": "[Elastic Agent] Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] S3 Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:30.995Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -2501,5 +2500,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -218,7 +218,7 @@
                 "panelIndex": "5664e555-81ae-4084-a71d-dcce85a487e1",
                 "title": "[Elastic Agent] TCP Average Processing Time",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -231,7 +231,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "638047ed-c0af-4588-980a-f52c6ffa8043",
+                                "name": "9b5bc371-68d8-4977-bf9d-83744d9651fd",
                                 "type": "index-pattern"
                             }
                         ],
@@ -250,17 +250,16 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "TCP Queue Length",
+                                                    "label": "Total Bytes Processed",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
-                                                            "id": "number",
+                                                            "id": "bytes",
                                                             "params": {
-                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
-                                                        "formula": "last_value(filebeat_input.receive_queue_length)",
+                                                        "formula": "last_value(filebeat_input.received_bytes_total)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -273,16 +272,16 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "filebeat_input.receive_queue_length: *"
+                                                        "query": "filebeat_input.received_bytes_total: *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of Average Processing Time (Milliseconds)",
+                                                    "label": "Part of TCP Queue Length",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "filebeat_input.receive_queue_length"
+                                                    "sourceField": "filebeat_input.received_bytes_total"
                                                 }
                                             },
                                             "sampling": 1
@@ -302,7 +301,7 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "filebeat_input.input",
-                                        "index": "638047ed-c0af-4588-980a-f52c6ffa8043",
+                                        "index": "9b5bc371-68d8-4977-bf9d-83744d9651fd",
                                         "key": "filebeat_input.input",
                                         "negate": false,
                                         "params": {
@@ -339,15 +338,15 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "ce966366-8909-42af-8783-8c24fb61c3b3",
+                    "i": "3fded80f-4cc8-4f50-8b23-76f9bce86253",
                     "w": 10,
-                    "x": 17,
+                    "x": 27,
                     "y": 0
                 },
-                "panelIndex": "ce966366-8909-42af-8783-8c24fb61c3b3",
-                "title": "[Elastic Agent] TCP Queue Length",
+                "panelIndex": "3fded80f-4cc8-4f50-8b23-76f9bce86253",
+                "title": "[Elastic Agent] TCP Total Bytes Processed",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -476,7 +475,7 @@
                 "panelIndex": "5e4c1696-79f0-47bd-bdae-76e0cdb391d7",
                 "title": "[Elastic Agent] TCP Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -489,7 +488,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "9b5bc371-68d8-4977-bf9d-83744d9651fd",
+                                "name": "638047ed-c0af-4588-980a-f52c6ffa8043",
                                 "type": "index-pattern"
                             }
                         ],
@@ -508,16 +507,17 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Total Bytes Processed",
+                                                    "label": "TCP Queue Length",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
-                                                            "id": "bytes",
+                                                            "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
-                                                        "formula": "last_value(filebeat_input.received_bytes_total)",
+                                                        "formula": "last_value(filebeat_input.receive_queue_length)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
@@ -530,16 +530,16 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "filebeat_input.received_bytes_total: *"
+                                                        "query": "filebeat_input.receive_queue_length: *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of TCP Queue Length",
+                                                    "label": "Part of Average Processing Time (Milliseconds)",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "filebeat_input.received_bytes_total"
+                                                    "sourceField": "filebeat_input.receive_queue_length"
                                                 }
                                             },
                                             "sampling": 1
@@ -559,7 +559,7 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "filebeat_input.input",
-                                        "index": "9b5bc371-68d8-4977-bf9d-83744d9651fd",
+                                        "index": "638047ed-c0af-4588-980a-f52c6ffa8043",
                                         "key": "filebeat_input.input",
                                         "negate": false,
                                         "params": {
@@ -596,15 +596,15 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "3fded80f-4cc8-4f50-8b23-76f9bce86253",
+                    "i": "ce966366-8909-42af-8783-8c24fb61c3b3",
                     "w": 10,
-                    "x": 27,
+                    "x": 17,
                     "y": 0
                 },
-                "panelIndex": "3fded80f-4cc8-4f50-8b23-76f9bce86253",
-                "title": "[Elastic Agent] TCP Total Bytes Processed",
+                "panelIndex": "ce966366-8909-42af-8783-8c24fb61c3b3",
+                "title": "[Elastic Agent] TCP Queue Length",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -844,7 +844,7 @@
                 "panelIndex": "e7830564-013b-41dc-9b1b-e9cb3dbc96ff",
                 "title": "[Elastic Agent] TCP Time Between Packets (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1084,7 +1084,7 @@
                 "panelIndex": "b3c35b54-00f2-4632-845d-60c7abefb703",
                 "title": "[Elastic Agent] TCP Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1277,7 +1277,7 @@
                 "panelIndex": "5a50cd27-634b-429c-8181-907c41a73bd9",
                 "title": "[Elastic Agent] TCP Bytes Processed",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1470,7 +1470,7 @@
                 "panelIndex": "c93aa741-efc1-4f81-8e4e-61f4458911b8",
                 "title": "[Elastic Agent] TCP Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1478,7 +1478,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:06:13.244Z",
     "id": "elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2",
     "managed": false,
     "references": [
@@ -1494,12 +1494,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "ce966366-8909-42af-8783-8c24fb61c3b3:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
+            "name": "3fded80f-4cc8-4f50-8b23-76f9bce86253:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "ce966366-8909-42af-8783-8c24fb61c3b3:638047ed-c0af-4588-980a-f52c6ffa8043",
+            "name": "3fded80f-4cc8-4f50-8b23-76f9bce86253:9b5bc371-68d8-4977-bf9d-83744d9651fd",
             "type": "index-pattern"
         },
         {
@@ -1514,12 +1514,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "3fded80f-4cc8-4f50-8b23-76f9bce86253:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
+            "name": "ce966366-8909-42af-8783-8c24fb61c3b3:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "3fded80f-4cc8-4f50-8b23-76f9bce86253:9b5bc371-68d8-4977-bf9d-83744d9651fd",
+            "name": "ce966366-8909-42af-8783-8c24fb61c3b3:638047ed-c0af-4588-980a-f52c6ffa8043",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n**[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)**  \n[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n\n[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n**[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)**  \n[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -100,6 +100,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -217,7 +218,7 @@
                 "panelIndex": "5664e555-81ae-4084-a71d-dcce85a487e1",
                 "title": "[Elastic Agent] TCP Average Processing Time",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -255,6 +256,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -345,7 +347,7 @@
                 "panelIndex": "ce966366-8909-42af-8783-8c24fb61c3b3",
                 "title": "[Elastic Agent] TCP Queue Length",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -383,6 +385,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -473,7 +476,7 @@
                 "panelIndex": "5e4c1696-79f0-47bd-bdae-76e0cdb391d7",
                 "title": "[Elastic Agent] TCP Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -601,7 +604,7 @@
                 "panelIndex": "3fded80f-4cc8-4f50-8b23-76f9bce86253",
                 "title": "[Elastic Agent] TCP Total Bytes Processed",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -841,7 +844,7 @@
                 "panelIndex": "e7830564-013b-41dc-9b1b-e9cb3dbc96ff",
                 "title": "[Elastic Agent] TCP Time Between Packets (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1081,7 +1084,7 @@
                 "panelIndex": "b3c35b54-00f2-4632-845d-60c7abefb703",
                 "title": "[Elastic Agent] TCP Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1274,7 +1277,7 @@
                 "panelIndex": "5a50cd27-634b-429c-8181-907c41a73bd9",
                 "title": "[Elastic Agent] TCP Bytes Processed",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1467,19 +1470,17 @@
                 "panelIndex": "c93aa741-efc1-4f81-8e4e-61f4458911b8",
                 "title": "[Elastic Agent] TCP Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] TCP Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:43.421Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1572,5 +1573,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -218,136 +218,7 @@
                 "panelIndex": "9e9962c8-3e2d-4bdc-8678-ba2ed7eb26c0",
                 "title": "[Elastic Agent] UDP Average Processing Time",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "04ad5f81-ed36-48ba-8ba7-a9d797498250": {
-                                            "columnOrder": [
-                                                "4524a05f-df5f-472f-9e2f-e84cc310a932",
-                                                "4524a05f-df5f-472f-9e2f-e84cc310a932X0"
-                                            ],
-                                            "columns": {
-                                                "4524a05f-df5f-472f-9e2f-e84cc310a932": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "UDP Queue Length",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "formula": "last_value(filebeat_input.receive_queue_length)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "4524a05f-df5f-472f-9e2f-e84cc310a932X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "4524a05f-df5f-472f-9e2f-e84cc310a932X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.receive_queue_length: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of TCP Queue Length",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.receive_queue_length"
-                                                }
-                                            },
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "udp"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "udp"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "04ad5f81-ed36-48ba-8ba7-a9d797498250",
-                                "layerType": "data",
-                                "metricAccessor": "4524a05f-df5f-472f-9e2f-e84cc310a932",
-                                "subtitle": "Linux Only - Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "88585bec-de77-4583-bac2-65e09d5aef91",
-                    "w": 8,
-                    "x": 15,
-                    "y": 0
-                },
-                "panelIndex": "88585bec-de77-4583-bac2-65e09d5aef91",
-                "title": "[Elastic Agent] UDP Queue Length",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -475,7 +346,7 @@
                 "panelIndex": "4e24548f-9e62-4d63-8491-0f96cf42d14a",
                 "title": "[Elastic Agent] UDP Total Bytes Processed",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -604,7 +475,7 @@
                 "panelIndex": "1f842daa-b447-48b7-9411-762f8aaf1b28",
                 "title": "[Elastic Agent] UDP Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -733,7 +604,136 @@
                 "panelIndex": "449b860a-a846-4d6d-b071-648e343a032e",
                 "title": "[Elastic Agent] UDP Packet Drops",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "04ad5f81-ed36-48ba-8ba7-a9d797498250": {
+                                            "columnOrder": [
+                                                "4524a05f-df5f-472f-9e2f-e84cc310a932",
+                                                "4524a05f-df5f-472f-9e2f-e84cc310a932X0"
+                                            ],
+                                            "columns": {
+                                                "4524a05f-df5f-472f-9e2f-e84cc310a932": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "UDP Queue Length",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "last_value(filebeat_input.receive_queue_length)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "4524a05f-df5f-472f-9e2f-e84cc310a932X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "4524a05f-df5f-472f-9e2f-e84cc310a932X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.receive_queue_length: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of TCP Queue Length",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.receive_queue_length"
+                                                }
+                                            },
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "udp"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "udp"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "04ad5f81-ed36-48ba-8ba7-a9d797498250",
+                                "layerType": "data",
+                                "metricAccessor": "4524a05f-df5f-472f-9e2f-e84cc310a932",
+                                "subtitle": "Linux Only - Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "88585bec-de77-4583-bac2-65e09d5aef91",
+                    "w": 8,
+                    "x": 15,
+                    "y": 0
+                },
+                "panelIndex": "88585bec-de77-4583-bac2-65e09d5aef91",
+                "title": "[Elastic Agent] UDP Queue Length",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -973,7 +973,7 @@
                 "panelIndex": "e77d9361-6abf-4ad5-ade7-d3722395f836",
                 "title": "[Elastic Agent] UDP Time Between Packets (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1213,7 +1213,7 @@
                 "panelIndex": "5685c224-f9ee-4a7d-8289-5bf089643543",
                 "title": "[Elastic Agent] UDP Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1364,7 +1364,7 @@
                 "panelIndex": "12f719cb-dcf1-4ebf-bafb-5e6b4f939844",
                 "title": "[Elastic Agent] UDP Packets Dropped",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1557,7 +1557,7 @@
                 "panelIndex": "5e2190a0-f988-457b-9ab7-02c0d0ddbbdc",
                 "title": "[Elastic Agent] UDP Bytes Processed",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1750,7 +1750,7 @@
                 "panelIndex": "0f14c4cc-dd72-4319-b980-5c37f9b15119",
                 "title": "[Elastic Agent] UDP Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1758,7 +1758,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:06:20.875Z",
     "id": "elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2",
     "managed": false,
     "references": [
@@ -1770,16 +1770,6 @@
         {
             "id": "metrics-*",
             "name": "9e9962c8-3e2d-4bdc-8678-ba2ed7eb26c0:db5ae8c8-0b1c-40be-b95f-c8aabb9ac6c6",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "88585bec-de77-4583-bac2-65e09d5aef91:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "88585bec-de77-4583-bac2-65e09d5aef91:f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
             "type": "index-pattern"
         },
         {
@@ -1810,6 +1800,16 @@
         {
             "id": "metrics-*",
             "name": "449b860a-a846-4d6d-b071-648e343a032e:a9c52e14-b77d-4242-ba62-02cbecbcc9a9",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "88585bec-de77-4583-bac2-65e09d5aef91:indexpattern-datasource-layer-04ad5f81-ed36-48ba-8ba7-a9d797498250",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "88585bec-de77-4583-bac2-65e09d5aef91:f3ea00aa-7bce-4bb8-890d-c6e2ae357984",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n**[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)**  \n[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n\n[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n**[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)**  \n[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -100,6 +100,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -217,7 +218,7 @@
                 "panelIndex": "9e9962c8-3e2d-4bdc-8678-ba2ed7eb26c0",
                 "title": "[Elastic Agent] UDP Average Processing Time",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -255,6 +256,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -345,7 +347,7 @@
                 "panelIndex": "88585bec-de77-4583-bac2-65e09d5aef91",
                 "title": "[Elastic Agent] UDP Queue Length",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -473,7 +475,7 @@
                 "panelIndex": "4e24548f-9e62-4d63-8491-0f96cf42d14a",
                 "title": "[Elastic Agent] UDP Total Bytes Processed",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -511,6 +513,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -601,7 +604,7 @@
                 "panelIndex": "1f842daa-b447-48b7-9411-762f8aaf1b28",
                 "title": "[Elastic Agent] UDP Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -639,6 +642,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         },
@@ -729,7 +733,7 @@
                 "panelIndex": "449b860a-a846-4d6d-b071-648e343a032e",
                 "title": "[Elastic Agent] UDP Packet Drops",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -969,7 +973,7 @@
                 "panelIndex": "e77d9361-6abf-4ad5-ade7-d3722395f836",
                 "title": "[Elastic Agent] UDP Time Between Packets (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1209,7 +1213,7 @@
                 "panelIndex": "5685c224-f9ee-4a7d-8289-5bf089643543",
                 "title": "[Elastic Agent] UDP Processing Time (Milliseconds)",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1360,7 +1364,7 @@
                 "panelIndex": "12f719cb-dcf1-4ebf-bafb-5e6b4f939844",
                 "title": "[Elastic Agent] UDP Packets Dropped",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1553,7 +1557,7 @@
                 "panelIndex": "5e2190a0-f988-457b-9ab7-02c0d0ddbbdc",
                 "title": "[Elastic Agent] UDP Bytes Processed",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1746,19 +1750,17 @@
                 "panelIndex": "0f14c4cc-dd72-4319-b980-5c37f9b15119",
                 "title": "[Elastic Agent] UDP Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] UDP Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:51.537Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1866,5 +1868,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n**[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)**  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard gives an overview of the current overall state and health of all Agents and their related enabled Integrations.\n\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n**[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)**  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard gives an overview of the current overall state and health of all Agents and their related enabled Integrations.\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "7ec831d9-fe10-44ae-8859-ac8ed50ef16f",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -103,6 +103,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -225,7 +226,7 @@
                 },
                 "panelIndex": "106d153c-b2ce-497f-92a2-a6e37f3fee48",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -356,7 +357,7 @@
                 },
                 "panelIndex": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -514,7 +515,7 @@
                 },
                 "panelIndex": "e8be8d39-4557-4077-bf45-e8c481f90699",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -690,7 +691,7 @@
                 "panelIndex": "b197eb2e-ee86-490c-afe1-605ce8e2edc1",
                 "title": "[Elastic Agent] Most Active Agents",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -728,6 +729,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -854,7 +856,7 @@
                 "panelIndex": "d9875e32-dd5f-4084-81c5-262f7bd0ccba",
                 "title": "Current Active Agents",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1011,7 +1013,7 @@
                 "panelIndex": "9ea33099-240d-4f37-b154-216aaccb6f4a",
                 "title": "[Elastic Agent] Most Active Integrations",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1173,19 +1175,17 @@
                 "panelIndex": "6e1bf032-bd2e-45e3-804b-d630d460228a",
                 "title": "[Elastic Agent] Total Ingest Rates",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:53:36.738Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -1283,5 +1283,6 @@
             "type": "dashboard"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824.json
@@ -61,7 +61,7 @@
                 "panelIndex": "7ec831d9-fe10-44ae-8859-ac8ed50ef16f",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -226,7 +226,7 @@
                 },
                 "panelIndex": "106d153c-b2ce-497f-92a2-a6e37f3fee48",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -234,7 +234,12 @@
                         "references": [
                             {
                                 "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-87b97f29-3b44-4769-8c7c-469a4d9a906f",
+                                "name": "indexpattern-datasource-layer-468dc136-5f5c-4cd1-8569-cc8529881e52",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
                                 "type": "index-pattern"
                             }
                         ],
@@ -243,26 +248,29 @@
                             "datasourceStates": {
                                 "formBased": {
                                     "layers": {
-                                        "87b97f29-3b44-4769-8c7c-469a4d9a906f": {
+                                        "468dc136-5f5c-4cd1-8569-cc8529881e52": {
                                             "columnOrder": [
-                                                "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2"
+                                                "a829ad10-3d32-47f1-8652-6cc35ed80edf"
                                             ],
                                             "columns": {
-                                                "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2": {
+                                                "a829ad10-3d32-47f1-8652-6cc35ed80edf": {
                                                     "customLabel": true,
                                                     "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "event.kind:\"pipeline_error\" "
-                                                    },
                                                     "isBucketed": false,
-                                                    "label": "Ingest Errors",
-                                                    "operationType": "count",
+                                                    "label": "Agents Ingested Data",
+                                                    "operationType": "unique_count",
                                                     "params": {
-                                                        "emptyAsNull": false
+                                                        "emptyAsNull": false,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 2
+                                                            }
+                                                        }
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "___records___"
+                                                    "sourceField": "agent.id"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -274,26 +282,49 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
                             "visualization": {
-                                "layerId": "87b97f29-3b44-4769-8c7c-469a4d9a906f",
+                                "layerId": "468dc136-5f5c-4cd1-8569-cc8529881e52",
                                 "layerType": "data",
-                                "metricAccessor": "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2",
+                                "metricAccessor": "a829ad10-3d32-47f1-8652-6cc35ed80edf",
                                 "palette": {
                                     "name": "custom",
                                     "params": {
                                         "colorStops": [
                                             {
-                                                "color": "#54B399",
+                                                "color": "#cc5642",
                                                 "stop": null
                                             },
                                             {
-                                                "color": "#cc5642",
+                                                "color": "#54B399",
                                                 "stop": 1
                                             }
                                         ],
@@ -308,17 +339,19 @@
                                         "steps": 3,
                                         "stops": [
                                             {
-                                                "color": "#54B399",
+                                                "color": "#cc5642",
                                                 "stop": 1
                                             },
                                             {
-                                                "color": "#cc5642",
+                                                "color": "#54B399",
                                                 "stop": 2
                                             }
                                         ]
                                     },
                                     "type": "palette"
-                                }
+                                },
+                                "showBar": false,
+                                "subtitle": ""
                             }
                         },
                         "title": "",
@@ -336,9 +369,9 @@
                                             "useCurrentFilters": true
                                         },
                                         "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
-                                        "name": "View Integrations Dashboard"
+                                        "name": "View Agents Dashboard"
                                     },
-                                    "eventId": "34bc44f3-8bfe-424b-ada8-225ec0ca67a6",
+                                    "eventId": "ff1c170b-d997-40ef-9093-ca8265c8c031",
                                     "triggers": [
                                         "FILTER_TRIGGER"
                                     ]
@@ -350,14 +383,15 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50",
+                    "i": "d9875e32-dd5f-4084-81c5-262f7bd0ccba",
                     "w": 10,
-                    "x": 18,
+                    "x": 28,
                     "y": 0
                 },
-                "panelIndex": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50",
+                "panelIndex": "d9875e32-dd5f-4084-81c5-262f7bd0ccba",
+                "title": "Current Active Agents",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -515,7 +549,295 @@
                 },
                 "panelIndex": "e8be8d39-4557-4077-bf45-e8c481f90699",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-87b97f29-3b44-4769-8c7c-469a4d9a906f",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "87b97f29-3b44-4769-8c7c-469a4d9a906f": {
+                                            "columnOrder": [
+                                                "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2"
+                                            ],
+                                            "columns": {
+                                                "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "event.kind:\"pipeline_error\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ingest Errors",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "87b97f29-3b44-4769-8c7c-469a4d9a906f",
+                                "layerType": "data",
+                                "metricAccessor": "ff7ba9db-cf33-4cda-be08-7ca4d3c4bcd2",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#54B399",
+                                                "stop": null
+                                            },
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": 1
+                                            }
+                                        ],
+                                        "continuity": "all",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": null,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#54B399",
+                                                "stop": 1
+                                            },
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": 2
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                }
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": false,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": true
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "View Integrations Dashboard"
+                                    },
+                                    "eventId": "34bc44f3-8bfe-424b-ada8-225ec0ca67a6",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "hidePanelTitles": true
+                },
+                "gridData": {
+                    "h": 4,
+                    "i": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50",
+                    "w": 10,
+                    "x": 18,
+                    "y": 0
+                },
+                "panelIndex": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
+                                            "columnOrder": [
+                                                "e8cc2c73-3c70-4ca4-b651-cee619a24dee",
+                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
+                                            ],
+                                            "columns": {
+                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Count of records",
+                                                    "operationType": "count",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "___records___"
+                                                },
+                                                "e8cc2c73-3c70-4ca4-b651-cee619a24dee": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 15 values of data_stream.dataset",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 15
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "data_stream.dataset"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
+                                        "key": "data_stream.dataset",
+                                        "negate": true,
+                                        "params": {
+                                            "query": "elastic_agent*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "categoryDisplay": "default",
+                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+                                        "layerType": "data",
+                                        "legendDisplay": "show",
+                                        "legendSize": "large",
+                                        "metrics": [
+                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
+                                        ],
+                                        "nestedLegend": false,
+                                        "numberDisplay": "percent",
+                                        "primaryGroups": [
+                                            "e8cc2c73-3c70-4ca4-b651-cee619a24dee"
+                                        ],
+                                        "truncateLegend": false
+                                    }
+                                ],
+                                "shape": "donut"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsPie"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": false,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": false
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "View Integrations Dashboard"
+                                    },
+                                    "eventId": "7c5aeb9a-d5d0-4e3a-89c0-98bb2f46e6cc",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 14,
+                    "i": "9ea33099-240d-4f37-b154-216aaccb6f4a",
+                    "w": 20,
+                    "x": 28,
+                    "y": 4
+                },
+                "panelIndex": "9ea33099-240d-4f37-b154-216aaccb6f4a",
+                "title": "[Elastic Agent] Most Active Integrations",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -691,329 +1013,7 @@
                 "panelIndex": "b197eb2e-ee86-490c-afe1-605ce8e2edc1",
                 "title": "[Elastic Agent] Most Active Agents",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-468dc136-5f5c-4cd1-8569-cc8529881e52",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "468dc136-5f5c-4cd1-8569-cc8529881e52": {
-                                            "columnOrder": [
-                                                "a829ad10-3d32-47f1-8652-6cc35ed80edf"
-                                            ],
-                                            "columns": {
-                                                "a829ad10-3d32-47f1-8652-6cc35ed80edf": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Agents Ingested Data",
-                                                    "operationType": "unique_count",
-                                                    "params": {
-                                                        "emptyAsNull": false,
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "agent.id"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "data_stream.dataset",
-                                        "index": "aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
-                                        "key": "data_stream.dataset",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "elastic_agent*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layerId": "468dc136-5f5c-4cd1-8569-cc8529881e52",
-                                "layerType": "data",
-                                "metricAccessor": "a829ad10-3d32-47f1-8652-6cc35ed80edf",
-                                "palette": {
-                                    "name": "custom",
-                                    "params": {
-                                        "colorStops": [
-                                            {
-                                                "color": "#cc5642",
-                                                "stop": null
-                                            },
-                                            {
-                                                "color": "#54B399",
-                                                "stop": 1
-                                            }
-                                        ],
-                                        "continuity": "all",
-                                        "maxSteps": 5,
-                                        "name": "custom",
-                                        "progression": "fixed",
-                                        "rangeMax": null,
-                                        "rangeMin": null,
-                                        "rangeType": "number",
-                                        "reverse": false,
-                                        "steps": 3,
-                                        "stops": [
-                                            {
-                                                "color": "#cc5642",
-                                                "stop": 1
-                                            },
-                                            {
-                                                "color": "#54B399",
-                                                "stop": 2
-                                            }
-                                        ]
-                                    },
-                                    "type": "palette"
-                                },
-                                "showBar": false,
-                                "subtitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": [
-                                {
-                                    "action": {
-                                        "config": {
-                                            "openInNewTab": false,
-                                            "useCurrentDateRange": true,
-                                            "useCurrentFilters": true
-                                        },
-                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
-                                        "name": "View Agents Dashboard"
-                                    },
-                                    "eventId": "ff1c170b-d997-40ef-9093-ca8265c8c031",
-                                    "triggers": [
-                                        "FILTER_TRIGGER"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    "hidePanelTitles": true
-                },
-                "gridData": {
-                    "h": 4,
-                    "i": "d9875e32-dd5f-4084-81c5-262f7bd0ccba",
-                    "w": 10,
-                    "x": 28,
-                    "y": 0
-                },
-                "panelIndex": "d9875e32-dd5f-4084-81c5-262f7bd0ccba",
-                "title": "Current Active Agents",
-                "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
-                                            "columnOrder": [
-                                                "e8cc2c73-3c70-4ca4-b651-cee619a24dee",
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                            ],
-                                            "columns": {
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "e8cc2c73-3c70-4ca4-b651-cee619a24dee": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 15 values of data_stream.dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 15
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "0769541a-e3f2-49c1-beb8-aaf9ecf101e2",
-                                        "key": "data_stream.dataset",
-                                        "negate": true,
-                                        "params": {
-                                            "query": "elastic_agent*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "layers": [
-                                    {
-                                        "categoryDisplay": "default",
-                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                        "layerType": "data",
-                                        "legendDisplay": "show",
-                                        "legendSize": "large",
-                                        "metrics": [
-                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "e8cc2c73-3c70-4ca4-b651-cee619a24dee"
-                                        ],
-                                        "truncateLegend": false
-                                    }
-                                ],
-                                "shape": "donut"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsPie"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": [
-                                {
-                                    "action": {
-                                        "config": {
-                                            "openInNewTab": false,
-                                            "useCurrentDateRange": true,
-                                            "useCurrentFilters": false
-                                        },
-                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
-                                        "name": "View Integrations Dashboard"
-                                    },
-                                    "eventId": "7c5aeb9a-d5d0-4e3a-89c0-98bb2f46e6cc",
-                                    "triggers": [
-                                        "FILTER_TRIGGER"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 14,
-                    "i": "9ea33099-240d-4f37-b154-216aaccb6f4a",
-                    "w": 20,
-                    "x": 28,
-                    "y": 4
-                },
-                "panelIndex": "9ea33099-240d-4f37-b154-216aaccb6f4a",
-                "title": "[Elastic Agent] Most Active Integrations",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1175,7 +1175,7 @@
                 "panelIndex": "6e1bf032-bd2e-45e3-804b-d630d460228a",
                 "title": "[Elastic Agent] Total Ingest Rates",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1183,7 +1183,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:13.328Z",
     "id": "elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824",
     "managed": false,
     "references": [
@@ -1204,12 +1204,17 @@
         },
         {
             "id": "logs-*",
-            "name": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50:indexpattern-datasource-layer-87b97f29-3b44-4769-8c7c-469a4d9a906f",
+            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:indexpattern-datasource-layer-468dc136-5f5c-4cd1-8569-cc8529881e52",
             "type": "index-pattern"
         },
         {
-            "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
-            "name": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:34bc44f3-8bfe-424b-ada8-225ec0ca67a6:dashboardId",
+            "id": "logs-*",
+            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
+            "type": "index-pattern"
+        },
+        {
+            "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
+            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:ff1c170b-d997-40ef-9093-ca8265c8c031:dashboardId",
             "type": "dashboard"
         },
         {
@@ -1229,32 +1234,12 @@
         },
         {
             "id": "logs-*",
-            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:indexpattern-datasource-layer-6c39da5e-0bfa-4ac0-b52c-75491ad21e8a",
+            "name": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50:indexpattern-datasource-layer-87b97f29-3b44-4769-8c7c-469a4d9a906f",
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
-            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:fbb56fc8-f301-483f-8d45-f6b2203ed246",
-            "type": "index-pattern"
-        },
-        {
-            "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
-            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:8b6dea27-19d8-4cbd-bc1a-cc1f5dd63544:dashboardId",
-            "type": "dashboard"
-        },
-        {
-            "id": "logs-*",
-            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:indexpattern-datasource-layer-468dc136-5f5c-4cd1-8569-cc8529881e52",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:aeb42231-d9f7-4e06-81cf-2d05bc0012ba",
-            "type": "index-pattern"
-        },
-        {
-            "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
-            "name": "d9875e32-dd5f-4084-81c5-262f7bd0ccba:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:ff1c170b-d997-40ef-9093-ca8265c8c031:dashboardId",
+            "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
+            "name": "f7fb14c3-542a-4dcb-a141-ea6f57f7ec50:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:34bc44f3-8bfe-424b-ada8-225ec0ca67a6:dashboardId",
             "type": "dashboard"
         },
         {
@@ -1270,6 +1255,21 @@
         {
             "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
             "name": "9ea33099-240d-4f37-b154-216aaccb6f4a:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:7c5aeb9a-d5d0-4e3a-89c0-98bb2f46e6cc:dashboardId",
+            "type": "dashboard"
+        },
+        {
+            "id": "logs-*",
+            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:indexpattern-datasource-layer-6c39da5e-0bfa-4ac0-b52c-75491ad21e8a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:fbb56fc8-f301-483f-8d45-f6b2203ed246",
+            "type": "index-pattern"
+        },
+        {
+            "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
+            "name": "b197eb2e-ee86-490c-afe1-605ce8e2edc1:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:8b6dea27-19d8-4cbd-bc1a-cc1f5dd63544:dashboardId",
             "type": "dashboard"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n**[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)**  \n[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Inputs**  \n\n**[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)**  \n[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest and its related Input ID to visualize the metrics correctly.**\n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -168,7 +168,7 @@
                 "panelIndex": "68a0a488-de6c-4441-8c53-1c813b574a13",
                 "title": "[Elastic Agent] Cloudwatch API Calls Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -275,7 +275,7 @@
                 "panelIndex": "c214633e-f265-4c67-a86b-4aedbc0486ac",
                 "title": "[Elastic Agent] Cloudwatch Events Received Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -382,7 +382,7 @@
                 "panelIndex": "2cf9cb64-2c05-4f79-9cb6-7eb0a722a5ab",
                 "title": "[Elastic Agent] Cloudwatch Unique Log Groups Total",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -489,7 +489,7 @@
                 "panelIndex": "d1361d8d-08da-45c1-8970-4d0a0b9b6194",
                 "title": "[Elastic Agent] Elasticsearch Events Created",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -676,7 +676,7 @@
                 "panelIndex": "81986d43-8041-41fd-a072-db5e554bfc63",
                 "title": "[Elastic Agent] API Calls",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -932,19 +932,17 @@
                 "panelIndex": "970d63f3-b3b2-40bc-a052-cc76796fbb3b",
                 "title": "[Elastic Agent] Event Collection/Creation",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] CloudWatch Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:19.367Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1017,5 +1015,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -168,221 +168,7 @@
                 "panelIndex": "68a0a488-de6c-4441-8c53-1c813b574a13",
                 "title": "[Elastic Agent] Cloudwatch API Calls Total",
                 "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "574a8110-4263-44e4-b2e3-c03a70558d29": {
-                                            "columnOrder": [
-                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a"
-                                            ],
-                                            "columns": {
-                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.log_events_received_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Cloudwatch Events Collected",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.log_events_received_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-cloudwatch"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-cloudwatch"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "574a8110-4263-44e4-b2e3-c03a70558d29",
-                                "layerType": "data",
-                                "metricAccessor": "9ea5ed62-73bf-484e-93ea-ec1c4c37656a",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "c214633e-f265-4c67-a86b-4aedbc0486ac",
-                    "w": 10,
-                    "x": 17,
-                    "y": 0
-                },
-                "panelIndex": "c214633e-f265-4c67-a86b-4aedbc0486ac",
-                "title": "[Elastic Agent] Cloudwatch Events Received Total",
-                "type": "lens",
-                "version": "8.9.0"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "39cacca6-cf7f-43d8-907e-e80e07064b1a",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "574a8110-4263-44e4-b2e3-c03a70558d29": {
-                                            "columnOrder": [
-                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a"
-                                            ],
-                                            "columns": {
-                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "filebeat_input.log_groups_total: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Unique Log Groups",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "filebeat_input.log_groups_total"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "filebeat_input.input",
-                                        "index": "39cacca6-cf7f-43d8-907e-e80e07064b1a",
-                                        "key": "filebeat_input.input",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "aws-cloudwatch"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "filebeat_input.input": "aws-cloudwatch"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "color": "#6092C0",
-                                "layerId": "574a8110-4263-44e4-b2e3-c03a70558d29",
-                                "layerType": "data",
-                                "metricAccessor": "9ea5ed62-73bf-484e-93ea-ec1c4c37656a",
-                                "subtitle": "Since last restart"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsMetric"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 5,
-                    "i": "2cf9cb64-2c05-4f79-9cb6-7eb0a722a5ab",
-                    "w": 10,
-                    "x": 37,
-                    "y": 0
-                },
-                "panelIndex": "2cf9cb64-2c05-4f79-9cb6-7eb0a722a5ab",
-                "title": "[Elastic Agent] Cloudwatch Unique Log Groups Total",
-                "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -489,7 +275,221 @@
                 "panelIndex": "d1361d8d-08da-45c1-8970-4d0a0b9b6194",
                 "title": "[Elastic Agent] Elasticsearch Events Created",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "39cacca6-cf7f-43d8-907e-e80e07064b1a",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "574a8110-4263-44e4-b2e3-c03a70558d29": {
+                                            "columnOrder": [
+                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a"
+                                            ],
+                                            "columns": {
+                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.log_groups_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Unique Log Groups",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.log_groups_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "39cacca6-cf7f-43d8-907e-e80e07064b1a",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-cloudwatch"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-cloudwatch"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "574a8110-4263-44e4-b2e3-c03a70558d29",
+                                "layerType": "data",
+                                "metricAccessor": "9ea5ed62-73bf-484e-93ea-ec1c4c37656a",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "2cf9cb64-2c05-4f79-9cb6-7eb0a722a5ab",
+                    "w": 10,
+                    "x": 37,
+                    "y": 0
+                },
+                "panelIndex": "2cf9cb64-2c05-4f79-9cb6-7eb0a722a5ab",
+                "title": "[Elastic Agent] Cloudwatch Unique Log Groups Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "574a8110-4263-44e4-b2e3-c03a70558d29": {
+                                            "columnOrder": [
+                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a"
+                                            ],
+                                            "columns": {
+                                                "9ea5ed62-73bf-484e-93ea-ec1c4c37656a": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "filebeat_input.log_events_received_total: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Cloudwatch Events Collected",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "filebeat_input.log_events_received_total"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "filebeat_input.input",
+                                        "index": "d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
+                                        "key": "filebeat_input.input",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "aws-cloudwatch"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "filebeat_input.input": "aws-cloudwatch"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "color": "#6092C0",
+                                "layerId": "574a8110-4263-44e4-b2e3-c03a70558d29",
+                                "layerType": "data",
+                                "metricAccessor": "9ea5ed62-73bf-484e-93ea-ec1c4c37656a",
+                                "subtitle": "Since last restart"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 5,
+                    "i": "c214633e-f265-4c67-a86b-4aedbc0486ac",
+                    "w": 10,
+                    "x": 17,
+                    "y": 0
+                },
+                "panelIndex": "c214633e-f265-4c67-a86b-4aedbc0486ac",
+                "title": "[Elastic Agent] Cloudwatch Events Received Total",
+                "type": "lens",
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -676,7 +676,7 @@
                 "panelIndex": "81986d43-8041-41fd-a072-db5e554bfc63",
                 "title": "[Elastic Agent] API Calls",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -932,7 +932,7 @@
                 "panelIndex": "970d63f3-b3b2-40bc-a052-cc76796fbb3b",
                 "title": "[Elastic Agent] Event Collection/Creation",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -940,7 +940,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:59.320Z",
     "id": "elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2",
     "managed": false,
     "references": [
@@ -956,12 +956,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "c214633e-f265-4c67-a86b-4aedbc0486ac:indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
+            "name": "d1361d8d-08da-45c1-8970-4d0a0b9b6194:indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "c214633e-f265-4c67-a86b-4aedbc0486ac:d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
+            "name": "d1361d8d-08da-45c1-8970-4d0a0b9b6194:b43f5e4f-66a9-4b2c-8760-9088bf2d8345",
             "type": "index-pattern"
         },
         {
@@ -976,12 +976,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "d1361d8d-08da-45c1-8970-4d0a0b9b6194:indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
+            "name": "c214633e-f265-4c67-a86b-4aedbc0486ac:indexpattern-datasource-layer-574a8110-4263-44e4-b2e3-c03a70558d29",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d1361d8d-08da-45c1-8970-4d0a0b9b6194:b43f5e4f-66a9-4b2c-8760-9088bf2d8345",
+            "name": "c214633e-f265-4c67-a86b-4aedbc0486ac:d79e4f9f-1a57-4adc-81ce-9aa3845696c3",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n**[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)**  \n\n**Inputs**  \n[Cloudwatch](/app/dashboards#/view/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](/app/dashboards#/view/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](/app/dashboards#/view/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](/app/dashboards#/view/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](/app/dashboards#/view/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest to visualize the metrics correctly.  \nUse the Metric counters to Drilldown to the specific Input Dashboard.**  \n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n**[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)**  \n\n**Inputs**  \n\n[Cloudwatch](#/dashboard/elastic_agent-a7b5e7a0-cd44-11ed-869d-e7dc1b551cd2)  \n[S3](#/dashboard/elastic_agent-77cdb1c0-cd45-11ed-869d-e7dc1b551cd2)  \n[TCP](#/dashboard/elastic_agent-7d110ba0-cd45-11ed-869d-e7dc1b551cd2)  \n[UDP](#/dashboard/elastic_agent-87ad4330-cd45-11ed-869d-e7dc1b551cd2)  \n[Winlog](#/dashboard/elastic_agent-1badd650-d136-11ed-b85f-4be0157fc90c)  \n\n\n**Overview**\n\nThis dashboards is used to monitor and troubleshoot ingest performance from integrations.  \n\n**For the best experience, filter on the specific Agent of interest to visualize the metrics correctly.  \nUse the Metric counters to Drilldown to the specific Input Dashboard.**  \n\n**This dashboard requires that \"Collect Agent Metrics\" are configured on the relevant Elastic Agent policy.**\n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -108,6 +108,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -254,7 +255,7 @@
                 "panelIndex": "c5993f79-dd0c-475a-b617-c01432f84604",
                 "title": "[Elastic Agent] Cloudwatch Input",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -301,6 +302,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -447,7 +449,7 @@
                 "panelIndex": "2020a64a-9f1d-4df6-8829-19d8701bbcf6",
                 "title": "[Elastic Agent] UDP Input",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -494,6 +496,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -640,7 +643,7 @@
                 "panelIndex": "5bf28bcd-233c-4710-b050-8baeba725cf9",
                 "title": "[Elastic Agent] S3 Input",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -687,6 +690,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -833,7 +837,7 @@
                 "panelIndex": "2f7cafa8-0bc5-4204-b5c7-a7dfd3ec17cf",
                 "title": "[Elastic Agent TCP Input",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -880,6 +884,7 @@
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
+                                                                "compact": true,
                                                                 "decimals": 2
                                                             }
                                                         }
@@ -1026,19 +1031,17 @@
                 "panelIndex": "e1cc73d5-e2f3-4b85-a23d-2a9c395a1b79",
                 "title": "[Elastic Agent] Winlog Input",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Input Metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:55:10.279Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1146,5 +1149,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2.json
@@ -61,7 +61,7 @@
                 "panelIndex": "f89ab83c-c65a-442f-9161-8459e71518cd",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -255,7 +255,7 @@
                 "panelIndex": "c5993f79-dd0c-475a-b617-c01432f84604",
                 "title": "[Elastic Agent] Cloudwatch Input",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -449,7 +449,7 @@
                 "panelIndex": "2020a64a-9f1d-4df6-8829-19d8701bbcf6",
                 "title": "[Elastic Agent] UDP Input",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -643,7 +643,7 @@
                 "panelIndex": "5bf28bcd-233c-4710-b050-8baeba725cf9",
                 "title": "[Elastic Agent] S3 Input",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -837,7 +837,7 @@
                 "panelIndex": "2f7cafa8-0bc5-4204-b5c7-a7dfd3ec17cf",
                 "title": "[Elastic Agent TCP Input",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1031,7 +1031,7 @@
                 "panelIndex": "e1cc73d5-e2f3-4b85-a23d-2a9c395a1b79",
                 "title": "[Elastic Agent] Winlog Input",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1039,7 +1039,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:49.385Z",
     "id": "elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2",
     "managed": false,
     "references": [

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -144,7 +144,7 @@
                 "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
                 "title": "[Elastic Agent] CPU Usage",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -165,7 +165,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](/app/dashboards#/view/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n**[Agent Metrics](/app/dashboards#/view/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)**  \n[Integrations](/app/dashboards#/view/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](/app/dashboards#/view/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard is used to show detailed metrics related to the specific agent used in the filter.\n\n",
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n**[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)**  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard is used to show detailed metrics related to the specific agent used in the filter.\n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -183,7 +183,7 @@
                 "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -345,7 +345,7 @@
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -479,7 +479,7 @@
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -677,7 +677,7 @@
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -867,7 +867,7 @@
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1057,7 +1057,7 @@
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1248,7 +1248,7 @@
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1445,7 +1445,7 @@
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.9.0"
             },
             {
                 "embeddableConfig": {
@@ -1600,19 +1600,17 @@
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
                 "type": "visualization",
-                "version": "8.7.1"
+                "version": "8.9.0"
             }
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Agent metrics",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:54:53.566Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -1695,5 +1693,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -144,7 +144,7 @@
                 "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
                 "title": "[Elastic Agent] CPU Usage",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -183,7 +183,7 @@
                 "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -345,7 +345,7 @@
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -479,7 +479,7 @@
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -677,7 +677,7 @@
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -867,7 +867,7 @@
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1057,7 +1057,7 @@
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1248,7 +1248,7 @@
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1445,7 +1445,7 @@
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -1600,7 +1600,7 @@
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
@@ -1608,7 +1608,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:05:31.257Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [

--- a/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
@@ -35,9 +35,9 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:04:04.312Z",
     "id": "elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logs-*",

--- a/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287.json
@@ -34,12 +34,10 @@
         "title": "[Elastic Agent] Integration Errors",
         "usesAdHocDataView": false
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:30:29.478Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-462b68c0-b10b-11ed-957f-f1c897630287",
-    "migrationVersion": {
-        "search": "8.0.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -47,5 +45,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "search"
+    "type": "search",
+    "typeMigrationVersion": "8.0.0"
 }

--- a/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
@@ -77,12 +77,10 @@
         "title": "[Elastic Agent] Agent Errors",
         "usesAdHocDataView": false
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:30:29.478Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-08-21T12:54:34.747Z",
     "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
-    "migrationVersion": {
-        "search": "8.0.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
@@ -100,5 +98,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "search"
+    "type": "search",
+    "typeMigrationVersion": "8.0.0"
 }

--- a/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
+++ b/packages/elastic_agent/kibana/search/elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287.json
@@ -78,9 +78,9 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-08-21T12:54:34.747Z",
+    "created_at": "2023-08-21T13:04:04.312Z",
     "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logs-*",

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,13 +1,13 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.11.1
+version: 1.12.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^8.9.0"
+  kibana.version: "^8.10.0"
 owner:
   github: elastic/elastic-agent
 icons:


### PR DESCRIPTION
## What does this PR do?

Due to incompatibility between 8.9 and 8.10 dashboard resources that had some export/import issues, this PR is a followup from https://github.com/elastic/integrations/pull/7471 which adds the resources that was ignored due to the incompatilibities for 8.9 dashboards.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #6691 

