### PR TITLE
[elastic_agent] Fix inconsistencies in field mapping types

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,15 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Fix mapping and description for the `system.process.cpu.{system,user,total}.time.ms` fields.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7872
+    - description: Align mapping for the `beat.stats.libbeat.config.{running,starts,stops}` fields with the `beat` integration.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7872
+    - description: For the `message` field, consistently use the ECS defined mapping type of `match_only_text`.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7872
 - version: "1.13.0"
   changes:
     - description: Remove metric mappings from the filebeat_input_logs data stream

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: decision_id
   type: text
   title: Decision ID

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: decision_id
   type: text
   title: Decision ID

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -45,17 +45,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -160,11 +160,11 @@
           type: group
           fields:
             - name: running
-              type: short
+              type: long
             - name: starts
-              type: short
+              type: long
             - name: stops
-              type: short
+              type: long
         - name: output
           type: group
           description: >

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -53,17 +53,17 @@
           type: long
           metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
           type: long
           metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
           type: long
           metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: message
-  type: text
-  title: Log Message
+  external: ecs
 - name: elastic_agent
   title: Elastic Agent
   description: Fields related to the Elastic Agents

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -50,17 +50,20 @@
           description: |
             The total CPU time spent by the process.
         - name: total.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The total CPU time spent by the process.
         - name: user.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in user space.
         - name: system.time.ms
-          type: date
+          type: long
+          metric_type: counter
           description: |
-            The time when the process was started.
+            The amount of CPU time the process spent in kernel space.
     - name: memory
       type: group
       fields:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.13.0
+version: 1.13.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix mapping and description for the `system.process.cpu.{system,user,total}.time.ms` fields. The fields should be of type `long` instead of `date`.

Align mapping for the `beat.stats.libbeat.config.{running,starts,stops}` fields with the `beat` integration. The beat integration uses `long` so align to that.

For the `message` field, consistently use the ECS defined mapping type of `match_only_text`.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Fixes https://github.com/elastic/integrations/issues/7846
- Fixes https://github.com/elastic/integrations/issues/4245
