### PR TITLE
[Custom Logs] Implement input parameter ignore_older

### DIFF
--- a/packages/log/agent/input/input.yml.hbs
+++ b/packages/log/agent/input/input.yml.hbs
@@ -3,6 +3,9 @@ paths:
   - {{this}}
 {{/each}}
 
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 data_stream:
   dataset: {{data_stream.dataset}}
 {{#if processors.length}}

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Expose ignore_older option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.0"
   changes:
     - description: Add mapping for message field

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose ignore_older option
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7615
 - version: "2.1.0"
   changes:
     - description: Add mapping for message field

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Logs
 description: >-
   Collect custom logs with Elastic Agent.
 type: input
-version: 2.1.0
+version: 2.2.0
 categories:
   - custom
   - custom_logs
@@ -24,6 +24,14 @@ policy_templates:
         description: Path to log files to be collected
         type: text
         multi: true
+      - name: ignore_older
+        type: text
+        title: Ignore events older than
+        default: 72h
+        required: false
+        show_user: false
+        description: >-
+          If this option is specified, events that are older than the specified amount of time are ignored. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       - name: data_stream.dataset
         required: true
         title: Dataset name

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -27,7 +27,7 @@ policy_templates:
       - name: ignore_older
         type: text
         title: Ignore events older than
-        default: 0
+        default: 72h
         required: false
         show_user: false
         description: >-

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -27,7 +27,7 @@ policy_templates:
       - name: ignore_older
         type: text
         title: Ignore events older than
-        default: 72h
+        default: 0
         required: false
         show_user: false
         description: >-


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Expose ignore_older option for the Custom Logs integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1.  Build package and startup test environment:
```
cd package/log
elastic-package build
elastic-package stack up -v -d --services package-registry
```
2.  Add a new "Custom Logs" integration to a policy
3.  Verify if the correct logs are collected by the datastream

## Related issues

- Closes #7614

