### PR TITLE
[Integrations][System] - Fixed user.target.domain extraction for nested domains

### DIFF
--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -2586,7 +2586,7 @@ processors:
           if (memberNameParts.length >= 4) {
             for (int i = 0; i < memberNameParts.length; i++) {
               def domainString = memberNameParts[i];
-              if ((domainString.contains("DC=") || domainString.contains("dc=")) && ctx.user.target.domain != null) {
+              if ((domainString.contains("DC=") || domainString.contains("dc=")) && ctx.user.target.domain == null) {
                 def domain = domainString.replace("DC=", "").replace("dc=", "");
                 ctx.user.target.put("domain", domain);
               }

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/standard.yml
@@ -2584,8 +2584,13 @@ processors:
             ctx.related.user.add(memberName);
           }
           if (memberNameParts.length >= 4) {
-            def domain = memberNameParts[3].replace("DC=", "").replace("dc=", "");
-            ctx.user.target.put("domain", domain);
+            for (int i = 0; i < memberNameParts.length; i++) {
+              def domainString = memberNameParts[i];
+              if ((domainString.contains("DC=") || domainString.contains("dc=")) && ctx.user.target.domain != null) {
+                def domain = domainString.replace("DC=", "").replace("dc=", "");
+                ctx.user.target.put("domain", domain);
+              }
+            }
           }
         }
         if (ctx.winlog?.event_data?.TargetUserSid != null) {


### PR DESCRIPTION
## Type of change
- Bug

## What does this PR do?

The security pipeline tries to extract the value of the user's domain for certain kinds of events (e.g., user added to a domain group) and stores it into user.target.domain. The current script is hard coded to split the member name on comma, and then extract a specific item in the array, which will only be valid for domains that are not nested under more than domain (e.g., AD_domain.company_domain.com.country_code will extract the company_domain rather than the AD_domain.

This PR updates the script to instead use a for loop to iterate over the array and match against the item that starts with "DC=" and use that for user.target.domain.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
