### PR TITLE
[crowdstrike] Convert Win32 timestamps to unix millisecond timestamp

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.3"
+  changes:
+    - description: Convert Win32 timestamps to unix millisecond timestamps.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.2"
   changes:
     - description: Fixed event tag handling for the falcon data-stream.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Convert Win32 timestamps to unix millisecond timestamps.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7734
 - version: "1.18.2"
   changes:
     - description: Fixed event tag handling for the falcon data-stream.

--- a/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-ipd-summary.log-expected.json
+++ b/packages/crowdstrike/data_stream/falcon/_dev/test/pipeline/test-falcon-ipd-summary.log-expected.json
@@ -5,10 +5,10 @@
             "crowdstrike": {
                 "event": {
                     "ActivityId": "12345678-1234-1234-1234-123456789000",
-                    "MostRecentActivityTimeStamp": 1686847975,
+                    "MostRecentActivityTimeStamp": 1686847975567,
                     "Objective": "Gain Access",
                     "PatternId": "51135",
-                    "PrecedingActivityTimeStamp": 1670971634,
+                    "PrecedingActivityTimeStamp": 1670971634578,
                     "SourceEndpointAccountObjectGuid": "12345678-1234-1234-1234-123456789000",
                     "SourceEndpointAccountObjectSid": "S-1-3-44-55555555-666666666-7777777777-88888",
                     "SourceEndpointSensorId": "12345678901234567890123456789012"

--- a/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/falcon/elasticsearch/ingest_pipeline/default.yml
@@ -55,12 +55,12 @@ processors:
                 - 'PrecedingActivityTimeStamp'
                 - 'StartTimestamp'
                 - 'UTCTimestamp'
-# Process to convert LDAP/WIN32 FILETIME to Unix timestamp. 
+# Process to convert LDAP/WIN32 FILETIME to Unix (milliseconds) timestamp.
 # More details can be found here https://devblogs.microsoft.com/oldnewthing/20030905-02/?p=42653 and here https://www.epochconverter.com/ldap
         source: |
             def convertToUnix(def longValue) {
                 if (longValue > 0x0100000000000000L) {
-                    return (longValue / 10000000) - 11644473600L;
+                    return (longValue / 10000) - 11644473600000L;
                 }
                 return longValue;
             }

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.18.2"
+version: "1.18.3"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: 2.7.0


### PR DESCRIPTION
## What does this PR do?

- Change the conversion function for Win32 timestamps to produce a millisecond result. A mapping error was occuring when trying to map certain fields, such as crowdstrike.event.PrecedingActivityTimeStamp, since (by default) the date field only handles string-based timestamps and millisecond-based unix timestamps.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- `elastic-package test`

## Related

- #7547 
