### PR TITLE
[GCP][CloudSQL] Set metric type

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.28.1"
+  changes:
+    - description: Set metric type for CloudSQL data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7461
 - version: "2.28.0"
   changes:
     - description: Migrate GCP Load Balancing L3 Overview dashboard to lens.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set metric type for CloudSQL data streams.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7461
+      link: https://github.com/elastic/integrations/pull/7556
 - version: "2.28.0"
   changes:
     - description: Migrate GCP Load Balancing L3 Overview dashboard to lens.

--- a/packages/gcp/data_stream/cloudsql_mysql/fields/fields.yml
+++ b/packages/gcp/data_stream/cloudsql_mysql/fields/fields.yml
@@ -12,7 +12,7 @@
       description: Indicates whether the instance is currently available using Windows Authentication.
     - name: database.auto_failover_request.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta of number of instance auto-failover requests.
     - name: database.available_for_failover
       type: long
@@ -25,9 +25,11 @@
     - name: database.cpu.usage_time.sec
       type: double
       unit: s
-      description: Cumulative CPU usage time in seconds.
+      metric_type: gauge
+      description: Delta CPU usage time in seconds.
     - name: database.cpu.utilization.pct
       type: double
+      unit: percent
       metric_type: gauge
       description: Current CPU utilization represented as a percentage of the reserved CPU that is currently in use.
     - name: database.disk.bytes_used.bytes
@@ -47,15 +49,16 @@
       description: Maximum data disk size in bytes.
     - name: database.disk.read_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk read IO operations.
     - name: database.disk.utilization.pct
       type: double
+      unit: percent
       metric_type: gauge
       description: The fraction of the disk quota that is currently in use.
     - name: database.disk.write_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk write IO operations.
     - name: database.instance_state
       type: long
@@ -95,31 +98,31 @@
       description: Total number of pages in the InnoDB buffer pool.
     - name: database.innodb_data_fsyncs.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of InnoDB fsync() calls.
     - name: database.innodb_os_log_fsyncs.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of InnoDB fsync() calls to the log file.
     - name: database.innodb_pages_read.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of InnoDB pages read.
     - name: database.innodb_pages_written.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of InnoDB pages written.
     - name: database.queries.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of statements executed by the server.
     - name: database.questions.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of statements executed by the server sent by the client.
     - name: database.received_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes received by MySQL process.
     - name: database.replication.last_io_errno
       type: long
@@ -150,7 +153,7 @@
       description: Indicates whether the SQL thread for executing events in the relay log is running. Possible values are Yes / No, and the values are exposed through the 'state' field.
     - name: database.sent_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes sent by MySQL process.
     - name: database.network.connections.count
       type: long
@@ -158,20 +161,20 @@
       description: Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server.
     - name: database.network.received_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes received through the network.
     - name: database.network.sent_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes sent through the network.
     - name: database.replication.log_archive_failure.count
       type: long
-      metric_type: counter
-      description: Number of failed attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta number of failed attempts for archiving replication log files.
     - name: database.replication.log_archive_success.count
       type: long
-      metric_type: counter
-      description: Number of successful attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta number of successful attempts for archiving replication log files.
     - name: database.replication.network_lag.sec
       type: long
       unit: s
@@ -196,4 +199,5 @@
     - name: database.uptime.sec
       type: long
       unit: s
+      metric_type: gauge
       description: Delta count of the time in seconds the instance has been running.

--- a/packages/gcp/data_stream/cloudsql_postgresql/fields/fields.yml
+++ b/packages/gcp/data_stream/cloudsql_postgresql/fields/fields.yml
@@ -12,7 +12,7 @@
       description: Indicates whether the instance is currently available using Windows Authentication.
     - name: database.auto_failover_request.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta of number of instance auto-failover requests.
     - name: database.available_for_failover
       type: long
@@ -25,7 +25,8 @@
     - name: database.cpu.usage_time.sec
       type: double
       unit: s
-      description: Cumulative CPU usage time in seconds.
+      metric_type: gauge
+      description: Delta CPU usage time in seconds.
     - name: database.cpu.utilization.pct
       type: double
       unit: percent
@@ -48,7 +49,7 @@
       description: Maximum data disk size in bytes.
     - name: database.disk.read_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk read IO operations.
     - name: database.disk.utilization.pct
       type: double
@@ -57,7 +58,7 @@
       description: The fraction of the disk quota that is currently in use.
     - name: database.disk.write_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk write IO operations.
     - name: database.instance_state
       type: long
