### PR TITLE
[qualys_vmdr] Update data collection of knowledge base data stream

### DIFF
--- a/packages/qualys_vmdr/_dev/build/docs/README.md
+++ b/packages/qualys_vmdr/_dev/build/docs/README.md
@@ -10,7 +10,7 @@ This module has been tested against the latest Qualys VMDR version **v2**.
 
 ## Data streams
 
-The Qualys VMDR integration collects logs for the following two events:
+The Qualys VMDR integration collects data for the following two events:
 
 | Event Type                    |
 |-------------------------------|
@@ -58,7 +58,7 @@ The minimum **kibana.version** required is **8.9.0**.
 2. In "Search for integrations" search bar, type Qualys VMDR
 3. Click on the "Qualys VMDR" integration from the search results.
 4. Click on the Add Qualys VMDR Integration button to add the integration.
-5. While adding the integration, if you want to collect Asset Host Detection logs via REST API, then you have to put the following details:
+5. While adding the integration, if you want to collect Asset Host Detection data via REST API, then you have to put the following details:
    - username
    - password
    - url
@@ -66,7 +66,7 @@ The minimum **kibana.version** required is **8.9.0**.
    - input parameters
    - batch size
 
-   or if you want to collect Knowledge Base logs via REST API, then you have to put the following details:
+   or if you want to collect Knowledge Base data via REST API, then you have to put the following details:
    - username
    - password
    - url
@@ -76,7 +76,7 @@ The minimum **kibana.version** required is **8.9.0**.
 
 **NOTE**: By default, the input parameter is set to "action=list".
 
-## Logs reference
+## Data reference
 
 ### Asset Host Detection
 

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Update data collection of knowledge base data stream to handle different log format.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial Release.

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update data collection of knowledge base data stream to handle different log format.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7623
 - version: "0.1.0"
   changes:
     - description: Initial Release.

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,5 @@
 ---
-description: Pipeline for processing Asset Host Detection logs.
+description: Pipeline for processing Asset Host Detection data.
 processors:
   - set:
       field: ecs.version

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/manifest.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/manifest.yml
@@ -1,9 +1,9 @@
-title: Collect Asset Host Detection logs from Qualys VMDR platform.
+title: Collect Asset Host Detection data from Qualys VMDR platform.
 type: logs
 streams:
   - input: cel
-    title: Asset Host Detection logs
-    description: Collect Asset Host Detection logs from Qualys VMDR platform.
+    title: Asset Host Detection data
+    description: Collect Asset Host Detection data from Qualys VMDR platform.
     template_path: input.yml.hbs
     vars:
       - name: url
@@ -42,7 +42,7 @@ streams:
         description: "Input Parameters for the URL. param1=value&param2=value&param3=....*"
         multi: false
         required: false
-        show_user: false
+        show_user: true
         default: ""
       - name: tags
         type: text
