### PR TITLE
o365: increase CEL resource.tracer.maxsize limit

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.0"
+  changes:
+    - description: Increase CEL resource.tracer.maxsize to prevent loss of trace responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7580
 - version: "1.20.1"
   changes:
     - description: Fix timestamp error in CEL input

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -50,6 +50,7 @@ resource.rate_limit.burst: {{resource_rate_limit_burst}}
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+resource.tracer.maxsize: 5
 {{/if}}
 
 state:

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.20.1"
+version: "1.21.0"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: 2.9.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

The default limit in the Filebeat input is 1MiB which is too small for some responses, resulting in loss of visibility in debugging issues in the integration, so increase to 5MiB.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
