### PR TITLE
[AWS] Remove duplicated number_of_workers settings from the custom logs integration (part 2)

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.5.1"
+  changes:
+    - description: Remove duplicated number_of_workers settings
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7481
 - version: "0.5.0"
   changes:
     - description: Add permissions to reroute events to logs-*-* for generic datastream

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: 0.5.0
+version: 0.5.1
 release: beta
 license: basic
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

Update the changelog to release a new version of the Custom AWS Logs integration.

In the previous PR, missed updating the changelog before merging the PR 🤦  ; the whole purpose of this PR is to release #7319.

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->


<!-- Recommended
## How to test this PR locally
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->

<!-- Optional
## Screenshots

Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
