### PR TITLE
[O11y][Citrix ADC] Resolve the conflicts in host.ip field

### DIFF
--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -52,10 +52,7 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 #### Type conflicts
 
-If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
-
-Note:
-- This [document](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) provides details about reindexing.
+If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by [reindexing](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
 
 ## Metrics reference
 

--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -51,8 +51,7 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 
 #### Type conflicts
-
-Conflicts in any field in any data stream can be solved by reindexing the data. 
+ 
 If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
 To reindex the data, the following steps must be performed.
 

--- a/packages/citrix_adc/_dev/build/docs/README.md
+++ b/packages/citrix_adc/_dev/build/docs/README.md
@@ -51,98 +51,11 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 
 #### Type conflicts
- 
+
 If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
-To reindex the data, the following steps must be performed.
 
-1. Stop the data stream by going to `Integrations -> Citrix ADC -> Integration policies` open the configuration of Citrix ADC and disable the `Collect Citrix ADC metrics` toggle to reindex logs data stream and save the integration.
-
-2. Copy data into the temporary index and delete the existing data stream and index template by performing the following steps in the Dev tools.
-
-```
-POST _reindex
-{
-  "source": {
-    "index": "<index_name>"
-  },
-  "dest": {
-    "index": "temp_index"
-  }
-}  
-```
-Example:
-```
-POST _reindex
-{
-  "source": {
-    "index": "logs-citrix_adc.interface-default"
-  },
-  "dest": {
-    "index": "temp_index"
-  }
-}
-```
-
-```
-DELETE /_data_stream/<data_stream>
-```
-Example:
-```
-DELETE /_data_stream/logs-citrix_adc.interface-default
-```
-
-```
-DELETE _index_template/<index_template>
-```
-Example:
-```
-DELETE _index_template/logs-citrix_adc.interface
-```
-3. Go to `Integrations -> Citrix ADC -> Settings` and click on `Reinstall Citrix ADC`.
-
-4. Copy data from temporary index to new index by performing the following steps in the Dev tools.
-
-```
-POST _reindex
-{
-  "conflicts": "proceed",
-  "source": {
-    "index": "temp_index"
-  },
-  "dest": {
-    "index": "<index_name>",
-    "op_type": "create"
-
-  }
-}
-```
-Example:
-```
-POST _reindex
-{
-  "conflicts": "proceed",
-  "source": {
-    "index": "temp_index"
-  },
-  "dest": {
-    "index": "logs-citrix_adc.interface-default",
-    "op_type": "create"
-
-  }
-}
-```
-
-5. Verify data is reindexed completely.
-
-6. Start the data stream by going to the `Integrations -> Citrix ADC -> Integration policies` and open configuration of integration and enable the `Collect Citrix ADC metrics` toggle and save the integration.
-
-7. Delete temporary index by performing the following step in the Dev tools.
-
-```
-DELETE temp_index
-```
-
-More details about reindexing can be found [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html).
+Note:
+- This [document](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) provides details about reindexing.
 
 ## Metrics reference
 

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Resolve host.ip field conflict.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7509
 - version: "0.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Resolve host.ip field conflict.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/citrix_adc/data_stream/interface/fields/ecs.yml
+++ b/packages/citrix_adc/data_stream/interface/fields/ecs.yml
@@ -15,6 +15,8 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.ip
+- external: ecs
   name: interface.id
 - external: ecs
   name: tags

--- a/packages/citrix_adc/data_stream/lbvserver/fields/ecs.yml
+++ b/packages/citrix_adc/data_stream/lbvserver/fields/ecs.yml
@@ -15,6 +15,8 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.ip
+- external: ecs
   name: related.ip
 - external: ecs
   name: server.ip

--- a/packages/citrix_adc/data_stream/service/fields/ecs.yml
+++ b/packages/citrix_adc/data_stream/service/fields/ecs.yml
@@ -15,6 +15,8 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.ip
+- external: ecs
   name: related.ip
 - external: ecs
   name: service.name

--- a/packages/citrix_adc/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/citrix_adc/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -124,10 +124,10 @@ processors:
             def bytes = (megabytes*1024*1024);
             return bytes;
         }
