### PR TITLE
aws: fix GuardDuty API call parameter

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.1"
+  changes:
+    - description: Fix GuardDuty API call parameter.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7785
 - version: "2.2.0"
   changes:
     - description: Add AWS API Gateway metrics dashboard Stage filter, control groups and clean up

--- a/packages/aws/data_stream/guardduty/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/guardduty/_dev/test/system/test-default-config.yml
@@ -1,7 +1,4 @@
 input: httpjson
-skip:
-  reason: "Support backward compatibility of Current AWS package."
-  link: https://github.com/elastic/integrations/issues/4911
 service: guardduty
 vars:
   secret_access_key: xxxx

--- a/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
@@ -19,7 +19,7 @@ request.transforms:
       target: header.X-Amz-Date
       value: '[[formatDate (now) "20060102T150405Z"]]'
   - set:
-      target: body.MaxResults
+      target: body.maxResults
       value: 50
       value_type: int
   - set:

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: aws
 title: AWS
-version: 2.2.0
+version: 2.2.1
 license: basic
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
<!-- Mandatory
Explain here the changes you made on the PR.
-->

The AWS documentation specifies that the maxResults parameter be
[droopingCamelCase](https://docs.aws.amazon.com/guardduty/latest/APIReference/API_ListFindings.html), while we are using CamelCase. This results in API
requests being rejected with the following error

```
{
  "message": "The request is rejected because the JSON could not be processed.",
  "__type": "InvalidInputException"
}
```

Also re-enable system tests for the data stream; the skip was in
place because we were testing on versions below 8.6. The kibana
version is now v8.9.0, so we can re-enable it.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #4911

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
