### PR TITLE
[O11y][IBM MQ] Remove forwarded tag from metrics data streams

### DIFF
--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove forwarded tag from metrics data stream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/7828
 - version: "1.2.2"
   changes:
     - description: Update the docker image.

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.3"
+  changes:
+    - description: Remove forwarded tag from metrics data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.2.2"
   changes:
     - description: Update the docker image.

--- a/packages/ibmmq/data_stream/qmgr/agent/stream/stream.yml.hbs
+++ b/packages/ibmmq/data_stream/qmgr/agent/stream/stream.yml.hbs
@@ -20,9 +20,6 @@ tags:
 {{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
-{{#contains "forwarded" tags}}
-publisher_pipeline.disable_host: true
-{{/contains}}
 {{#if processors}}
 processors:
 {{processors}}

--- a/packages/ibmmq/data_stream/qmgr/manifest.yml
+++ b/packages/ibmmq/data_stream/qmgr/manifest.yml
@@ -17,7 +17,6 @@ streams:
         required: false
         show_user: false
         default:
-          - forwarded
           - ibmmq-qmgr
       - name: processors
         type: yaml

--- a/packages/ibmmq/data_stream/qmgr/sample_event.json
+++ b/packages/ibmmq/data_stream/qmgr/sample_event.json
@@ -284,7 +284,6 @@
         "type": "ibmmq"
     },
     "tags": [
-        "forwarded",
         "ibmmq-qmgr"
     ]
 }

--- a/packages/ibmmq/docs/README.md
+++ b/packages/ibmmq/docs/README.md
@@ -309,7 +309,6 @@ An example event for `qmgr` looks as following:
         "type": "ibmmq"
     },
     "tags": [
-        "forwarded",
         "ibmmq-qmgr"
     ]
 }

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ibmmq
 title: IBM MQ
-version: "1.2.2"
+version: "1.2.3"
 license: basic
 description: Collect logs and metrics from IBM MQ with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bug
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

- This PR remove forwarded tag from the metricbeat-based data streams.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7635
