### PR TITLE
[bitdefender,forcepoint_web,jumpcloud,tines] Remove version from ingest pipeline definitions

### DIFF
--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Remove version attribute from ingest node pipelines.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7807
 - version: "1.3.0"
   changes:
     - description: Add support for HTTP request trace logging.

--- a/packages/bitdefender/data_stream/push_configuration/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_configuration/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline for BitDefender push notification configuration
 processors:
 - json:

--- a/packages/bitdefender/data_stream/push_notifications/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_notifications/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 2
 description: Processes HTTP JSON events from BitDefender
 processors:
 - json:

--- a/packages/bitdefender/data_stream/push_statistics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_statistics/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline for BitDefender push notification stats
 processors:
 - json:

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: bitdefender
 title: "BitDefender"
-version: "1.3.0"
+version: "1.3.1"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"
@@ -9,8 +9,10 @@ type: integration
 categories:
   - security
 conditions:
-  kibana.version: "^8.5.1"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.5.1"
+  elastic:
+    subscription: "basic"
 screenshots:
   - src: /img/bitdefender-dashboard-push-notifications.png
     title: Push Notifications Dashboard

--- a/packages/forcepoint_web/changelog.yml
+++ b/packages/forcepoint_web/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Remove version attribute from ingest node pipelines.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7807
 - version: "1.1.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/forcepoint_web/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/forcepoint_web/data_stream/logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline to process Forcepoint Web logs
 processors:
 

--- a/packages/forcepoint_web/manifest.yml
+++ b/packages/forcepoint_web/manifest.yml
@@ -10,8 +10,10 @@ categories:
   - network
   - security
 conditions:
-  kibana.version: "^8.5.1"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.5.1"
+  elastic:
+    subscription: "basic"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/packages/forcepoint_web/manifest.yml
+++ b/packages/forcepoint_web/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: forcepoint_web
 title: "Forcepoint Web Security"
-version: "1.1.0"
+version: "1.1.1"
 source:
   license: "Elastic-2.0"
 description: "Forcepoint Web Security"

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Remove version attribute from ingest node pipelines.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7807
 - version: "1.2.1"
   changes:
     - description: Add missing field definitions for `input.type` and `jumpcloud.event.version`.

--- a/packages/jumpcloud/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jumpcloud/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline for JumpCloud Events
 processors:
 - set:

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,15 +1,17 @@
 format_version: 2.7.0
 name: jumpcloud
 title: "JumpCloud"
-version: "1.2.1"
+version: "1.2.2"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:
   - cloud
   - security
 conditions:
-  kibana.version: "^8.7.1"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.7.1"
+  elastic:
+    subscription: "basic"
 screenshots:
   - src: /img/sample-screenshot.png
     title: Sample screenshot

--- a/packages/tines/changelog.yml
+++ b/packages/tines/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Remove version attribute from ingest node pipelines.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7807
 - version: "1.2.0"
   changes:
     - description: Update package to ECS 8.9.0.

--- a/packages/tines/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tines/data_stream/audit_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline for Tines Audit Logs
 processors:
 - json:

--- a/packages/tines/data_stream/time_saved/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tines/data_stream/time_saved/elasticsearch/ingest_pipeline/default.yml
@@ -1,5 +1,4 @@
 ---
-version: 1
 description: Pipeline for Tines Time Saved data
 processors:
 - json:

--- a/packages/tines/manifest.yml
+++ b/packages/tines/manifest.yml
@@ -1,15 +1,17 @@
 format_version: 2.7.0
 name: tines
 title: "Tines"
-version: "1.2.0"
+version: "1.2.1"
 description: "Tines Logs & Time Saved Reports"
 type: integration
 categories:
   - cloud
   - security
 conditions:
-  kibana.version: "^8.7.1"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.7.1"
+  elastic:
+    subscription: "basic"
 screenshots:
   - src: /img/tines-audit-logs-dashboard.png
     title: Audit Logs


### PR DESCRIPTION
The ingest node pipelines contained a version attribute that is not useful in Fleet pipelines. This will not be allowed in future versions of package-spec.

Relates: https://github.com/elastic/package-spec/issues/529

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates https://github.com/elastic/package-spec/issues/529
- Relates https://github.com/elastic/integrations/issues/7810
