### PR TITLE
[CEL] Update format_version to 3.0.0 for Serverless

### DIFF
--- a/packages/cel/changelog.yml
+++ b/packages/cel/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.3.0"
+  changes:
+    - description: Update format_version to 3.0.0
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7852
 - version: "1.2.1"
   changes:
     - description: Fix location of request trace log destination.

--- a/packages/cel/manifest.yml
+++ b/packages/cel/manifest.yml
@@ -1,14 +1,16 @@
-format_version: 2.7.0
+format_version: 3.0.0
 name: cel
 title: CEL Custom API
 description: Collect custom events from an API with Elastic agent
 type: input
-version: "1.2.1"
+version: "1.3.0"
 categories:
   - custom
 conditions:
-  kibana.version: "^8.8.0"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.8.0"
+  elastic:
+    subscription: "basic"
 policy_templates:
   - name: cel
     type: logs


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->
- Updates `format_version: 3.0.0` required for Serverless offering

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7814

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
