### PR TITLE
[hid_bravura_monitor] Use ECS definition for message and tags

### DIFF
--- a/packages/hid_bravura_monitor/changelog.yml
+++ b/packages/hid_bravura_monitor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: For field type consistency, use the ECS value for message and tags.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7873
 - version: "1.11.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/hid_bravura_monitor/data_stream/log/manifest.yml
+++ b/packages/hid_bravura_monitor/data_stream/log/manifest.yml
@@ -62,7 +62,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: >
+        description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
 
     template_path: filestream.yml.hbs

--- a/packages/hid_bravura_monitor/data_stream/winlog/fields/base-fields.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/fields/base-fields.yml
@@ -19,8 +19,3 @@
   type: constant_keyword
   description: Event dataset.
   value: hid_bravura_monitor.winlog
-- name: tags
-  description: List of keywords used to tag each event.
-  example: '["production", "env2"]'
-  ignore_above: 1024
-  type: keyword

--- a/packages/hid_bravura_monitor/data_stream/winlog/fields/ecs.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/fields/ecs.yml
@@ -35,6 +35,8 @@
 - external: ecs
   name: log.level
 - external: ecs
+  name: message
+- external: ecs
   name: process.args
 - external: ecs
   name: process.args_count
@@ -72,6 +74,8 @@
   name: source.ip
 - external: ecs
   name: source.port
+- external: ecs
+  name: tags
 - external: ecs
   name: user.domain
 - external: ecs

--- a/packages/hid_bravura_monitor/data_stream/winlog/fields/fields.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/fields/fields.yml
@@ -1,6 +1,3 @@
 - name: winlog.symbolic_id
   type: keyword
   description: Symbolic event id
-- name: message
-  type: keyword
-  description: initial raw message

--- a/packages/hid_bravura_monitor/docs/README.md
+++ b/packages/hid_bravura_monitor/docs/README.md
@@ -586,7 +586,7 @@ An example event for `winlog` looks as following:
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
-| message | initial raw message | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | wildcard |

--- a/packages/hid_bravura_monitor/manifest.yml
+++ b/packages/hid_bravura_monitor/manifest.yml
@@ -1,6 +1,6 @@
 name: hid_bravura_monitor
 title: Bravura Monitor
-version: "1.11.0"
+version: "1.11.1"
 categories: ["security", "iam"]
 description: Collect logs from Bravura Security Fabric with Elastic Agent.
 type: integration


### PR DESCRIPTION

## What does this PR do?

For field type consistency, use the ECS value for `message` and `tags`.

Also fix an inconsistency between the data streams for the `processors` variable description.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
