### PR TITLE
[ti_util] Change dashboard queries from `match_phrase` to `wildcard`

### DIFF
--- a/packages/ti_util/changelog.yml
+++ b/packages/ti_util/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Fix the query type for matching 'event.dataset'.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7731
 - version: "1.2.2"
   changes:
     - description: Update to use new Threat Indicator Match rule names.

--- a/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
+++ b/packages/ti_util/kibana/dashboard/ti_util-9eff2529-fff5-4064-b825-fa089f260bfa.json
@@ -123,10 +123,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -416,10 +416,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -564,10 +564,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -708,10 +708,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -1043,10 +1043,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -1225,10 +1225,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }
@@ -1378,10 +1378,10 @@
                                         "params": {
                                             "query": "ti_*"
                                         },
-                                        "type": "phrase"
+                                        "type": "wildcard"
                                     },
                                     "query": {
-                                        "match_phrase": {
+                                        "wildcard": {
                                             "event.dataset": "ti_*"
                                         }
                                     }

--- a/packages/ti_util/manifest.yml
+++ b/packages/ti_util/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_util
 title: "Threat Intelligence Utilities"
-version: 1.2.2
+version: 1.2.3
 description: Prebuilt Threat Intelligence dashboard for Elastic Security
 categories:
   - security


### PR DESCRIPTION
The `ti_util` generic threat intelligence dashboard wasn't picking up my data.

It was looking for a wildcard value (`ti_*`) using a `match_phrase` query type.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).