### PR TITLE
[File Integrity Monitoring] Exclude files that regularly changes

### DIFF
--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -43,7 +43,6 @@ vars:
       - /sbin
       - /usr/sbin
       - /etc
-      - /usr/share
   - name: recursive
     type: bool
     title: Recursive monitoring

--- a/packages/fim/manifest.yml
+++ b/packages/fim/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: fim
 title: "File Integrity Monitoring"
-version: "1.10.0"
+version: "1.10.1"
 description: "The File Integrity Monitoring integration reports filesystem changes in real time."
 type: integration
 categories:
@@ -108,6 +108,9 @@ vars:
       - '(?i)\.sw[nop]$'
       - '~$'
       - '/\.git($|/)'
+      - '\.tmp$'
+      - '\.log$'
+      - '\.db$'
   - name: keep_null
     type: bool
     title: Keep null fields


### PR DESCRIPTION
## What does this PR do?

- Avoid monitoring by default `/usr/share`. It contains the folder where the elastic agent is installed, including the `beat.db` database which is updated every time a change in FIM happens, so it generates an infinite loop.

- Exclude by default files that are expected to be modified, in particular, `.tmp`, `.log` and `.db` files. FIM should be focused on monitoring files whose changes may represent a security issue, monitoring files that change regularly may imply a noise that makes this task more difficult.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

