### PR TITLE
[Airflow] Remove metric_type mapping for 'airflow.scheduler.heartbeat' field and adjust the dashboard to visualize this 

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update metric_type mapping for field `airflow.scheduler.heartbeat` from counter to gauge.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/7554
 - version: "0.3.0"
   changes:
     - description: Revert metrics field definition to the format used before introducing metric_type.

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Update metric_type mapping for field `airflow.scheduler.heartbeat` from counter to gauge.
+      type: bugfix
+      link: tba
 - version: "0.3.0"
   changes:
     - description: Revert metrics field definition to the format used before introducing metric_type.

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.3.1"
   changes:
-    - description: Update metric_type mapping for field `airflow.scheduler.heartbeat` from counter to gauge.
+    - description: Remove metric_type mapping for 'airflow.scheduler.heartbeat' field and adjust the dashboard to visualize this field using 'last_value'.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/7554
 - version: "0.3.0"

--- a/packages/airflow/data_stream/statsd/fields/fields.yml
+++ b/packages/airflow/data_stream/statsd/fields/fields.yml
@@ -7,6 +7,10 @@
       object_type_mapping_type: "*"
       metric_type: counter
       description: Airflow counters
+    - name: scheduler_heartbeat.count
+      type: double
+      metric_type: gauge
+      description: Airflow scheduler heartbeat
     - name: '*.max'
       type: object
       object_type: double

--- a/packages/airflow/data_stream/statsd/fields/fields.yml
+++ b/packages/airflow/data_stream/statsd/fields/fields.yml
@@ -9,7 +9,6 @@
       description: Airflow counters
     - name: scheduler_heartbeat.count
       type: double
-      metric_type: gauge
       description: Airflow scheduler heartbeat
     - name: '*.max'
       type: object

--- a/packages/airflow/docs/README.md
+++ b/packages/airflow/docs/README.md
@@ -42,7 +42,7 @@ statsd_prefix =
 | airflow.job_name | Airflow job name metadata | keyword |  |
 | airflow.operator_name | Airflow operator name metadata | keyword |  |
 | airflow.pool_name | Airflow pool name metadata | keyword |  |
-| airflow.scheduler_heartbeat.count | Airflow scheduler heartbeat | double | gauge |
+| airflow.scheduler_heartbeat.count | Airflow scheduler heartbeat | double |  |
 | airflow.status | Airflow status metadata | keyword |  |
 | airflow.task_id | Airflow task id metadata | keyword |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |

--- a/packages/airflow/docs/README.md
+++ b/packages/airflow/docs/README.md
@@ -42,6 +42,7 @@ statsd_prefix =
 | airflow.job_name | Airflow job name metadata | keyword |  |
 | airflow.operator_name | Airflow operator name metadata | keyword |  |
 | airflow.pool_name | Airflow pool name metadata | keyword |  |
+| airflow.scheduler_heartbeat.count | Airflow scheduler heartbeat | double | gauge |
 | airflow.status | Airflow status metadata | keyword |  |
 | airflow.task_id | Airflow task id metadata | keyword |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |

--- a/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
+++ b/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
@@ -433,17 +433,21 @@
                                                 "048f8624-04ff-4967-8515-011f90aae3ab": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "airflow.scheduler_heartbeat.count: *"
+                                                    },
                                                     "isBucketed": false,
                                                     "label": "Scheduler Heartbeat",
-                                                    "operationType": "max",
+                                                    "operationType": "last_value",
                                                     "params": {
-                                                        "emptyAsNull": true,
                                                         "format": {
                                                             "id": "number",
                                                             "params": {
                                                                 "decimals": 0
                                                             }
-                                                        }
+                                                        },
+                                                        "sortField": "@timestamp"
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "airflow.scheduler_heartbeat.count"
@@ -944,16 +948,6 @@
             "id": "metrics-*",
             "name": "1582880b-fb1a-4969-800d-bd594057a5ac:indexpattern-datasource-layer-a12d3d3c-3859-4532-a639-fdb7ba3fd1eb",
             "type": "index-pattern"
-        },
-        {
-            "id": "airflow-fleet-managed-default",
-            "name": "tag-fleet-managed-default",
-            "type": "tag"
-        },
-        {
-            "id": "airflow-fleet-pkg-airflow-default",
-            "name": "tag-fleet-pkg-airflow-default",
-            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.3.0"
+version: "0.3.1"
 description: Airflow Integration.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
- Bug


## What does this PR do?

This PR modifies the metric_type of `airflow.scheduler.heartbeat` from counter to gauge. Despite the field being labeled as a counter in the airflow [documentation](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/metrics.html#counters), the behavior of the values—consistently 1 or 2—suggests it aligns better with the characteristics of a gauge metric. 
Additionally,  dashboard is modified to accurately represent this data, with the aggregator function updated to use last_value.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




## Related issues

- Relates #7504 


## Screenshots

<img width="1705" alt="Screenshot 2023-08-28 at 11 40 39 AM" src="https://github.com/elastic/integrations/assets/102972658/1ffe5078-e848-4fbb-8ba0-cfb6f4e183fd">
<img width="1719" alt="Screenshot 2023-08-28 at 11 36 26 AM" src="https://github.com/elastic/integrations/assets/102972658/f0c73e11-0ff4-4bd2-aab4-be5972ad834d">