@@ -89,20 +90,20 @@
       description: Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server.
     - name: database.network.received_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes received through the network.
     - name: database.network.sent_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes sent through the network.
     - name: database.blocks_read.count
       type: long
-      metric_type: counter
-      description: Number of disk blocks read by this database. The source field distingushes actual reads from disk versus reads from buffer cache.
+      metric_type: gauge
+      description: Delta count of disk blocks read by this database. The source field distingushes actual reads from disk versus reads from buffer cache.
     - name: database.deadlock.count
       type: long
-      metric_type: counter
-      description: Number of deadlocks detected for this database.
+      metric_type: gauge
+      description: Delta count of deadlocks detected for this database.
     - name: database.external_sync.initial_sync_complete
       type: long
       metric_type: gauge
@@ -114,15 +115,19 @@
       description: Replication lag in bytes for Postgres External Server (ES) replicas. Aggregated across all DBs on the replica.
     - name: database.insights.aggregate.execution_time
       type: long
+      metric_type: counter
       description: Accumulated query execution time per user per database. This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
     - name: database.insights.aggregate.io_time
       type: long
+      metric_type: counter
       description: Accumulated IO time per user per database.
     - name: database.insights.aggregate.latencies
       type: long
+      metric_type: counter
       description: Query latency distribution per user per database.
     - name: database.insights.aggregate.lock_time
       type: long
+      metric_type: counter
       description: Accumulated lock wait time per user per database.
     - name: database.insights.aggregate.row.count
       type: long
@@ -134,15 +139,18 @@
       description: Shared blocks (regular tables & indexed) accessed by statement execution.
     - name: database.insights.perquery.execution_time
       type: long
+      metric_type: counter
       description: Accumulated execution times per user per database per query.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
     - name: database.insights.perquery.io_time
       type: long
+      metric_type: counter
       description: Accumulated IO time per user per database per query.
     - name: database.insights.perquery.latencies
       type: histogram
       description: Query latency distribution per user per database per query.
     - name: database.insights.perquery.lock_time
       type: long
+      metric_type: counter
       description: Accumulated lock wait time per user per database per query.
     - name: database.insights.perquery.row.count
       type: long
@@ -154,15 +162,18 @@
       description: Shared blocks (regular tables & indexed) accesssed by statement execution.
     - name: database.insights.pertag.execution_time
       type: long
+      metric_type: counter
       description: Accumulated execution times per user per database per tag.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
     - name: database.insights.pertag.io_time
       type: long
+      metric_type: counter
       description: Accumulated IO write time per user per database per tag.
     - name: database.insights.pertag.latencies
       type: histogram
       description: Query latency distribution per user per database per tag.
     - name: database.insights.pertag.lock_time
       type: long
+      metric_type: counter
       description: Accumulated lock wait time per user per database per tag.
     - name: database.insights.pertag.row.count
       type: long
@@ -187,11 +198,11 @@
       description: Replication lag in bytes. Reported from the master per replica.
     - name: database.transaction.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of number of transactions.
     - name: database.transaction_id.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of transaction ID.
     - name: database.transaction_id_utilization.pct
       type: double
@@ -204,20 +215,20 @@
       description: Number of tuples (rows) in the database.
     - name: database.tuples_processed.count
       type: long
-      metric_type: counter
-      description: Number of tuples(rows) processed for a given database for operations like insert, update or delete.
+      metric_type: gauge
+      description: Delta count of tuples(rows) processed for a given database for operations like insert, update or delete.
     - name: database.vacuum.oldest_transaction_age
       type: long
       metric_type: gauge
       description: Age of the oldest transaction yet to be vacuumed in the Cloud SQL PostgreSQL instance, measured in number of transactions that have happened since the oldest transaction.
     - name: database.replication.log_archive_failure.count
       type: long
-      metric_type: counter
-      description: Number of failed attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta count of failed attempts for archiving replication log files.
     - name: database.replication.log_archive_success.count
       type: long
-      metric_type: counter
-      description: Number of successful attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta count of successful attempts for archiving replication log files.
     - name: database.replication.network_lag.sec
       type: long
       unit: s
@@ -242,4 +253,5 @@
     - name: database.uptime.sec
       type: long
       unit: s
+      metric_type: gauge
       description: Delta count of the time in seconds the instance has been running.

--- a/packages/gcp/data_stream/cloudsql_sqlserver/fields/fields.yml
+++ b/packages/gcp/data_stream/cloudsql_sqlserver/fields/fields.yml
@@ -12,7 +12,7 @@
       description: Indicates whether the instance is currently available using Windows Authentication.
     - name: database.auto_failover_request.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta of number of instance auto-failover requests.
     - name: database.available_for_failover
       type: long
