### PR TITLE
[Fortinet Fortigate] Change default TCP framing to RFC 6587

### DIFF
--- a/packages/fortinet_fortigate/_dev/build/docs/README.md
+++ b/packages/fortinet_fortigate/_dev/build/docs/README.md
@@ -6,6 +6,10 @@ This integration is for Fortinet FortiGate logs sent in the syslog format.
 
 This integration has been tested against FortiOS version 6.0.x and 6.2.x. Versions above this are expected to work but have not been tested.
 
+## Note
+
+- When using the TCP input, be careful with the configured TCP framing. According to the [Fortigate reference](https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/405620/config-log-syslogd-setting), framing should be set to `rfc6587` when the syslog mode is reliable.
+
 ### Log
 
 The `log` dataset collects JFortinet FortiGate logs.

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1"
+  changes:
+    - description: Enable RFC 6587 framing by default on TCP input.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7516
 - version: "1.16.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/fortinet_fortigate/data_stream/log/manifest.yml
+++ b/packages/fortinet_fortigate/data_stream/log/manifest.yml
@@ -82,9 +82,9 @@ streams:
         required: false
         show_user: false
         default: |
+          framing: rfc6587
+          #max_message_size: 50KiB
           #max_connections: 1
-          #framing: delimitier
-          #line_delimiter: "\n"
         description: Specify custom configuration options for the TCP input.
     template_path: tcp.yml.hbs
     title: Fortinet firewall logs (tcp)

--- a/packages/fortinet_fortigate/docs/README.md
+++ b/packages/fortinet_fortigate/docs/README.md
@@ -6,6 +6,10 @@ This integration is for Fortinet FortiGate logs sent in the syslog format.
 
 This integration has been tested against FortiOS version 6.0.x and 6.2.x. Versions above this are expected to work but have not been tested.
 
+## Note
+
+- When using the TCP input, be careful with the configured TCP framing. According to the [Fortigate reference](https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/405620/config-log-syslogd-setting), framing should be set to `rfc6587` when the syslog mode is reliable.
+
 ### Log
 
 The `log` dataset collects JFortinet FortiGate logs.

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.16.0"
+version: "1.16.1"
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
## What does this PR do?

- It enables the RFC 6587 by default on the TCP input. Regarding the [Fortigate reference](https://docs.fortinet.com/document/fortigate/7.4.0/cli-reference/405620/config-log-syslogd-setting), when the syslog mode is set to `reliable`, it uses RFC 6587 for TCP forwarding.
- Added a note in the docs, just in case it would help users to be warned about this.

The framing value has been set to `rfc6587` by default because I assume that the reliable mode should be the default one when forwarding over TCP syslog from Fortigate, the other available option is `legacy-reliable`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
