### PR TITLE
Update timeout for CI pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
     ELASTIC_PACKAGE_REPOSITORY_LICENSE = "licenses/Elastic-2.0.txt"
   }
   options {
-    timeout(time: 4, unit: 'HOURS')
+    timeout(time: 6, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
Latest builds are finishing after 4 hours, that was the timeout set in the pipeline definition: https://github.com/elastic/integrations/blob/8143f223c4fb51515c05bec2e3cf04e24307e9e2/.ci/Jenkinsfile#L54

```
[2023-09-14T14:23:42.771Z] [Pipeline] // stage
[2023-09-14T14:23:42.781Z] Error when executing always post condition:
[2023-09-14T14:23:42.781Z] org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
[2023-09-14T14:23:42.781Z] 	at org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution.cancel(TimeoutStepExecution.java:168)
[2023-09-14T14:23:42.781Z] 	at jenkins.security.ImpersonatingScheduledExecutorService$1.run(ImpersonatingScheduledExecutorService.java:67)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2023-09-14T14:23:42.781Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2023-09-14T14:23:42.781Z] 	at java.lang.Thread.run(Thread.java:750)
[2023-09-14T14:23:42.781Z] 
```

With this PR, this timeout has been increased up to 6 hours.
Schedule daily pipeline has already 6 hours of timeout for their builds.https://github.com/elastic/integrations/blob/8143f223c4fb51515c05bec2e3cf04e24307e9e2/.ci/schedule-daily.groovy#L12