-        if(ctx.citrix_adc?.system?.memory?.size?.value!=null || ctx.citrix_adc?.system?.memory?.size?.value!=""){
+        if(ctx.citrix_adc?.system?.memory?.size?.value!=null && ctx.citrix_adc?.system?.memory?.size?.value!=""){
             ctx.citrix_adc.system.memory.size.value = convert(ctx.citrix_adc.system.memory.size.value);
         }
-        if(ctx.citrix_adc?.system?.memory?.usage?.value!=null || ctx.citrix_adc?.system?.memory?.usage?.value!=""){
+        if(ctx.citrix_adc?.system?.memory?.usage?.value!=null && ctx.citrix_adc?.system?.memory?.usage?.value!=""){
             ctx.citrix_adc.system.memory.usage.value = convert(ctx.citrix_adc.system.memory.usage.value);
         }
   - script:

--- a/packages/citrix_adc/data_stream/system/fields/ecs.yml
+++ b/packages/citrix_adc/data_stream/system/fields/ecs.yml
@@ -15,4 +15,6 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.ip
+- external: ecs
   name: tags

--- a/packages/citrix_adc/data_stream/vpn/fields/ecs.yml
+++ b/packages/citrix_adc/data_stream/vpn/fields/ecs.yml
@@ -15,4 +15,6 @@
 - external: ecs
   name: event.type
 - external: ecs
+  name: host.ip
+- external: ecs
   name: tags

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -52,10 +52,7 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 #### Type conflicts
 
-If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
-
-Note:
-- This [document](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) provides details about reindexing.
+If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by [reindexing](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
 
 ## Metrics reference
 

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -51,8 +51,7 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 
 #### Type conflicts
-
-Conflicts in any field in any data stream can be solved by reindexing the data. 
+ 
 If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
 To reindex the data, the following steps must be performed.
 

--- a/packages/citrix_adc/docs/README.md
+++ b/packages/citrix_adc/docs/README.md
@@ -51,98 +51,11 @@ There could be a possibility that for some of the fields, Citrix ADC sets dummy 
 
 
 #### Type conflicts
- 
+
 If host.ip is shown conflicted under ``logs-*`` data view, then this issue can be solved by reindexing the ``Interface``, ``LBVserver``, ``Service``, ``System``, and ``VPN`` data stream's indices.
-To reindex the data, the following steps must be performed.
 
-1. Stop the data stream by going to `Integrations -> Citrix ADC -> Integration policies` open the configuration of Citrix ADC and disable the `Collect Citrix ADC metrics` toggle to reindex logs data stream and save the integration.
-
-2. Copy data into the temporary index and delete the existing data stream and index template by performing the following steps in the Dev tools.
-
-```
-POST _reindex
-{
-  "source": {
-    "index": "<index_name>"
-  },
-  "dest": {
-    "index": "temp_index"
-  }
-}  
-```
-Example:
-```
-POST _reindex
-{
-  "source": {
-    "index": "logs-citrix_adc.interface-default"
-  },
-  "dest": {
-    "index": "temp_index"
-  }
-}
-```
-
-```
-DELETE /_data_stream/<data_stream>
-```
-Example:
-```
-DELETE /_data_stream/logs-citrix_adc.interface-default
-```
-
-```
-DELETE _index_template/<index_template>
-```
-Example:
-```
-DELETE _index_template/logs-citrix_adc.interface
-```
-3. Go to `Integrations -> Citrix ADC -> Settings` and click on `Reinstall Citrix ADC`.
-
-4. Copy data from temporary index to new index by performing the following steps in the Dev tools.
-
-```
-POST _reindex
-{
-  "conflicts": "proceed",
-  "source": {
-    "index": "temp_index"
-  },
-  "dest": {
-    "index": "<index_name>",
-    "op_type": "create"
-
-  }
-}
-```
-Example:
-```
-POST _reindex
-{
-  "conflicts": "proceed",
-  "source": {
-    "index": "temp_index"
-  },
-  "dest": {
-    "index": "logs-citrix_adc.interface-default",
-    "op_type": "create"
-
-  }
-}
-```
-
-5. Verify data is reindexed completely.
-
-6. Start the data stream by going to the `Integrations -> Citrix ADC -> Integration policies` and open configuration of integration and enable the `Collect Citrix ADC metrics` toggle and save the integration.
-
-7. Delete temporary index by performing the following step in the Dev tools.
-
-```
-DELETE temp_index
-```
-
-More details about reindexing can be found [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html).
+Note:
+- This [document](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#reindex-with-a-data-stream) provides details about reindexing.
 
 ## Metrics reference
 

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: citrix_adc
 title: Citrix ADC
-version: "0.7.0"
+version: "0.7.1"
 description: This Elastic integration collects metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
- Bug
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- Added host.ip field in ecs.yml to avoid field conflicts for users.
- Updated the condition in system datastream for ingest_pipeline.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.

<!--
## Author's Checklist

Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

<!--
## How to test this PR locally

Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/7282
- Relates https://github.com/elastic/integrations/issues/7243

<!--
## Screenshots

 Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
