### PR TITLE
Add routing rules for WAF logs based on log format

### DIFF
--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: 0.2.1
+  changes:
+    - description: Route WAF logs based on log format
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7836
+    - description: Remove namespaces in routing rules
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7836
 - version: 0.2.0
   changes:
     - description: Add support for routing api gateway logs

--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -4,9 +4,6 @@
     - description: Route WAF logs based on log format
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7836
-    - description: Remove namespaces in routing rules
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/7836
 - version: 0.2.0
   changes:
     - description: Add support for routing api gateway logs

--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -5,7 +5,7 @@
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7836
     - description: Remove namespaces in routing rules
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/7836
 - version: 0.2.0
   changes:

--- a/packages/awsfirehose/data_stream/logs/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/logs/routing_rules.yml
@@ -2,8 +2,14 @@
   rules:
     - target_dataset: aws.firewall_logs
       if: ctx.message != null && ctx.message.contains('firewall_name') && ctx.message.contains('availability_zone') && ctx.message.contains('event_timestamp') && ctx.message.contains('event')
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.cloudtrail
       if: ctx['aws.cloudwatch.log_stream'] != null && ctx['aws.cloudwatch.log_stream'].contains('CloudTrail')
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.route53_public_logs
       if: >-
         if (ctx['aws.cloudwatch.log_stream'] == null) {
@@ -19,6 +25,9 @@
             return true;
         }
         return false;
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.route53_resolver_logs
       if: >-
         ctx.message != null && ctx.message.contains('version') && ctx.message.contains('account_id') && ctx.message.contains('region') && 
@@ -26,6 +35,9 @@
         && ctx.message.contains('query_type') && ctx.message.contains('query_class') && ctx.message.contains('rcode')
         && ctx.message.contains('answers') && ctx.message.contains('srcaddr') && ctx.message.contains('srcport')
         && ctx.message.contains('transport') && ctx.message.contains('srcids')
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.vpcflow
       if: >-
         if (ctx.message!= null) {
@@ -35,6 +47,9 @@
           }
         }
         return false;
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.waf
       # Kinesis Data Firehose stream name begins with `aws-waf-logs-`
       # CloudWatch log group name begins with `aws-waf-logs-`
@@ -48,6 +63,9 @@
         || (ctx.message != null && ctx.message.contains('webaclld') && ctx.message.contains('terminatingRule')
         && ctx.message.contains('httpSource') && ctx.message.contains('ruleGroupList') && ctx.message.contains('rateBasedRuleList')
         && ctx.message.contains('nonTerminatingMatchingRules') && ctx.message.contains('httpRequest') && ctx.message.contains('labels'))
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default
     - target_dataset: aws.apigateway_logs
       # Supported API Gateway log format by API type
       # HTTP: requestId ip requestTime httpMethod routeKey status protocol responseLength
@@ -64,3 +82,6 @@
         || (ctx.message != null && ctx.message.contains('requestId') && ctx.message.contains('ip') && ctx.message.contains('caller')
         && ctx.message.contains('user') && ctx.message.contains('requestTime') && ctx.message.contains('eventType')
         && ctx.message.contains('routeKey') && ctx.message.contains('status') && ctx.message.contains('connectionId'))
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default

--- a/packages/awsfirehose/data_stream/logs/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/logs/routing_rules.yml
@@ -45,10 +45,8 @@
       if: >-
         (ctx['aws.kinesis.name'] != null && ctx['aws.kinesis.name'].contains('aws-waf-logs-')) 
         || (ctx['aws.cloudwatch.log_group'] != null && ctx['aws.cloudwatch.log_group'].contains('aws-waf-logs-'))
