### PR TITLE
[awsfirehose] Add support for routing api gateway logs

### DIFF
--- a/packages/awsfirehose/_dev/build/docs/README.md
+++ b/packages/awsfirehose/_dev/build/docs/README.md
@@ -6,6 +6,7 @@ by this integration:
 
 | AWS service log    | Log destination           |
 |--------------------|---------------------------|
+| API Gateway        | CloudWatch                |
 | CloudTrail         | CloudWatch                |
 | Network Firewall   | Firehose, CloudWatch, S3  |
 | Route53 Public DNS | CloudWatch                |

--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.0
+  changes:
+    - description: Add support for routing api gateway logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7146
 - version: 0.1.0
   changes:
     - description: initial release

--- a/packages/awsfirehose/data_stream/logs/_dev/test/pipeline/test-apigateway-log.json
+++ b/packages/awsfirehose/data_stream/logs/_dev/test/pipeline/test-apigateway-log.json
@@ -1,0 +1,58 @@
+{
+  "events": [
+    {
+      "cloud.region": "us-east-1",
+      "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+      "data_stream.namespace": "default",
+      "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+      "message": "{\"requestId\":\"GQIVriFLIAMEMsA=\",\"ip\":\"1.128.0.0\",\"requestTime\":\"09/Jun/2023:12:54:08 +0000\",\"httpMethod\":\"GET\",\"routeKey\":\"GET /\",\"status\":\"200\",\"protocol\":\"HTTP/1.1\",\"responseLength\":\"47140\"}",
+      "aws.kinesis.type": "deliverystream",
+      "data_stream.type": "logs",
+      "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+      "aws.cloudwatch.log_stream": "6am6mj7iqf_.default-2023-07-25-21-04",
+      "cloud.provider": "aws",
+      "@timestamp": "2023-07-25T21:04:35Z",
+      "cloud.account.id": "123456",
+      "data_stream.dataset": "awsfirehose.logs",
+      "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+      "event.id": "37670326805251200781477669690942747782212394134076063744",
+      "aws.cloudwatch.log_group": "aws/api-gateway/test-HTTP"
+    },
+    {
+      "cloud.region": "us-east-1",
+      "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+      "data_stream.namespace": "default",
+      "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+      "message": "{\"requestId\":\"Iq9gjE_aIAMFZTg=\",\"ip\":\"1.128.0.0\",\"caller\":\"-\",\"user\":\"-\",\"requestTime\":\"26/Jul/2023:12:20:44 +0000\",\"eventType\":\"CONNECT\",\"routeKey\":\"$connect\",\"status\":\"500\",\"connectionId\":\"Iq8gj1UmIAMCKpA=\",\"apiId\":\"z1ctxygne5\",\"stage\":\"production\",\"domainName\":\"z1ctxygne5.execute-api.us-east-1.amazonaws.com\"}",
+      "aws.kinesis.type": "deliverystream",
+      "data_stream.type": "logs",
+      "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+      "aws.cloudwatch.log_stream": "640eb3bb5f9b64a78b51fd67d59e53d1",
+      "cloud.provider": "aws",
+      "@timestamp": "2023-07-25T21:04:35Z",
+      "cloud.account.id": "123456",
+      "data_stream.dataset": "awsfirehose.logs",
+      "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+      "event.id": "37670326805251200781477669690942747782212394134076063744",
+      "aws.cloudwatch.log_group": "aws/api-gateway/test-websocket"
+    },
+    {
+      "cloud.region": "us-east-1",
+      "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+      "data_stream.namespace": "default",
+      "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+      "message": "{\"requestId\":\"48752d0f-c99d-4cfa-a5a7-f3c6834d19e5\",\"ip\":\"1.128.0.0\",\"caller\":\"-\",\"user\":\"-\",\"requestTime\":\"10/Jun/2023:15:36:28 +0000\",\"httpMethod\":\"GET\",\"resourcePath\":\"/pets\",\"status\":\"200\",\"protocol\":\"HTTP/1.1\",\"responseLength\":\"184\"}",
+      "aws.kinesis.type": "deliverystream",
+      "data_stream.type": "logs",
+      "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+      "aws.cloudwatch.log_stream": "198fbff89762157ff651566b645c6730",
+      "cloud.provider": "aws",
+      "@timestamp": "2023-07-25T21:04:35Z",
+      "cloud.account.id": "123456",
+      "data_stream.dataset": "awsfirehose.logs",
+      "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+      "event.id": "37670326805251200781477669690942747782212394134076063744",
+      "aws.cloudwatch.log_group": "aws/api-gateway/test-REST"
+    }
+  ]
+}

--- a/packages/awsfirehose/data_stream/logs/_dev/test/pipeline/test-apigateway-log.json-expected.json
+++ b/packages/awsfirehose/data_stream/logs/_dev/test/pipeline/test-apigateway-log.json-expected.json
@@ -1,0 +1,76 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-07-25T21:04:35Z",
+            "aws.cloudwatch.log_group": "aws/api-gateway/test-HTTP",
+            "aws.cloudwatch.log_stream": "6am6mj7iqf_.default-2023-07-25-21-04",
+            "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+            "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+            "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+            "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+            "aws.kinesis.type": "deliverystream",
+            "cloud": {
+                "provider": "aws"
+            },
+            "cloud.account.id": "123456",
+            "cloud.provider": "aws",
+            "cloud.region": "us-east-1",
+            "data_stream.dataset": "aws.apigateway_logs",
+            "data_stream.namespace": "default",
+            "data_stream.type": "logs",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event.id": "37670326805251200781477669690942747782212394134076063744",
+            "message": "{\"requestId\":\"GQIVriFLIAMEMsA=\",\"ip\":\"1.128.0.0\",\"requestTime\":\"09/Jun/2023:12:54:08 +0000\",\"httpMethod\":\"GET\",\"routeKey\":\"GET /\",\"status\":\"200\",\"protocol\":\"HTTP/1.1\",\"responseLength\":\"47140\"}"
+        },
+        {
+            "@timestamp": "2023-07-25T21:04:35Z",
+            "aws.cloudwatch.log_group": "aws/api-gateway/test-websocket",
+            "aws.cloudwatch.log_stream": "640eb3bb5f9b64a78b51fd67d59e53d1",
+            "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+            "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+            "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+            "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+            "aws.kinesis.type": "deliverystream",
+            "cloud": {
+                "provider": "aws"
+            },
+            "cloud.account.id": "123456",
+            "cloud.provider": "aws",
+            "cloud.region": "us-east-1",
+            "data_stream.dataset": "aws.apigateway_logs",
+            "data_stream.namespace": "default",
+            "data_stream.type": "logs",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event.id": "37670326805251200781477669690942747782212394134076063744",
+            "message": "{\"requestId\":\"Iq9gjE_aIAMFZTg=\",\"ip\":\"1.128.0.0\",\"caller\":\"-\",\"user\":\"-\",\"requestTime\":\"26/Jul/2023:12:20:44 +0000\",\"eventType\":\"CONNECT\",\"routeKey\":\"$connect\",\"status\":\"500\",\"connectionId\":\"Iq8gj1UmIAMCKpA=\",\"apiId\":\"z1ctxygne5\",\"stage\":\"production\",\"domainName\":\"z1ctxygne5.execute-api.us-east-1.amazonaws.com\"}"
+        },
+        {
+            "@timestamp": "2023-07-25T21:04:35Z",
+            "aws.cloudwatch.log_group": "aws/api-gateway/test-REST",
+            "aws.cloudwatch.log_stream": "198fbff89762157ff651566b645c6730",
+            "aws.firehose.arn": "arn:aws:firehose:us-east-2:123456:deliverystream/firehose-apigateway-logs-to-elastic",
+            "aws.firehose.request_id": "971ae05f-a128-4a7f-b623-30f9bc513e55",
+            "aws.firehose.subscription_filters": "[apigateway-to-firehose]",
+            "aws.kinesis.name": "firehose-apigateway-logs-to-elastic",
+            "aws.kinesis.type": "deliverystream",
+            "cloud": {
+                "provider": "aws"
+            },
+            "cloud.account.id": "123456",
+            "cloud.provider": "aws",
+            "cloud.region": "us-east-1",
+            "data_stream.dataset": "aws.apigateway_logs",
+            "data_stream.namespace": "default",
+            "data_stream.type": "logs",
+            "ecs": {
+                "version": "8.0.0"
+            },
+            "event.id": "37670326805251200781477669690942747782212394134076063744",
+            "message": "{\"requestId\":\"48752d0f-c99d-4cfa-a5a7-f3c6834d19e5\",\"ip\":\"1.128.0.0\",\"caller\":\"-\",\"user\":\"-\",\"requestTime\":\"10/Jun/2023:15:36:28 +0000\",\"httpMethod\":\"GET\",\"resourcePath\":\"/pets\",\"status\":\"200\",\"protocol\":\"HTTP/1.1\",\"responseLength\":\"184\"}"
+        }
+    ]
+}

