### PR TITLE
[Oracle] Resolve divisor error in performance datastream

### DIFF
--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Resolved `ORA-01476` error in `Performance` datastream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7718
 - version: "1.20.0"
   changes:
     - description: Add support for processors

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.1"
+  changes:
+    - description: Resolved `ORA-01476` error in `Performance` datastream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.20.0"
   changes:
     - description: Add support for processors

--- a/packages/oracle/data_stream/performance/agent/stream/stream.yml.hbs
+++ b/packages/oracle/data_stream/performance/agent/stream/stream.yml.hbs
@@ -7,7 +7,7 @@ hosts:
 raw_data.enabled: true
 driver: "oracle"
 sql_queries: 
-  - query: SELECT name, physical_reads, db_block_gets, consistent_gets, 1 - (physical_reads / (db_block_gets + consistent_gets)) "Hit_Ratio" FROM V$BUFFER_POOL_STATISTICS
+  - query: SELECT name, physical_reads, db_block_gets, consistent_gets, 1 - (physical_reads / (db_block_gets + consistent_gets)) "Hit_Ratio" FROM V$BUFFER_POOL_STATISTICS where (db_block_gets + consistent_gets) > 0
     response_format: table
   - query: SELECT sum(a.value) total_cur, avg(a.value) avg_cur, max(a.value) max_cur, S.username, s.machine FROM v$sesstat a, v$statname b, v$session s WHERE a.statistic# = b.statistic# AND s.sid = a.sid GROUP BY s.username, s.machine
     response_format: table

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: oracle
 title: "Oracle"
-version: "1.20.0"
+version: "1.20.1"
 license: basic
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration


### PR DESCRIPTION
- Bug


## What does this PR do?

The query `SELECT name, physical_reads, db_block_gets, consistent_gets, 1 - (physical_reads / (db_block_gets + consistent_gets)) "Hit_Ratio" FROM V$BUFFER_POOL_STATISTICS` may result in error when `(db_block_gets + consistent_gets)` is zero.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## How to test this PR locally

  - elastic-package build
  - elastic-package stack up -v -d --services package-registry
 

## Related issues


- Closes https://github.com/elastic/sdh-beats/issues/3762


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
After the change

<img width="804" alt="image" src="https://github.com/elastic/integrations/assets/101976829/91394eae-23ea-446c-bae7-72c7bbb16433">

## PR Review Priority - High 
  The PR is related to an SDH