### PR TITLE
[O11y][Apache Tomcat] Remove forwarded tag from metrics data streams 

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.2"
+  changes:
+    - description: Remove forwarded tag from metrics data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.12.1"
   changes:
     - description: Add supported log formats for Catalina and Localhost logs in README.

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove forwarded tag from metrics data streams.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7824
 - version: "0.12.1"
   changes:
     - description: Add supported log formats for Catalina and Localhost logs in README.

--- a/packages/apache_tomcat/data_stream/cache/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/cache/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/cache/manifest.yml
+++ b/packages/apache_tomcat/data_stream/cache/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-cache
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/cache/sample_event.json
+++ b/packages/apache_tomcat/data_stream/cache/sample_event.json
@@ -94,7 +94,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "forwarded",
         "apache_tomcat-cache"
     ]
 }

--- a/packages/apache_tomcat/data_stream/connection_pool/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/connection_pool/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/connection_pool/manifest.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-connection_pool
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/connection_pool/sample_event.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/sample_event.json
@@ -141,7 +141,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-connection_pool",
-        "forwarded"
+        "apache_tomcat-connection_pool"
     ]
 }

--- a/packages/apache_tomcat/data_stream/memory/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/memory/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/memory/manifest.yml
+++ b/packages/apache_tomcat/data_stream/memory/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-memory
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/memory/sample_event.json
+++ b/packages/apache_tomcat/data_stream/memory/sample_event.json
@@ -102,7 +102,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-memory",
-        "forwarded"
+        "apache_tomcat-memory"
     ]
 }

--- a/packages/apache_tomcat/data_stream/request/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/request/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/request/manifest.yml
+++ b/packages/apache_tomcat/data_stream/request/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-request
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/request/sample_event.json
+++ b/packages/apache_tomcat/data_stream/request/sample_event.json
@@ -84,7 +84,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "forwarded",
         "apache_tomcat-request"
     ]
 }

--- a/packages/apache_tomcat/data_stream/session/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/session/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/session/manifest.yml
+++ b/packages/apache_tomcat/data_stream/session/manifest.yml
@@ -19,7 +19,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-session
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/session/sample_event.json
+++ b/packages/apache_tomcat/data_stream/session/sample_event.json
@@ -100,7 +100,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-session",
-        "forwarded"
+        "apache_tomcat-session"
     ]
 }

--- a/packages/apache_tomcat/data_stream/thread_pool/agent/stream/stream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/thread_pool/agent/stream/stream.yml.hbs
@@ -19,9 +19,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/apache_tomcat/data_stream/thread_pool/manifest.yml
+++ b/packages/apache_tomcat/data_stream/thread_pool/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - apache_tomcat-thread_pool
       - name: processors
         type: yaml

--- a/packages/apache_tomcat/data_stream/thread_pool/sample_event.json
+++ b/packages/apache_tomcat/data_stream/thread_pool/sample_event.json
@@ -116,7 +116,6 @@
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-thread_pool",
-        "forwarded"
+        "apache_tomcat-thread_pool"
     ]
 }

--- a/packages/apache_tomcat/docs/README.md
+++ b/packages/apache_tomcat/docs/README.md
@@ -581,7 +581,6 @@ An example event for `cache` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "forwarded",
         "apache_tomcat-cache"
     ]
 }
@@ -768,8 +767,7 @@ An example event for `connection_pool` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-connection_pool",
-        "forwarded"
+        "apache_tomcat-connection_pool"
     ]
 }
 ```
@@ -946,8 +944,7 @@ An example event for `memory` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-memory",
-        "forwarded"
+        "apache_tomcat-memory"
     ]
 }
 ```
@@ -1085,7 +1082,6 @@ An example event for `request` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "forwarded",
         "apache_tomcat-request"
     ]
 }
@@ -1231,8 +1227,7 @@ An example event for `session` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-session",
-        "forwarded"
+        "apache_tomcat-session"
     ]
 }
 ```
@@ -1401,8 +1396,7 @@ An example event for `thread_pool` looks as following:
         "type": "prometheus"
     },
     "tags": [
-        "apache_tomcat-thread_pool",
-        "forwarded"
+        "apache_tomcat-thread_pool"
     ]
 }
 ```

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: apache_tomcat
 title: Apache Tomcat
-version: "0.12.1"
+version: "0.12.2"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
- Bug
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- This PR removes the forwarded tag from the metricbeat-based data streams.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7635
