### PR TITLE
[Elastic Agent] Add queue depth, output batch size and rate

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.11.3"
+- version: "1.12.0"
   changes:
     - description: Add metrics for input queue depth, output queue depth, and output write batches
       type: enhancement

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,12 +1,7 @@
 # newer versions go on top
 - version: "1.11.3"
   changes:
-    - description: Add visualizations for Agent output queue depth and write batches
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/7476
-- version: "1.11.2"
-  changes:
-    - description: Adding hyperlinks that works when installed on different spaces.
+    - description: Add metrics for input queue depth, output queue depth, and output write batches
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7476
 - version: "1.11.2"

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.12.0"
   changes:
-    - description: Add metrics for input queue depth, output queue depth, and output write batches
+    - description: Add metrics for queue depth, output batch size and output batch rate.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7476
 - version: "1.11.2"

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: "1.11.3"
+  changes:
+    - description: Add visualizations for Agent output queue depth and write batches
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7476
+- version: "1.11.2"
+  changes:
+    - description: Adding hyperlinks that works when installed on different spaces.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7476
 - version: "1.11.2"
   changes:
     - description: Adding hyperlinks that works when installed on different spaces.

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -26,3 +26,50 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -60,7 +60,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -68,8 +68,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -31,6 +31,27 @@
       ignore_above: 1024
       description: Elastic agent version.
 
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams
@@ -43,7 +64,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -51,8 +72,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -30,3 +30,29 @@
       type: keyword
       ignore_above: 1024
       description: Elastic agent version.
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -26,3 +26,50 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -60,7 +60,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -68,8 +68,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -63,7 +63,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -71,8 +71,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -29,3 +29,50 @@
 - name: event.dataset
   type: constant_keyword
   description: Event dataset
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -26,3 +26,50 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -60,7 +60,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -68,8 +68,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -26,3 +26,50 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -60,7 +60,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -68,8 +68,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -26,3 +26,50 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+
+- name: component
+  type: group
+  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
+  fields:
+    - name: id
+      type: wildcard
+      ignore_above: 1024
+      description: Component id
+    - name: type
+      type: keyword
+      ignore_above: 1024
+      description: The type of the component
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+    - name: dataset
+      type: keyword
+      ignore_above: 1024
+
+# Metrics currently logged in "Non-zero metrics in the last 30s" logs
+# TODO: Update Agent to move these to the "metrics" data streams
+# Note: none of thes metric_type fields are used on logs data streams
+- name: monitoring.metrics.libbeat.pipeline
+  type: group
+  fields:
+    - name: events
+      type: group
+      fields:
+        - name: active
+          type: long
+          metric_type: gauge
+          description: Number of events currently in the pipeline
+        - name: published
+          type: long
+          metric_type: counter
+          description: Number of events published by the pipeline
+        - name: total
+          type: long
+          metric_type: counter
+          description: Number of events by the pipeline
+    - name: queue.acked
+      type: long
+      metric_type: counter
+      description: Number of events by the pipeline

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -60,7 +60,7 @@
         - name: active
           type: long
           metric_type: gauge
-          description: Number of events currently in the pipeline
+          description: Number of events currently in the pipeline. The maximum size is the configured queue size plus one event per event pipeline client.
         - name: published
           type: long
           metric_type: counter
@@ -68,8 +68,8 @@
         - name: total
           type: long
           metric_type: counter
-          description: Number of events by the pipeline
+          description: Number of events processed by the pipeline
     - name: queue.acked
       type: long
       metric_type: counter
-      description: Number of events by the pipeline
+      description: Number of events successfully acknowledged by the output

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -1332,10 +1332,10 @@
                                                 "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Maximum of beat.stats.libbeat.output.write.errors",
+                                                    "label": "Batches sent/s",
                                                     "operationType": "max",
                                                     "scale": "ratio",
