### PR TITLE
[symantec_endpoint] Adopt ECS log.syslog mappings

### DIFF
--- a/packages/symantec_endpoint/changelog.yml
+++ b/packages/symantec_endpoint/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "2.11.0"
+  changes:
+    - description: Use the ECS syslog fields. Added `log.syslog.appname` and `log.syslog.procid`. Documented `log.syslog.process.{name,pid}` as deprecated.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7878
+    - description: Change `log.syslog.version` field type from long to keyword to align with ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7878
 - version: "2.10.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log-expected.json
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-policy-rfc3164-sep14-3ru7.log-expected.json
@@ -15,11 +15,9 @@
             },
             "log": {
                 "syslog": {
+                    "appname": "SymantecServer",
                     "hostname": "SERVER",
-                    "priority": 54,
-                    "process": {
-                        "name": "SymantecServer"
-                    }
+                    "priority": 54
                 }
             },
             "message": "Received a new policy with serial number AB13-05/30/2023 23:01:52 031 from Symantec Endpoint Protection Manager.",

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-rfc3164.log-expected.json
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-rfc3164.log-expected.json
@@ -47,11 +47,9 @@
             },
             "log": {
                 "syslog": {
+                    "appname": "SymantecServer",
                     "hostname": "symantec.endpointprotection.english.test",
-                    "priority": 51,
-                    "process": {
-                        "name": "SymantecServer"
-                    }
+                    "priority": 51
                 }
             },
             "network": {

--- a/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-rfc5424.log-expected.json
+++ b/packages/symantec_endpoint/data_stream/log/_dev/test/pipeline/test-rfc5424.log-expected.json
@@ -44,13 +44,14 @@
             },
             "log": {
                 "syslog": {
+                    "appname": "myproc",
                     "hostname": "192.0.2.1",
                     "priority": 165,
                     "process": {
-                        "name": "myproc",
                         "pid": 8710
                     },
-                    "version": 1
+                    "procid": "8710",
+                    "version": "1"
                 }
             },
             "network": {

--- a/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/symantec_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -19,9 +19,9 @@ processors:
       - '^<%{NONNEGINT:log.syslog.priority:long}>(?:%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp})(?: %{SYSLOGFACILITY})?(?: %{SYSLOGHOST:log.syslog.hostname})?(?: %{SYSLOGPROG}:)? %{GREEDYDATA:message}'
       - '^%{SYSLOG5424LINE}'
     pattern_definitions:
-      SYSLOGPROG: '%{PROG:log.syslog.process.name}(?:\[%{POSINT:log.syslog.process.pid:long}\])?'
+      SYSLOGPROG: '%{PROG:log.syslog.appname}(?:\[%{POSINT:log.syslog.procid}\])?'
       SYSLOG5424PRI: '<%{NONNEGINT:log.syslog.priority:long}>'
-      SYSLOG5424BASE: '%{SYSLOG5424PRI}%{NONNEGINT:log.syslog.version:long} +(?:-|%{TIMESTAMP_ISO8601:timestamp}) +(?:-|%{IPORHOST:log.syslog.hostname}) +(?:-|%{SYSLOG5424PRINTASCII:log.syslog.process.name}) +(?:-|%{POSINT:log.syslog.process.pid:long}) +(?:-|%{SYSLOG5424PRINTASCII:log.syslog.message_id}) +(?:-|%{SYSLOG5424SD:log.syslog.structured_data})?'
+      SYSLOG5424BASE: '%{SYSLOG5424PRI}%{NONNEGINT:log.syslog.version} +(?:-|%{TIMESTAMP_ISO8601:timestamp}) +(?:-|%{IPORHOST:log.syslog.hostname}) +(?:-|%{SYSLOG5424PRINTASCII:log.syslog.appname}) +(?:-|%{POSINT:log.syslog.procid}) +(?:-|%{SYSLOG5424PRINTASCII:log.syslog.message_id}) +(?:-|%{SYSLOG5424SD:log.syslog.structured_data})?'
       SYSLOG5424LINE: '%{SYSLOG5424BASE} +%{GREEDYDATA:message}'
 - grok:
     description: Parse date/severity from log file dump format.
@@ -1111,6 +1111,14 @@ processors:
       - _csv_array
       - _fingerprint
       - _temp
+
+- convert:
+    description: Copy ECS log.syslog.procid into log.syslog.process.pid for backwards-compatability.
+    field: log.syslog.procid
+    target_field: log.syslog.process.pid
+    type: long
+    ignore_missing: true
+    ignore_failure: true
 
 on_failure:
 - set:

--- a/packages/symantec_endpoint/data_stream/log/fields/agent.yml
+++ b/packages/symantec_endpoint/data_stream/log/fields/agent.yml
@@ -199,9 +199,6 @@
 - name: log.offset
   type: long
   description: Offset of the entry in the log file.
-- name: log.file.path
-  type: keyword
-  description: Path to the log file.
 - name: log.source.address
   type: keyword
   description: Source address from which the log event was read / sent from.

--- a/packages/symantec_endpoint/data_stream/log/fields/ecs.yml
+++ b/packages/symantec_endpoint/data_stream/log/fields/ecs.yml
@@ -64,7 +64,21 @@
   external: ecs
 - name: file.x509.serial_number
   external: ecs
+- name: log.file.path
+  external: ecs
 - name: log.level
+  external: ecs
+- name: log.syslog.appname
+  external: ecs
+- name: log.syslog.hostname
+  external: ecs
+- name: log.syslog.priority
+  external: ecs
+- name: log.syslog.procid
+  external: ecs
+- name: log.syslog.structured_data
+  external: ecs
+- name: log.syslog.version
   external: ecs
 - name: message
   external: ecs

--- a/packages/symantec_endpoint/data_stream/log/fields/fields.yml
+++ b/packages/symantec_endpoint/data_stream/log/fields/fields.yml
@@ -318,16 +318,10 @@
     - name: web_domain
       type: keyword
       description: The web domain.
-- name: log.syslog.hostname
-  type: keyword
-  description: Hostname parsed from syslog header.
 - name: log.syslog.process.name
-  type: keyword
+  type: alias
+  path: log.syslog.appname
+  description: Deprecated. Use the ECS log.syslog.appname field.
 - name: log.syslog.process.pid
   type: long
-- name: log.syslog.priority
-  type: long
-- name: log.syslog.version
-  type: long
-- name: log.syslog.structured_data
-  type: flattened
+  description: Deprecated. Use the ECS log.syslog.procid field.

--- a/packages/symantec_endpoint/docs/README.md
+++ b/packages/symantec_endpoint/docs/README.md
@@ -191,16 +191,18 @@ See vendor documentation: [External Logging settings and log event severity leve
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Input type. | keyword |
-| log.file.path | Path to the log file. | keyword |
+| log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
 | log.source.address | Source address from which the log event was read / sent from. | keyword |
-| log.syslog.hostname | Hostname parsed from syslog header. | keyword |
-| log.syslog.priority |  | long |
-| log.syslog.process.name |  | keyword |
-| log.syslog.process.pid |  | long |
-| log.syslog.structured_data |  | flattened |
-| log.syslog.version |  | long |
+| log.syslog.appname | The device or application that originated the Syslog message, if available. | keyword |
+| log.syslog.hostname | The hostname, FQDN, or IP of the machine that originally sent the Syslog message. This is sourced from the hostname field of the syslog header. Depending on the environment, this value may be different from the host that handled the event, especially if the host handling the events is acting as a collector. | keyword |
+| log.syslog.priority | Syslog numeric priority of the event, if available. According to RFCs 5424 and 3164, the priority is 8 \* facility + severity. This number is therefore expected to contain a value between 0 and 191. | long |
+| log.syslog.process.name | Deprecated. Use the ECS log.syslog.appname field. | alias |
+| log.syslog.process.pid | Deprecated. Use the ECS log.syslog.procid field. | long |
+| log.syslog.procid | The process name or ID that originated the Syslog message, if available. | keyword |
+| log.syslog.structured_data | Structured data expressed in RFC 5424 messages, if available. These are key-value pairs formed from the structured data portion of the syslog message, as defined in RFC 5424 Section 6.3. | flattened |
+| log.syslog.version | The version of the Syslog protocol specification. Only applicable for RFC 5424 messages. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows. Learn more at https://github.com/corelight/community-id-spec. | keyword |
 | network.direction | Direction of the network traffic. When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress". When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of the network perimeter, using the values "inbound", "outbound", "internal" or "external". Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to the perimeter. This could for example be useful for ISPs or VPN service providers. | keyword |

--- a/packages/symantec_endpoint/manifest.yml
+++ b/packages/symantec_endpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: symantec_endpoint
 title: Symantec Endpoint Protection
-version: "2.10.0"
+version: "2.11.0"
 description: Collect logs from Symantec Endpoint Protection with Elastic Agent.
 type: integration
 format_version: 2.11.0


### PR DESCRIPTION
## What does this PR do?

ECS added log.syslog fields and those needed to be adopted by symantec_endpoint to avoid type conflicts across integrations and to make the syslog data representation consist.

As much as possible this tries to avoid breaking changes, but the field data type of log.syslog.version had to change from long to keyword to be consistent with ECS.

The other existing symantec_endpoint log.syslog fields that are not part of ECS were maintained and documented as deprecated. log.syslog.process.name is an alias to ECS log.syslog.appname. And log.syslog.process.name is kept as a long representation of ECS log.syslog.procid.

Fixes #7843

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates #7843
