### PR TITLE
[cisco_secure_email_gateway] Correct escaping to match both Unix and Windows-style paths

### DIFF
--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.2"
+  changes:
+    - description: Match both Unix and Windows-style paths, correctly.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7572
 - version: "1.11.1"
   changes:
     - description: Match both Unix and Windows-style paths

--- a/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,7 +12,7 @@ processors:
       field: _tmp.filepath
       if: ctx.log?.file?.path != null
       patterns:
-        - "^%{DATA}[\\\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"
+        - '^%{DATA}[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$'
   - rename:
       field: message
       target_field: event.original

--- a/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,7 +12,7 @@ processors:
       field: _tmp.filepath
       if: ctx.log?.file?.path != null
       patterns:
-        - "^%{DATA}[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"
+        - "^%{DATA}[\\\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"
   - rename:
       field: message
       target_field: event.original

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.11.1"
+version: "1.11.2"
 license: basic
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

This fixes the change attempted in https://github.com/elastic/integrations/pull/7452. The problem was insufficient escaping.

Here's a summary of the various versions:

```
Original pattern raw:
^%{DATA}/%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$

Fixed pattern raw:
^%{DATA}/[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$

Assumed fixed pattern as the broken string:
"^%{DATA}[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"

Assumed fixed pattern, raw from the broken string:
^%{DATA}[\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$

Actually fixed pattern as the correct string:
"^%{DATA}[\\\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$"

Actually fixed pattern, raw from the correct string:
^%{DATA}[\\/]%{WORD:cisco_secure_email_gateway.log.category.name}.@%{GREEDYDATA}.s$

```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Doesn't break existing tests:
```
cd packages/cisco_secure_email_gateway
elastic-package test
```

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/3729