### PR TITLE
[windows] perfmon add refresh_wildcard_counters variable

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.37.0"
+  changes:
+    - description: Add perfmon refresh_wildcard_counters option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9999999
 - version: "1.36.0"
   changes:
     - description: Enable time series data streams for the service metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.37.0"
   changes:
-    - description: Add perfmon refresh_wildcard_counters option
+    - description: Add refresh_wildcard_counters option to windows perfmon datastream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9999999
+      link: https://github.com/elastic/integrations/pull/7897
 - version: "1.36.0"
   changes:
     - description: Enable time series data streams for the service metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

--- a/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
+++ b/packages/windows/data_stream/perfmon/agent/stream/stream.yml.hbs
@@ -2,6 +2,7 @@ metricsets: ["perfmon"]
 condition: ${host.platform} == 'windows'
 perfmon.group_measurements_by_instance: {{perfmon.group_measurements_by_instance}}
 perfmon.ignore_non_existent_counters: {{perfmon.ignore_non_existent_counters}}
+perfmon.refresh_wildcard_counters: {{perfmon.refresh_wildcard_counters}}
 perfmon.queries: {{perfmon.queries}}
 period: {{period}}
 {{#if processors}}

--- a/packages/windows/data_stream/perfmon/manifest.yml
+++ b/packages/windows/data_stream/perfmon/manifest.yml
@@ -19,6 +19,14 @@ streams:
         show_user: true
         default: false
         description: Enabling this option will make sure to ignore any errors caused by counters that do not exist
+      - name: perfmon.refresh_wildcard_counters
+        type: bool
+        title: Perfmon Refresh Wildcard Counters
+        multi: false
+        required: false
+        show_user: true
+        default: false
+        description: Enabling this option will cause the counter list to be retrieved after each fetch, rather than once at start time.
       - name: perfmon.queries
         type: yaml
         title: Perfmon Queries

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.36.0
+version: 1.37.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Add the `refresh_wildcard_counters` [variable](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-metricset-windows-perfmon.html#_configuration_19) to the windows perfmon data stream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] 

## How to test this PR locally

1. `elastic-package build`
2. `elastic-package stack up -d`
3. login to Kibana
4. create empty policy
5. make add windows integration
6. Enable `refresh_wildcard_counters` variable
7. Save policy
8. Inspect policy, make sure variable exists and is `true`

## Related issues

- Closes #7895
