### PR TITLE
statsd_input: Add changelog entry for PR #6580

### DIFF
--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.3"
+  changes:
+    - description: Improve documentation for the package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6580
 - version: "0.2.2"
   changes:
     - description: Add system tests for the package.

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: statsd_input
 title: StatsD Input
-version: "0.2.2"
+version: "0.2.3"
 description: StatsD Input Package
 type: input
 categories:


### PR DESCRIPTION
## What does this PR do?

Adds changelog entry for https://github.com/elastic/integrations/pull/6580 as it was not done in that PR.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).