### PR TITLE
[AWS][EC2] Add metric type to EC2

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.53.5"
+  changes:
+    - description: Set metric type in EC2 data stream fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7487
 - version: "1.53.4"
   changes:
     - description: Add dimension fields to EC2 data stream.

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set metric type in EC2 data stream fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7487
+      link: https://github.com/elastic/integrations/pull/7490
 - version: "1.53.4"
   changes:
     - description: Add dimension fields to EC2 data stream.

--- a/packages/aws/data_stream/ec2_metrics/fields/fields.yml
+++ b/packages/aws/data_stream/ec2_metrics/fields/fields.yml
@@ -28,98 +28,122 @@
           fields:
             - name: CPUCreditUsage.avg
               type: long
+              metric_type: gauge
               description: |
                 The number of CPU credits spent by the instance for CPU utilization.
             - name: CPUCreditBalance.avg
               type: long
+              metric_type: gauge
               description: |
                 The number of earned CPU credits that an instance has accrued since it was launched or started.
             - name: CPUSurplusCreditBalance.avg
               type: long
+              metric_type: gauge
               description: |
                 The number of surplus credits that have been spent by an unlimited instance when its CPUCreditBalance value is zero.
             - name: CPUSurplusCreditsCharged.avg
               type: long
+              metric_type: gauge
               description: |
                 The number of spent surplus credits that are not paid down by earned CPU credits, and which thus incur an additional charge.
             - name: CPUUtilization.avg
               type: long
+              metric_type: gauge
               description: |
                 The average percentage of physical CPU time that Amazon EC2 uses to run the EC2 instance.
             - name: NetworkPacketsIn.rate
               type: long
+              metric_type: gauge
               description: |
                 The number of packets per second sent out on all network interfaces by the instance.
             - name: NetworkPacketsIn.sum
               type: long
+              metric_type: gauge
               description: |
                 The number of packets total sent out on all network interfaces by the instance.
             - name: NetworkPacketsOut.rate
               type: long
+              metric_type: gauge
               description: |
                 The number of packets per second sent out on all network interfaces by the instance.
             - name: NetworkPacketsOut.sum
               type: long
+              metric_type: gauge
               description: |
                 The number of packets total sent out on all network interfaces by the instance.
             - name: NetworkIn.rate
               type: long
+              metric_type: gauge
               description: |
                 The number of bytes per second received on all network interfaces by the instance.
             - name: NetworkIn.sum
               type: long
+              metric_type: gauge
               description: |
                 The number of bytes total received on all network interfaces by the instance.
             - name: NetworkOut.rate
               type: long
+              metric_type: gauge
               description: |
                 The number of bytes per second sent out on all network interfaces by the instance.
             - name: NetworkOut.sum
               type: long
+              metric_type: gauge
               description: |
                 The number of bytes total sent out on all network interfaces by the instance.
             - name: DiskReadBytes.rate
               type: long
+              metric_type: gauge
               description: |
                 Bytes read per second from all instance store volumes available to the instance.
             - name: DiskReadBytes.sum
               type: long
+              metric_type: gauge
               description: |
                 Total bytes read from all instance store volumes available to the instance.
             - name: DiskWriteBytes.rate
               type: long
+              metric_type: gauge
               description: |
                 Bytes written per second to all instance store volumes available to the instance.
             - name: DiskWriteBytes.sum
               type: long
+              metric_type: gauge
               description: |
                 Total bytes written to all instance store volumes available to the instance.
             - name: DiskReadOps.rate
               type: long
+              metric_type: gauge
               description: |
                 Completed read operations per second from all instance store volumes available to the instance in a specified period of time.
             - name: DiskReadOps.sum
               type: long
+              metric_type: gauge
               description: |
                 Total completed read operations from all instance store volumes available to the instance in a specified period of time.
             - name: DiskWriteOps.rate
               type: long
+              metric_type: gauge
               description: |
                 Completed write operations per second to all instance store volumes available to the instance in a specified period of time.
             - name: DiskWriteOps.sum
               type: long
+              metric_type: gauge
               description: |
                 Total completed write operations to all instance store volumes available to the instance in a specified period of time.
             - name: StatusCheckFailed.avg
               type: long
+              metric_type: gauge
               description: |
                 Reports whether the instance has passed both the instance status check and the system status check in the last minute.
             - name: StatusCheckFailed_System.avg
               type: long
+              metric_type: gauge
               description: |
                 Reports whether the instance has passed the system status check in the last minute.
             - name: StatusCheckFailed_Instance.avg
               type: long
+              metric_type: gauge
               description: |
                 Reports whether the instance has passed the instance status check in the last minute.
         - name: instance.core.count

