### PR TITLE
[prometheus] Use ecs definition of the 'event.dataset' field

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Use ecs definition of the 'event.dataset' field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7598
 - version: "1.11.0"
   changes:
     - description: Enable TSDB by default for remote_write datastreams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use ecs definition of the 'event.dataset' field
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7598
+      link: https://github.com/elastic/integrations/pull/7667
 - version: "1.11.0"
   changes:
     - description: Enable TSDB by default for remote_write datastreams. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html

--- a/packages/prometheus/data_stream/collector/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/collector/fields/base-fields.yml
@@ -14,7 +14,3 @@
   type: constant_keyword
   description: Event module.
   value: prometheus
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset.
-  value: prometheus.collector

--- a/packages/prometheus/data_stream/collector/fields/ecs.yml
+++ b/packages/prometheus/data_stream/collector/fields/ecs.yml
@@ -8,3 +8,5 @@
 - external: ecs
   name: agent.id
   dimension: true
+- external: ecs
+  name: event.dataset

--- a/packages/prometheus/data_stream/query/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/query/fields/base-fields.yml
@@ -14,7 +14,3 @@
   type: constant_keyword
   description: Event module.
   value: prometheus
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset.
-  value: prometheus.query

--- a/packages/prometheus/data_stream/query/fields/ecs.yml
+++ b/packages/prometheus/data_stream/query/fields/ecs.yml
@@ -8,3 +8,5 @@
 - external: ecs
   name: agent.id
   dimension: true
+- external: ecs
+  name: event.dataset

--- a/packages/prometheus/data_stream/remote_write/fields/base-fields.yml
+++ b/packages/prometheus/data_stream/remote_write/fields/base-fields.yml
@@ -14,7 +14,3 @@
   type: constant_keyword
   description: Event module.
   value: prometheus
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset.
-  value: prometheus.remote_write

--- a/packages/prometheus/data_stream/remote_write/fields/ecs.yml
+++ b/packages/prometheus/data_stream/remote_write/fields/ecs.yml
@@ -7,3 +7,5 @@
 - external: ecs
   name: agent.id
   dimension: true
+- external: ecs
+  name: event.dataset

--- a/packages/prometheus/docs/README.md
+++ b/packages/prometheus/docs/README.md
@@ -200,7 +200,7 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
-| event.dataset | Event dataset. | constant_keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
 | event.module | Event module. | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.containerized | If the host is a container. | boolean |  |
@@ -414,7 +414,7 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
-| event.dataset | Event dataset. | constant_keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
 | event.module | Event module. | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.containerized | If the host is a container. | boolean |  |
@@ -637,7 +637,7 @@ The fields reported are:
 | data_stream.namespace | Data stream namespace. | constant_keyword |  |
 | data_stream.type | Data stream type. | constant_keyword |  |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
-| event.dataset | Event dataset. | constant_keyword |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |  |
 | event.module | Event module. | constant_keyword |  |
 | host.architecture | Operating system architecture. | keyword |  |
 | host.containerized | If the host is a container. | boolean |  |

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.11.0
+version: 1.12.0
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

1, There is no need to set `event.dataset` explicitly - this should be done on the elastic-agent side https://github.com/elastic/beats/pull/20076.

due to the existence of predefined value, there can happen this error:
```
{"type":"illegal_argument_exception","reason":"[constant_keyword] field [event.dataset] only accepts values that are equal to the value defined in the mappings [prometheus.collector], but got [prometheus.topolvm]"}}, dropping event!
```
Since the type defined for this field in ecs is `keyword`, I decided to switch to ecs definition.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/7654

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