@@ -25,7 +25,8 @@
     - name: database.cpu.usage_time.sec
       type: double
       unit: s
-      description: Cumulative CPU usage time in seconds.
+      metric_type: gauge
+      description: Delta CPU usage time in seconds.
     - name: database.cpu.utilization.pct
       type: double
       unit: percent
@@ -48,7 +49,7 @@
       description: Maximum data disk size in bytes.
     - name: database.disk.read_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk read IO operations.
     - name: database.disk.utilization.pct
       type: double
@@ -57,7 +58,7 @@
       description: The fraction of the disk quota that is currently in use.
     - name: database.disk.write_ops.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of data disk write IO operations.
     - name: database.instance_state
       type: long
@@ -89,20 +90,20 @@
       description: Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server.
     - name: database.network.received_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes received through the network.
     - name: database.network.sent_bytes.count
       type: long
-      metric_type: counter
+      metric_type: gauge
       description: Delta count of bytes sent through the network.
     - name: database.replication.log_archive_failure.count
       type: long
-      metric_type: counter
-      description: Number of failed attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta count of failed attempts for archiving replication log files.
     - name: database.replication.log_archive_success.count
       type: long
-      metric_type: counter
-      description: Number of successful attempts for archiving replication log files.
+      metric_type: gauge
+      description: Delta count of successful attempts for archiving replication log files.
     - name: database.replication.network_lag.sec
       type: long
       unit: s
@@ -120,12 +121,12 @@
     - name: database.audits_size.bytes
       type: long
       unit: byte
-      metric_type: counter
+      metric_type: gauge
       description: Tracks the size in bytes of stored SQLServer audit files on an instance.
     - name: database.audits_upload.count
       type: long
-      metric_type: counter
-      description: Counts total number of SQLServer audit file uploads to a GCS bucket and whether or not an upload was successful.
+      metric_type: gauge
+      description: Delta count of total number of SQLServer audit file uploads to a GCS bucket and whether or not an upload was successful.
     - name: database.external_sync.primary_to_replica_connection_health
       type: long
       metric_type: gauge
@@ -140,4 +141,5 @@
     - name: database.uptime.sec
       type: long
       unit: s
+      metric_type: gauge
       description: Delta count of the time in seconds the instance has been running.

--- a/packages/gcp/docs/cloudsql.md
+++ b/packages/gcp/docs/cloudsql.md
@@ -90,39 +90,39 @@ An example event for `cloudsql_mysql` looks as following:
 | event.module | Event module | constant_keyword |  |  |
 | gcp.cloudsql_mysql.database.active_directory.domain_reachable | Indicates whether the instance is able to ping a domain controller from the connected Managed Active Directory domain. | long |  | gauge |
 | gcp.cloudsql_mysql.database.active_directory.instance_available | Indicates whether the instance is currently available using Windows Authentication. | long |  | gauge |
-| gcp.cloudsql_mysql.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | counter |
+| gcp.cloudsql_mysql.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | gauge |
 | gcp.cloudsql_mysql.database.available_for_failover | This is \> 0 if the failover operation is available on the instance. | long |  | gauge |
 | gcp.cloudsql_mysql.database.cpu.reserved_cores.count | Number of cores reserved for the database. | double |  | gauge |
-| gcp.cloudsql_mysql.database.cpu.usage_time.sec | Cumulative CPU usage time in seconds. | double | s |  |
-| gcp.cloudsql_mysql.database.cpu.utilization.pct | Current CPU utilization represented as a percentage of the reserved CPU that is currently in use. | double |  | gauge |
+| gcp.cloudsql_mysql.database.cpu.usage_time.sec | Delta CPU usage time in seconds. | double | s | gauge |
+| gcp.cloudsql_mysql.database.cpu.utilization.pct | Current CPU utilization represented as a percentage of the reserved CPU that is currently in use. | double | percent | gauge |
 | gcp.cloudsql_mysql.database.disk.bytes_used.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_mysql.database.disk.bytes_used_by_data_type.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_mysql.database.disk.quota.bytes | Maximum data disk size in bytes. | long | byte | gauge |
