### PR TITLE
[auditd] Remove elasticsearch.dynamic_{dataset,namespace}

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.13.1"
+  changes:
+    - description: Remove the unnecessary permission for the package to write to arbitrary `logs-*` data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7800
 - version: "3.13.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/auditd/data_stream/log/manifest.yml
+++ b/packages/auditd/data_stream/log/manifest.yml
@@ -39,6 +39,3 @@ streams:
     template_path: log.yml.hbs
     title: Auditd logs
     description: Collect Auditd logs using log input
-# Ensures agents have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.13.0"
+version: "3.13.1"
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
auditd is not a generic input type that you would be applying to different sources. It specifically reads the output of the Linux auditd daemon. It does not need to be able to write to arbitrary logs-* data streams.

Relates: https://github.com/elastic/integrations/pull/6808#issuecomment-1623650344

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/integrations/pull/6808#issuecomment-1623650344
- Relates https://github.com/elastic/integrations/issues/7810
