### PR TITLE
[AWS] Add dimensions to EC2 data stream.

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.53.4"
+  changes:
+    - description: Add dimension fields to EC2 data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7425
 - version: "1.53.3"
   changes:
     - description: Add missing fields definition for ec2

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add dimension fields to EC2 data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7425
+      link: https://github.com/elastic/integrations/pull/7487
 - version: "1.53.3"
   changes:
     - description: Add missing fields definition for ec2

--- a/packages/aws/data_stream/ec2_metrics/fields/ecs.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/ecs.yml
@@ -2,6 +2,7 @@
   name: cloud
 - external: ecs
   name: cloud.account.id
+  dimension: true
 - external: ecs
   name: cloud.account.name
 - external: ecs
@@ -14,6 +15,7 @@
   name: cloud.provider
 - external: ecs
   name: cloud.region
+  dimension: true
 - external: ecs
   name: ecs.version
 - external: ecs
@@ -36,3 +38,6 @@
   name: host.network.ingress.bytes
 - external: ecs
   name: host.network.ingress.packets
+- name: agent.id
+  external: ecs
+  dimension: true

--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -6,15 +6,19 @@
       fields:
         - name: AutoScalingGroupName
           type: keyword
+          dimension: true
           description: An Auto Scaling group is a collection of instances you define if you're using Auto Scaling.
         - name: ImageId
           type: keyword
+          dimension: true
           description: This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI)
         - name: InstanceId
           type: keyword
+          dimension: true
           description: Amazon EC2 instance ID
         - name: InstanceType
           type: keyword
+          dimension: true
           description: This dimension filters the data you request for all instances running with this specified instance type.
     - name: ec2
       type: group

--- a/packages/aws/docs/ec2.md
+++ b/packages/aws/docs/ec2.md
@@ -326,6 +326,7 @@ An example event for `ec2` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
 | aws.dimensions.AutoScalingGroupName | An Auto Scaling group is a collection of instances you define if you're using Auto Scaling. | keyword |
 | aws.dimensions.ImageId | This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI) | keyword |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.53.3
+version: 1.53.4
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Set the dimension fields for EC2 data stream.

All `dimension.*` fields in `fields.yml` are dimensions.

For the ecs fields, the reasoning for the fields can be found in [this comment](https://github.com/elastic/integrations/issues/5193#issuecomment-1536090359).

Result of successful [testing](https://github.com/elastic/TSDB-migration-test-kit):
```
All 130 documents taken from index .ds-metrics-aws.ec2_metrics-default-2023.08.22-000001 were successfully placed to index tsdb-index-enabled.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.