-                                                    "sourceField": "beat.stats.libbeat.output.write.errors"
+                                                    "sourceField": "beat.stats.libbeat.output.events.batches"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -1441,6 +1441,530 @@
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
                 "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "a867faed-481f-461e-9416-0b99b025f7a8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "beat.type:*"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Queue depth",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.active",
+                                                    "timeScale": "s"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "a867faed-481f-461e-9416-0b99b025f7a8",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output write errors (copy)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "d004044a-99f4-44fa-964a-361accd1810d",
+                    "w": 24,
+                    "x": 24,
+                    "y": 45
+                },
+                "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
+                "title": "[Elastic Agent] Output queue depth",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "97ad75be-db47-4cb4-bb1e-0c0320d04edd",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "38cd2447-deab-49b7-9d84-400f2ba12511": {
+                                            "columnOrder": [
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b",
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                            ],
+                                            "columns": {
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of component.id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c37367a6-4c26-4f3f-86eb-10db67933171",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "component.id"
+                                                },
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Input queue",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "monitoring.metrics.libbeat.pipeline.events.active"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "97ad75be-db47-4cb4-bb1e-0c0320d04edd",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                        ],
+                                        "layerId": "38cd2447-deab-49b7-9d84-400f2ba12511",
+                                        "layerType": "data",
+                                        "seriesType": "area_stacked",
+                                        "splitAccessor": "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                        "xAccessor": "6093c949-5f5d-4c72-baba-5a84ce2f1a9b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output write errors (copy)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
+                    "w": 24,
+                    "x": 24,
+                    "y": 54
+                },
+                "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
+                "title": "[Elastic Agent] Input queue depth",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [
+                                    {
+                                        "$state": {
+                                            "store": "appState"
+                                        },
+                                        "meta": {
+                                            "alias": null,
+                                            "disabled": false,
+                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                                            "key": "data_stream.dataset",
+                                            "negate": false,
+                                            "params": {
+                                                "query": "elastic_agent.elastic_agent"
+                                            },
+                                            "type": "phrase"
+                                        },
+                                        "query": {
+                                            "match_phrase": {
+                                                "data_stream.dataset": "elastic_agent.elastic_agent"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "params": {
+                            "axis_formatter": "number",
+                            "axis_position": "left",
+                            "axis_scale": "normal",
+                            "drop_last_bucket": 0,
+                            "filter": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "id": "f0383b91-4a09-4b03-a013-f5938add6bfa",
+                            "index_pattern_ref_name": "metrics_42ec7297-eb0f-492b-bb18-d1301fa1ead7_0_index_pattern",
+                            "interval": "",
+                            "isModelInvalid": false,
+                            "max_lines_legend": 1,
+                            "series": [
+                                {
+                                    "axis_position": "right",
+                                    "chart_type": "line",
+                                    "color": "#68BC00",
+                                    "fill": 0.5,
+                                    "filter": {
+                                        "language": "kuery",
+                                        "query": ""
+                                    },
+                                    "formatter": "number",
+                                    "id": "a35c4256-5cee-4b6a-ae21-bdd0f0f6d4a2",
+                                    "label": "Cgroup CPU usage",
+                                    "line_width": 1,
+                                    "metrics": [
+                                        {
+                                            "field": "system.process.cgroup.cpuacct.total.ns",
+                                            "id": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
+                                            "type": "max"
+                                        },
+                                        {
+                                            "field": "system.process.cgroup.cpu.cfs.quota.us",
+                                            "id": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
+                                            "type": "min"
+                                        },
+                                        {
+                                            "field": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
+                                            "id": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
+                                            "type": "derivative",
+                                            "unit": "1s"
+                                        },
+                                        {
+                                            "field": "90f31960-fc31-11eb-9d3e-9d72967e3395",
+                                            "id": "4661f000-fc32-11eb-9d3e-9d72967e3395",
+                                            "type": "derivative",
+                                            "unit": "1s"
+                                        },
+                                        {
+                                            "field": "system.process.cgroup.cpu.stats.periods",
+                                            "id": "90f31960-fc31-11eb-9d3e-9d72967e3395",
+                                            "type": "max"
+                                        },
+                                        {
+                                            "id": "5c737680-fc31-11eb-9d3e-9d72967e3395",
+                                            "script": "\n      if (params.deltaUsageDerivNormalizedValue \u003e 0 \u0026\u0026 params.periodsDerivNormalizedValue \u003e0  \u0026\u0026 params.quota \u003e 0) {\n        // if throttling is configured\n        double  factor = params.deltaUsageDerivNormalizedValue / (params.periodsDerivNormalizedValue * params.quota * 1000); \n\n        return factor * 100; \n      }\n\n      return null;",
+                                            "type": "calculation",
+                                            "variables": [
+                                                {
+                                                    "field": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
+                                                    "id": "60300950-fc31-11eb-9d3e-9d72967e3395",
+                                                    "name": "deltaUsageDerivNormalizedValue"
+                                                },
+                                                {
+                                                    "field": "4661f000-fc32-11eb-9d3e-9d72967e3395",
+                                                    "id": "d6060d50-fc31-11eb-9d3e-9d72967e3395",
+                                                    "name": "periodsDerivNormalizedValue"
+                                                },
+                                                {
+                                                    "field": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
+                                                    "id": "e3368450-fc31-11eb-9d3e-9d72967e3395",
+                                                    "name": "quota"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "palette": {
+                                        "name": "default",
+                                        "type": "palette"
+                                    },
+                                    "point_size": 1,
+                                    "separate_axis": 0,
+                                    "split_mode": "terms",
+                                    "stacked": "stacked",
+                                    "terms_field": "elastic_agent.process",
+                                    "time_range_mode": "entire_time_range",
+                                    "type": "timeseries",
+                                    "value_template": "{{value}}%"
+                                }
+                            ],
+                            "show_grid": 1,
+                            "show_legend": 1,
+                            "time_field": "@timestamp",
+                            "time_range_mode": "entire_time_range",
+                            "tooltip_mode": "show_all",
+                            "truncate_legend": 1,
+                            "type": "timeseries",
+                            "use_kibana_indexes": true
+                        },
+                        "type": "metrics",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
+                    "w": 24,
+                    "x": 0,
+                    "y": 54
+                },
+                "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
+                "title": "[Elastic Agent] CGroup CPU Usage",
+                "type": "visualization",
                 "version": "8.7.1"
             },
             {
@@ -1633,348 +2157,11 @@
                     "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
                     "x": 24,
-                    "y": 54
+                    "y": 63
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "7afe5427-e140-490e-995a-e29a4ba562cf",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
-                                            "columnOrder": [
-                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
-                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
-                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
-                                            ],
-                                            "columns": {
-                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Beat types",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "beat.type"
-                                                },
-                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Queue depth",
-                                                    "operationType": "max",
-                                                    "scale": "ratio",
-                                                    "sourceField": "beat.stats.libbeat.output.events.active",
-                                                    "timeScale": "s"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "7afe5427-e140-490e-995a-e29a4ba562cf",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.*"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
-                                        ],
-                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
-                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right",
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "valuesInLegend": true,
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightExtent": {
-                                    "mode": "full"
-                                }
-                            }
-                        },
-                        "title": "[Elastic Agent] Output write errors (copy)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "d004044a-99f4-44fa-964a-361accd1810d",
-                    "w": 24,
-                    "x": 24,
-                    "y": 45
-                },
-                "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
-                "title": "[Elastic Agent] Output queue depth",
-                "type": "lens",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "data_stream.dataset",
-                                            "negate": false,
-                                            "params": {
-                                                "query": "elastic_agent.elastic_agent"
-                                            },
-                                            "type": "phrase"
-                                        },
-                                        "query": {
-                                            "match_phrase": {
-                                                "data_stream.dataset": "elastic_agent.elastic_agent"
-                                            }
-                                        }
-                                    }
-                                ],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 0,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "f0383b91-4a09-4b03-a013-f5938add6bfa",
-                            "index_pattern_ref_name": "metrics_42ec7297-eb0f-492b-bb18-d1301fa1ead7_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "number",
-                                    "id": "a35c4256-5cee-4b6a-ae21-bdd0f0f6d4a2",
-                                    "label": "Cgroup CPU usage",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "field": "system.process.cgroup.cpuacct.total.ns",
-                                            "id": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
-                                            "type": "max"
-                                        },
-                                        {
-                                            "field": "system.process.cgroup.cpu.cfs.quota.us",
-                                            "id": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
-                                            "type": "min"
-                                        },
-                                        {
-                                            "field": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
-                                            "id": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
-                                            "type": "derivative",
-                                            "unit": "1s"
-                                        },
-                                        {
-                                            "field": "90f31960-fc31-11eb-9d3e-9d72967e3395",
-                                            "id": "4661f000-fc32-11eb-9d3e-9d72967e3395",
-                                            "type": "derivative",
-                                            "unit": "1s"
-                                        },
-                                        {
-                                            "field": "system.process.cgroup.cpu.stats.periods",
-                                            "id": "90f31960-fc31-11eb-9d3e-9d72967e3395",
-                                            "type": "max"
-                                        },
-                                        {
-                                            "id": "5c737680-fc31-11eb-9d3e-9d72967e3395",
-                                            "script": "\n      if (params.deltaUsageDerivNormalizedValue \u003e 0 \u0026\u0026 params.periodsDerivNormalizedValue \u003e0  \u0026\u0026 params.quota \u003e 0) {\n        // if throttling is configured\n        double  factor = params.deltaUsageDerivNormalizedValue / (params.periodsDerivNormalizedValue * params.quota * 1000); \n\n        return factor * 100; \n      }\n\n      return null;",
-                                            "type": "calculation",
-                                            "variables": [
-                                                {
-                                                    "field": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
-                                                    "id": "60300950-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "deltaUsageDerivNormalizedValue"
-                                                },
-                                                {
-                                                    "field": "4661f000-fc32-11eb-9d3e-9d72967e3395",
-                                                    "id": "d6060d50-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "periodsDerivNormalizedValue"
-                                                },
-                                                {
-                                                    "field": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
-                                                    "id": "e3368450-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "quota"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "stacked",
-                                    "terms_field": "elastic_agent.process",
-                                    "time_range_mode": "entire_time_range",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}%"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": true
-                        },
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
-                    "w": 24,
-                    "x": 0,
-                    "y": 54
-                },
-                "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
-                "title": "[Elastic Agent] CGroup CPU Usage",
-                "type": "visualization",
                 "version": "8.7.1"
             }
         ],
