### PR TITLE
[ti_otx] - update package-spec to 2.10.0

### DIFF
--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.15.0"
   changes:
-    - description: Update package to ECS 8.9.0.
+    - description: Update package-spec to 2.10.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7574
 - version: "1.14.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_otx/changelog.yml
+++ b/packages/ti_otx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Update package to ECS 8.9.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.14.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-no-preserve-ndjson.log-expected.json
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-no-preserve-ndjson.log-expected.json
@@ -5,9 +5,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "threat": {
@@ -22,9 +26,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65",
@@ -46,9 +54,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "threat": {
@@ -65,9 +77,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "threat": {
@@ -82,9 +98,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "threat": {
@@ -103,9 +123,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09"

--- a/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log-expected.json
+++ b/packages/ti_otx/data_stream/threat/_dev/test/pipeline/test-otx-sample-ndjson.log-expected.json
@@ -5,10 +5,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1588938}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -26,10 +30,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"90421f8531f963d81cf54245b72cde80\",\"description\":\"MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65\",\"title\":\"Win32:Hoblig-B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":9751110}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of a5725af4391d21a232dc6d4ad33d7d915bd190bdac9b1826b73f364dc5c1aa65",
@@ -54,10 +62,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"ip.anysrc.net\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"hostname\",\"id\":16782717}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -77,10 +89,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":19901748}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -98,10 +114,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"d8c70ca70fd3555a0828fede6cc1f59e2c320ede80157039b6a2f09c336d5f7a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":31612067}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -123,10 +143,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"f8e58af3ffefd4037fef246e93a55dc8\",\"description\":\"MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":34413770}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of df9b37477a83189cd4541674e64ce29bf7bf98338ed0d635276660e0c6419d09"
@@ -150,10 +174,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"1c62f004d0c9b91d3467b1b8106772e667e7e2075470c2ec7982b63573c90c54\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":111154034}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -175,10 +203,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"8d24a14f2600482d0231396b6350cf21773335ec2f0b8919763317fdab78baae\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":151858953}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -202,10 +234,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":311294364}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -223,10 +259,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"c758ec922b173820374e552c2f015ac53cc5d9f99cc92080e608652aaa63695b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":406540408}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -248,10 +288,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":565556753}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -273,10 +317,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"aeb08b0651bc8a13dcf5e5f6c0d482f8\",\"description\":\"MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6\",\"title\":null,\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":565556755}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 0df586aa0334dcbe047d24ce859d00e537fdb5e0ca41886dab27479b6fc61ba6"
@@ -300,10 +348,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"6df5e1a017dff52020c7ff6ad92fdd37494e31769e1be242f6b23d1ea2d60140\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672549}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -325,10 +377,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"c72fef3835f65cb380f6920b22c3488554d1af6d298562ccee92284f265c9619\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":575672550}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -350,10 +406,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"e711fcd0f182b214c6ec74011a395f4c853068d59eb7c57f90c4a3e1de64434a\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":995160791}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -375,10 +435,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"d3ec8f4a46b21fb189fc3d58f3d87bf9897653ecdf90b7952dcc71f3b4023b4e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989699}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -400,10 +464,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"70447996722e5c04514d20b7a429d162b46546002fb0c87f512b40f16bac99bb\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1011989701}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -425,10 +493,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"29340643ca2e6677c19e1d3bf351d654\",\"description\":\"MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472176322}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec",
@@ -453,10 +525,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"86c314bc2dc37ba84f7364acd5108c2b\",\"description\":\"MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457325}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2",
@@ -481,10 +557,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"cb0c1248d3899358a375888bb4e8f3fe\",\"description\":\"MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457326}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56",
@@ -509,10 +589,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"d348f536e214a47655af387408b4fca5\",\"description\":\"MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1472457327}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4",
@@ -537,10 +621,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"description\":null,\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012751}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "vad_contains_network_strings"
@@ -564,10 +652,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"b105891f90b2a8730bbadf02b5adeccbba539883bf75dec2ff7a5a97625dd222\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012939}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -589,10 +681,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"e4db5405ac7ab517d43722e1ca8d653ea4a32802bc8a5410d032275eedc7b7ee\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1546012967}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -614,10 +710,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"description\":null,\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141498}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win.Malware.TrickbotSystemInfo-6335590-0"
@@ -641,10 +741,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"5051906d6ed1b2ae9c9a9f070ef73c9be8f591d2e41d144649a0dc96e28d0400\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1564141523}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -666,10 +770,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"14b74cb9be8cad8eb5fa8842d00bb692\",\"description\":\"MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1564142109}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa",
@@ -694,10 +802,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"a5b59f7d133e354dfc73f40517aab730f322f0ef\",\"description\":\"SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa\",\"title\":\"Win.Malware.TrickbotSystemInfo-6335590-0\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1564142964}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "SHA1 of 465e7c1e36899284da5c4425dfd687af2496f397fe60c85ea2b4d85dff5a08aa",
@@ -722,10 +834,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"8d3f68b16f0710f858d8c1d2c699260e6f43161a5510abb0e7ba567bd72c965b\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1566067095}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -747,10 +863,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"ff2dcea4963e060a658f4dffbb119529\",\"description\":\"MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1566999970}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 5cb822616d2c9435c9ddd060d6abdbc286ab57cfcf6dc64768c52976029a925b",
@@ -775,10 +895,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"0d73f1a1c4b2f8723fffc83eb3d00f31\",\"description\":\"MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413\",\"title\":\"vad_contains_network_strings\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":1569290125}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 29ff1903832827e328ad9ec05fdf268eadd6db8b613597cf65f8740c211be413",
@@ -803,10 +927,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1592876453}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -824,10 +952,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"d35a30264c0698709ad554489004e0077e263d354ced0c54552a0b500f91ecc0\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1597058431}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -849,10 +981,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"5264b455f453820be629a324196131492ff03c80491e823ac06657c9387250dd\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1603343478}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -874,10 +1010,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"description\":null,\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260302}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Trojan:Win32/Occamy.B"
@@ -901,10 +1041,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260304}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -928,10 +1072,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"b8e463789a076b16a90d1aae73cea9d3880ac0ead1fd16587b8cd79e37a1a3d8\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260305}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -953,10 +1101,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260310}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -980,10 +1132,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260311}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -1007,10 +1163,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"c51024bb119211c335f95e731cfa9a744fcdb645a57d35fb379d01b7dbdd098e\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":1606260316}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1032,10 +1192,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"ad20c6fac565f901c82a21b70f9739037eb54818\",\"description\":\"SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260341}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "SHA1 of 9b86a50b36aea5cc4cb60573a3660cf799a9ec1f69a3d4572d3dc277361a0ad2",
@@ -1060,10 +1224,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"13f11e273f9a4a56557f03821c3bfd591cca6ebc\",\"description\":\"SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260344}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "SHA1 of 3012f472969327d5f8c9dac63b8ea9c5cb0de002d16c120a6bba4685120f58b4",
@@ -1088,10 +1256,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"1581fe76e3c96dc33182daafd09c8cf5c17004e0\",\"description\":\"SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec\",\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260353}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "SHA1 of 113af75f13547be184822f1268f984b79f35965a1b1f963d23b50a09741b0aec",
@@ -1116,10 +1288,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"b72e75e9e901a44b655a5cf89cf0eadcaff46037\",\"description\":\"SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56\",\"title\":\"Trojan:Win32/Occamy.B\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":1606260364}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "SHA1 of 1455091954ecf9ccd6fe60cb8e982d9cfb4b3dc8414443ccfdfc444079829d56",
@@ -1144,10 +1320,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"maper.info\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":1634015726}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1167,10 +1347,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1635374317}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1188,10 +1372,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":1756014820}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1209,10 +1397,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543412}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1236,10 +1428,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"be9fb556a3c7aef0329e768d7f903e7dd42a821abc663e11fb637ce33b007087\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543416}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1263,10 +1459,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"3bfec096c4837d1e6485fe0ae0ea6f1c0b44edc611d4f2204cc9cf73c985cbc2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543440}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1290,10 +1490,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"dff2e39b2e008ea89a3d6b36dcd9b8c927fb501d60c1ad5a52ed1ffe225da2e2\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543441}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1317,10 +1521,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"6b4d271a48d118843aee3dee4481fa2930732ed7075db3241a8991418f00d92b\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543445}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1344,10 +1552,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"26de4265303491bed1424d85b263481ac153c2b3513f9ee48ffb42c12312ac43\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543456}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1371,10 +1583,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"02f54da6c6f2f87ff7b713d46e058dedac1cedabd693643bb7f6dfe994b2105d\",\"description\":null,\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2114543458}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "xor_0x20_xord_javascript"
@@ -1398,10 +1614,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754074}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1419,10 +1639,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754077}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1440,10 +1664,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754078}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1461,10 +1689,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2114754080}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1482,10 +1714,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2117062744}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1503,10 +1739,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"e999b83629355ec7ff3b6fda465ef53ce6992c9327344fbf124f7eb37808389d\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"FileHash-SHA256\",\"id\":2117884668}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1528,10 +1768,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2119746545}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1549,10 +1793,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2129763785}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1570,10 +1818,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2136050161}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1591,10 +1843,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2136079568}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Trickbot"
@@ -1614,10 +1870,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"fotmailz.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741373}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1637,10 +1897,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"pori89g5jqo3v8.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2137741468}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1660,10 +1924,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"sebco.co.ke\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2178708355}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1683,10 +1951,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2180669102}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Trickbot"
@@ -1706,10 +1978,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"chishir.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034800}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1729,10 +2005,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"kostunivo.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034803}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1752,10 +2032,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"mangoclone.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034805}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1775,10 +2059,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"onixcellent.com\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"domain\",\"id\":2186034807}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1798,10 +2086,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"fc0efd612ad528795472e99cae5944b68b8e26dc\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034891}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -1825,10 +2117,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"24d4bbc982a6a561f0426a683b9617de1a96a74a\",\"description\":null,\"title\":\"Sf:ShellCode-DZ\\\\ [Trj]\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034903}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Sf:ShellCode-DZ\\ [Trj]"
@@ -1852,10 +2148,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"fa98074dc18ad7e2d357b5d168c00a91256d87d1\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034912}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -1879,10 +2179,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"e5dc7c8bfa285b61dda1618f0ade9c256be75d1a\",\"description\":null,\"title\":\"Win64:Malware-gen\",\"content\":\"\",\"type\":\"FileHash-SHA1\",\"id\":2186034924}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Win64:Malware-gen"
@@ -1906,10 +2210,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":\"Trickbot\",\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036445}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "title": "Trickbot"
@@ -1929,10 +2237,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2189036446}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1950,10 +2262,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"89.160.20.156\",\"description\":null,\"title\":null,\"content\":\"\",\"type\":\"IPv4\",\"id\":2190596263}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -1971,10 +2287,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"indicator\":\"10ec3571596c30b9993b89f12d29d23c\",\"description\":\"MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6\",\"title\":\"xor_0x20_xord_javascript\",\"content\":\"\",\"type\":\"FileHash-MD5\",\"id\":2192837907}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {
                 "description": "MD5 of 9af8a93519d22ed04ffb9ccf6861c9df1b77dc5d22e0aeaff4a582dbf8660ba6",
