### PR TITLE
[ti_anomali] Remove dotted-yaml keys

### DIFF
--- a/packages/ti_anomali/changelog.yml
+++ b/packages/ti_anomali/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.1-next"
+  changes:
+    - description: Remove dotted YAML keys.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7803
 - version: "1.16.0"
   changes:
     - description: Update package-spec to 2.10.0.

--- a/packages/ti_anomali/elasticsearch/transform/latest_ioc/manifest.yml
+++ b/packages/ti_anomali/elasticsearch/transform/latest_ioc/manifest.yml
@@ -2,13 +2,13 @@ start: true
 destination_index_template:
   settings:
     index:
-      sort.field:
-        - "@timestamp"
-      sort.order:
-        - desc
+      sort:
+        field:
+          - "@timestamp"
+        order:
+          - desc
   mappings:
     dynamic: true
-    _meta: {}
     dynamic_templates:
       - strings_as_keyword:
           match_mapping_type: string

--- a/packages/ti_anomali/manifest.yml
+++ b/packages/ti_anomali/manifest.yml
@@ -6,7 +6,8 @@ type: integration
 format_version: 2.10.0
 categories: ["security", "threat_intel"]
 conditions:
-  kibana.version: ^8.8.0
+  kibana:
+    version: ^8.8.0
 icons:
   - src: /img/anomali.svg
     title: Anomali


### PR DESCRIPTION
In preparation for upgrading to package-spec 3.0.0, this replaces YAML keys containing dots with an unambiguous YAML form. It also removes the empty _meta object from the transform definition.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