-| gcp.cloudsql_mysql.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | counter |
-| gcp.cloudsql_mysql.database.disk.utilization.pct | The fraction of the disk quota that is currently in use. | double |  | gauge |
-| gcp.cloudsql_mysql.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | counter |
+| gcp.cloudsql_mysql.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | gauge |
+| gcp.cloudsql_mysql.database.disk.utilization.pct | The fraction of the disk quota that is currently in use. | double | percent | gauge |
+| gcp.cloudsql_mysql.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | gauge |
 | gcp.cloudsql_mysql.database.innodb_buffer_pool_pages_dirty.count | Number of unflushed pages in the InnoDB buffer pool. | long |  | gauge |
 | gcp.cloudsql_mysql.database.innodb_buffer_pool_pages_free.count | Number of unused pages in the InnoDB buffer pool. | long |  | gauge |
 | gcp.cloudsql_mysql.database.innodb_buffer_pool_pages_total.count | Total number of pages in the InnoDB buffer pool. | long |  | gauge |
-| gcp.cloudsql_mysql.database.innodb_data_fsyncs.count | Delta count of InnoDB fsync() calls. | long |  | counter |
-| gcp.cloudsql_mysql.database.innodb_os_log_fsyncs.count | Delta count of InnoDB fsync() calls to the log file. | long |  | counter |
-| gcp.cloudsql_mysql.database.innodb_pages_read.count | Delta count of InnoDB pages read. | long |  | counter |
-| gcp.cloudsql_mysql.database.innodb_pages_written.count | Delta count of InnoDB pages written. | long |  | counter |
+| gcp.cloudsql_mysql.database.innodb_data_fsyncs.count | Delta count of InnoDB fsync() calls. | long |  | gauge |
+| gcp.cloudsql_mysql.database.innodb_os_log_fsyncs.count | Delta count of InnoDB fsync() calls to the log file. | long |  | gauge |
+| gcp.cloudsql_mysql.database.innodb_pages_read.count | Delta count of InnoDB pages read. | long |  | gauge |
+| gcp.cloudsql_mysql.database.innodb_pages_written.count | Delta count of InnoDB pages written. | long |  | gauge |
 | gcp.cloudsql_mysql.database.instance_state | The current serving state of the Cloud SQL instance. | long |  | gauge |
 | gcp.cloudsql_mysql.database.memory.quota.bytes | Maximum RAM size in bytes. | long | byte | gauge |
 | gcp.cloudsql_mysql.database.memory.total_usage.bytes | Total RAM usage in bytes. This metric reports the RAM usage of the database process, including the buffer/cache. | long | byte | gauge |
 | gcp.cloudsql_mysql.database.memory.usage.bytes | RAM usage in bytes. This metric reports the RAM usage of the server, excluding the buffer/cache. | long | byte | gauge |
 | gcp.cloudsql_mysql.database.memory.utilization.pct | The fraction of the memory quota that is currently in use. | double | percent | gauge |
 | gcp.cloudsql_mysql.database.network.connections.count | Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server. | long |  | gauge |
-| gcp.cloudsql_mysql.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | counter |
-| gcp.cloudsql_mysql.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | counter |
-| gcp.cloudsql_mysql.database.queries.count | Delta count of statements executed by the server. | long |  | counter |
-| gcp.cloudsql_mysql.database.questions.count | Delta count of statements executed by the server sent by the client. | long |  | counter |
-| gcp.cloudsql_mysql.database.received_bytes.count | Delta count of bytes received by MySQL process. | long |  | counter |
+| gcp.cloudsql_mysql.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | gauge |
+| gcp.cloudsql_mysql.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | gauge |
+| gcp.cloudsql_mysql.database.queries.count | Delta count of statements executed by the server. | long |  | gauge |
+| gcp.cloudsql_mysql.database.questions.count | Delta count of statements executed by the server sent by the client. | long |  | gauge |
+| gcp.cloudsql_mysql.database.received_bytes.count | Delta count of bytes received by MySQL process. | long |  | gauge |
 | gcp.cloudsql_mysql.database.replication.last_io_errno | The error number of the most recent error that caused the I/O thread to stop. | long |  | gauge |
 | gcp.cloudsql_mysql.database.replication.last_sql_errno | The error number of the most recent error that caused the SQL thread to stop. | long |  | gauge |