@@ -1983,7 +2170,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-08-30T11:58:25.613Z",
+    "created_at": "2023-08-30T14:21:48.118Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -2056,22 +2243,22 @@
         },
         {
             "id": "metrics-*",
-            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "d004044a-99f4-44fa-964a-361accd1810d:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d004044a-99f4-44fa-964a-361accd1810d:7afe5427-e140-490e-995a-e29a4ba562cf",
+            "name": "d004044a-99f4-44fa-964a-361accd1810d:a867faed-481f-461e-9416-0b99b025f7a8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1:97ad75be-db47-4cb4-bb1e-0c0320d04edd",
             "type": "index-pattern"
         },
         {
@@ -2082,6 +2269,16 @@
         {
             "id": "metrics-*",
             "name": "42ec7297-eb0f-492b-bb18-d1301fa1ead7:metrics_42ec7297-eb0f-492b-bb18-d1301fa1ead7_0_index_pattern",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -27,6 +27,45 @@
             {
                 "embeddableConfig": {
                     "enhancements": {},
+                    "hidePanelTitles": false,
+                    "savedVis": {
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
+                        "description": "",
+                        "id": "",
+                        "params": {
+                            "fontSize": 12,
+                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n**[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)**  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard is used to show detailed metrics related to the specific agent used in the filter.\n\n",
+                            "openLinksInNewTab": false
+                        },
+                        "title": "",
+                        "type": "markdown",
+                        "uiState": {}
+                    }
+                },
+                "gridData": {
+                    "h": 27,
+                    "i": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
+                    "w": 8,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
+                "title": "Table of Contents",
+                "type": "visualization",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -143,45 +182,6 @@
                 },
                 "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
                 "title": "[Elastic Agent] CPU Usage",
-                "type": "visualization",
-                "version": "8.7.1"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false,
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "id": "",
-                        "params": {
-                            "fontSize": 12,
-                            "markdown": "**Navigation**\n\n**Agent Health**  \n\n[Overview](#/dashboard/elastic_agent-a148dc70-6b3c-11ed-98de-67bdecd21824)  \n[Agent Info](#/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824)  \n**[Agent Metrics](#/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395)**  \n[Integrations](#/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824)  \n[Input Metrics](#/dashboard/elastic_agent-a8192f90-cd3f-11ed-869d-e7dc1b551cd2)  \n\n**Overview**\n\nThis dashboard is used to show detailed metrics related to the specific agent used in the filter.\n\n",
-                            "openLinksInNewTab": false
-                        },
-                        "title": "",
-                        "type": "markdown",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 27,
-                    "i": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
-                    "w": 8,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
-                "title": "Table of Contents",
                 "type": "visualization",
                 "version": "8.7.1"
             },
@@ -487,6 +487,196 @@
                         "references": [
                             {
                                 "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "1f53ae6d-f631-4ef1-8da4-e1918fd352af",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                            ],
+                                            "columns": {
+                                                "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of beat.type",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Events Rate /s",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of beat.stats.libbeat.output.events.total",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.total"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "1f53ae6d-f631-4ef1-8da4-e1918fd352af",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
+                    "w": 24,
+                    "x": 0,
+                    "y": 27
+                },
+                "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
+                "title": "[Elastic Agent] Total events rate /s",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-47363713-6910-43c5-9f85-328b9ee18f0d",
                                 "type": "index-pattern"
                             },
@@ -690,7 +880,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "1f53ae6d-f631-4ef1-8da4-e1918fd352af",
+                                "name": "9ef414bb-7c9f-40b2-a01f-da090834917a",
                                 "type": "index-pattern"
                             }
                         ],
@@ -701,16 +891,30 @@
                                     "layers": {
                                         "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
                                             "columnOrder": [
-                                                "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a",
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
                                                 "49cd060d-6f21-4d81-ad6b-1c8462c97353",
                                                 "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
                                                 "f5cbe487-2a43-425b-9cd1-40283e5e596c"
                                             ],
                                             "columns": {
-                                                "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top values of beat.type",
+                                                    "label": "Beat types",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "missingBucket": false,
@@ -728,19 +932,6 @@
                                                     "scale": "ordinal",
                                                     "sourceField": "beat.type"
                                                 },
-                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
                                                 "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
                                                     "customLabel": true,
                                                     "dataType": "number",
@@ -749,7 +940,7 @@
                                                         "query": "data_stream.dataset : \"elastic_agent.*\" "
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Events Rate /s",
+                                                    "label": "Output Errors",
                                                     "operationType": "counter_rate",
                                                     "references": [
                                                         "f5cbe487-2a43-425b-9cd1-40283e5e596c"
@@ -760,10 +951,10 @@
                                                 "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Maximum of beat.stats.libbeat.output.events.total",
+                                                    "label": "Maximum of beat.stats.libbeat.output.write.errors",
                                                     "operationType": "max",
                                                     "scale": "ratio",
-                                                    "sourceField": "beat.stats.libbeat.output.events.total"
+                                                    "sourceField": "beat.stats.libbeat.output.write.errors"
                                                 }
                                             },
                                             "incompleteColumns": {}
@@ -779,7 +970,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "1f53ae6d-f631-4ef1-8da4-e1918fd352af",
+                                        "index": "9ef414bb-7c9f-40b2-a01f-da090834917a",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -826,7 +1017,7 @@
                                         "position": "top",
                                         "seriesType": "line",
                                         "showGridlines": false,
-                                        "splitAccessor": "2e112c50-5bc4-4c0b-a69b-8c17e0f9fc0a",
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
                                         "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
                                     }
                                 ],
