### PR TITLE
[O11y][IBM MQ] Update the docker image

### DIFF
--- a/packages/ibmmq/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ibmmq/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ibmmq:
-    image: ibmcom/mq:${SERVICE_VERSION:-v9.2.4.0-r1-amd64}
+    image: ibmcom/mq:${SERVICE_VERSION:-9.2.4.0-r1-amd64}
     environment:
       - LICENSE=accept
       - MQ_QMGR_NAME=QM1

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.2.2"
   changes:
-    - description: Update the docker image for system tests.
+    - description: Update the docker image.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7754
 - version: "1.2.1"
   changes:
     - description: Update description for compatibility

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Update the docker image for system tests.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.2.1"
   changes:
     - description: Update description for compatibility

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ibmmq
 title: IBM MQ
-version: "1.2.1"
+version: "1.2.2"
 license: basic
 description: Collect logs and metrics from IBM MQ with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug


## What does this PR do?

- This PR updates the docker image for IBM MQ. Refer to more details in this [comment](https://github.com/elastic/observability-test-environments/issues/10575#issuecomment-1708563294).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).