### PR TITLE
[ti_maltiverse] Remove dotted yaml keys

### DIFF
--- a/packages/ti_maltiverse/changelog.yml
+++ b/packages/ti_maltiverse/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.2.1-next"
+  changes:
+    - description: Remove dotted YAML keys.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7804
 - version: "0.2.0"
   changes:
     - description: Add support for HTTP request trace logging.

--- a/packages/ti_maltiverse/elasticsearch/transform/latest/manifest.yml
+++ b/packages/ti_maltiverse/elasticsearch/transform/latest/manifest.yml
@@ -2,7 +2,8 @@ start: true
 destination_index_template:
   settings:
     index:
-      sort.field:
-        - "@timestamp"
-      sort.order:
-        - desc
+      sort:
+        field:
+          - "@timestamp"
+        order:
+          - desc

--- a/packages/ti_maltiverse/manifest.yml
+++ b/packages/ti_maltiverse/manifest.yml
@@ -6,7 +6,8 @@ type: integration
 format_version: 2.9.0
 categories: ["security", "threat_intel"]
 conditions:
-  kibana.version: ^8.8.0
+  kibana:
+    version: ^8.8.0
 icons:
   - src: /img/logo-maltiverse.svg
     title: Maltiverse


### PR DESCRIPTION
In preparation for upgrading to package-spec 3.0.0, this replaces YAML keys containing dots with an unambiguous YAML form.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