@@ -859,13 +1050,13 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
+                    "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                     "w": 24,
                     "x": 0,
-                    "y": 27
+                    "y": 36
                 },
-                "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
-                "title": "[Elastic Agent] Total events rate /s",
+                "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
+                "title": "[Elastic Agent] Output write errors",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -1070,7 +1261,7 @@
                             },
                             {
                                 "id": "metrics-*",
-                                "name": "9ef414bb-7c9f-40b2-a01f-da090834917a",
+                                "name": "ea5a0af6-28f9-412b-bbd7-99c48037b794",
                                 "type": "index-pattern"
                             }
                         ],
@@ -1130,7 +1321,7 @@
                                                         "query": "data_stream.dataset : \"elastic_agent.*\" "
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Output Errors",
+                                                    "label": "Batches sent/s",
                                                     "operationType": "counter_rate",
                                                     "references": [
                                                         "f5cbe487-2a43-425b-9cd1-40283e5e596c"
@@ -1160,7 +1351,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "9ef414bb-7c9f-40b2-a01f-da090834917a",
+                                        "index": "ea5a0af6-28f9-412b-bbd7-99c48037b794",
                                         "key": "data_stream.dataset",
                                         "negate": false,
                                         "params": {
@@ -1233,6 +1424,8 @@
                                 }
                             }
                         },
