### PR TITLE
[Zookeeper] Add metric type mapping for server datastream

### DIFF
--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added metric_type mapping for mntr datastream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7779
 - version: "1.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Added metric_type mapping for mntr datastream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.0"
   changes:
     - description: Rename ownership from obs-service-integrations to obs-infraobs-integrations

--- a/packages/zookeeper/data_stream/mntr/fields/fields.yml
+++ b/packages/zookeeper/data_stream/mntr/fields/fields.yml
@@ -7,54 +7,67 @@
         ZooKeeper hostname.
     - name: approximate_data_size
       type: long
+      metric_type: gauge
       description: |
         Approximate size of ZooKeeper data.
     - name: latency.avg
       type: long
+      metric_type: gauge
       description: |
         Average latency between ensemble hosts in milliseconds.
     - name: ephemerals_count
       type: long
+      metric_type: gauge
       description: |
         Number of ephemeral znodes.
     - name: followers
       type: long
+      metric_type: gauge
       description: |
         Number of followers seen by the current host.
     - name: max_file_descriptor_count
       type: long
+      metric_type: gauge
       description: |
         Maximum number of file descriptors allowed for the ZooKeeper process.
     - name: latency.max
       type: long
+      metric_type: gauge
       description: |
         Maximum latency in milliseconds.
     - name: latency.min
       type: long
+      metric_type: gauge
       description: |
         Minimum latency in milliseconds.
     - name: num_alive_connections
       type: long
+      metric_type: gauge
       description: |
         Number of connections to ZooKeeper that are currently alive.
     - name: open_file_descriptor_count
       type: long
+      metric_type: gauge
       description: |
         Number of file descriptors open by the ZooKeeper process.
     - name: outstanding_requests
       type: long
+      metric_type: gauge
       description: |
         Number of outstanding requests that need to be processed by the cluster.
     - name: packets.received
       type: long
+      metric_type: gauge
       description: |
         Number of ZooKeeper network packets received.
     - name: packets.sent
       type: long
+      metric_type: gauge
       description: |
         Number of ZooKeeper network packets sent.
     - name: pending_syncs
       type: long
+      metric_type: gauge
       description: |
         Number of pending syncs to carry out to ZooKeeper ensemble followers.
     - name: server_state
@@ -63,13 +76,16 @@
         Role in the ZooKeeper ensemble.
     - name: synced_followers
       type: long
+      metric_type: gauge
       description: |
         Number of synced followers reported when a node server_state is leader.
     - name: watch_count
       type: long
+      metric_type: gauge
       description: |
         Number of watches currently set on the local ZooKeeper process.
     - name: znode_count
       type: long
+      metric_type: gauge
       description: |
         Number of znodes reported by the local ZooKeeper process.