@@ -68,4 +68,4 @@ streams:
         required: false
         show_user: false
         description: >-
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the data is parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
@@ -1,8 +1,8 @@
 {
-    "@timestamp": "2023-08-02T13:38:44.115Z",
+    "@timestamp": "2023-08-28T09:53:52.909Z",
     "agent": {
-        "ephemeral_id": "f8ce1789-cd24-4605-99f3-4c8edbc2e353",
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "ephemeral_id": "24c009cf-e26d-4f8a-b66f-7412425ed0fe",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -16,7 +16,7 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -26,7 +26,7 @@
             "host"
         ],
         "dataset": "qualys_vmdr.asset_host_detection",
-        "ingested": "2023-08-02T13:38:47Z",
+        "ingested": "2023-08-28T09:53:53Z",
         "kind": "alert",
         "type": [
             "info"

--- a/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
@@ -33,11 +33,11 @@ program: |
       }
   }).do_request().as(resp, bytes(resp.Body).decode_xml('qualys_api_2_0').as(body, {
       "events": (has(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST) ?
-        body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e,{
-          "message": e.encode_json()
-        })
+          body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e,{
+            "message": e.encode_json()
+          })
         :
-        body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET
+          body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET
       ),
       "cursor": {
         "last_modified": (

--- a/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
@@ -32,12 +32,16 @@ program: |
           "Authorization": ["Basic "+string(base64(state.user+":"+state.password))],
       }
   }).do_request().as(resp, bytes(resp.Body).decode_xml('qualys_api_2_0').as(body, {
-      "events": body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, {
-        "message": e.encode_json(),
-      }),
+      "events": (has(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST) ?
+        body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e,{
+          "message": e.encode_json()
+        })
+        :
+        body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.ID_SET
+      ),
       "cursor": {
         "last_modified": (
-          has(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN) && body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.size() > 0
+          has(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST) && has(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN) && body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.size() > 0
           ?
             body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, e.LAST_SERVICE_MODIFICATION_DATETIME).max()
           :

--- a/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,5 @@
 ---
-description: Pipeline for processing Knowledge Base logs.
+description: Pipeline for processing Knowledge Base data.
 processors:
   - set:
       field: ecs.version
@@ -21,6 +21,7 @@ processors:
       field: message
       tag: json_message
       target_field: json
+      if: ctx.message != null
       on_failure:
         - append:
             field: error.message
@@ -30,6 +31,16 @@ processors:
         - json.QID
         - json.LAST_SERVICE_MODIFICATION_DATETIME
       target_field: _id
+      ignore_missing: true
+  - rename:
+      field: ID_RANGE
+      tag: rename_ID_RANGE
+      target_field: qualys_vmdr.knowledge_base.id_range
+      ignore_missing: true
+  - rename:
+      field: ID
+      tag: rename_ID
+      target_field: qualys_vmdr.knowledge_base.ids
       ignore_missing: true
   - rename:
       field: json.CONSEQUENCE
@@ -622,6 +633,8 @@ processors:
         - json
         - message
         - qualys_vmdr.knowledge_base.changelog_list.info.CHANGE_DATE
+        - ID_RANGE
+        - ID
       ignore_missing: true
   - remove:
       field:

--- a/packages/qualys_vmdr/data_stream/knowledge_base/fields/fields.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/fields/fields.yml
@@ -187,6 +187,10 @@
           type: keyword
         - name: remote
           type: long
+    - name: ids
+      type: keyword
+    - name: id_range
+      type: keyword
     - name: is_disabled
       type: boolean
     - name: last

--- a/packages/qualys_vmdr/data_stream/knowledge_base/manifest.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/manifest.yml
@@ -1,9 +1,9 @@
-title: Collect Knowledge Base logs from Qualys VMDR platform.
+title: Collect Knowledge Base data from Qualys VMDR platform.
 type: logs
 streams:
   - input: cel
-    title: Knowledge Base logs
-    description: Collect Knowledge Base logs from Qualys VMDR platform.
+    title: Knowledge Base data
+    description: Collect Knowledge Base data from Qualys VMDR platform.
     template_path: input.yml.hbs
     vars:
       - name: url
@@ -15,7 +15,7 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: "How far back to pull the Knowledge Base logs from Qualys VMDR. Supported units for this parameter are s, m, h."
+        description: "How far back to pull the Knowledge Base data from Qualys VMDR. Supported units for this parameter are s, m, h."
         multi: false
         required: true
         show_user: true
@@ -42,7 +42,7 @@ streams:
         description: "Input Parameters for the URL. param1=value&param2=value&param3=....*"
         multi: false
         required: false
-        show_user: false
+        show_user: true
         default: ""
       - name: tags
         type: text
@@ -68,4 +68,4 @@ streams:
         required: false
         show_user: false
         description: >-
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the data is parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.

--- a/packages/qualys_vmdr/data_stream/knowledge_base/sample_event.json
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2023-06-29T12:20:46.000Z",
     "agent": {
-        "ephemeral_id": "59582de9-dc2f-4c69-81c2-4caca64218ee",
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "ephemeral_id": "24c009cf-e26d-4f8a-b66f-7412425ed0fe",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -16,7 +16,7 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -27,7 +27,7 @@
         ],
         "dataset": "qualys_vmdr.knowledge_base",
         "id": "11830",
-        "ingested": "2023-08-02T13:39:40Z",
+        "ingested": "2023-08-28T09:54:51Z",
         "kind": "alert",
         "type": [
             "info"

--- a/packages/qualys_vmdr/docs/README.md
+++ b/packages/qualys_vmdr/docs/README.md
@@ -10,7 +10,7 @@ This module has been tested against the latest Qualys VMDR version **v2**.
 
 ## Data streams
 
-The Qualys VMDR integration collects logs for the following two events:
+The Qualys VMDR integration collects data for the following two events:
 
 | Event Type                    |
 |-------------------------------|
@@ -58,7 +58,7 @@ The minimum **kibana.version** required is **8.9.0**.
 2. In "Search for integrations" search bar, type Qualys VMDR
 3. Click on the "Qualys VMDR" integration from the search results.
 4. Click on the Add Qualys VMDR Integration button to add the integration.
-5. While adding the integration, if you want to collect Asset Host Detection logs via REST API, then you have to put the following details:
+5. While adding the integration, if you want to collect Asset Host Detection data via REST API, then you have to put the following details:
    - username
    - password
    - url
@@ -66,7 +66,7 @@ The minimum **kibana.version** required is **8.9.0**.
    - input parameters
    - batch size
 
-   or if you want to collect Knowledge Base logs via REST API, then you have to put the following details:
+   or if you want to collect Knowledge Base data via REST API, then you have to put the following details:
    - username
    - password
    - url
@@ -76,7 +76,7 @@ The minimum **kibana.version** required is **8.9.0**.
 
 **NOTE**: By default, the input parameter is set to "action=list".
 
-## Logs reference
+## Data reference
 
 ### Asset Host Detection
 
@@ -88,10 +88,10 @@ An example event for `asset_host_detection` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-08-02T13:38:44.115Z",
+    "@timestamp": "2023-08-28T09:53:52.909Z",
     "agent": {
-        "ephemeral_id": "f8ce1789-cd24-4605-99f3-4c8edbc2e353",
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "ephemeral_id": "24c009cf-e26d-4f8a-b66f-7412425ed0fe",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -105,7 +105,7 @@ An example event for `asset_host_detection` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -115,7 +115,7 @@ An example event for `asset_host_detection` looks as following:
             "host"
         ],
         "dataset": "qualys_vmdr.asset_host_detection",
-        "ingested": "2023-08-02T13:38:47Z",
+        "ingested": "2023-08-28T09:53:53Z",
         "kind": "alert",
         "type": [
             "info"
@@ -291,8 +291,8 @@ An example event for `knowledge_base` looks as following:
 {
     "@timestamp": "2023-06-29T12:20:46.000Z",
     "agent": {
-        "ephemeral_id": "59582de9-dc2f-4c69-81c2-4caca64218ee",
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "ephemeral_id": "24c009cf-e26d-4f8a-b66f-7412425ed0fe",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.9.0"
@@ -306,7 +306,7 @@ An example event for `knowledge_base` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "34d4af1b-e042-4964-b319-3a10baae135b",
+        "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
         "snapshot": false,
         "version": "8.9.0"
     },
@@ -317,7 +317,7 @@ An example event for `knowledge_base` looks as following:
         ],
         "dataset": "qualys_vmdr.knowledge_base",
         "id": "11830",
-        "ingested": "2023-08-02T13:39:40Z",
+        "ingested": "2023-08-28T09:54:51Z",
         "kind": "alert",
         "type": [
             "info"
@@ -433,6 +433,8 @@ An example event for `knowledge_base` looks as following:
 | qualys_vmdr.knowledge_base.discovery.additional_info |  | keyword |
 | qualys_vmdr.knowledge_base.discovery.auth_type_list.value |  | keyword |
 | qualys_vmdr.knowledge_base.discovery.remote |  | long |
+| qualys_vmdr.knowledge_base.id_range |  | keyword |
+| qualys_vmdr.knowledge_base.ids |  | keyword |
 | qualys_vmdr.knowledge_base.is_disabled |  | boolean |
 | qualys_vmdr.knowledge_base.last.customization.datetime |  | date |
 | qualys_vmdr.knowledge_base.last.customization.user_login |  | keyword |

--- a/packages/qualys_vmdr/kibana/dashboard/qualys_vmdr-017c0220-1001-11ee-b28e-615808a979fd.json
+++ b/packages/qualys_vmdr/kibana/dashboard/qualys_vmdr-017c0220-1001-11ee-b28e-615808a979fd.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "This dashboard shows Asset Host Detection logs collected by the Qualys VMDR integration.",
+        "description": "This dashboard shows Asset Host Detection data collected by the Qualys VMDR integration.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],

--- a/packages/qualys_vmdr/kibana/dashboard/qualys_vmdr-686c4470-11b6-11ee-a722-91244a8ae892.json
+++ b/packages/qualys_vmdr/kibana/dashboard/qualys_vmdr-686c4470-11b6-11ee-a722-91244a8ae892.json
@@ -1,6 +1,6 @@
 {
     "attributes": {
-        "description": "This dashboard shows Knowledge Base logs collected by the Qualys VMDR integration.",
+        "description": "This dashboard shows Knowledge Base data collected by the Qualys VMDR integration.",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [],

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,8 +1,8 @@
 format_version: 2.8.0
 name: qualys_vmdr
 title: Qualys VMDR
-version: 0.1.0
-description: Collect logs from Qualys VMDR platform with Elastic Agent.
+version: 0.2.0
+description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:
   - security
@@ -26,11 +26,11 @@ icons:
     type: image/svg+xml
 policy_templates:
   - name: qualys_vmdr
-    title: Qualys VMDR logs
-    description: Collect Qualys VMDR logs.
+    title: Qualys VMDR data
+    description: Collect Qualys VMDR data.
     inputs:
       - type: cel
-        title: Collect Qualys VMDR logs via API
+        title: Collect Qualys VMDR data via API
         description: Collecting Qualys VMDR via API.
         vars:
           - name: username


### PR DESCRIPTION
Type of change
- Bug

## What does this PR do?
- [x] Enhancement 
    - Replace `logs` keyword with `data`.
    - Shift input parameter textbox from advance to main section in `manifest.yml` file.
- [x] Bug 
    - Error handling for different filter (input parameter) `details=None` in Knowledge Base data stream causes adding 2 more fields such as `id_range` and `ids`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally
Clone integrations repo.
Install elastic package locally.
Start elastic stack using elastic-package.
Move to integrations/packages/qualys_vmdr directory.
Run the following command to run tests.
```elastic-package test```

## Related issues

- Closes https://github.com/elastic/infosec/issues/14223

## Automated Test
```
[root@co7 qualys_vmdr]# elastic-package test -v
2023/08/28 15:26:32 DEBUG Enable verbose logging
2023/08/28 15:26:32  INFO New version is available - v0.85.0. Download from: https://github.com/elastic/elastic-package/releases/tag/v0.85.0
Run test suite for the package
Run system tests for the package
2023/08/28 15:26:32 DEBUG Running system tests for data stream
2023/08/28 15:26:32 DEBUG running test with configuration 'default'
2023/08/28 15:26:32 DEBUG setting up service...
2023/08/28 15:26:32 DEBUG setting up service using Docker Compose service deployer
2023/08/28 15:26:32 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:26:33 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:26:33 DEBUG output command: /usr/bin/docker network inspect elastic-package-stack_default
2023/08/28 15:26:33 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service up --build -d
Creating network "elastic-package-service_default" with the default driver
Creating elastic-package-service_qualys_vmdr_1 ... done
2023/08/28 15:26:34 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service ps -q
2023/08/28 15:26:34 DEBUG Wait for healthy containers: db5fa50b2884470da77e02a9908ec3f2bae7691c30d92188f9a12b935479f7e1
2023/08/28 15:26:34 DEBUG output command: /usr/bin/docker inspect db5fa50b2884470da77e02a9908ec3f2bae7691c30d92188f9a12b935479f7e1
2023/08/28 15:26:34 DEBUG Container status: {"Config":{"Image":"docker.elastic.co/observability/stream:v0.10.0","Labels":{"BRANCH_NAME":"v0.10.0","GIT_SHA":"2a076c9b1acdf1c35b5f5c2f8c23904c7c2c441a","GO_VERSION":"1.19.5","TIMESTAMP":"2023-01-30_11:29","com.docker.compose.config-hash":"f7206ac64ae020a5bfd4d0b2a7051f129dcfca12573b1127cdb958fd1f839e11","com.docker.compose.container-number":"1","com.docker.compose.oneoff":"False","com.docker.compose.project":"elastic-package-service","com.docker.compose.service":"qualys_vmdr","com.docker.compose.version":"1.23.2"}},"ID":"db5fa50b2884470da77e02a9908ec3f2bae7691c30d92188f9a12b935479f7e1","State":{"Status":"running","ExitCode":0,"Health":null}}
2023/08/28 15:26:34 DEBUG run command: /usr/bin/docker network connect elastic-package-stack_default elastic-package-service_qualys_vmdr_1
2023/08/28 15:26:34 DEBUG adding service container elastic-package-service_qualys_vmdr_1 internal ports to context
2023/08/28 15:26:34 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service config
2023/08/28 15:26:35 DEBUG Installing package...
2023/08/28 15:26:35 DEBUG GET https://127.0.0.1:5601/api/status
2023/08/28 15:26:35 DEBUG Build directory: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0
2023/08/28 15:26:35 DEBUG Clear target directory (path: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0)
2023/08/28 15:26:35 DEBUG Copy package content (source: /root/integration/integrations/packages/qualys_vmdr)
2023/08/28 15:26:35 DEBUG Copy license file if needed
2023/08/28 15:26:35  INFO License text found in "/root/integration/integrations/LICENSE.txt" will be included in package
2023/08/28 15:26:35 DEBUG Encode dashboards
2023/08/28 15:26:35 DEBUG Resolve external fields
2023/08/28 15:26:35 DEBUG Package has external dependencies defined
2023/08/28 15:26:35 DEBUG data_stream/asset_host_detection/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:26:35 DEBUG data_stream/asset_host_detection/fields/beats.yml: source file hasn't been changed
2023/08/28 15:26:35 DEBUG data_stream/asset_host_detection/fields/fields.yml: source file hasn't been changed
2023/08/28 15:26:35 DEBUG data_stream/knowledge_base/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:26:35 DEBUG data_stream/knowledge_base/fields/beats.yml: source file hasn't been changed
2023/08/28 15:26:35 DEBUG data_stream/knowledge_base/fields/fields.yml: source file hasn't been changed
2023/08/28 15:26:35  INFO Import ECS mappings into the built package (technical preview)
2023/08/28 15:26:35 DEBUG Build zipped package
2023/08/28 15:26:35 DEBUG Compress using archiver.Zip (destination: /root/integration/integrations/build/packages/qualys_vmdr-0.2.0.zip)
2023/08/28 15:26:35 DEBUG Create work directory for archiving: /tmp/elastic-package-571567651/qualys_vmdr-0.2.0
2023/08/28 15:26:35 DEBUG Skip validation of the built .zip package
2023/08/28 15:26:35 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
2023/08/28 15:26:37 DEBUG creating test policy...
2023/08/28 15:26:37 DEBUG POST https://127.0.0.1:5601/api/fleet/agent_policies
2023/08/28 15:26:41 DEBUG adding package data stream to test policy...
2023/08/28 15:26:41 DEBUG POST https://127.0.0.1:5601/api/fleet/package_policies
2023/08/28 15:26:43 DEBUG deleting old data in data stream...
2023/08/28 15:26:43 DEBUG found 0 hits in logs-qualys_vmdr.asset_host_detection-ep data stream
2023/08/28 15:26:43 DEBUG GET https://127.0.0.1:5601/api/fleet/agents
2023/08/28 15:26:43 DEBUG filter agents using criteria: NamePrefix=docker-fleet-agent
2023/08/28 15:26:43 DEBUG found 1 enrolled agent(s)
2023/08/28 15:26:43 DEBUG GET https://127.0.0.1:5601/api/fleet/agent_policies/2d9a5830-4589-11ee-8bce-e39abd1e4de5
2023/08/28 15:26:43 DEBUG assigning package data stream to agent...
2023/08/28 15:26:43 DEBUG PUT https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec/reassign
2023/08/28 15:26:45 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:26:45 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"2d9a5830-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:26:45 DEBUG Wait until the policy (ID: 2d9a5830-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:26:47 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:26:47 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"2d9a5830-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:26:47 DEBUG Wait until the policy (ID: 2d9a5830-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:26:49 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:26:49 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"2d9a5830-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:26:49 DEBUG Wait until the policy (ID: 2d9a5830-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:26:51 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:26:51 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"2d9a5830-4589-11ee-8bce-e39abd1e4de5","policy_revision":2,"local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:26:51 DEBUG Policy revision assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:26:51 DEBUG checking for expected data in data stream...
2023/08/28 15:26:51 DEBUG found 0 hits in logs-qualys_vmdr.asset_host_detection-ep data stream
2023/08/28 15:26:52 DEBUG found 1 hits in logs-qualys_vmdr.asset_host_detection-ep data stream
2023/08/28 15:26:56 DEBUG found 1 hits in logs-qualys_vmdr.asset_host_detection-ep data stream
2023/08/28 15:26:56 DEBUG check whether or not synthetics is enabled (component template logs-qualys_vmdr.asset_host_detection@package)...
2023/08/28 15:26:56 DEBUG data stream logs-qualys_vmdr.asset_host_detection-ep has synthetics enabled: false
2023/08/28 15:26:56 DEBUG assert hit count expected 1, observed 1
2023/08/28 15:26:56 DEBUG reassigning original policy back to agent...
2023/08/28 15:26:56 DEBUG PUT https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec/reassign
2023/08/28 15:26:58 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:26:58 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:26:58 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:00 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:00 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:00 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:02 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:02 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:02 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:04 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:04 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:04 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:06 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:06 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","policy_revision":30,"local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:06 DEBUG Policy revision assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:06 DEBUG deleting test policy...
2023/08/28 15:27:06 DEBUG POST https://127.0.0.1:5601/api/fleet/agent_policies/delete
2023/08/28 15:27:09 DEBUG DELETE https://127.0.0.1:5601/api/fleet/epm/packages/qualys_vmdr-0.2.0
2023/08/28 15:27:09  WARN failed to uninstall package "qualys_vmdr": can't remove the package: could not remove package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"unable to remove package with existing package policy(s) in use by agent(s)"}
2023/08/28 15:27:09 DEBUG tearing down service...
2023/08/28 15:27:09 DEBUG tearing down service using Docker Compose runner
2023/08/28 15:27:09 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:09 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:09 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service logs
2023/08/28 15:27:10  INFO Write container logs to file: /root/integration/integrations/build/container-logs/qualys_vmdr-1693216630516968053.log
2023/08/28 15:27:10 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service down --volumes
Stopping elastic-package-service_qualys_vmdr_1 ... done
Removing elastic-package-service_qualys_vmdr_1 ... done
Removing network elastic-package-service_default
2023/08/28 15:27:11 DEBUG deleting data in data stream...
2023/08/28 15:27:11 DEBUG Dump Elastic stack data
2023/08/28 15:27:11 DEBUG Dump stack logs (location: /tmp/test-system-2680867580)
2023/08/28 15:27:11 DEBUG Dump stack logs for elasticsearch
2023/08/28 15:27:11 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:12 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:12 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs elasticsearch
2023/08/28 15:27:14 DEBUG Dump stack logs for elastic-agent
2023/08/28 15:27:14 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:14 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:14 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs elastic-agent
2023/08/28 15:27:22 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:22 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:22 DEBUG run command: /usr/bin/docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/data/logs/ /tmp/test-system-2680867580/logs/elastic-agent-internal
2023/08/28 15:27:23 DEBUG Dump stack logs for fleet-server
2023/08/28 15:27:23 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:23 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:23 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs fleet-server
2023/08/28 15:27:28 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:28 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:28 DEBUG run command: /usr/bin/docker cp elastic-package-stack_fleet-server_1:/usr/share/elastic-agent/state/data/logs/ /tmp/test-system-2680867580/logs/fleet-server-internal
2023/08/28 15:27:28 DEBUG Dump stack logs for kibana
2023/08/28 15:27:28 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:29 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:29 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs kibana
2023/08/28 15:27:29 DEBUG Dump stack logs for package-registry
2023/08/28 15:27:29 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:30 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:30 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs package-registry
2023/08/28 15:27:31 DEBUG skipped malformed docker-compose log line: Attaching to elastic-package-stack_elastic-agent_1
2023/08/28 15:27:31 DEBUG Running system tests for data stream
2023/08/28 15:27:31 DEBUG running test with configuration 'default'
2023/08/28 15:27:31 DEBUG setting up service...
2023/08/28 15:27:31 DEBUG setting up service using Docker Compose service deployer
2023/08/28 15:27:31 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:27:31 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:27:31 DEBUG output command: /usr/bin/docker network inspect elastic-package-stack_default
2023/08/28 15:27:31 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service up --build -d
Creating network "elastic-package-service_default" with the default driver
Creating elastic-package-service_qualys_vmdr_1 ... done
2023/08/28 15:27:32 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service ps -q
2023/08/28 15:27:33 DEBUG Wait for healthy containers: 5f8571848d23045345461e01d6cc4a0442c030ddc6902689e89af48790c56fdb
2023/08/28 15:27:33 DEBUG output command: /usr/bin/docker inspect 5f8571848d23045345461e01d6cc4a0442c030ddc6902689e89af48790c56fdb
2023/08/28 15:27:33 DEBUG Container status: {"Config":{"Image":"docker.elastic.co/observability/stream:v0.10.0","Labels":{"BRANCH_NAME":"v0.10.0","GIT_SHA":"2a076c9b1acdf1c35b5f5c2f8c23904c7c2c441a","GO_VERSION":"1.19.5","TIMESTAMP":"2023-01-30_11:29","com.docker.compose.config-hash":"f7206ac64ae020a5bfd4d0b2a7051f129dcfca12573b1127cdb958fd1f839e11","com.docker.compose.container-number":"1","com.docker.compose.oneoff":"False","com.docker.compose.project":"elastic-package-service","com.docker.compose.service":"qualys_vmdr","com.docker.compose.version":"1.23.2"}},"ID":"5f8571848d23045345461e01d6cc4a0442c030ddc6902689e89af48790c56fdb","State":{"Status":"running","ExitCode":0,"Health":null}}
2023/08/28 15:27:33 DEBUG run command: /usr/bin/docker network connect elastic-package-stack_default elastic-package-service_qualys_vmdr_1
2023/08/28 15:27:33 DEBUG adding service container elastic-package-service_qualys_vmdr_1 internal ports to context
2023/08/28 15:27:33 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service config
2023/08/28 15:27:33 DEBUG Installing package...
2023/08/28 15:27:33 DEBUG GET https://127.0.0.1:5601/api/status
2023/08/28 15:27:34 DEBUG Build directory: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0
2023/08/28 15:27:34 DEBUG Clear target directory (path: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0)
2023/08/28 15:27:34 DEBUG Copy package content (source: /root/integration/integrations/packages/qualys_vmdr)
2023/08/28 15:27:34 DEBUG Copy license file if needed
2023/08/28 15:27:34  INFO License text found in "/root/integration/integrations/LICENSE.txt" will be included in package
2023/08/28 15:27:34 DEBUG Encode dashboards
2023/08/28 15:27:34 DEBUG Resolve external fields
2023/08/28 15:27:34 DEBUG Package has external dependencies defined
2023/08/28 15:27:34 DEBUG data_stream/asset_host_detection/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:27:34 DEBUG data_stream/asset_host_detection/fields/beats.yml: source file hasn't been changed
2023/08/28 15:27:34 DEBUG data_stream/asset_host_detection/fields/fields.yml: source file hasn't been changed
2023/08/28 15:27:34 DEBUG data_stream/knowledge_base/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:27:34 DEBUG data_stream/knowledge_base/fields/beats.yml: source file hasn't been changed
2023/08/28 15:27:34 DEBUG data_stream/knowledge_base/fields/fields.yml: source file hasn't been changed
2023/08/28 15:27:34  INFO Import ECS mappings into the built package (technical preview)
2023/08/28 15:27:34 DEBUG Build zipped package
2023/08/28 15:27:34 DEBUG Compress using archiver.Zip (destination: /root/integration/integrations/build/packages/qualys_vmdr-0.2.0.zip)
2023/08/28 15:27:34 DEBUG Create work directory for archiving: /tmp/elastic-package-3151470936/qualys_vmdr-0.2.0
2023/08/28 15:27:34 DEBUG Skip validation of the built .zip package
2023/08/28 15:27:34 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
2023/08/28 15:27:35 DEBUG creating test policy...
2023/08/28 15:27:35 DEBUG POST https://127.0.0.1:5601/api/fleet/agent_policies
2023/08/28 15:27:39 DEBUG adding package data stream to test policy...
2023/08/28 15:27:39 DEBUG POST https://127.0.0.1:5601/api/fleet/package_policies
2023/08/28 15:27:42 DEBUG deleting old data in data stream...
2023/08/28 15:27:42 DEBUG found 0 hits in logs-qualys_vmdr.knowledge_base-ep data stream
2023/08/28 15:27:42 DEBUG GET https://127.0.0.1:5601/api/fleet/agents
2023/08/28 15:27:42 DEBUG filter agents using criteria: NamePrefix=docker-fleet-agent
2023/08/28 15:27:42 DEBUG found 1 enrolled agent(s)
2023/08/28 15:27:42 DEBUG GET https://127.0.0.1:5601/api/fleet/agent_policies/503c9dd0-4589-11ee-8bce-e39abd1e4de5
2023/08/28 15:27:42 DEBUG assigning package data stream to agent...
2023/08/28 15:27:42 DEBUG PUT https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec/reassign
2023/08/28 15:27:44 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:44 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"503c9dd0-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:44 DEBUG Wait until the policy (ID: 503c9dd0-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:46 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:46 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"503c9dd0-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:46 DEBUG Wait until the policy (ID: 503c9dd0-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:48 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:48 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"503c9dd0-4589-11ee-8bce-e39abd1e4de5","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:48 DEBUG Wait until the policy (ID: 503c9dd0-4589-11ee-8bce-e39abd1e4de5, revision: 2) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:50 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:50 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"503c9dd0-4589-11ee-8bce-e39abd1e4de5","policy_revision":2,"local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:50 DEBUG Policy revision assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:50 DEBUG checking for expected data in data stream...
2023/08/28 15:27:50 DEBUG found 0 hits in logs-qualys_vmdr.knowledge_base-ep data stream
2023/08/28 15:27:51 DEBUG found 1 hits in logs-qualys_vmdr.knowledge_base-ep data stream
2023/08/28 15:27:51 DEBUG check whether or not synthetics is enabled (component template logs-qualys_vmdr.knowledge_base@package)...
2023/08/28 15:27:51 DEBUG data stream logs-qualys_vmdr.knowledge_base-ep has synthetics enabled: false
2023/08/28 15:27:51 DEBUG reassigning original policy back to agent...
2023/08/28 15:27:51 DEBUG PUT https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec/reassign
2023/08/28 15:27:53 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:53 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:53 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:55 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:55 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:55 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:57 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:57 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:57 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:27:59 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:27:59 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:27:59 DEBUG Wait until the policy (ID: elastic-agent-managed-ep, revision: 30) is assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:28:01 DEBUG GET https://127.0.0.1:5601/api/fleet/agents/6b293533-5b3c-4cb2-a00c-b2b25ba9edec
2023/08/28 15:28:01 DEBUG Agent data: {"id":"6b293533-5b3c-4cb2-a00c-b2b25ba9edec","policy_id":"elastic-agent-managed-ep","policy_revision":30,"local_metadata":{"host":{"name":"docker-fleet-agent"}}}
2023/08/28 15:28:01 DEBUG Policy revision assigned to the agent (ID: 6b293533-5b3c-4cb2-a00c-b2b25ba9edec)...
2023/08/28 15:28:01 DEBUG deleting test policy...
2023/08/28 15:28:01 DEBUG POST https://127.0.0.1:5601/api/fleet/agent_policies/delete
2023/08/28 15:28:04 DEBUG DELETE https://127.0.0.1:5601/api/fleet/epm/packages/qualys_vmdr-0.2.0
2023/08/28 15:28:04  WARN failed to uninstall package "qualys_vmdr": can't remove the package: could not remove package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"unable to remove package with existing package policy(s) in use by agent(s)"}
2023/08/28 15:28:04 DEBUG tearing down service...
2023/08/28 15:28:04 DEBUG tearing down service using Docker Compose runner
2023/08/28 15:28:04 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:04 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:04 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service logs
2023/08/28 15:28:05  INFO Write container logs to file: /root/integration/integrations/build/container-logs/qualys_vmdr-1693216685574812552.log
2023/08/28 15:28:05 DEBUG running command: /usr/local/bin/docker-compose -f /root/integration/integrations/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml -p elastic-package-service down --volumes
Stopping elastic-package-service_qualys_vmdr_1 ... done
Removing elastic-package-service_qualys_vmdr_1 ... done
Removing network elastic-package-service_default
2023/08/28 15:28:06 DEBUG deleting data in data stream...
2023/08/28 15:28:06 DEBUG Dump Elastic stack data
2023/08/28 15:28:06 DEBUG Dump stack logs (location: /tmp/test-system-3229771995)
2023/08/28 15:28:06 DEBUG Dump stack logs for elasticsearch
2023/08/28 15:28:06 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:07 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:07 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs elasticsearch
2023/08/28 15:28:09 DEBUG Dump stack logs for elastic-agent
2023/08/28 15:28:09 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:09 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:09 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs elastic-agent
2023/08/28 15:28:17 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:18 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:18 DEBUG run command: /usr/bin/docker cp elastic-package-stack_elastic-agent_1:/usr/share/elastic-agent/state/data/logs/ /tmp/test-system-3229771995/logs/elastic-agent-internal
2023/08/28 15:28:18 DEBUG Dump stack logs for fleet-server
2023/08/28 15:28:18 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:18 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:18 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs fleet-server
2023/08/28 15:28:23 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:23 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:23 DEBUG run command: /usr/bin/docker cp elastic-package-stack_fleet-server_1:/usr/share/elastic-agent/state/data/logs/ /tmp/test-system-3229771995/logs/fleet-server-internal
2023/08/28 15:28:23 DEBUG Dump stack logs for kibana
2023/08/28 15:28:23 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:24 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:24 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs kibana
2023/08/28 15:28:24 DEBUG Dump stack logs for package-registry
2023/08/28 15:28:24 DEBUG running command: /usr/local/bin/docker-compose version --short
2023/08/28 15:28:25 DEBUG Determined Docker Compose version: 1.23.2, the tool will use Compose V1
2023/08/28 15:28:25 DEBUG running command: /usr/local/bin/docker-compose -f /root/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs package-registry
2023/08/28 15:28:26 DEBUG skipped malformed docker-compose log line: Attaching to elastic-package-stack_elastic-agent_1
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼───────────┼────────┼───────────────┤
│ qualys_vmdr │ asset_host_detection │ system    │ default   │ PASS   │  23.83281862s │
│ qualys_vmdr │ knowledge_base       │ system    │ default   │ PASS   │ 20.209714922s │
╰─────────────┴──────────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
Run asset tests for the package
2023/08/28 15:28:26 DEBUG installing package...
2023/08/28 15:28:26 DEBUG GET https://127.0.0.1:5601/api/status
2023/08/28 15:28:26 DEBUG Build directory: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0
2023/08/28 15:28:26 DEBUG Clear target directory (path: /root/integration/integrations/build/packages/qualys_vmdr/0.2.0)
2023/08/28 15:28:26 DEBUG Copy package content (source: /root/integration/integrations/packages/qualys_vmdr)
2023/08/28 15:28:26 DEBUG Copy license file if needed
2023/08/28 15:28:26  INFO License text found in "/root/integration/integrations/LICENSE.txt" will be included in package
2023/08/28 15:28:26 DEBUG Encode dashboards
2023/08/28 15:28:26 DEBUG Resolve external fields
2023/08/28 15:28:26 DEBUG Package has external dependencies defined
2023/08/28 15:28:26 DEBUG data_stream/asset_host_detection/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:28:26 DEBUG data_stream/asset_host_detection/fields/beats.yml: source file hasn't been changed
2023/08/28 15:28:26 DEBUG data_stream/asset_host_detection/fields/fields.yml: source file hasn't been changed
2023/08/28 15:28:26 DEBUG data_stream/knowledge_base/fields/base-fields.yml: source file hasn't been changed
2023/08/28 15:28:26 DEBUG data_stream/knowledge_base/fields/beats.yml: source file hasn't been changed
2023/08/28 15:28:26 DEBUG data_stream/knowledge_base/fields/fields.yml: source file hasn't been changed
2023/08/28 15:28:26  INFO Import ECS mappings into the built package (technical preview)
2023/08/28 15:28:26 DEBUG Build zipped package
2023/08/28 15:28:26 DEBUG Compress using archiver.Zip (destination: /root/integration/integrations/build/packages/qualys_vmdr-0.2.0.zip)
2023/08/28 15:28:26 DEBUG Create work directory for archiving: /tmp/elastic-package-3841370420/qualys_vmdr-0.2.0
2023/08/28 15:28:26 DEBUG Skip validation of the built .zip package
2023/08/28 15:28:26 DEBUG POST https://127.0.0.1:5601/api/fleet/epm/packages
2023/08/28 15:28:28 DEBUG removing package...
2023/08/28 15:28:28 DEBUG DELETE https://127.0.0.1:5601/api/fleet/epm/packages/qualys_vmdr-0.2.0
2023/08/28 15:28:28  WARN failed to uninstall package "qualys_vmdr": can't remove the package: could not remove package; API status code = 400; response body = {"statusCode":400,"error":"Bad Request","message":"unable to remove package with existing package policy(s) in use by agent(s)"}
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬───────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME                                                             │ RESULT │ TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼───────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ qualys_vmdr │                      │ asset     │ dashboard qualys_vmdr-017c0220-1001-11ee-b28e-615808a979fd is loaded  │ PASS   │      2.102µs │
│ qualys_vmdr │                      │ asset     │ dashboard qualys_vmdr-686c4470-11b6-11ee-a722-91244a8ae892 is loaded  │ PASS   │        113ns │
│ qualys_vmdr │                      │ asset     │ search qualys_vmdr-4119cae0-100e-11ee-b28e-615808a979fd is loaded     │ PASS   │        120ns │
│ qualys_vmdr │                      │ asset     │ search qualys_vmdr-fc0b5150-125e-11ee-a722-91244a8ae892 is loaded     │ PASS   │         97ns │
│ qualys_vmdr │ asset_host_detection │ asset     │ index_template logs-qualys_vmdr.asset_host_detection is loaded        │ PASS   │        191ns │
│ qualys_vmdr │ asset_host_detection │ asset     │ ingest_pipeline logs-qualys_vmdr.asset_host_detection-0.2.0 is loaded │ PASS   │         91ns │
│ qualys_vmdr │ knowledge_base       │ asset     │ index_template logs-qualys_vmdr.knowledge_base is loaded              │ PASS   │        178ns │
│ qualys_vmdr │ knowledge_base       │ asset     │ ingest_pipeline logs-qualys_vmdr.knowledge_base-0.2.0 is loaded       │ PASS   │        146ns │
╰─────────────┴──────────────────────┴───────────┴───────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
Run pipeline tests for the package
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬───────────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME                     │ RESULT │ TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼───────────────────────────────┼────────┼──────────────┤
│ qualys_vmdr │ asset_host_detection │ pipeline  │ test-asset-host-detection.log │ PASS   │   8.352897ms │
│ qualys_vmdr │ knowledge_base       │ pipeline  │ test-knowledge-base.log       │ PASS   │   4.107074ms │
╰─────────────┴──────────────────────┴───────────┴───────────────────────────────┴────────┴──────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
Run static tests for the package
--- Test results for package: qualys_vmdr - START ---
╭─────────────┬──────────────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE     │ DATA STREAM          │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├─────────────┼──────────────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ qualys_vmdr │ asset_host_detection │ static    │ Verify sample_event.json │ PASS   │  88.179509ms │
│ qualys_vmdr │ knowledge_base       │ static    │ Verify sample_event.json │ PASS   │   96.87412ms │
╰─────────────┴──────────────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: qualys_vmdr - END   ---
Done
```