-        || (ctx.message != null && ctx.message.contains('timestamp') && ctx.message.contains('formatVersion')
-        && ctx.message.contains('webaclld') && ctx.message.contains('terminatingRuleId') && ctx.message.contains('terminatingRuleType')
-        && ctx.message.contains('action') && ctx.message.contains('terminatingRuleMatchDetails') && ctx.message.contains('httpSourceName')
-        && ctx.message.contains('httpSourceId') && ctx.message.contains('ruleGroupList') && ctx.message.contains('rateBasedRuleList')
+        || (ctx.message != null && ctx.message.contains('webaclld') && ctx.message.contains('terminatingRule')
+        && ctx.message.contains('httpSource') && ctx.message.contains('ruleGroupList') && ctx.message.contains('rateBasedRuleList')
         && ctx.message.contains('nonTerminatingMatchingRules') && ctx.message.contains('httpRequest') && ctx.message.contains('labels'))
     - target_dataset: aws.apigateway_logs
       # Supported API Gateway log format by API type

--- a/packages/awsfirehose/data_stream/logs/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/logs/routing_rules.yml
@@ -2,14 +2,8 @@
   rules:
     - target_dataset: aws.firewall_logs
       if: ctx.message != null && ctx.message.contains('firewall_name') && ctx.message.contains('availability_zone') && ctx.message.contains('event_timestamp') && ctx.message.contains('event')
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
     - target_dataset: aws.cloudtrail
       if: ctx['aws.cloudwatch.log_stream'] != null && ctx['aws.cloudwatch.log_stream'].contains('CloudTrail')
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
     - target_dataset: aws.route53_public_logs
       if: >-
         if (ctx['aws.cloudwatch.log_stream'] == null) {
@@ -25,9 +19,6 @@
             return true;
         }
         return false;
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
     - target_dataset: aws.route53_resolver_logs
       if: >-
         ctx.message != null && ctx.message.contains('version') && ctx.message.contains('account_id') && ctx.message.contains('region') && 
@@ -35,9 +26,6 @@
         && ctx.message.contains('query_type') && ctx.message.contains('query_class') && ctx.message.contains('rcode')
         && ctx.message.contains('answers') && ctx.message.contains('srcaddr') && ctx.message.contains('srcport')
         && ctx.message.contains('transport') && ctx.message.contains('srcids')
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
     - target_dataset: aws.vpcflow
       if: >-
         if (ctx.message!= null) {
@@ -47,15 +35,21 @@
           }
         }
         return false;
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
     - target_dataset: aws.waf
+      # Kinesis Data Firehose stream name begins with `aws-waf-logs-`
+      # CloudWatch log group name begins with `aws-waf-logs-`
+      # Log fields:
+      # timestamp formatVersion webaclld terminatingRuleId terminatingRuleType action
+      # terminatingRuleMatchDetails httpSourceName httpSourceId ruleGroupList rateBasedRuleList
+      # nonTerminatingMatchingRules httpRequest labels
       if: >-
-        (ctx['aws.kinesis.name'] != null && ctx['aws.kinesis.name'].contains('aws-waf-logs-')) || (ctx['aws.cloudwatch.log_group'] != null && ctx['aws.cloudwatch.log_group'].contains('aws-waf-logs-'))
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default
+        (ctx['aws.kinesis.name'] != null && ctx['aws.kinesis.name'].contains('aws-waf-logs-')) 
+        || (ctx['aws.cloudwatch.log_group'] != null && ctx['aws.cloudwatch.log_group'].contains('aws-waf-logs-'))
+        || (ctx.message != null && ctx.message.contains('timestamp') && ctx.message.contains('formatVersion')
+        && ctx.message.contains('webaclld') && ctx.message.contains('terminatingRuleId') && ctx.message.contains('terminatingRuleType')
+        && ctx.message.contains('action') && ctx.message.contains('terminatingRuleMatchDetails') && ctx.message.contains('httpSourceName')
+        && ctx.message.contains('httpSourceId') && ctx.message.contains('ruleGroupList') && ctx.message.contains('rateBasedRuleList')
+        && ctx.message.contains('nonTerminatingMatchingRules') && ctx.message.contains('httpRequest') && ctx.message.contains('labels'))
     - target_dataset: aws.apigateway_logs
       # Supported API Gateway log format by API type
       # HTTP: requestId ip requestTime httpMethod routeKey status protocol responseLength
@@ -72,6 +66,3 @@
         || (ctx.message != null && ctx.message.contains('requestId') && ctx.message.contains('ip') && ctx.message.contains('caller')
         && ctx.message.contains('user') && ctx.message.contains('requestTime') && ctx.message.contains('eventType')
         && ctx.message.contains('routeKey') && ctx.message.contains('status') && ctx.message.contains('connectionId'))
-      namespace:
-        - "{{data_stream.namespace}}"
-        - default

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: awsfirehose
 title: Amazon Kinesis Data Firehose
-version: 0.2.0
+version: 0.2.1
 description: Stream logs from Amazon Kinesis Data Firehose into Elastic Cloud.
 type: integration
 categories:

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -8,7 +8,7 @@ categories:
   - observability
   - aws
 conditions:
-  kibana.version: "^8.10.0"
+  kibana.version: "^8.10.1"
 owner:
   github: elastic/obs-cloud-monitoring
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to enhance routing rules for WAF logs based its log format instead of firehose stream name and cloudwatch log group name. This way when WAF logs are sent to S3 bucket -> lambda -> firehose, our `awsfirehose` integration will still be able to route it correctly.

~~This PR also removes all `namespace` in routing rules since we are using the default, no need to specify it.~~ (will make this a separate change, this is causing error when running ` elastic-package test -v --report-format xUnit --report-output file --test-coverage
` command)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).