### PR TITLE
[box_events] - update package-spec to 2.10.0

### DIFF
--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Update package-spec to 2.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/box_events/data_stream/events/fields/ecs.yml
+++ b/packages/box_events/data_stream/events/fields/ecs.yml
@@ -75,8 +75,6 @@
 - external: ecs
   name: threat.enrichments.indicator.description
 - external: ecs
-  name: threat.enrichments.indicator.ip
-- external: ecs
   name: threat.enrichments.indicator.first_seen
 - external: ecs
   name: threat.enrichments.indicator.geo.city_name

--- a/packages/box_events/data_stream/events/fields/fields.yml
+++ b/packages/box_events/data_stream/events/fields/fields.yml
@@ -229,12 +229,6 @@
     - name: recorded_at
       description: The date and time at which this event occurred
       type: date
-    - name: created_at
-      description: When the event object was created
-      type: date
-    - name: created_at
-      description: When the event object was created
-      type: date
     - name: session
       description: Extend ECS related fields
       type: object
@@ -387,13 +381,13 @@
               fields:
                 - name: type
                   description: Value is always `folder`. This field is an array
-                  type: array
+                  type: keyword
                 - name: id
                   description: The unique identifier that represent a folder. This field is an array
-                  type: array
+                  type: keyword
                 - name: name
                   description: The name of the folder. This field is an array
-                  type: array
+                  type: keyword
         - name: purged_at
           description: The time at which this file is expected to be purged from the trash
           type: boolean

--- a/packages/box_events/data_stream/events/sample_event.json
+++ b/packages/box_events/data_stream/events/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-12-08T08:00:00.000Z",
     "agent": {
-        "ephemeral_id": "19d0e7ab-6422-44e5-ab1b-a4344fde2a4f",
-        "id": "52ca6e8b-8f09-4ce6-a173-ec44c538809f",
+        "ephemeral_id": "764c37eb-8835-4094-ba76-e4a16049d6b9",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.9.1"
     },
     "box": {
         "additional_details": {
@@ -60,9 +60,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "52ca6e8b-8f09-4ce6-a173-ec44c538809f",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "snapshot": false,
+        "version": "8.9.1"
     },
     "event": {
         "action": "SHIELD_ALERT",
@@ -71,10 +71,10 @@
             "threat",
             "file"
         ],
-        "created": "2023-01-13T11:47:22.940Z",
+        "created": "2023-08-29T15:21:44.833Z",
         "dataset": "box_events.events",
         "id": "97f1b31f-f143-4777-81f8-1b557b39ca33",
-        "ingested": "2023-01-13T11:47:24Z",
+        "ingested": "2023-08-29T15:21:47Z",
         "kind": "alert",
         "risk_score": 77,
         "type": [
@@ -84,24 +84,24 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": false,
+        "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "4547978d96e74314a1c62b73cc5cad86",
+        "id": "c2615f282eb54b57a5bab10d7ee84193",
         "ip": [
-            "172.25.0.7"
+            "172.21.0.7"
         ],
         "mac": [
-            "02-42-AC-19-00-07"
+            "02-42-AC-15-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.15.49-linuxkit",
+            "kernel": "5.10.47-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
-            "version": "20.04.5 LTS (Focal Fossa)"
+            "version": "20.04.6 LTS (Focal Fossa)"
         }
     },
     "input": {

--- a/packages/box_events/docs/README.md
+++ b/packages/box_events/docs/README.md
@@ -239,9 +239,9 @@ Preserves a raw copy of the original event, added to the field `event.original`.
 | box.source.parent.sequence_id | A numeric identifier that represents the most recent user event that has been applied to this item (parent) | keyword |
 | box.source.parent.type | Value is always `folder` | keyword |
 | box.source.path_collection.entries | The parent folders for this item | object |
-| box.source.path_collection.entries.id | The unique identifier that represent a folder. This field is an array | array |
-| box.source.path_collection.entries.name | The name of the folder. This field is an array | array |
-| box.source.path_collection.entries.type | Value is always `folder`. This field is an array | array |
+| box.source.path_collection.entries.id | The unique identifier that represent a folder. This field is an array | keyword |
+| box.source.path_collection.entries.name | The name of the folder. This field is an array | keyword |
+| box.source.path_collection.entries.type | Value is always `folder`. This field is an array | keyword |
 | box.source.path_collection.total_count | The number of folders in this list | long |
 | box.source.phone | Phone number | boolean |
 | box.source.purged_at | The time at which this file is expected to be purged from the trash | boolean |

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,9 +1,7 @@
-format_version: 1.0.0
+format_version: 2.10.0
 name: box_events
 title: Box Events
-version: "1.7.0"
-release: ga
-license: basic
+version: "1.8.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.10.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.10.0 packages/box_events
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870