### PR TITLE
Remove confusing documentation about Windows support from docker integration

### DIFF
--- a/packages/docker/_dev/build/docs/README.md
+++ b/packages/docker/_dev/build/docs/README.md
@@ -8,8 +8,7 @@ The `container_logs` data stream for containers' logs collection is enabled by d
 ## Compatibility
 
 The Docker module is currently tested on Linux and Mac with the community
-edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
-but it should also work there.
+edition engine, versions 1.11 and 17.09.0-ce.
 
 ## Running from within Docker
 

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove confusing documentation about Windows support.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXX
+      link: https://github.com/elastic/integrations/pull/7645
 - version: "2.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.1"
+  changes:
+    - description: Remove confusing documentation about Windows support.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "2.8.0"
   changes:
     - description: Enable time series data streams for the metrics datasets, except for event dataset. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -8,8 +8,7 @@ The `container_logs` data stream for containers' logs collection is enabled by d
 ## Compatibility
 
 The Docker module is currently tested on Linux and Mac with the community
-edition engine, versions 1.11 and 17.09.0-ce. It is not tested on Windows,
-but it should also work there.
+edition engine, versions 1.11 and 17.09.0-ce.
 
 ## Running from within Docker
 

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.8.0
+version: 2.8.1
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

remove mention of windows support from docker documentation