-| gcp.cloudsql_mysql.database.replication.log_archive_failure.count | Number of failed attempts for archiving replication log files. | long |  | counter |
-| gcp.cloudsql_mysql.database.replication.log_archive_success.count | Number of successful attempts for archiving replication log files. | long |  | counter |
+| gcp.cloudsql_mysql.database.replication.log_archive_failure.count | Delta number of failed attempts for archiving replication log files. | long |  | gauge |
+| gcp.cloudsql_mysql.database.replication.log_archive_success.count | Delta number of successful attempts for archiving replication log files. | long |  | gauge |
 | gcp.cloudsql_mysql.database.replication.network_lag.sec | Indicates time taken from primary binary log to IO thread on replica. Only applicable to replicas. | long | s | gauge |
 | gcp.cloudsql_mysql.database.replication.replica_lag.sec | Number of seconds the read replica is behind its primary (approximation). | double | s | gauge |
 | gcp.cloudsql_mysql.database.replication.seconds_behind_master.sec | Number of seconds the read replica is behind its primary (approximation). | long | s | gauge |
@@ -131,10 +131,10 @@ An example event for `cloudsql_mysql` looks as following:
 | gcp.cloudsql_mysql.database.replication.slave_sql_running | Indicates whether the SQL thread for executing events in the relay log is running. | keyword |  |  |
 | gcp.cloudsql_mysql.database.replication.slave_sql_running_state | Indicates whether the SQL thread for executing events in the relay log is running. Possible values are Yes / No, and the values are exposed through the 'state' field. | long |  | gauge |
 | gcp.cloudsql_mysql.database.replication.state | The current serving state of replication. | long |  | gauge |
-| gcp.cloudsql_mysql.database.sent_bytes.count | Delta count of bytes sent by MySQL process. | long |  | counter |
+| gcp.cloudsql_mysql.database.sent_bytes.count | Delta count of bytes sent by MySQL process. | long |  | gauge |
 | gcp.cloudsql_mysql.database.state | The current serving state of the Cloud SQL instance. | keyword |  |  |
 | gcp.cloudsql_mysql.database.up | Indicates if the server is up or not. | long |  | gauge |
-| gcp.cloudsql_mysql.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s |  |
+| gcp.cloudsql_mysql.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s | gauge |
 | gcp.labels.metadata.\* |  | object |  |  |
 | gcp.labels.metrics.\* |  | object |  |  |
 | gcp.labels.resource.\* |  | object |  |  |
@@ -247,37 +247,37 @@ An example event for `cloudsql_postgresql` looks as following:
 | event.module | Event module | constant_keyword |  |  |
 | gcp.cloudsql_postgresql.database.active_directory.domain_reachable | Indicates whether the instance is able to ping a domain controller from the connected Managed Active Directory domain. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.active_directory.instance_available | Indicates whether the instance is currently available using Windows Authentication. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | counter |
+| gcp.cloudsql_postgresql.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.available_for_failover | This is \> 0 if the failover operation is available on the instance. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.blocks_read.count | Number of disk blocks read by this database. The source field distingushes actual reads from disk versus reads from buffer cache. | long |  | counter |
+| gcp.cloudsql_postgresql.database.blocks_read.count | Delta count of disk blocks read by this database. The source field distingushes actual reads from disk versus reads from buffer cache. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.cpu.reserved_cores.count | Number of cores reserved for the database. | double |  | gauge |
-| gcp.cloudsql_postgresql.database.cpu.usage_time.sec | Cumulative CPU usage time in seconds. | double | s |  |
+| gcp.cloudsql_postgresql.database.cpu.usage_time.sec | Delta CPU usage time in seconds. | double | s | gauge |
 | gcp.cloudsql_postgresql.database.cpu.utilization.pct | Current CPU utilization represented as a percentage of the reserved CPU that is currently in use. | double | percent | gauge |
