### PR TITLE
[m365_defender] Correct link to PR - Update changelog.yml

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Major improvements in ECS field coverage and additional field mappings.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7255
+      link: https://github.com/elastic/integrations/pull/7522
 - version: "1.17.1"
   changes:
     - description: Fix fingerprint processor on `log` datastream to avoid document conflicts


### PR DESCRIPTION
- Bug


## What does this PR do?

Looks like the wrong PR number was added to the link.

![image](https://github.com/elastic/integrations/assets/5582679/495611c1-aa26-4e43-b41a-b1caf579bf81)

