### PR TITLE
[pfsense] - update package-spec to 2.10.0

### DIFF
--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package-spec to 2.10.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7602
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Update package-spec to 2.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.11.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/pfsense/data_stream/log/fields/fields.yml
+++ b/packages/pfsense/data_stream/log/fields/fields.yml
@@ -53,7 +53,7 @@
       description: |
         Urgent pointer data.
     - name: options
-      type: array
+      type: keyword
       description: |
         TCP Options.
     - name: length

--- a/packages/pfsense/data_stream/log/sample_event.json
+++ b/packages/pfsense/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-07-04T00:10:14.578Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "5594945b-ed0f-4496-aa7a-3a121ed00404",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "pfsense.log",
@@ -33,9 +33,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "snapshot": false,
+        "version": "8.9.1"
     },
     "event": {
         "action": "block",
@@ -44,7 +44,7 @@
             "network"
         ],
         "dataset": "pfsense.log",
-        "ingested": "2023-01-13T12:35:06Z",
+        "ingested": "2023-08-29T18:51:22Z",
         "kind": "event",
         "original": "\u003c134\u003e1 2021-07-03T19:10:14.578288-05:00 pfSense.example.com filterlog 72237 - - 146,,,1535324496,igb1.12,match,block,in,4,0x0,,63,32989,0,DF,6,tcp,60,10.170.12.50,175.16.199.1,49652,853,0,S,1818117648,,64240,,mss;sackOK;TS;nop;wscale",
         "provider": "filterlog",
@@ -60,7 +60,7 @@
     },
     "log": {
         "source": {
-            "address": "172.27.0.4:60508"
+            "address": "172.21.0.4:35028"
         },
         "syslog": {
             "priority": 134

--- a/packages/pfsense/docs/README.md
+++ b/packages/pfsense/docs/README.md
@@ -48,11 +48,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2021-07-04T00:10:14.578Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "5594945b-ed0f-4496-aa7a-3a121ed00404",
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.9.1"
     },
     "data_stream": {
         "dataset": "pfsense.log",
@@ -80,9 +80,9 @@ An example event for `log` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "snapshot": false,
+        "version": "8.9.1"
     },
     "event": {
         "action": "block",
@@ -91,7 +91,7 @@ An example event for `log` looks as following:
             "network"
         ],
         "dataset": "pfsense.log",
-        "ingested": "2023-01-13T12:35:06Z",
+        "ingested": "2023-08-29T18:51:22Z",
         "kind": "event",
         "original": "\u003c134\u003e1 2021-07-03T19:10:14.578288-05:00 pfSense.example.com filterlog 72237 - - 146,,,1535324496,igb1.12,match,block,in,4,0x0,,63,32989,0,DF,6,tcp,60,10.170.12.50,175.16.199.1,49652,853,0,S,1818117648,,64240,,mss;sackOK;TS;nop;wscale",
         "provider": "filterlog",
@@ -107,7 +107,7 @@ An example event for `log` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.27.0.4:60508"
+            "address": "172.21.0.4:35028"
         },
         "syslog": {
             "priority": 134
@@ -367,7 +367,7 @@ An example event for `log` looks as following:
 | pfsense.tcp.ack | TCP Acknowledgment number. | long |
 | pfsense.tcp.flags | TCP flags. | keyword |
 | pfsense.tcp.length | Length of the TCP header and payload. | long |
-| pfsense.tcp.options | TCP Options. | array |
+| pfsense.tcp.options | TCP Options. | keyword |
 | pfsense.tcp.seq | TCP sequence number. | long |
 | pfsense.tcp.urg | Urgent pointer data. | keyword |
 | pfsense.tcp.window | Advertised TCP window size. | long |

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,7 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.11.0"
-release: ga
+version: "1.12.0"
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration
 icons:
@@ -9,8 +8,7 @@ icons:
     title: pfsense
     size: 512x143
     type: image/svg+xml
-format_version: 1.0.0
-license: basic
+format_version: 2.10.0
 categories:
   - network
   - security


### PR DESCRIPTION
## What does this PR do?

- Update package-spec to 2.10.0

```
[git-generate]
go run github.com/andrewkroh/go-examples/ecs-update@latest -ecs-version=8.9.0 -ecs-git-ref=v8.9.0 -format-version=2.10.0 packages/pfsense
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#5870