### PR TITLE
[prometheus][remote_write] Fix remote_write ingest pipeline to include both metric path 'prometheus.*' and 'prometheus.metrics.*' to fingerprint calculation

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix remote_write ingest pipeline to include both metric path 'prometheus.*' and 'prometheus.metrics.*' to fingerprint calculation
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/7667
+      link: https://github.com/elastic/integrations/pull/7882
 - version: "1.12.0"
   changes:
     - description: Use ecs definition of the 'event.dataset' field

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Fix remote_write ingest pipeline to include both metric path 'prometheus.*' and 'prometheus.metrics.*' to fingerprint calculation
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7667
 - version: "1.12.0"
   changes:
     - description: Use ecs definition of the 'event.dataset' field

--- a/packages/prometheus/data_stream/remote_write/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/prometheus/data_stream/remote_write/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,15 @@ processors:
       allow_duplicates: false
       description: Create an empty field of the object type to temporarily store list of all metrics names
   - foreach:
+      if: ctx.prometheus?.metrics != null
+      field: "prometheus.metrics"
+      processor:
+        append:
+          field: "prometheus.labels.metrics_names"
+          value: ["{{_ingest._key}}"]
+          description: Add all keys of the 'prometheus' object to the earlier created field, it includes all metric names in 'prometheus.metrics' object
+  - foreach:
+      if: ctx.prometheus?.metrics == null
       field: "prometheus"
       processor:
         append:
@@ -24,6 +33,6 @@ on_failure:
   - set:
       field: event.kind
       value: pipeline_error
-  - set:
+  - append:
       field: error.message
       value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.12.0
+version: 1.12.1
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

Fix remote_write ingest pipeline to include both metric path 'prometheus.*' and 'prometheus.metrics.*' to fingerprint calculation

There are 2 use cases:
1. If `Use Types` is enabled - metrics will be added under `prometheus.*` in this format:
```
{ "prometheus":
  "metric1": {
    "counter": x
  },
  "metric2": {
    "value": y
  }
  "labels": { 
    ...
  }
}
```

2. If `Use Types` is disabled - metrics will be added under `prometheus.metrics.*` in this format:
```
{ "prometheus":
  "metrics": {
    "metric1": x
    "metric2": y
  }
  "labels": { 
    ...
  }
}
```

This fix is needed to support both cases, otherwise when TSDB is enabled, some documents will be dropped in case `Use Types` is disabled

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

## Screenshots

**Previous version - 1.12.0**
> For demonstration purpose I've remove `remove` processor in the local setup - https://github.com/elastic/integrations/blob/ce0f9ec649f50ee1dbcdc2a951e0963543f1db38/packages/prometheus/data_stream/remote_write/elasticsearch/ingest_pipeline/default.yml#L29-L31

`Use_type` disabled:
<img width="777" alt="Screenshot 2023-09-25 at 16 26 19" src="https://github.com/elastic/integrations/assets/28299531/cef1ec49-4ff6-43cd-a3cb-c7917c41fa64">

In this case fingerprint based on the `[metric, labels]` object is not unique that can cause some dropping of documents.

`Use_type` enabled:
<img width="1219" alt="Screenshot 2023-09-25 at 16 29 38" src="https://github.com/elastic/integrations/assets/28299531/19f55ed6-5cf2-4d17-b252-73f499f5cbd1">

**Upgrade prometheus version to 1.12.1**

<img width="892" alt="Screenshot 2023-09-25 at 16 31 41" src="https://github.com/elastic/integrations/assets/28299531/a1d5d72d-899a-4861-93ab-0243276e295e">
Upgrade caused recreation of the ingest pipeline, I've removed `remove` processor.

`Use_type` enabled:
<img width="991" alt="Screenshot 2023-09-25 at 16 33 51" src="https://github.com/elastic/integrations/assets/28299531/95efa58b-add2-4465-910e-0852eb8d828d">

`Use_type` disabled (notice that metrics are stored under `prometheus.metric`):
<img width="1148" alt="Screenshot 2023-09-25 at 16 35 39" src="https://github.com/elastic/integrations/assets/28299531/a3366ce4-d85a-4080-a51b-54b27c37d3ad">


