### PR TITLE
[Cloud Security] Add Azure ARM url

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -5,8 +5,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.6.0-preview12"
+- version: "1.6.0-preview13"
   changes:
+    - description: Add support for Azure benchmark
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7892
     - description: Add support for GCP organizations
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7403

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.6.0-preview12"
+version: "1.6.0-preview13"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -129,6 +129,16 @@ policy_templates:
       - type: cloudbeat/cis_azure
         title: Azure
         description: CIS Benchmark for Microsoft Azure Foundations
+        vars:
+          - name: arm_template_url
+            type: text
+            title: ARM Template URL
+            multi: false
+            required: true
+            show_user: false
+            description: A URL to the ARM Template for creating a new deployment
+            # TODO: Update main to 8.11 when ready
+            default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2Fmain%2Fdeploy%2Fazure%2FazureARMTemplate.json
   - name: vuln_mgmt
     title: Cloud Native Vulnerability Management (CNVM)
     description: Scan for cloud workload vulnerabilities


### PR DESCRIPTION
## What does this PR do?
This adds a URL to the ARM template that is used for CSPM Azure onboarding. The file is hosted directly in the [elastic/cloudbeat](https://github.com/elastic/cloudbeat) repo. Azure does not support modifying the template parameters via a link like in AWS. The link is hardcoded to the `main` branch for now but should be updated to point to the $current_version branch.

## Related issues
- Fixes https://github.com/elastic/cloudbeat/issues/1296
- Related to https://github.com/elastic/cloudbeat/issues/1320 (branch approach is the same)

## Screenshots

https://github.com/elastic/integrations/assets/5778622/674255ef-82da-4592-8a79-e81228cdef62
