### PR TITLE
[aws] Change include_linked_accounts default to true

### DIFF
--- a/packages/aws/data_stream/apigateway_metrics/manifest.yml
+++ b/packages/aws/data_stream/apigateway_metrics/manifest.yml
@@ -37,8 +37,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/billing/manifest.yml
+++ b/packages/aws/data_stream/billing/manifest.yml
@@ -47,7 +47,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS Billing Metrics
     description: Collect billing metrics from Amazon Web Services with Elastic Agent.

--- a/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
+++ b/packages/aws/data_stream/cloudwatch_metrics/manifest.yml
@@ -25,8 +25,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: regions
         type: text
         title: Regions

--- a/packages/aws/data_stream/dynamodb/manifest.yml
+++ b/packages/aws/data_stream/dynamodb/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS DynamoDB metrics
     description: Collect AWS DynamoDB metrics

--- a/packages/aws/data_stream/ebs/manifest.yml
+++ b/packages/aws/data_stream/ebs/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS EBS metrics
     description: Collect AWS EBS metrics

--- a/packages/aws/data_stream/ec2_metrics/manifest.yml
+++ b/packages/aws/data_stream/ec2_metrics/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS EC2 metrics
     description: Collect AWS EC2 metrics

--- a/packages/aws/data_stream/ecs_metrics/manifest.yml
+++ b/packages/aws/data_stream/ecs_metrics/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS ECS metrics
     description: Collect AWS ECS metrics

--- a/packages/aws/data_stream/elb_metrics/manifest.yml
+++ b/packages/aws/data_stream/elb_metrics/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS ELB metrics
     description: Collect AWS ELB metrics

--- a/packages/aws/data_stream/emr_metrics/manifest.yml
+++ b/packages/aws/data_stream/emr_metrics/manifest.yml
@@ -38,8 +38,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/firewall_metrics/manifest.yml
+++ b/packages/aws/data_stream/firewall_metrics/manifest.yml
@@ -37,8 +37,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: metrics
         type: yaml
         title: Metrics

--- a/packages/aws/data_stream/kinesis/manifest.yml
+++ b/packages/aws/data_stream/kinesis/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS Kinesis Data Stream metrics
     description: Collect AWS Kinesis Data Stream metrics

--- a/packages/aws/data_stream/lambda/manifest.yml
+++ b/packages/aws/data_stream/lambda/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS Lambda metrics
     description: Collect AWS Lambda metrics

--- a/packages/aws/data_stream/natgateway/manifest.yml
+++ b/packages/aws/data_stream/natgateway/manifest.yml
@@ -37,8 +37,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/rds/manifest.yml
+++ b/packages/aws/data_stream/rds/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS RDS metrics
     description: Collect AWS RDS metrics

--- a/packages/aws/data_stream/redshift/manifest.yml
+++ b/packages/aws/data_stream/redshift/manifest.yml
@@ -37,8 +37,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/s3_daily_storage/manifest.yml
+++ b/packages/aws/data_stream/s3_daily_storage/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS S3 daily storage metrics
     description: Collect AWS S3 daily storage metrics

--- a/packages/aws/data_stream/s3_request/manifest.yml
+++ b/packages/aws/data_stream/s3_request/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS S3 request metrics
     description: Collect AWS S3 request metrics

--- a/packages/aws/data_stream/s3_storage_lens/manifest.yml
+++ b/packages/aws/data_stream/s3_storage_lens/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS S3 Storage Lens metrics
     description: Collect AWS S3 Storage Lens metrics

--- a/packages/aws/data_stream/sns/manifest.yml
+++ b/packages/aws/data_stream/sns/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS SNS metrics
     description: Collect AWS SNS metrics

--- a/packages/aws/data_stream/sqs/manifest.yml
+++ b/packages/aws/data_stream/sqs/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS SQS metrics
     description: Collect AWS SQS metrics

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -37,8 +37,8 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/usage/manifest.yml
+++ b/packages/aws/data_stream/usage/manifest.yml
@@ -37,7 +37,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS usage metrics
     description: Collect AWS usage metrics

--- a/packages/aws/data_stream/vpn/manifest.yml
+++ b/packages/aws/data_stream/vpn/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: false
-        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is false.
+        default: true
+        description: When include_linked_accounts is set to true, CloudWatch metrics will be collected from both linked accounts and the monitoring account. Default is true.
     title: AWS VPN metrics
     description: Collect AWS VPN metrics


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

This PR is to change `include_linked_accounts` default to true to match metricbeat. 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

