### PR TITLE
[ti_threatq] - update package-spec to 2.10.0

### DIFF
--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Update package-spec to 2.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.15.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.10.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7589
 - version: "1.15.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/ti_threatq/data_stream/threat/_dev/test/pipeline/test-threatq-no-preserve-ndjson.log-expected.json
+++ b/packages/ti_threatq/data_stream/threat/_dev/test/pipeline/test-threatq-no-preserve-ndjson.log-expected.json
@@ -6,9 +6,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "threat": {
                 "indicator": {
@@ -51,9 +55,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "threat": {
                 "indicator": {
@@ -96,9 +104,13 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "threat": {
                 "indicator": {

--- a/packages/ti_threatq/data_stream/threat/_dev/test/pipeline/test-threatq-sample-ndjson.log-expected.json
+++ b/packages/ti_threatq/data_stream/threat/_dev/test/pipeline/test-threatq-sample-ndjson.log-expected.json
@@ -6,10 +6,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1877,\"indicator_id\":336,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1878,\"indicator_id\":336,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"MP\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1879,\"indicator_id\":336,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Saipan\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1880,\"indicator_id\":336,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1881,\"indicator_id\":336,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1882,\"indicator_id\":336,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"1ece659dcec98b1e1141160b55655c96\",\"id\":336,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":336,\"indicator_id\":336,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -55,10 +59,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1883,\"indicator_id\":337,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1884,\"indicator_id\":337,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1885,\"indicator_id\":337,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1886,\"indicator_id\":337,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1887,\"indicator_id\":337,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1888,\"indicator_id\":337,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Sacramento\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"73c98d43519990c841a5d022546fedd4\",\"id\":337,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":337,\"indicator_id\":337,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -104,10 +112,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1889,\"indicator_id\":338,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1890,\"indicator_id\":338,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1891,\"indicator_id\":338,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1892,\"indicator_id\":338,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1893,\"indicator_id\":338,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"New York\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1894,\"indicator_id\":338,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"a9c6773919112627495d87c51fe89b15\",\"id\":338,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":338,\"indicator_id\":338,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -153,10 +165,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:43\",\"id\":184,\"indicator_id\":34,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:35:49\",\"updated_at\":\"2020-10-15 14:35:49\",\"value\":\"4\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:43\",\"id\":185,\"indicator_id\":34,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:35:49\",\"updated_at\":\"2020-10-15 14:35:49\",\"value\":\"3\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:43\",\"id\":186,\"indicator_id\":34,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:35:49\",\"updated_at\":\"2020-10-15 14:35:49\",\"value\":\"Malicious Host\"},{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:43\",\"id\":187,\"indicator_id\":34,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:35:49\",\"updated_at\":\"2020-10-15 14:35:49\",\"value\":\"2\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:41\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:02\",\"hash\":\"56f3cb07a9055f52947bb4c4244f762d\",\"id\":34,\"published_at\":\"2020-09-11 14:35:41\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:43\",\"creator_source_id\":12,\"id\":34,\"indicator_id\":34,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:43\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:35:49\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -196,10 +212,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1901,\"indicator_id\":340,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1902,\"indicator_id\":340,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1903,\"indicator_id\":340,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1904,\"indicator_id\":340,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1905,\"indicator_id\":340,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1906,\"indicator_id\":340,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Sacramento\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"97624a37200db6ba0bcfce8c9c28f527\",\"id\":340,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":340,\"indicator_id\":340,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -245,10 +265,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1907,\"indicator_id\":341,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1908,\"indicator_id\":341,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1909,\"indicator_id\":341,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1910,\"indicator_id\":341,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Houston\"},{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1911,\"indicator_id\":341,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1912,\"indicator_id\":341,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"56a1917632c03f230c5645f432e71495\",\"id\":341,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":341,\"indicator_id\":341,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\",\"provider\":\"testprovider\",\"tlp_name\":\"testtlp\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -297,10 +321,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1913,\"indicator_id\":342,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1914,\"indicator_id\":342,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Fort Lauderdale\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1915,\"indicator_id\":342,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1916,\"indicator_id\":342,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1917,\"indicator_id\":342,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1918,\"indicator_id\":342,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"6de45834c2a81597b59a91ead4fbdf59\",\"id\":342,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":342,\"indicator_id\":342,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -346,10 +374,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1919,\"indicator_id\":343,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1920,\"indicator_id\":343,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Pompano Beach\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1921,\"indicator_id\":343,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1922,\"indicator_id\":343,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1923,\"indicator_id\":343,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1924,\"indicator_id\":343,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"994a4586b27e46db67a59220ab6dd73f\",\"id\":343,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":343,\"indicator_id\":343,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -395,10 +427,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1937,\"indicator_id\":346,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1938,\"indicator_id\":346,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1939,\"indicator_id\":346,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1940,\"indicator_id\":346,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1941,\"indicator_id\":346,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Little Elm\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1942,\"indicator_id\":346,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"40e81e10007099902cf40cfe3a8227dc\",\"id\":346,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":346,\"indicator_id\":346,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"
@@ -444,10 +480,14 @@
                 "version": "8.9.0"
             },
             "event": {
-                "category": "threat",
+                "category": [
+                    "threat"
+                ],
                 "kind": "enrichment",
                 "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":7,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1943,\"indicator_id\":347,\"name\":\"AlienVault Threat Level\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"2\"},{\"attribute_id\":4,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1944,\"indicator_id\":347,\"name\":\"Country\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"US\"},{\"attribute_id\":3,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1945,\"indicator_id\":347,\"name\":\"Description\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Malicious Host\"},{\"attribute_id\":6,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1946,\"indicator_id\":347,\"name\":\"AlienVault Revision\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"3\"},{\"attribute_id\":5,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1947,\"indicator_id\":347,\"name\":\"City\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"Dallas\"},{\"attribute_id\":8,\"created_at\":\"2020-09-11 14:35:53\",\"id\":1948,\"indicator_id\":347,\"name\":\"AlienVault Reliability\",\"touched_at\":\"2020-10-15 14:36:00\",\"updated_at\":\"2020-10-15 14:36:00\",\"value\":\"4\"}],\"class\":\"network\",\"created_at\":\"2020-09-11 14:35:51\",\"expired_at\":\"2020-11-15 00:00:02\",\"expires_calculated_at\":\"2020-10-15 14:40:03\",\"hash\":\"418a88a2a1bac6980a7d83e6b2b2a27d\",\"id\":347,\"published_at\":\"2020-09-11 14:35:51\",\"score\":4,\"sources\":[{\"created_at\":\"2020-09-11 14:35:53\",\"creator_source_id\":12,\"id\":347,\"indicator_id\":347,\"indicator_status_id\":2,\"indicator_type_id\":15,\"name\":\"AlienVault OTX\",\"published_at\":\"2020-09-11 14:35:53\",\"reference_id\":1,\"source_expire_days\":\"30\",\"source_id\":12,\"source_score\":1,\"source_type\":\"connectors\",\"updated_at\":\"2020-10-15 14:36:00\"}],\"status\":{\"description\":\"No longer poses a serious threat.\",\"id\":2,\"name\":\"Expired\"},\"status_id\":2,\"touched_at\":\"2021-06-07 19:47:27\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2020-11-15 00:00:02\",\"value\":\"89.160.20.156\"}",
-                "type": "indicator"
+                "type": [
+                    "indicator"
+                ]
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/ti_threatq/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_threatq/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -12,10 +12,10 @@ processors:
       value: enrichment
   - set:
       field: event.category
-      value: threat
+      value: [threat]
   - set:
       field: event.type
-      value: indicator
+      value: [indicator]
 
   ###############
   # Parse dates #

--- a/packages/ti_threatq/data_stream/threat/sample_event.json
+++ b/packages/ti_threatq/data_stream/threat/sample_event.json
@@ -1,7 +1,7 @@
 {
     "@timestamp": "2021-10-01T18:36:03.000Z",
     "agent": {
-        "ephemeral_id": "0df9e1dd-9174-4a84-8aa9-1a183a5508e1",
+        "ephemeral_id": "37eb63bd-5e42-4366-be2e-c82dfceae102",
         "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -25,9 +25,9 @@
         "category": [
             "threat"
         ],
-        "created": "2023-08-29T13:17:06.040Z",
+        "created": "2023-08-29T13:46:54.929Z",
         "dataset": "ti_threatq.threat",
-        "ingested": "2023-08-29T13:17:09Z",
+        "ingested": "2023-08-29T13:46:57Z",
         "kind": "enrichment",
         "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":5,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893068,\"indicator_id\":106767,\"name\":\"Contact\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"email:Quetzalcoatl_relays[]protonmail.com url:https://quetzalcoatl-relays.org proof:uri-rsa hoster:frantech.ca\"},{\"attribute_id\":9,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893069,\"indicator_id\":106767,\"name\":\"Router Port\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"9000\"},{\"attribute_id\":6,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893070,\"indicator_id\":106767,\"name\":\"Flags\",\"touched_at\":\"2021-10-02 18:36:08\",\"updated_at\":\"2021-10-02 18:36:08\",\"value\":\"ERDV\"}],\"class\":\"network\",\"created_at\":\"2021-10-01 18:36:03\",\"expires_calculated_at\":\"2021-10-23 18:40:17\",\"hash\":\"69beef49fdbd1f54eef3cab324c7b6cf\",\"id\":106767,\"published_at\":\"2021-10-01 18:36:03\",\"score\":0,\"sources\":[{\"created_at\":\"2021-10-01 18:36:06\",\"creator_source_id\":12,\"id\":3699669,\"indicator_id\":106767,\"indicator_status_id\":1,\"indicator_type_id\":15,\"name\":\"www.dan.me.uk Tor Node List\",\"published_at\":\"2021-10-01 18:36:06\",\"reference_id\":37,\"source_id\":12,\"source_type\":\"connectors\",\"updated_at\":\"2021-10-24 18:36:10\"}],\"status\":{\"description\":\"Poses a threat and is being exported to detection tools.\",\"id\":1,\"name\":\"Active\"},\"status_id\":1,\"touched_at\":\"2021-10-24 18:36:10\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2021-10-01 18:36:03\",\"value\":\"107.189.1.90\"}",
         "type": [

--- a/packages/ti_threatq/data_stream/threat/sample_event.json
+++ b/packages/ti_threatq/data_stream/threat/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-10-01T18:36:03.000Z",
     "agent": {
-        "ephemeral_id": "9d50b50e-cf01-4905-b2ed-3557c6d540db",
-        "id": "a7be703c-0d78-40ea-8ad7-a02245cca635",
+        "ephemeral_id": "0df9e1dd-9174-4a84-8aa9-1a183a5508e1",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "ti_threatq.threat",
@@ -16,19 +16,23 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "a7be703c-0d78-40ea-8ad7-a02245cca635",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.9.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-01T16:06:47.804Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-29T13:17:06.040Z",
         "dataset": "ti_threatq.threat",
-        "ingested": "2022-08-01T16:06:48Z",
+        "ingested": "2023-08-29T13:17:09Z",
         "kind": "enrichment",
         "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":5,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893068,\"indicator_id\":106767,\"name\":\"Contact\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"email:Quetzalcoatl_relays[]protonmail.com url:https://quetzalcoatl-relays.org proof:uri-rsa hoster:frantech.ca\"},{\"attribute_id\":9,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893069,\"indicator_id\":106767,\"name\":\"Router Port\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"9000\"},{\"attribute_id\":6,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893070,\"indicator_id\":106767,\"name\":\"Flags\",\"touched_at\":\"2021-10-02 18:36:08\",\"updated_at\":\"2021-10-02 18:36:08\",\"value\":\"ERDV\"}],\"class\":\"network\",\"created_at\":\"2021-10-01 18:36:03\",\"expires_calculated_at\":\"2021-10-23 18:40:17\",\"hash\":\"69beef49fdbd1f54eef3cab324c7b6cf\",\"id\":106767,\"published_at\":\"2021-10-01 18:36:03\",\"score\":0,\"sources\":[{\"created_at\":\"2021-10-01 18:36:06\",\"creator_source_id\":12,\"id\":3699669,\"indicator_id\":106767,\"indicator_status_id\":1,\"indicator_type_id\":15,\"name\":\"www.dan.me.uk Tor Node List\",\"published_at\":\"2021-10-01 18:36:06\",\"reference_id\":37,\"source_id\":12,\"source_type\":\"connectors\",\"updated_at\":\"2021-10-24 18:36:10\"}],\"status\":{\"description\":\"Poses a threat and is being exported to detection tools.\",\"id\":1,\"name\":\"Active\"},\"status_id\":1,\"touched_at\":\"2021-10-24 18:36:10\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2021-10-01 18:36:03\",\"value\":\"107.189.1.90\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_threatq/docs/README.md
+++ b/packages/ti_threatq/docs/README.md
@@ -106,11 +106,11 @@ An example event for `threat` looks as following:
 {
     "@timestamp": "2021-10-01T18:36:03.000Z",
     "agent": {
-        "ephemeral_id": "9d50b50e-cf01-4905-b2ed-3557c6d540db",
-        "id": "a7be703c-0d78-40ea-8ad7-a02245cca635",
+        "ephemeral_id": "37eb63bd-5e42-4366-be2e-c82dfceae102",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.3.2"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "ti_threatq.threat",
@@ -121,19 +121,23 @@ An example event for `threat` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "a7be703c-0d78-40ea-8ad7-a02245cca635",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "snapshot": false,
-        "version": "8.3.2"
+        "version": "8.9.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "category": "threat",
-        "created": "2022-08-01T16:06:47.804Z",
+        "category": [
+            "threat"
+        ],
+        "created": "2023-08-29T13:46:54.929Z",
         "dataset": "ti_threatq.threat",
-        "ingested": "2022-08-01T16:06:48Z",
+        "ingested": "2023-08-29T13:46:57Z",
         "kind": "enrichment",
         "original": "{\"adversaries\":[],\"attributes\":[{\"attribute_id\":5,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893068,\"indicator_id\":106767,\"name\":\"Contact\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"email:Quetzalcoatl_relays[]protonmail.com url:https://quetzalcoatl-relays.org proof:uri-rsa hoster:frantech.ca\"},{\"attribute_id\":9,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893069,\"indicator_id\":106767,\"name\":\"Router Port\",\"touched_at\":\"2021-10-24 18:36:10\",\"updated_at\":\"2021-10-24 18:36:10\",\"value\":\"9000\"},{\"attribute_id\":6,\"created_at\":\"2021-10-01 18:36:06\",\"id\":4893070,\"indicator_id\":106767,\"name\":\"Flags\",\"touched_at\":\"2021-10-02 18:36:08\",\"updated_at\":\"2021-10-02 18:36:08\",\"value\":\"ERDV\"}],\"class\":\"network\",\"created_at\":\"2021-10-01 18:36:03\",\"expires_calculated_at\":\"2021-10-23 18:40:17\",\"hash\":\"69beef49fdbd1f54eef3cab324c7b6cf\",\"id\":106767,\"published_at\":\"2021-10-01 18:36:03\",\"score\":0,\"sources\":[{\"created_at\":\"2021-10-01 18:36:06\",\"creator_source_id\":12,\"id\":3699669,\"indicator_id\":106767,\"indicator_status_id\":1,\"indicator_type_id\":15,\"name\":\"www.dan.me.uk Tor Node List\",\"published_at\":\"2021-10-01 18:36:06\",\"reference_id\":37,\"source_id\":12,\"source_type\":\"connectors\",\"updated_at\":\"2021-10-24 18:36:10\"}],\"status\":{\"description\":\"Poses a threat and is being exported to detection tools.\",\"id\":1,\"name\":\"Active\"},\"status_id\":1,\"touched_at\":\"2021-10-24 18:36:10\",\"type\":{\"class\":\"network\",\"id\":15,\"name\":\"IP Address\"},\"type_id\":15,\"updated_at\":\"2021-10-01 18:36:03\",\"value\":\"107.189.1.90\"}",
-        "type": "indicator"
+        "type": [
+            "indicator"
+        ]
     },
     "input": {
         "type": "httpjson"

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,11 +1,9 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.15.0"
-release: ga
+version: "1.16.0"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 2.10.0
 categories: ["security", "threat_intel"]
 conditions:
   kibana.version: ^8.7.1


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.10.0
- Ensure event.category is an array
- Ensure event.type is an array

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.10.0 packages/ti_threatq
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870