--- a/packages/zookeeper/docs/README.md
+++ b/packages/zookeeper/docs/README.md
@@ -172,66 +172,66 @@ An example event for `mntr` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |
-| cloud.availability_zone | Availability zone in which this host is running. | keyword |
-| cloud.image.id | Image ID for the cloud instance. | keyword |
-| cloud.instance.id | Instance ID of the host machine. | keyword |
-| cloud.instance.name | Instance name of the host machine. | keyword |
-| cloud.machine.type | Machine type of the host machine. | keyword |
-| cloud.project.id | Name of the project in Google Cloud. | keyword |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |
-| cloud.region | Region in which this host is running. | keyword |
-| container.id | Unique container id. | keyword |
-| container.image.name | Name of the image the container was built on. | keyword |
-| container.labels | Image labels. | object |
-| container.name | Container name. | keyword |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host.architecture | Operating system architecture. | keyword |
-| host.containerized | If the host is a container. | boolean |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
-| host.ip | Host ip addresses. | ip |
-| host.mac | Host mac addresses. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
-| host.os.build | OS build information. | keyword |
-| host.os.codename | OS codename, if any. | keyword |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |
-| host.os.name | Operating system name, without the version. | keyword |
-| host.os.name.text | Multi-field of `host.os.name`. | text |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
-| host.os.version | Operating system version as a raw string. | keyword |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
-| service.version | Version of the service the data was collected from. This allows to look at a data set only for a specific version of a service. | keyword |
-| zookeeper.mntr.approximate_data_size | Approximate size of ZooKeeper data. | long |
-| zookeeper.mntr.ephemerals_count | Number of ephemeral znodes. | long |
-| zookeeper.mntr.followers | Number of followers seen by the current host. | long |
-| zookeeper.mntr.hostname | ZooKeeper hostname. | keyword |
-| zookeeper.mntr.latency.avg | Average latency between ensemble hosts in milliseconds. | long |
-| zookeeper.mntr.latency.max | Maximum latency in milliseconds. | long |
-| zookeeper.mntr.latency.min | Minimum latency in milliseconds. | long |
-| zookeeper.mntr.max_file_descriptor_count | Maximum number of file descriptors allowed for the ZooKeeper process. | long |
-| zookeeper.mntr.num_alive_connections | Number of connections to ZooKeeper that are currently alive. | long |
-| zookeeper.mntr.open_file_descriptor_count | Number of file descriptors open by the ZooKeeper process. | long |
-| zookeeper.mntr.outstanding_requests | Number of outstanding requests that need to be processed by the cluster. | long |
-| zookeeper.mntr.packets.received | Number of ZooKeeper network packets received. | long |
-| zookeeper.mntr.packets.sent | Number of ZooKeeper network packets sent. | long |
-| zookeeper.mntr.pending_syncs | Number of pending syncs to carry out to ZooKeeper ensemble followers. | long |
-| zookeeper.mntr.server_state | Role in the ZooKeeper ensemble. | keyword |
-| zookeeper.mntr.synced_followers | Number of synced followers reported when a node server_state is leader. | long |
-| zookeeper.mntr.watch_count | Number of watches currently set on the local ZooKeeper process. | long |
-| zookeeper.mntr.znode_count | Number of znodes reported by the local ZooKeeper process. | long |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
+| cloud.availability_zone | Availability zone in which this host is running. | keyword |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |
+| cloud.project.id | Name of the project in Google Cloud. | keyword |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
+| cloud.region | Region in which this host is running. | keyword |  |
+| container.id | Unique container id. | keyword |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |
+| container.labels | Image labels. | object |  |
+| container.name | Container name. | keyword |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host.architecture | Operating system architecture. | keyword |  |
+| host.containerized | If the host is a container. | boolean |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| host.mac | Host mac addresses. | keyword |  |
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |  |
+| host.os.build | OS build information. | keyword |  |
+| host.os.codename | OS codename, if any. | keyword |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
+| host.os.name | Operating system name, without the version. | keyword |  |
+| host.os.name.text | Multi-field of `host.os.name`. | text |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
+| service.version | Version of the service the data was collected from. This allows to look at a data set only for a specific version of a service. | keyword |  |
+| zookeeper.mntr.approximate_data_size | Approximate size of ZooKeeper data. | long | gauge |
+| zookeeper.mntr.ephemerals_count | Number of ephemeral znodes. | long | gauge |
+| zookeeper.mntr.followers | Number of followers seen by the current host. | long | gauge |
+| zookeeper.mntr.hostname | ZooKeeper hostname. | keyword |  |
+| zookeeper.mntr.latency.avg | Average latency between ensemble hosts in milliseconds. | long | gauge |
+| zookeeper.mntr.latency.max | Maximum latency in milliseconds. | long | gauge |
+| zookeeper.mntr.latency.min | Minimum latency in milliseconds. | long | gauge |
+| zookeeper.mntr.max_file_descriptor_count | Maximum number of file descriptors allowed for the ZooKeeper process. | long | gauge |
+| zookeeper.mntr.num_alive_connections | Number of connections to ZooKeeper that are currently alive. | long | gauge |
+| zookeeper.mntr.open_file_descriptor_count | Number of file descriptors open by the ZooKeeper process. | long | gauge |
+| zookeeper.mntr.outstanding_requests | Number of outstanding requests that need to be processed by the cluster. | long | gauge |
+| zookeeper.mntr.packets.received | Number of ZooKeeper network packets received. | long | gauge |
+| zookeeper.mntr.packets.sent | Number of ZooKeeper network packets sent. | long | gauge |
+| zookeeper.mntr.pending_syncs | Number of pending syncs to carry out to ZooKeeper ensemble followers. | long | gauge |
+| zookeeper.mntr.server_state | Role in the ZooKeeper ensemble. | keyword |  |
+| zookeeper.mntr.synced_followers | Number of synced followers reported when a node server_state is leader. | long | gauge |
+| zookeeper.mntr.watch_count | Number of watches currently set on the local ZooKeeper process. | long | gauge |
+| zookeeper.mntr.znode_count | Number of znodes reported by the local ZooKeeper process. | long | gauge |
 
 
 ### server

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper Metrics
-version: "1.7.0"
+version: "1.8.1"
 description: Collect metrics from ZooKeeper service with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Added metric_type mapping for `server` datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

- elastic-package build
- Mapping tests completed
- Dashboard tests completed

## Related issues


- https://github.com/elastic/integrations/issues/7752


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