--- a/packages/awsfirehose/data_stream/logs/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/logs/routing_rules.yml
@@ -56,3 +56,18 @@
       namespace:
         - "{{data_stream.namespace}}"
         - default
+    - target_dataset: aws.apigateway_logs
+      if: >-
+        (ctx.message != null && ctx.message.contains('requestId') && ctx.message.contains('ip')
+        && ctx.message.contains('requestTime') && ctx.message.contains('httpMethod') && ctx.message.contains('routeKey')
+        && ctx.message.contains('status') && ctx.message.contains('protocol') && ctx.message.contains('responseLength'))
+        || (ctx.message != null && ctx.message.contains('requestId') && ctx.message.contains('ip') && ctx.message.contains('caller')
+        && ctx.message.contains('user') && ctx.message.contains('requestTime') && ctx.message.contains('httpMethod')
+        && ctx.message.contains('resourcePath') && ctx.message.contains('status') && ctx.message.contains('protocol')
+        && ctx.message.contains('responseLength')) 
+        || (ctx.message != null && ctx.message.contains('requestId') && ctx.message.contains('ip') && ctx.message.contains('caller')
+        && ctx.message.contains('user') && ctx.message.contains('requestTime') && ctx.message.contains('eventType')
+        && ctx.message.contains('routeKey') && ctx.message.contains('status') && ctx.message.contains('connectionId'))
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default

--- a/packages/awsfirehose/docs/README.md
+++ b/packages/awsfirehose/docs/README.md
@@ -6,6 +6,7 @@ by this integration:
 
 | AWS service log    | Log destination           |
 |--------------------|---------------------------|
+| API Gateway        | CloudWatch                |
 | CloudTrail         | CloudWatch                |
 | Network Firewall   | Firehose, CloudWatch, S3  |
 | Route53 Public DNS | CloudWatch                |

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: awsfirehose
 title: Amazon Kinesis Data Firehose
-version: 0.1.0
+version: 0.2.0
 description: Stream logs from Amazon Kinesis Data Firehose into Elastic Cloud.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR adds routing rules for API gateway access logs.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).