### PR TITLE
[CouchDB] Migrate to GA

### DIFF
--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.0.0"
   changes:
-    - description: Make Couchdb GA.
+    - description: Make CouchDB GA.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7666
 - version: "0.7.1"

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Make Couchdb GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7666
 - version: "0.7.1"
   changes:
     - description: Resolve the conflicts in host.ip field.

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Make Couchdb GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.7.1"
   changes:
     - description: Resolve the conflicts in host.ip field.

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchdb
 title: CouchDB
-version: "0.7.1"
+version: "1.0.0"
 license: basic
 description: Collect metrics from CouchDB with Elastic Agent.
 type: integration
@@ -69,4 +69,3 @@ policy_templates:
             show_user: false
 owner:
   github: elastic/obs-infraobs-integrations
-


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Migrates the integration from BETA to GA.

## Related issues

- Closes https://github.com/elastic/integrations/issues/7253