### PR TITLE
[cisco_secure_email_gateway] Remove unused field mappings

### DIFF
--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Remove the unused mappings for 'type' and 'filepath'.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7875
 - version: "1.13.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/cisco_secure_email_gateway/data_stream/log/fields/fields.yml
+++ b/packages/cisco_secure_email_gateway/data_stream/log/fields/fields.yml
@@ -528,14 +528,9 @@
       description: This is the number of messages currently in the work queue.
     - name: zone
       type: keyword
-- name: filepath
-  type: keyword
 - name: log.file.path
   type: keyword
   description: File path from which the log event was read / sent from.
 - name: log.source.address
   type: keyword
   description: Source address from which the log event was read / sent from.
-- name: type
-  type: keyword
-  description: Input type.

--- a/packages/cisco_secure_email_gateway/docs/README.md
+++ b/packages/cisco_secure_email_gateway/docs/README.md
@@ -492,7 +492,6 @@ An example event for `log` looks as following:
 | event.module | Event module. | constant_keyword |
 | event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
 | event.reason | Reason why this event happened, according to the source. This describes the why of a particular action or outcome captured in the event. Where `event.action` captures the action from the event, `event.reason` describes why that action was taken. For example, a web proxy with an `event.action` which denied the request may also populate `event.reason` with the reason why (e.g. `blocked site`). | keyword |
-| filepath |  | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.containerized | If the host is a container. | boolean |
 | host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
@@ -528,7 +527,6 @@ An example event for `log` looks as following:
 | source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.port | Port of the source. | long |
 | tags | List of keywords used to tag each event. | keyword |
-| type | Input type. | keyword |
 | url.path | Path of the request, such as "/search". | wildcard |
 | user.name | Short name or login of the user. | keyword |
 | user.name.text | Multi-field of `user.name`. | match_only_text |

--- a/packages/cisco_secure_email_gateway/manifest.yml
+++ b/packages/cisco_secure_email_gateway/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: cisco_secure_email_gateway
 title: Cisco Secure Email Gateway
-version: "1.13.0"
+version: "1.13.1"
 description: Collect logs from Cisco Secure Email Gateway with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

The `type` and `filepath` fields were unused so this removes them.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
