### PR TITLE
[O11y][Traefik] Enable time series data stream for the health

### DIFF
--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.10.0"
+  changes:
+    - description: Enable time series data streams for the metrics datasets. This dramatically reduces storage for metrics and is expected to progressively improve query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.8.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/traefik/data_stream/health/manifest.yml
+++ b/packages/traefik/data_stream/health/manifest.yml
@@ -12,3 +12,5 @@ streams:
         default: 10s
     title: Traefik health metrics
     description: Collect Traefik health metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: "1.8.0"
+version: "1.10.0"
 release: ga
 description: Collect logs and metrics from Traefik servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement

## What does this PR do?

This PR enables TSDB by default for Traefik health datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #7766  