+                        "title": "[Elastic Agent] Output write errors (copy)",
+                        "type": "lens",
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
@@ -1240,13 +1433,13 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
+                    "i": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                     "w": 24,
                     "x": 0,
-                    "y": 36
+                    "y": 45
                 },
-                "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
-                "title": "[Elastic Agent] Output write errors",
+                "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
+                "title": "[Elastic Agent] Output write batches",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -1440,10 +1633,192 @@
                     "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
                     "x": 24,
-                    "y": 45
+                    "y": 54
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
+                "type": "lens",
+                "version": "8.7.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "7afe5427-e140-490e-995a-e29a4ba562cf",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Queue depth",
+                                                    "operationType": "max",
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.active",
+                                                    "timeScale": "s"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "7afe5427-e140-490e-995a-e29a4ba562cf",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output write errors (copy)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "d004044a-99f4-44fa-964a-361accd1810d",
+                    "w": 24,
+                    "x": 24,
+                    "y": 45
+                },
+                "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
+                "title": "[Elastic Agent] Output queue depth",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -1595,7 +1970,7 @@
                     "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                     "w": 24,
                     "x": 0,
-                    "y": 45
+                    "y": 54
                 },
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
@@ -1608,7 +1983,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-05-04T11:54:53.566Z",
+    "created_at": "2023-08-30T11:58:25.613Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "migrationVersion": {
         "dashboard": "8.7.0"
