### PR TITLE
m365_defender: fix template snippet escaping behaviour and add event.kind for pipeline errors

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Fix template snippet escaping and add event.kind for pipeline errors.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7707
 - version: "2.0.0"
   changes:
     - description: Major improvements in ECS field coverage and additional field mappings.

--- a/packages/m365_defender/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/incident/elasticsearch/ingest_pipeline/default.yml
@@ -2341,6 +2341,9 @@ processors:
         }
         dropEmptyFields(ctx);
 on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/m365_defender/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/m365_defender/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -47,7 +47,7 @@ processors:
       value: azure
   - set:
       field: "@timestamp"
-      value: "{{json.lastUpdateTime}}"
+      value: "{{{json.lastUpdateTime}}}"
       if: ctx.json?.lastUpdateTime != null
   - rename:
       field: json.alerts.title
@@ -257,19 +257,19 @@ processors:
   #########################
   - append:
       field: related.ip
-      value: "{{json.alerts.entities.ipAddress}}"
+      value: "{{{json.alerts.entities.ipAddress}}}"
       if: ctx.json?.alerts?.entities?.ipAddress != null
   - append:
       field: related.user
-      value: "{{user.name}}"
+      value: "{{{user.name}}}"
       if: ctx.user?.name != null
   - append:
       field: related.hash
-      value: "{{file.hash.sha1}}"
+      value: "{{{file.hash.sha1}}}"
       if: ctx.file?.hash?.sha1 != null
   - append:
       field: related.hash
-      value: "{{file.hash.sha256}}"
+      value: "{{{file.hash.sha256}}}"
       if: ctx.file?.hash?.sha256 != null
   - foreach:
       field: json.alerts.devices
@@ -277,7 +277,7 @@ processors:
       processor:
         append:
           field: related.hosts
-          value: "{{ _ingest._value.deviceDnsName }}"
+          value: "{{{ _ingest._value.deviceDnsName }}}"
           allow_duplicates: false
           ignore_failure: true
   - foreach:
@@ -286,7 +286,7 @@ processors:
       processor:
         append:
           field: host.name
-          value: "{{ _ingest._value.deviceDnsName }}"
+          value: "{{{ _ingest._value.deviceDnsName }}}"
           allow_duplicates: false
           ignore_failure: true
   - lowercase:
@@ -370,5 +370,8 @@ processors:
       ignore_missing: true
 on_failure:
   - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
       field: error.message
-      value: "{{_ingest.on_failure_message}}"
+      value: "{{{_ingest.on_failure_message}}}"

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.0.0"
+version: "2.0.1"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

See title.

(The majority of the work fixing template snippets in m365_defender was done in #7522, so this is just to knock it on the head).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #7641

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