-| gcp.cloudsql_postgresql.database.deadlock.count | Number of deadlocks detected for this database. | long |  | counter |
+| gcp.cloudsql_postgresql.database.deadlock.count | Delta count of deadlocks detected for this database. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.disk.bytes_used.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_postgresql.database.disk.bytes_used_by_data_type.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_postgresql.database.disk.quota.bytes | Maximum data disk size in bytes. | long | byte | gauge |
-| gcp.cloudsql_postgresql.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | counter |
+| gcp.cloudsql_postgresql.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.disk.utilization.pct | The fraction of the disk quota that is currently in use. | double | percent | gauge |
-| gcp.cloudsql_postgresql.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | counter |
+| gcp.cloudsql_postgresql.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.external_sync.initial_sync_complete | Whether all databases on the Postgres External Server (ES) replica have completed the initial sync and are replicating changes from the source. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.external_sync.max_replica_byte_lag.bytes | Replication lag in bytes for Postgres External Server (ES) replicas. Aggregated across all DBs on the replica. | long | byte | gauge |
-| gcp.cloudsql_postgresql.database.insights.aggregate.execution_time | Accumulated query execution time per user per database. This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  |  |
-| gcp.cloudsql_postgresql.database.insights.aggregate.io_time | Accumulated IO time per user per database. | long |  |  |
-| gcp.cloudsql_postgresql.database.insights.aggregate.latencies | Query latency distribution per user per database. | long |  |  |
-| gcp.cloudsql_postgresql.database.insights.aggregate.lock_time | Accumulated lock wait time per user per database. | long |  |  |
+| gcp.cloudsql_postgresql.database.insights.aggregate.execution_time | Accumulated query execution time per user per database. This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  | counter |
+| gcp.cloudsql_postgresql.database.insights.aggregate.io_time | Accumulated IO time per user per database. | long |  | counter |
+| gcp.cloudsql_postgresql.database.insights.aggregate.latencies | Query latency distribution per user per database. | long |  | counter |
+| gcp.cloudsql_postgresql.database.insights.aggregate.lock_time | Accumulated lock wait time per user per database. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.aggregate.row.count | Total number of rows affected during query execution. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.aggregate.shared_blk_access.count | Shared blocks (regular tables & indexed) accessed by statement execution. | long |  | counter |
-| gcp.cloudsql_postgresql.database.insights.perquery.execution_time | Accumulated execution times per user per database per query.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  |  |
-| gcp.cloudsql_postgresql.database.insights.perquery.io_time | Accumulated IO time per user per database per query. | long |  |  |
+| gcp.cloudsql_postgresql.database.insights.perquery.execution_time | Accumulated execution times per user per database per query.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  | counter |
+| gcp.cloudsql_postgresql.database.insights.perquery.io_time | Accumulated IO time per user per database per query. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.perquery.latencies | Query latency distribution per user per database per query. | histogram |  |  |
-| gcp.cloudsql_postgresql.database.insights.perquery.lock_time | Accumulated lock wait time per user per database per query. | long |  |  |
+| gcp.cloudsql_postgresql.database.insights.perquery.lock_time | Accumulated lock wait time per user per database per query. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.perquery.row.count | Total number of rows affected during query execution. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.perquery.shared_blk_access.count | Shared blocks (regular tables & indexed) accesssed by statement execution. | long |  | counter |
-| gcp.cloudsql_postgresql.database.insights.pertag.execution_time | Accumulated execution times per user per database per tag.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  |  |
-| gcp.cloudsql_postgresql.database.insights.pertag.io_time | Accumulated IO write time per user per database per tag. | long |  |  |
+| gcp.cloudsql_postgresql.database.insights.pertag.execution_time | Accumulated execution times per user per database per tag.This is the sum of cpu time, io wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution. | long |  | counter |
+| gcp.cloudsql_postgresql.database.insights.pertag.io_time | Accumulated IO write time per user per database per tag. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.pertag.latencies | Query latency distribution per user per database per tag. | histogram |  |  |
-| gcp.cloudsql_postgresql.database.insights.pertag.lock_time | Accumulated lock wait time per user per database per tag. | long |  |  |
+| gcp.cloudsql_postgresql.database.insights.pertag.lock_time | Accumulated lock wait time per user per database per tag. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.pertag.row.count | Total number of rows affected during query execution. | long |  | counter |
 | gcp.cloudsql_postgresql.database.insights.pertag.shared_blk_access.count | Shared blocks (regular tables & indexed) accessed by statement execution. | long |  | counter |
 | gcp.cloudsql_postgresql.database.instance_state | The current serving state of the Cloud SQL instance. | long |  | gauge |
@@ -286,24 +286,24 @@ An example event for `cloudsql_postgresql` looks as following:
 | gcp.cloudsql_postgresql.database.memory.usage.bytes | RAM usage in bytes. This metric reports the RAM usage of the server, excluding the buffer/cache. | long | byte | gauge |
 | gcp.cloudsql_postgresql.database.memory.utilization.pct | The fraction of the memory quota that is currently in use. | double | percent | gauge |
 | gcp.cloudsql_postgresql.database.network.connections.count | Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | counter |
