### PR TITLE
[O11y][CouchDB] Remove forwarded tag from metrics data streams

### DIFF
--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Remove forwarded tag from metrics data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.0.0"
   changes:
     - description: Make CouchDB GA.

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove forwarded tag from metrics data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7826
 - version: "1.0.0"
   changes:
     - description: Make CouchDB GA.

--- a/packages/couchdb/data_stream/server/agent/stream/stream.yml.hbs
+++ b/packages/couchdb/data_stream/server/agent/stream/stream.yml.hbs
@@ -12,9 +12,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/couchdb/data_stream/server/fields/ecs.yml
+++ b/packages/couchdb/data_stream/server/fields/ecs.yml
@@ -47,4 +47,3 @@
 - external: ecs
   name: cloud.availability_zone
   dimension: true
-

--- a/packages/couchdb/data_stream/server/manifest.yml
+++ b/packages/couchdb/data_stream/server/manifest.yml
@@ -20,7 +20,6 @@ streams:
         required: true
         show_user: false
         default:
-          - forwarded
           - couchdb-server
       - name: processors
         type: yaml
@@ -30,5 +29,6 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.  This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
 elasticsearch:
   index_mode: "time_series"

--- a/packages/couchdb/data_stream/server/sample_event.json
+++ b/packages/couchdb/data_stream/server/sample_event.json
@@ -115,7 +115,6 @@
         "type": "http"
     },
     "tags": [
-        "forwarded",
         "couchdb-server"
     ]
 }

--- a/packages/couchdb/docs/README.md
+++ b/packages/couchdb/docs/README.md
@@ -144,7 +144,6 @@ An example event for `server` looks as following:
         "type": "http"
     },
     "tags": [
-        "forwarded",
         "couchdb-server"
     ]
 }

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: couchdb
 title: CouchDB
-version: "1.0.0"
+version: "1.0.1"
 license: basic
 description: Collect metrics from CouchDB with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- This PR remove forwarded tag from the metricbeat-based data streams.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7635