--- a/packages/aws/docs/ec2.md
+++ b/packages/aws/docs/ec2.md
@@ -323,76 +323,76 @@ An example event for `ec2` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |
-| aws.dimensions.AutoScalingGroupName | An Auto Scaling group is a collection of instances you define if you're using Auto Scaling. | keyword |
-| aws.dimensions.ImageId | This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI) | keyword |
-| aws.dimensions.InstanceId | Amazon EC2 instance ID | keyword |
-| aws.dimensions.InstanceType | This dimension filters the data you request for all instances running with this specified instance type. | keyword |
-| aws.ec2.instance.core.count | The number of CPU cores for the instance. | integer |
-| aws.ec2.instance.image.id | The ID of the image used to launch the instance. | keyword |
-| aws.ec2.instance.monitoring.state | Indicates whether detailed monitoring is enabled. | keyword |
-| aws.ec2.instance.private.dns_name | The private DNS name of the network interface. | keyword |
-| aws.ec2.instance.private.ip | The private IPv4 address associated with the network interface. | ip |
-| aws.ec2.instance.public.dns_name | The public DNS name of the instance. | keyword |
-| aws.ec2.instance.public.ip | The address of the Elastic IP address (IPv4) bound to the network interface. | ip |
-| aws.ec2.instance.state.code | The state of the instance, as a 16-bit unsigned integer. | integer |
-| aws.ec2.instance.state.name | The state of the instance (pending | running | shutting-down | terminated | stopping | stopped). | keyword |
-| aws.ec2.instance.threads_per_core | The number of threads per CPU core. | integer |
-| aws.ec2.metrics.CPUCreditBalance.avg | The number of earned CPU credits that an instance has accrued since it was launched or started. | long |
-| aws.ec2.metrics.CPUCreditUsage.avg | The number of CPU credits spent by the instance for CPU utilization. | long |
-| aws.ec2.metrics.CPUSurplusCreditBalance.avg | The number of surplus credits that have been spent by an unlimited instance when its CPUCreditBalance value is zero. | long |
-| aws.ec2.metrics.CPUSurplusCreditsCharged.avg | The number of spent surplus credits that are not paid down by earned CPU credits, and which thus incur an additional charge. | long |
-| aws.ec2.metrics.CPUUtilization.avg | The average percentage of physical CPU time that Amazon EC2 uses to run the EC2 instance. | long |
-| aws.ec2.metrics.DiskReadBytes.rate | Bytes read per second from all instance store volumes available to the instance. | long |
-| aws.ec2.metrics.DiskReadBytes.sum | Total bytes read from all instance store volumes available to the instance. | long |
-| aws.ec2.metrics.DiskReadOps.rate | Completed read operations per second from all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.metrics.DiskReadOps.sum | Total completed read operations from all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.metrics.DiskWriteBytes.rate | Bytes written per second to all instance store volumes available to the instance. | long |
-| aws.ec2.metrics.DiskWriteBytes.sum | Total bytes written to all instance store volumes available to the instance. | long |
-| aws.ec2.metrics.DiskWriteOps.rate | Completed write operations per second to all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.metrics.DiskWriteOps.sum | Total completed write operations to all instance store volumes available to the instance in a specified period of time. | long |
-| aws.ec2.metrics.NetworkIn.rate | The number of bytes per second received on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkIn.sum | The number of bytes total received on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkOut.rate | The number of bytes per second sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkOut.sum | The number of bytes total sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkPacketsIn.rate | The number of packets per second sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkPacketsIn.sum | The number of packets total sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkPacketsOut.rate | The number of packets per second sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.NetworkPacketsOut.sum | The number of packets total sent out on all network interfaces by the instance. | long |
-| aws.ec2.metrics.StatusCheckFailed.avg | Reports whether the instance has passed both the instance status check and the system status check in the last minute. | long |
-| aws.ec2.metrics.StatusCheckFailed_Instance.avg | Reports whether the instance has passed the instance status check in the last minute. | long |
-| aws.ec2.metrics.StatusCheckFailed_System.avg | Reports whether the instance has passed the system status check in the last minute. | long |
-| aws.s3.bucket.name | Name of a S3 bucket. | keyword |
-| aws.tags.\* | Tag key value pairs from aws resources. | object |
-| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |
-| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |
-| error.message | Error message. | match_only_text |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.cpu.usage | Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1. Scaling factor: 1000. For example: For a two core host, this value should be the average of the two cores, between 0 and 1. | scaled_float |
-| host.disk.read.bytes | The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection. | long |
-| host.disk.write.bytes | The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection. | long |
-| host.network.egress.bytes | The number of bytes (gauge) sent out on all network interfaces by the host since the last metric collection. | long |
-| host.network.egress.packets | The number of packets (gauge) sent out on all network interfaces by the host since the last metric collection. | long |
-| host.network.ingress.bytes | The number of bytes received (gauge) on all network interfaces by the host since the last metric collection. | long |
-| host.network.ingress.packets | The number of packets (gauge) received on all network interfaces by the host since the last metric collection. | long |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
+| aws.dimensions.AutoScalingGroupName | An Auto Scaling group is a collection of instances you define if you're using Auto Scaling. | keyword |  |
+| aws.dimensions.ImageId | This dimension filters the data you request for all instances running this Amazon EC2 Amazon Machine Image (AMI) | keyword |  |
+| aws.dimensions.InstanceId | Amazon EC2 instance ID | keyword |  |
+| aws.dimensions.InstanceType | This dimension filters the data you request for all instances running with this specified instance type. | keyword |  |
+| aws.ec2.instance.core.count | The number of CPU cores for the instance. | integer |  |
+| aws.ec2.instance.image.id | The ID of the image used to launch the instance. | keyword |  |
+| aws.ec2.instance.monitoring.state | Indicates whether detailed monitoring is enabled. | keyword |  |
+| aws.ec2.instance.private.dns_name | The private DNS name of the network interface. | keyword |  |
+| aws.ec2.instance.private.ip | The private IPv4 address associated with the network interface. | ip |  |
+| aws.ec2.instance.public.dns_name | The public DNS name of the instance. | keyword |  |
+| aws.ec2.instance.public.ip | The address of the Elastic IP address (IPv4) bound to the network interface. | ip |  |
+| aws.ec2.instance.state.code | The state of the instance, as a 16-bit unsigned integer. | integer |  |
+| aws.ec2.instance.state.name | The state of the instance (pending | running | shutting-down | terminated | stopping | stopped). | keyword |  |
+| aws.ec2.instance.threads_per_core | The number of threads per CPU core. | integer |  |
+| aws.ec2.metrics.CPUCreditBalance.avg | The number of earned CPU credits that an instance has accrued since it was launched or started. | long | gauge |
+| aws.ec2.metrics.CPUCreditUsage.avg | The number of CPU credits spent by the instance for CPU utilization. | long | gauge |
+| aws.ec2.metrics.CPUSurplusCreditBalance.avg | The number of surplus credits that have been spent by an unlimited instance when its CPUCreditBalance value is zero. | long | gauge |
+| aws.ec2.metrics.CPUSurplusCreditsCharged.avg | The number of spent surplus credits that are not paid down by earned CPU credits, and which thus incur an additional charge. | long | gauge |
+| aws.ec2.metrics.CPUUtilization.avg | The average percentage of physical CPU time that Amazon EC2 uses to run the EC2 instance. | long | gauge |
+| aws.ec2.metrics.DiskReadBytes.rate | Bytes read per second from all instance store volumes available to the instance. | long | gauge |
+| aws.ec2.metrics.DiskReadBytes.sum | Total bytes read from all instance store volumes available to the instance. | long | gauge |
+| aws.ec2.metrics.DiskReadOps.rate | Completed read operations per second from all instance store volumes available to the instance in a specified period of time. | long | gauge |
+| aws.ec2.metrics.DiskReadOps.sum | Total completed read operations from all instance store volumes available to the instance in a specified period of time. | long | gauge |
+| aws.ec2.metrics.DiskWriteBytes.rate | Bytes written per second to all instance store volumes available to the instance. | long | gauge |
+| aws.ec2.metrics.DiskWriteBytes.sum | Total bytes written to all instance store volumes available to the instance. | long | gauge |
+| aws.ec2.metrics.DiskWriteOps.rate | Completed write operations per second to all instance store volumes available to the instance in a specified period of time. | long | gauge |
+| aws.ec2.metrics.DiskWriteOps.sum | Total completed write operations to all instance store volumes available to the instance in a specified period of time. | long | gauge |
+| aws.ec2.metrics.NetworkIn.rate | The number of bytes per second received on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkIn.sum | The number of bytes total received on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkOut.rate | The number of bytes per second sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkOut.sum | The number of bytes total sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkPacketsIn.rate | The number of packets per second sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkPacketsIn.sum | The number of packets total sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkPacketsOut.rate | The number of packets per second sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.NetworkPacketsOut.sum | The number of packets total sent out on all network interfaces by the instance. | long | gauge |
+| aws.ec2.metrics.StatusCheckFailed.avg | Reports whether the instance has passed both the instance status check and the system status check in the last minute. | long | gauge |
+| aws.ec2.metrics.StatusCheckFailed_Instance.avg | Reports whether the instance has passed the instance status check in the last minute. | long | gauge |
+| aws.ec2.metrics.StatusCheckFailed_System.avg | Reports whether the instance has passed the system status check in the last minute. | long | gauge |
+| aws.s3.bucket.name | Name of a S3 bucket. | keyword |  |
+| aws.tags.\* | Tag key value pairs from aws resources. | object |  |
+| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |  |
+| error.message | Error message. | match_only_text |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.cpu.usage | Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1. Scaling factor: 1000. For example: For a two core host, this value should be the average of the two cores, between 0 and 1. | scaled_float |  |
+| host.disk.read.bytes | The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection. | long |  |
+| host.disk.write.bytes | The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection. | long |  |
+| host.network.egress.bytes | The number of bytes (gauge) sent out on all network interfaces by the host since the last metric collection. | long |  |
+| host.network.egress.packets | The number of packets (gauge) sent out on all network interfaces by the host since the last metric collection. | long |  |
+| host.network.ingress.bytes | The number of bytes received (gauge) on all network interfaces by the host since the last metric collection. | long |  |
+| host.network.ingress.packets | The number of packets (gauge) received on all network interfaces by the host since the last metric collection. | long |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 1.53.4
+version: 1.53.5
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

Add metric type to EC2.

All metrics are `gauge` since they are all computed as aggregations. 

There are a few numeric fields (example `instance.state.code`) that I did not mark as a metric, since they seem to be all constant.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/6293.