-| gcp.cloudsql_postgresql.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | counter |
+| gcp.cloudsql_postgresql.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | gauge |
+| gcp.cloudsql_postgresql.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.num_backends.count | Number of connections to the Cloud SQL PostgreSQL instance. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.num_backends_by_state.count | Number of connections to the Cloud SQL PostgreSQL instance, grouped by its state. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.replication.log_archive_failure.count | Number of failed attempts for archiving replication log files. | long |  | counter |
-| gcp.cloudsql_postgresql.database.replication.log_archive_success.count | Number of successful attempts for archiving replication log files. | long |  | counter |
+| gcp.cloudsql_postgresql.database.replication.log_archive_failure.count | Delta count of failed attempts for archiving replication log files. | long |  | gauge |
+| gcp.cloudsql_postgresql.database.replication.log_archive_success.count | Delta count of successful attempts for archiving replication log files. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.replication.network_lag.sec | Indicates time taken from primary binary log to IO thread on replica. Only applicable to replicas. | long | s | gauge |
 | gcp.cloudsql_postgresql.database.replication.replica_byte_lag.bytes | Replication lag in bytes. Reported from the master per replica. | long | byte | gauge |
 | gcp.cloudsql_postgresql.database.replication.replica_lag.sec | Number of seconds the read replica is behind its primary (approximation). | double | s | gauge |
 | gcp.cloudsql_postgresql.database.replication.state | The current serving state of replication. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.state | The current serving state of the Cloud SQL instance. | keyword |  |  |
-| gcp.cloudsql_postgresql.database.transaction.count | Delta count of number of transactions. | long |  | counter |
-| gcp.cloudsql_postgresql.database.transaction_id.count | Delta count of transaction ID. | long |  | counter |
+| gcp.cloudsql_postgresql.database.transaction.count | Delta count of number of transactions. | long |  | gauge |
+| gcp.cloudsql_postgresql.database.transaction_id.count | Delta count of transaction ID. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.transaction_id_utilization.pct | Current utilization represented as a percentage of transaction IDs consumed by the Cloud SQL PostgreSQL instance. Values are typically numbers between 0.0 and 1.0. Charts display the values as a percentage between 0% and 100%. | double | percent | gauge |
 | gcp.cloudsql_postgresql.database.tuple_size.count | Number of tuples (rows) in the database. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.tuples_processed.count | Number of tuples(rows) processed for a given database for operations like insert, update or delete. | long |  | counter |
+| gcp.cloudsql_postgresql.database.tuples_processed.count | Delta count of tuples(rows) processed for a given database for operations like insert, update or delete. | long |  | gauge |
 | gcp.cloudsql_postgresql.database.up | Indicates if the server is up or not. | long |  | gauge |
-| gcp.cloudsql_postgresql.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s |  |
+| gcp.cloudsql_postgresql.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s | gauge |
 | gcp.cloudsql_postgresql.database.vacuum.oldest_transaction_age | Age of the oldest transaction yet to be vacuumed in the Cloud SQL PostgreSQL instance, measured in number of transactions that have happened since the oldest transaction. | long |  | gauge |
 | gcp.labels.metadata.\* |  | object |  |  |
 | gcp.labels.metrics.\* |  | object |  |  |
@@ -418,19 +418,19 @@ An example event for `cloudsql_sqlserver` looks as following:
 | event.module | Event module | constant_keyword |  |  |
 | gcp.cloudsql_sqlserver.database.active_directory.domain_reachable | Indicates whether the instance is able to ping a domain controller from the connected Managed Active Directory domain. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.active_directory.instance_available | Indicates whether the instance is currently available using Windows Authentication. | long |  | gauge |
-| gcp.cloudsql_sqlserver.database.audits_size.bytes | Tracks the size in bytes of stored SQLServer audit files on an instance. | long | byte | counter |
-| gcp.cloudsql_sqlserver.database.audits_upload.count | Counts total number of SQLServer audit file uploads to a GCS bucket and whether or not an upload was successful. | long |  | counter |
-| gcp.cloudsql_sqlserver.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | counter |
+| gcp.cloudsql_sqlserver.database.audits_size.bytes | Tracks the size in bytes of stored SQLServer audit files on an instance. | long | byte | gauge |
+| gcp.cloudsql_sqlserver.database.audits_upload.count | Delta count of total number of SQLServer audit file uploads to a GCS bucket and whether or not an upload was successful. | long |  | gauge |
+| gcp.cloudsql_sqlserver.database.auto_failover_request.count | Delta of number of instance auto-failover requests. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.available_for_failover | This is \> 0 if the failover operation is available on the instance. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.cpu.reserved_cores.count | Number of cores reserved for the database. | double |  | gauge |
-| gcp.cloudsql_sqlserver.database.cpu.usage_time.sec | Cumulative CPU usage time in seconds. | double | s |  |
+| gcp.cloudsql_sqlserver.database.cpu.usage_time.sec | Delta CPU usage time in seconds. | double | s | gauge |
 | gcp.cloudsql_sqlserver.database.cpu.utilization.pct | Current CPU utilization represented as a percentage of the reserved CPU that is currently in use. | double | percent | gauge |
 | gcp.cloudsql_sqlserver.database.disk.bytes_used.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_sqlserver.database.disk.bytes_used_by_data_type.bytes | Data utilization in bytes. | long | byte | gauge |
 | gcp.cloudsql_sqlserver.database.disk.quota.bytes | Maximum data disk size in bytes. | long | byte | gauge |