@@ -1999,10 +2319,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"id\":73,\"indicator\":\"http://www.playboysplus.com\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -2026,10 +2350,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"id\":74,\"indicator\":\"http://join.playboysplus.com/signup/\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [
@@ -2053,10 +2381,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"count\": 1, \"results\": {\"id\":970,\"indicator\":\"http://api.vk.com/method/wall.get?count=1\u0026owner_id=-81972386\",\"type\":\"URL\",\"title\":null,\"description\":null,\"content\":\"\"}}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "otx": {},
             "tags": [

--- a/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_otx/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ######################
   # General ECS fields #

--- a/packages/ti_otx/data_stream/threat/sample_event.json
+++ b/packages/ti_otx/data_stream/threat/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2022-12-21T09:24:01.501Z",
+    "@timestamp": "2023-08-28T16:47:36.240Z",
     "agent": {
-        "ephemeral_id": "32ac7970-c892-46ef-baf2-d8a0ce377748",
-        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
+        "ephemeral_id": "86276bd7-10fe-4c14-91e1-7708cc0134b8",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "ti_otx.threat",
@@ -16,19 +16,23 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.9.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-12-21T09:24:01.501Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-28T16:47:36.240Z",
         "dataset": "ti_otx.threat",
-        "ingested": "2022-12-21T09:24:02Z",
+        "ingested": "2023-08-28T16:47:39Z",
         "kind": "enrichment",
         "original": "{\"count\":40359,\"next\":\"https://otx.alienvault.com/api/v1/indicators/export?types=domain%2CIPv4%2Chostname%2Curl%2CFileHash-SHA256\\u0026modified_since=2020-11-29T01%3A10%3A00+00%3A00\\u0026page=2\",\"previous\":null,\"results\":{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_otx/docs/README.md
+++ b/packages/ti_otx/docs/README.md
@@ -101,13 +101,13 @@ An example event for `threat` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-12-21T09:24:01.501Z",
+    "@timestamp": "2023-08-28T16:47:36.240Z",
     "agent": {
-        "ephemeral_id": "32ac7970-c892-46ef-baf2-d8a0ce377748",
-        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
+        "ephemeral_id": "86276bd7-10fe-4c14-91e1-7708cc0134b8",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.3"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "ti_otx.threat",
@@ -118,19 +118,23 @@ An example event for `threat` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "a7d83bcb-0b6d-41f4-8edf-aa29923f67ec",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "snapshot": false,
-        "version": "8.3.3"
+        "version": "8.9.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-12-21T09:24:01.501Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-28T16:47:36.240Z",
         "dataset": "ti_otx.threat",
-        "ingested": "2022-12-21T09:24:02Z",
+        "ingested": "2023-08-28T16:47:39Z",
         "kind": "enrichment",
         "original": "{\"count\":40359,\"next\":\"https://otx.alienvault.com/api/v1/indicators/export?types=domain%2CIPv4%2Chostname%2Curl%2CFileHash-SHA256\\u0026modified_since=2020-11-29T01%3A10%3A00+00%3A00\\u0026page=2\",\"previous\":null,\"results\":{\"content\":\"\",\"description\":null,\"id\":1251,\"indicator\":\"info.3000uc.com\",\"title\":null,\"type\":\"hostname\"}}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_otx/manifest.yml
+++ b/packages/ti_otx/manifest.yml
@@ -1,11 +1,9 @@
 name: ti_otx
 title: AlienVault OTX
-version: "1.14.0"
-release: ga
+version: "1.15.0"
 description: Ingest threat intelligence indicators from AlienVault Open Threat Exchange (OTX) with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.10.0
 categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.10.0
- Ensure event.category is an array
- Ensure event.type is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.10.0 packages/ti_otx
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870
