### PR TITLE
[Citrix ADC] Migrate to GA

### DIFF
--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Make Citrix ADC GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.7.1"
   changes:
     - description: Resolve host.ip field conflict.

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Make Citrix ADC GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7664
 - version: "0.7.1"
   changes:
     - description: Resolve host.ip field conflict.

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: citrix_adc
 title: Citrix ADC
-version: "0.7.1"
+version: "1.0.0"
 description: This Elastic integration collects metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Migrates the integration from BETA to GA.

## Related issues

- Closes https://github.com/elastic/integrations/issues/7243