-| gcp.cloudsql_sqlserver.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | counter |
+| gcp.cloudsql_sqlserver.database.disk.read_ops.count | Delta count of data disk read IO operations. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.disk.utilization.pct | The fraction of the disk quota that is currently in use. | double | percent | gauge |
-| gcp.cloudsql_sqlserver.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | counter |
+| gcp.cloudsql_sqlserver.database.disk.write_ops.count | Delta count of data disk write IO operations. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.external_sync.primary_to_replica_connection_health | Indicates whether there is connectivity from Primary to the Replica to push replication updates. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.instance_state | The current serving state of the Cloud SQL instance. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.memory.quota.bytes | Maximum RAM size in bytes. | long | byte | gauge |
@@ -438,16 +438,16 @@ An example event for `cloudsql_sqlserver` looks as following:
 | gcp.cloudsql_sqlserver.database.memory.usage.bytes | RAM usage in bytes. This metric reports the RAM usage of the server, excluding the buffer/cache. | long | byte | gauge |
 | gcp.cloudsql_sqlserver.database.memory.utilization.pct | The fraction of the memory quota that is currently in use. | double | percent | gauge |
 | gcp.cloudsql_sqlserver.database.network.connections.count | Number of connections to databases on the Cloud SQL instance. Only applicable to MySQL and SQL Server. | long |  | gauge |
-| gcp.cloudsql_sqlserver.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | counter |
-| gcp.cloudsql_sqlserver.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | counter |
-| gcp.cloudsql_sqlserver.database.replication.log_archive_failure.count | Number of failed attempts for archiving replication log files. | long |  | counter |
-| gcp.cloudsql_sqlserver.database.replication.log_archive_success.count | Number of successful attempts for archiving replication log files. | long |  | counter |
+| gcp.cloudsql_sqlserver.database.network.received_bytes.count | Delta count of bytes received through the network. | long |  | gauge |
+| gcp.cloudsql_sqlserver.database.network.sent_bytes.count | Delta count of bytes sent through the network. | long |  | gauge |
+| gcp.cloudsql_sqlserver.database.replication.log_archive_failure.count | Delta count of failed attempts for archiving replication log files. | long |  | gauge |
+| gcp.cloudsql_sqlserver.database.replication.log_archive_success.count | Delta count of successful attempts for archiving replication log files. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.replication.network_lag.sec | Indicates time taken from primary binary log to IO thread on replica. Only applicable to replicas. | long | s | gauge |
 | gcp.cloudsql_sqlserver.database.replication.replica_lag.sec | Number of seconds the read replica is behind its primary (approximation). | double | s | gauge |
 | gcp.cloudsql_sqlserver.database.replication.state | The current serving state of replication. | long |  | gauge |
 | gcp.cloudsql_sqlserver.database.state | The current serving state of the Cloud SQL instance. | keyword |  |  |
 | gcp.cloudsql_sqlserver.database.up | Indicates if the server is up or not. | long |  | gauge |
-| gcp.cloudsql_sqlserver.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s |  |
+| gcp.cloudsql_sqlserver.database.uptime.sec | Delta count of the time in seconds the instance has been running. | long | s | gauge |
 | gcp.labels.metadata.\* |  | object |  |  |
 | gcp.labels.metrics.\* |  | object |  |  |
 | gcp.labels.resource.\* |  | object |  |  |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.28.0"
+version: "2.28.1"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## What does this PR do?

Metric type of GCP CloudSQL metrics can be found [here](https://cloud.google.com/sql/docs/mysql/admin-api/metrics).

Set the metric type for:

- [x] CloudSQL - MySQL
- [x] CloudSQL - PostgreSQL
- [x] CloudSQL - SQL Server


Changes:

1. Switch every delta metric marked as `counter` to `gauge`.
     - Related issue for delta metrics: https://github.com/elastic/elasticsearch/issues/98171
2. Add metric type to the metrics without type.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

Relates to https://github.com/elastic/integrations/issues/7555.