### PR TITLE
[Couchbase] Added dimensions mapping to database_stats datastream

### DIFF
--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add dimension mapping for `database_stats` datastream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7540
 - version: "1.2.3"
   changes:
     - description: Add dimension mapping for `cluster` datastream.

--- a/packages/couchbase/changelog.yml
+++ b/packages/couchbase/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.4"
+  changes:
+    - description: Add dimension mapping for `database_stats` datastream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.2.3"
   changes:
     - description: Add dimension mapping for `cluster` datastream.

--- a/packages/couchbase/data_stream/database_stats/fields/ecs.yml
+++ b/packages/couchbase/data_stream/database_stats/fields/ecs.yml
@@ -20,7 +20,32 @@
   name: server.address
 - external: ecs
   name: service.address
+  dimension: true
 - external: ecs
   name: service.type
 - external: ecs
   name: tags
+- external: ecs
+  name: agent.id
+  dimension: true
+- external: ecs
+  name: cloud.account.id
+  dimension: true
+- external: ecs
+  name: cloud.region
+  dimension: true
+- external: ecs
+  name: cloud.availability_zone
+  dimension: true
+- external: ecs
+  name: cloud.instance.id
+  dimension: true
+- external: ecs
+  name: cloud.provider
+  dimension: true
+- external: ecs
+  name: container.id
+  dimension: true
+- external: ecs
+  name: host.name
+  dimension: true

--- a/packages/couchbase/data_stream/database_stats/fields/fields.yml
+++ b/packages/couchbase/data_stream/database_stats/fields/fields.yml
@@ -6,6 +6,7 @@
       fields:
         - name: database.name
           type: keyword
+          dimension: true
           description: The database for which the data is being extracted.
         - name: dcp.received.time
           type: long

--- a/packages/couchbase/docs/README.md
+++ b/packages/couchbase/docs/README.md
@@ -862,6 +862,13 @@ An example event for `database_stats` looks as following:
 | Field | Description | Type | Unit | Metric Type |
 |---|---|---|---|---|
 | @timestamp | Event timestamp. | date |  |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
 | couchbase.database_stats.database.name | The database for which the data is being extracted. | keyword |  |  |
 | couchbase.database_stats.dcp.received.time | The time between a document write and that document being received by Sync Gateway over DCP. | long | s | gauge |
 | couchbase.database_stats.document.reads.blip | The total number of documents read via Couchbase Lite 2.x replication since Sync Gateway node startup. | long |  | counter |
@@ -881,6 +888,7 @@ An example event for `database_stats` looks as following:
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |  |  |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |  |  |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |  |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |  |
 | server.address | Some event server addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |  |

--- a/packages/couchbase/manifest.yml
+++ b/packages/couchbase/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchbase
 title: Couchbase
-version: "1.2.3"
+version: "1.2.4"
 license: basic
 description: Collect metrics from Couchbase databases with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Add dimensions to `database_stats` datastream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## How to test this PR locally

1. Build verification
`elastic-package build`
`elastic-package stack up -v -d --services package-registry`

- [x] 2. Document count verification after enablement
- [x] 3. Dashboard verification after enablement
- [x] 4. Index template verification
- [x] 5. Index mapping verification
- [x] 6. Index settings verification.

- [x] Verified that there exists mapping time_series_dimensions mapping after tsdb enablement
- [x] Verified that there exists time_series settings after TSDB enablement.
- [x] Verified that the dashboards are not broken after the TSDB enablement.
- [ ] Index rollover after TSDB disablement

## Related issues
- Relates #7378