@@ -1631,16 +2006,6 @@
         },
         {
             "id": "metrics-*",
-            "name": "daff36f6-d0b5-45e8-b0d9-910bace3c15b:indexpattern-datasource-layer-47363713-6910-43c5-9f85-328b9ee18f0d",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "daff36f6-d0b5-45e8-b0d9-910bace3c15b:4984682b-b209-448b-a8bc-239d1858c0ae",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "6f1753a7-612d-4e25-a33f-8aa3542d3c39:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
             "type": "index-pattern"
         },
@@ -1651,12 +2016,12 @@
         },
         {
             "id": "metrics-*",
-            "name": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "name": "daff36f6-d0b5-45e8-b0d9-910bace3c15b:indexpattern-datasource-layer-47363713-6910-43c5-9f85-328b9ee18f0d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f:d8c4f995-b5b9-4da1-9c7c-32fd11cfbcee",
+            "name": "daff36f6-d0b5-45e8-b0d9-910bace3c15b:4984682b-b209-448b-a8bc-239d1858c0ae",
             "type": "index-pattern"
         },
         {
@@ -1671,12 +2036,42 @@
         },
         {
             "id": "metrics-*",
+            "name": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f:d8c4f995-b5b9-4da1-9c7c-32fd11cfbcee",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1a30ba18-2c22-4935-b245-6ec8f1a37ced:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "1a30ba18-2c22-4935-b245-6ec8f1a37ced:ea5a0af6-28f9-412b-bbd7-99c48037b794",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
             "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
             "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d004044a-99f4-44fa-964a-361accd1810d:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d004044a-99f4-44fa-964a-361accd1810d:7afe5427-e140-490e-995a-e29a4ba562cf",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -1513,7 +1513,7 @@
                                                         "query": "beat.type:*"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Queue depth",
+                                                    "label": "Batch size",
                                                     "operationType": "max",
                                                     "scale": "ratio",
                                                     "sourceField": "beat.stats.libbeat.output.events.active",
@@ -1621,7 +1621,7 @@
                     "y": 45
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
-                "title": "[Elastic Agent] Output queue depth",
+                "title": "[Elastic Agent] Output batch size",
                 "type": "lens",
                 "version": "8.7.1"
             },
