### PR TITLE
[elasticsearch] add api_key authentication

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Add support for api_key authentication
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/6861
 - version: "1.9.0"
   changes:
     - description: Enable time series data streams for the metrics datasets Index, Index Summary, Index Recovery, ML Job, Ingest Pipeline, Node and Node Stats. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add support for api_key authentication
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/6861
+      link: https://github.com/elastic/integrations/pull/7637
 - version: "1.9.0"
   changes:
     - description: Enable time series data streams for the metrics datasets Index, Index Summary, Index Recovery, ML Job, Ingest Pipeline, Node and Node Stats. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ccr/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/cluster_stats/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/enrich/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_recovery/agent/stream/stream.yml.hbs
@@ -11,6 +11,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/index_summary/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ingest_pipeline/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/ml_job/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/node_stats/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/pending_tasks/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
+++ b/packages/elasticsearch/data_stream/shard/agent/stream/stream.yml.hbs
@@ -10,6 +10,9 @@ username: {{username}}
 {{#if password}}
 password: {{password}}
 {{/if}}
+{{#if api_key}}
+api_key: {{api_key}}
+{{/if}}
 period: {{period}}
 {{#if ssl}}
 ssl: {{ssl}}

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.9.0
+version: 1.10.0
 description: Elasticsearch Integration
 type: integration
 icons:
@@ -12,7 +12,7 @@ format_version: 2.6.0
 categories: ["elastic_stack", "datastore"]
 conditions:
   elastic.subscription: basic
-  kibana.version: ^8.8.0
+  kibana.version: ^8.10.0
 owner:
   github: elastic/infra-monitoring-ui
 policy_templates:
@@ -54,6 +54,13 @@ policy_templates:
             type: password
             title: Password
             description: Use when connecting to elasticsearch
+            multi: false
+            required: false
+            show_user: false
+          - name: api_key
+            type: password
+            title: API Key
+            description: Elasticsearch API Key in Beats format. Use when connecting to elasticsearch in place of username/password.
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/integrations/issues/7377

Adds support for api_key authentication in elasticsearch integration

### Testing
- create an api key and grab the beats format[1]
- configure elasticsearch integration to use that api_key instead of username/password
- elasticsearch data is successfully collecting documents and Stack Monitoring shows up. No authentication failure appears in elastic-agent logs/metrics-* data

[1]
![Screenshot 2023-08-09 at 17 23 25](https://github.com/elastic/beats/assets/5239883/1008feb8-afa9-4e90-a47c-8d0c1379a8ed)