@@ -1698,7 +1698,7 @@
                                                         "query": ""
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Input queue",
+                                                    "label": "Queue depth",
                                                     "operationType": "max",
                                                     "params": {
                                                         "emptyAsNull": true
@@ -1793,7 +1793,7 @@
                                 }
                             }
                         },
-                        "title": "[Elastic Agent] Output write errors (copy)",
+                        "title": "[Elastic Agent] Queue depth",
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
@@ -1808,7 +1808,7 @@
                     "y": 54
                 },
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
-                "title": "[Elastic Agent] Input queue depth",
+                "title": "[Elastic Agent] Queue depth",
                 "type": "lens",
                 "version": "8.7.1"
             },

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.11.3
+version: 1.12.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.11.2
+version: 1.11.3
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This adds more in depth metrics for viewing output batches sizes, batches/sec, and input queue sizes. This helps with tuning `workers` and `bulk_max_size` to avoid filling up the queues.

For the input queue metrics, we currently only have this data on the `logs-elastic_agent.*beat-*` data streams, rather than on the `metrics-*` data streams. Fixing this requires some fixes in Agent and I'd like to get value out on this sooner, so I'm deciding to map these fields for now on `logs` and we'll fix later (opened https://github.com/elastic/elastic-agent/issues/3334) on a future Agent version.

@elastic/elastic-agent-data-plane I would like confirmation that I am interpreting this metric fields correctly.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

`elastic-package stack up && elastic-package build && elastic-package install`

Go to Fleet -> click on an Agent -> View more agent metrics

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/3315

## Screenshots

### Output write batches/sec

<img width="785" alt="image" src="https://github.com/elastic/integrations/assets/1813008/b4df347f-f992-4821-b584-a7b8b3a75687">

### Output batch size by beat type

<img width="790" alt="image" src="https://github.com/elastic/integrations/assets/1813008/7e8d48f0-ca7a-4cac-85dd-5490db4d30c3">


### Queue depth by input

<img width="791" alt="image" src="https://github.com/elastic/integrations/assets/1813008/409e05f3-280c-4600-b08e-dd4baaafed5b">

