### PR TITLE
[ECS] Updating box_events to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/box_events/_dev/build/build.yml
+++ b/packages/box_events/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
-- version: "1.10.0"
+- version: "2.0.0"
   changes:
-    - description: Update package to ECS 8.10.0.
+    - description: Aligned ECS categorization fields and update package to ECS 8.10.0.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7906
 - version: "1.9.0"

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to ECS 8.10.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7906
 - version: "1.9.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.0"
+  changes:
+    - description: Update package to ECS 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.9.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-anomalous-download.log-expected.json
@@ -47,7 +47,7 @@
                 "ip": "10.1.2.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",
@@ -191,7 +191,7 @@
                 "ip": "10.1.2.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-copy.log-expected.json
@@ -54,7 +54,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_COPY",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-create.log-expected.json
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_CREATE",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-download.log-expected.json
@@ -71,7 +71,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_DOWNLOAD",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-event-types.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-event-types.log-expected.json
@@ -2,7 +2,7 @@
     "expected": [
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ACCESS_GRANTED",
@@ -22,7 +22,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ACCESS_REVOKED",
@@ -42,7 +42,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ADD_DEVICE_ASSOCIATION",
@@ -60,7 +60,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ADD_LOGIN_ACTIVITY_DEVICE",
@@ -79,7 +79,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ADMIN_LOGIN",
@@ -97,7 +97,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "APPLICATION_CREATED",
@@ -115,7 +115,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "APPLICATION_PUBLIC_KEY_ADDED",
@@ -135,7 +135,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "APPLICATION_PUBLIC_KEY_DELETED",
@@ -155,7 +155,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CHANGE_ADMIN_ROLE",
@@ -173,7 +173,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CHANGE_FOLDER_PERMISSION",
@@ -192,7 +192,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLABORATION_ACCEPT",
@@ -211,7 +211,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLABORATION_EXPIRATION",
@@ -230,7 +230,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLABORATION_INVITE",
@@ -250,7 +250,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLABORATION_REMOVE",
@@ -270,7 +270,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLABORATION_ROLE_CHANGE",
@@ -290,7 +290,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLAB_ADD_COLLABORATOR",
@@ -310,7 +310,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLAB_INVITE_COLLABORATOR",
@@ -330,7 +330,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLAB_REMOVE_COLLABORATOR",
@@ -350,7 +350,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COLLAB_ROLE_CHANGE",
@@ -369,7 +369,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COMMENT_CREATE",
@@ -387,7 +387,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COMMENT_DELETE",
@@ -405,7 +405,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_ACCESS",
@@ -423,7 +423,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_ABNORMAL_DOWNLOAD_ACTIVITY",
@@ -443,7 +443,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_AUTOMATION_ADD",
@@ -461,7 +461,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_AUTOMATION_DELETE",
@@ -479,7 +479,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_POLICY_ADD",
@@ -498,7 +498,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_SHARING_POLICY_VIOLATION",
@@ -518,7 +518,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CONTENT_WORKFLOW_UPLOAD_POLICY_VIOLATION",
@@ -538,7 +538,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "COPY",
@@ -556,7 +556,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DATA_RETENTION_CREATE_RETENTION",
@@ -575,7 +575,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DATA_RETENTION_REMOVE_RETENTION",
@@ -594,7 +594,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DELETE",
@@ -612,7 +612,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DELETE_USER",
@@ -631,7 +631,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DEVICE_TRUST_CHECK_FAILED",
@@ -651,7 +651,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DOWNLOAD",
@@ -669,7 +669,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "EDIT",
@@ -688,7 +688,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "EDIT_USER",
@@ -706,7 +706,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "EMAIL_ALIAS_CONFIRM",
@@ -724,7 +724,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "EMAIL_ALIAS_REMOVE",
@@ -742,7 +742,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ENABLE_TWO_FACTOR_AUTH",
@@ -760,7 +760,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ENTERPRISE_APP_AUTHORIZATION_UPDATE",
@@ -779,7 +779,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "FAILED_LOGIN",
@@ -799,7 +799,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "FILE_MARKED_MALICIOUS",
@@ -818,7 +818,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "FILE_WATERMARKED_DOWNLOAD",
@@ -836,7 +836,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_ADD_ITEM",
@@ -855,7 +855,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_ADD_USER",
@@ -874,7 +874,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_CREATION",
@@ -893,7 +893,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_DELETION",
@@ -912,7 +912,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_EDITED",
@@ -931,7 +931,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_REMOVE_ITEM",
@@ -950,7 +950,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "GROUP_REMOVE_USER",
@@ -970,7 +970,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_COPY",
@@ -988,7 +988,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_CREATE",
@@ -1006,7 +1006,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_DOWNLOAD",
@@ -1024,7 +1024,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_MAKE_CURRENT_VERSION",
@@ -1043,7 +1043,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_MODIFY",
@@ -1061,7 +1061,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_MOVE",
@@ -1080,7 +1080,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_OPEN",
@@ -1098,7 +1098,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_PREVIEW",
@@ -1116,7 +1116,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_RENAME",
@@ -1135,7 +1135,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_SHARED",
@@ -1154,7 +1154,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_SHARED_CREATE",
@@ -1173,7 +1173,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_SHARED_UNSHARE",
@@ -1192,7 +1192,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_SHARED_UPDATE",
@@ -1211,7 +1211,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_SYNC",
@@ -1230,7 +1230,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_TRASH",
@@ -1249,7 +1249,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_UNDELETE_VIA_TRASH",
@@ -1268,7 +1268,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_UNSYNC",
@@ -1287,7 +1287,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_UPLOAD",
@@ -1305,7 +1305,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LEGAL_HOLD_ASSIGNMENT_CREATE",
@@ -1324,7 +1324,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LEGAL_HOLD_ASSIGNMENT_DELETE",
@@ -1343,7 +1343,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LEGAL_HOLD_POLICY_CREATE",
@@ -1362,7 +1362,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LEGAL_HOLD_POLICY_DELETE",
@@ -1381,7 +1381,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LEGAL_HOLD_POLICY_UPDATE",
@@ -1400,7 +1400,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOCK",
@@ -1419,7 +1419,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOCK_CREATE",
@@ -1438,7 +1438,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOCK_DESTROY",
@@ -1457,7 +1457,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN",
@@ -1475,7 +1475,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "MASTER_INVITE_ACCEPT",
@@ -1493,7 +1493,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "MASTER_INVITE_REJECT",
@@ -1511,7 +1511,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_INSTANCE_CREATE",
@@ -1529,7 +1529,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_INSTANCE_DELETE",
@@ -1547,7 +1547,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_INSTANCE_UPDATE",
@@ -1565,7 +1565,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_TEMPLATE_CREATE",
@@ -1583,7 +1583,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_TEMPLATE_DELETE",
@@ -1601,7 +1601,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "METADATA_TEMPLATE_UPDATE",
@@ -1619,7 +1619,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "MOVE",
@@ -1638,7 +1638,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "NEW_USER",
@@ -1656,7 +1656,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "PREVIEW",
@@ -1674,7 +1674,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "REMOVE_DEVICE_ASSOCIATION",
@@ -1692,7 +1692,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "REMOVE_LOGIN_ACTIVITY_DEVICE",
@@ -1711,7 +1711,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "RENAME",
@@ -1730,7 +1730,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "RETENTION_POLICY_ASSIGNMENT_ADD",
@@ -1749,7 +1749,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHARE",
@@ -1768,7 +1768,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHARE_EXPIRATION",
@@ -1787,7 +1787,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",
@@ -1805,7 +1805,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED",
@@ -1824,7 +1824,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED_MISSING_JUSTIFICATION",
@@ -1843,7 +1843,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED",
@@ -1862,7 +1862,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED_MISSING_JUSTIFICATION",
@@ -1881,7 +1881,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_JUSTIFICATION_APPROVAL",
@@ -1900,7 +1900,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_ASSIGNED",
@@ -1919,7 +1919,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_CANCELLED",
@@ -1938,7 +1938,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_COMPLETED",
@@ -1957,7 +1957,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_CONVERTED",
@@ -1976,7 +1976,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_CREATED",
@@ -1995,7 +1995,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_DECLINED",
@@ -2014,7 +2014,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_EXPIRED",
@@ -2033,7 +2033,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_SIGNED",
@@ -2052,7 +2052,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGN_DOCUMENT_VIEWED_BY_SIGNED",
@@ -2071,7 +2071,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGNER_DOWNLOADED",
@@ -2090,7 +2090,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SIGNER_FORWARDED",
@@ -2109,7 +2109,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "STORAGE_EXPIRATION",
@@ -2127,7 +2127,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TAG_ITEM_CREATE",
@@ -2146,7 +2146,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TASK_ASSIGNMENT_CREATE",
@@ -2165,7 +2165,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TASK_ASSIGNMENT_DELETE",
@@ -2184,7 +2184,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TASK_ASSIGNMENT_UPDATE",
@@ -2203,7 +2203,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TASK_CREATE",
@@ -2222,7 +2222,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TASK_UPDATE",
@@ -2241,7 +2241,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TERMS_OF_SERVICE_ACCEPT",
@@ -2260,7 +2260,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "TERMS_OF_SERVICE_REJECT",
@@ -2279,7 +2279,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UNDELETE",
@@ -2297,7 +2297,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UNLOCK",
@@ -2315,7 +2315,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UNSHARE",
@@ -2334,7 +2334,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UPDATE_COLLABORATION_EXPIRATION",
@@ -2353,7 +2353,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UPDATE_SHARE_EXPIRATION",
@@ -2372,7 +2372,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UPLOAD",
@@ -2390,7 +2390,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "USER_AUTHENTICATE_OAUTH2_ACCESS_TOKEN_CREATE",
@@ -2410,7 +2410,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "WATERMARK_LABEL_CREATE",
@@ -2429,7 +2429,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "WATERMARK_LABEL_DELETE",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-event-types.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-event-types.log-expected.json
@@ -7,12 +7,13 @@
             "event": {
                 "action": "ACCESS_GRANTED",
                 "category": [
-                    "configuration"
+                    "configuration",
+                    "iam"
                 ],
                 "original": "{\"event_type\":\"ACCESS_GRANTED\"}",
                 "type": [
                     "access",
-                    "allowed"
+                    "creation"
                 ]
             },
             "tags": [
@@ -26,12 +27,13 @@
             "event": {
                 "action": "ACCESS_REVOKED",
                 "category": [
-                    "configuration"
+                    "configuration",
+                    "iam"
                 ],
                 "original": "{\"event_type\":\"ACCESS_REVOKED\"}",
                 "type": [
                     "access",
-                    "denied"
+                    "deletion"
                 ]
             },
             "tags": [
@@ -49,8 +51,7 @@
                 ],
                 "original": "{\"event_type\":\"ADD_DEVICE_ASSOCIATION\"}",
                 "type": [
-                    "access",
-                    "allowed"
+                    "access"
                 ]
             },
             "tags": [
@@ -69,8 +70,7 @@
                 ],
                 "original": "{\"event_type\":\"ADD_LOGIN_ACTIVITY_DEVICE\"}",
                 "type": [
-                    "access",
-                    "allowed"
+                    "access"
                 ]
             },
             "tags": [
@@ -88,7 +88,7 @@
                 ],
                 "original": "{\"event_type\":\"ADMIN_LOGIN\"}",
                 "type": [
-                    "admin"
+                    "start"
                 ]
             },
             "tags": [
@@ -106,7 +106,7 @@
                 ],
                 "original": "{\"event_type\":\"APPLICATION_CREATED\"}",
                 "type": [
-                    "creation"
+                    "start"
                 ]
             },
             "tags": [
@@ -160,7 +160,7 @@
             "event": {
                 "action": "CHANGE_ADMIN_ROLE",
                 "category": [
-                    "configuration"
+                    "iam"
                 ],
                 "original": "{\"event_type\":\"CHANGE_ADMIN_ROLE\"}",
                 "type": [
@@ -221,7 +221,7 @@
                 "original": "{\"event_type\":\"COLLABORATION_EXPIRATION\"}",
                 "type": [
                     "access",
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -240,7 +240,8 @@
                 "original": "{\"event_type\":\"COLLABORATION_INVITE\"}",
                 "type": [
                     "access",
-                    "creation"
+                    "info",
+                    "start"
                 ]
             },
             "tags": [
@@ -259,6 +260,7 @@
                 "original": "{\"event_type\":\"COLLABORATION_REMOVE\"}",
                 "type": [
                     "access",
+                    "info",
                     "end"
                 ]
             },
@@ -278,6 +280,7 @@
                 "original": "{\"event_type\":\"COLLABORATION_ROLE_CHANGE\"}",
                 "type": [
                     "access",
+                    "info",
                     "change"
                 ]
             },
@@ -297,7 +300,8 @@
                 "original": "{\"event_type\":\"COLLAB_ADD_COLLABORATOR\"}",
                 "type": [
                     "access",
-                    "creation"
+                    "info",
+                    "start"
                 ]
             },
             "tags": [
@@ -315,7 +319,9 @@
                 ],
                 "original": "{\"event_type\":\"COLLAB_INVITE_COLLABORATOR\"}",
                 "type": [
-                    "access"
+                    "access",
+                    "info",
+                    "start"
                 ]
             },
             "tags": [
@@ -334,7 +340,8 @@
                 "original": "{\"event_type\":\"COLLAB_REMOVE_COLLABORATOR\"}",
                 "type": [
                     "access",
-                    "deletion"
+                    "info",
+                    "change"
                 ]
             },
             "tags": [
@@ -367,11 +374,11 @@
             "event": {
                 "action": "COMMENT_CREATE",
                 "category": [
-                    "database"
+                    "file"
                 ],
                 "original": "{\"event_type\":\"COMMENT_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -385,11 +392,11 @@
             "event": {
                 "action": "COMMENT_DELETE",
                 "category": [
-                    "database"
+                    "file"
                 ],
                 "original": "{\"event_type\":\"COMMENT_DELETE\"}",
                 "type": [
-                    "deletion"
+                    "info"
                 ]
             },
             "tags": [
@@ -427,7 +434,6 @@
                 "original": "{\"event_type\":\"CONTENT_WORKFLOW_ABNORMAL_DOWNLOAD_ACTIVITY\"}",
                 "type": [
                     "access",
-                    "connection",
                     "indicator"
                 ]
             },
@@ -635,7 +641,7 @@
                 ],
                 "original": "{\"event_type\":\"DEVICE_TRUST_CHECK_FAILED\"}",
                 "type": [
-                    "denied",
+                    "info",
                     "indicator"
                 ]
             },
@@ -783,7 +789,7 @@
                 ],
                 "original": "{\"event_type\":\"FAILED_LOGIN\"}",
                 "type": [
-                    "denied",
+                    "info",
                     "indicator"
                 ]
             },
@@ -1309,7 +1315,7 @@
                 ],
                 "original": "{\"event_type\":\"LEGAL_HOLD_ASSIGNMENT_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -1328,7 +1334,7 @@
                 ],
                 "original": "{\"event_type\":\"LEGAL_HOLD_ASSIGNMENT_DELETE\"}",
                 "type": [
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -1347,7 +1353,7 @@
                 ],
                 "original": "{\"event_type\":\"LEGAL_HOLD_POLICY_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -1366,7 +1372,7 @@
                 ],
                 "original": "{\"event_type\":\"LEGAL_HOLD_POLICY_DELETE\"}",
                 "type": [
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -1456,11 +1462,11 @@
             "event": {
                 "action": "LOGIN",
                 "category": [
-                    "authentication"
+                    "session"
                 ],
                 "original": "{\"event_type\":\"LOGIN\"}",
                 "type": [
-                    "access"
+                    "start"
                 ]
             },
             "tags": [
@@ -1474,11 +1480,11 @@
             "event": {
                 "action": "MASTER_INVITE_ACCEPT",
                 "category": [
-                    "process"
+                    "iam"
                 ],
                 "original": "{\"event_type\":\"MASTER_INVITE_ACCEPT\"}",
                 "type": [
-                    "allowed"
+                    "user"
                 ]
             },
             "tags": [
@@ -1496,7 +1502,7 @@
                 ],
                 "original": "{\"event_type\":\"MASTER_INVITE_REJECT\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "tags": [
@@ -1514,7 +1520,7 @@
                 ],
                 "original": "{\"event_type\":\"METADATA_INSTANCE_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -1532,7 +1538,7 @@
                 ],
                 "original": "{\"event_type\":\"METADATA_INSTANCE_DELETE\"}",
                 "type": [
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -1568,7 +1574,7 @@
                 ],
                 "original": "{\"event_type\":\"METADATA_TEMPLATE_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -1586,7 +1592,7 @@
                 ],
                 "original": "{\"event_type\":\"METADATA_TEMPLATE_DELETE\"}",
                 "type": [
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -1677,7 +1683,7 @@
                 ],
                 "original": "{\"event_type\":\"REMOVE_DEVICE_ASSOCIATION\"}",
                 "type": [
-                    "deletion"
+                    "end"
                 ]
             },
             "tags": [
@@ -1696,7 +1702,7 @@
                 ],
                 "original": "{\"event_type\":\"REMOVE_LOGIN_ACTIVITY_DEVICE\"}",
                 "type": [
-                    "deletion"
+                    "end"
                 ]
             },
             "tags": [
@@ -1734,7 +1740,7 @@
                 ],
                 "original": "{\"event_type\":\"RETENTION_POLICY_ASSIGNMENT_ADD\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -1772,7 +1778,7 @@
                 ],
                 "original": "{\"event_type\":\"SHARE_EXPIRATION\"}",
                 "type": [
-                    "deletion"
+                    "change"
                 ]
             },
             "tags": [
@@ -1809,7 +1815,7 @@
                 ],
                 "original": "{\"event_type\":\"SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED\"}",
                 "type": [
-                    "denied"
+                    "access"
                 ]
             },
             "tags": [
@@ -1828,7 +1834,7 @@
                 ],
                 "original": "{\"event_type\":\"SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED_MISSING_JUSTIFICATION\"}",
                 "type": [
-                    "denied"
+                    "access"
                 ]
             },
             "tags": [
@@ -1847,7 +1853,7 @@
                 ],
                 "original": "{\"event_type\":\"SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED\"}",
                 "type": [
-                    "denied"
+                    "access"
                 ]
             },
             "tags": [
@@ -1866,7 +1872,7 @@
                 ],
                 "original": "{\"event_type\":\"SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED_MISSING_JUSTIFICATION\"}",
                 "type": [
-                    "denied"
+                    "access"
                 ]
             },
             "tags": [
@@ -1885,7 +1891,7 @@
                 ],
                 "original": "{\"event_type\":\"SHIELD_JUSTIFICATION_APPROVAL\"}",
                 "type": [
-                    "admin"
+                    "access"
                 ]
             },
             "tags": [
@@ -1999,7 +2005,7 @@
                 ],
                 "original": "{\"event_type\":\"SIGN_DOCUMENT_DECLINED\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "tags": [
@@ -2150,8 +2156,7 @@
                 ],
                 "original": "{\"event_type\":\"TASK_ASSIGNMENT_CREATE\"}",
                 "type": [
-                    "user",
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -2170,8 +2175,7 @@
                 ],
                 "original": "{\"event_type\":\"TASK_ASSIGNMENT_DELETE\"}",
                 "type": [
-                    "user",
-                    "deletion"
+                    "info"
                 ]
             },
             "tags": [
@@ -2190,7 +2194,6 @@
                 ],
                 "original": "{\"event_type\":\"TASK_ASSIGNMENT_UPDATE\"}",
                 "type": [
-                    "user",
                     "change"
                 ]
             },
@@ -2210,7 +2213,7 @@
                 ],
                 "original": "{\"event_type\":\"TASK_CREATE\"}",
                 "type": [
-                    "creation"
+                    "info"
                 ]
             },
             "tags": [
@@ -2229,7 +2232,7 @@
                 ],
                 "original": "{\"event_type\":\"TASK_UPDATE\"}",
                 "type": [
-                    "creation"
+                    "change"
                 ]
             },
             "tags": [
@@ -2248,7 +2251,7 @@
                 ],
                 "original": "{\"event_type\":\"TERMS_OF_SERVICE_ACCEPT\"}",
                 "type": [
-                    "user"
+                    "info"
                 ]
             },
             "tags": [
@@ -2267,7 +2270,7 @@
                 ],
                 "original": "{\"event_type\":\"TERMS_OF_SERVICE_REJECT\"}",
                 "type": [
-                    "user"
+                    "info"
                 ]
             },
             "tags": [
@@ -2341,7 +2344,6 @@
                 ],
                 "original": "{\"event_type\":\"UPDATE_COLLABORATION_EXPIRATION\"}",
                 "type": [
-                    "user",
                     "change"
                 ]
             },

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-malicious-content.log-expected.json
@@ -61,7 +61,7 @@
                 "ip": "10.1.2.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",
@@ -199,7 +199,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-preview.log-expected.json
@@ -71,7 +71,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_PREVIEW",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-rename.log-expected.json
@@ -54,7 +54,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_RENAME",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-locations.log-expected.json
@@ -19,7 +19,7 @@
                 "ip": "67.43.156.0"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",
@@ -114,7 +114,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-suspicious-sessions.log-expected.json
@@ -22,7 +22,7 @@
                 "ip": "10.1.2.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",
@@ -116,7 +116,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "SHIELD_ALERT",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-trash.log-expected.json
@@ -49,7 +49,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_TRASH",

--- a/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
+++ b/packages/box_events/data_stream/events/_dev/test/pipeline/test-upload.log-expected.json
@@ -78,7 +78,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "ITEM_UPLOAD",

--- a/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Box Events
 processors:
   - set:
       field: ecs.version
-      value: "8.9.0"
+      value: "8.10.0"
   - rename:
       field: message
       target_field: event.original

--- a/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/box_events/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -48,28 +48,28 @@ processors:
       params:
         ACCESS_GRANTED:
           map:
-            category: ['configuration']
-            type: ['access','allowed']
+            category: ['configuration', 'iam']
+            type: ['access', 'creation']
         ACCESS_REVOKED:
           map:
-            category: ['configuration']
-            type: ['access','denied']
+            category: ['configuration', 'iam']
+            type: ['access','deletion']
         ADD_DEVICE_ASSOCIATION:
           map:
             category: ['host']
-            type: ['access','allowed']
+            type: ['access']
         ADD_LOGIN_ACTIVITY_DEVICE:
           map:
             category: ['host','session']
-            type: ['access','allowed']
+            type: ['access']
         ADMIN_LOGIN:
           map:
             category: ['session']
-            type: ['admin']
+            type: ['start']
         APPLICATION_CREATED:
           map:
             category: ['process']
-            type: ['creation']
+            type: ['start']
         APPLICATION_PUBLIC_KEY_ADDED:
           map:
             category: ['process','authentication','iam']
@@ -80,7 +80,7 @@ processors:
             type: ['deletion']
         CHANGE_ADMIN_ROLE:
           map:
-            category: ['configuration']
+            category: ['iam']
             type: ['admin']
         CHANGE_FOLDER_PERMISSION:
           map:
@@ -93,43 +93,43 @@ processors:
         COLLABORATION_EXPIRATION:
           map:
             category: ['process']
-            type: ['access','deletion']
+            type: ['access','change']
         COLLABORATION_INVITE:
           map:
             category: ['process']
-            type: ['access','creation']
+            type: ['access','info','start']
         COLLABORATION_REMOVE:
           map:
             category: ['process']
-            type: ['access','end']
+            type: ['access','info','end']
         COLLABORATION_ROLE_CHANGE:
           map:
             category: ['process']
-            type: ['access','change']
+            type: ['access','info','change']
         COLLAB_ADD_COLLABORATOR:
           map:
             category: ['process']
-            type: ['access','creation']
+            type: ['access','info','start']
         COLLAB_INVITE_COLLABORATOR:
           map:
             category: ['process']
-            type: ['access']
+            type: ['access','info','start']
         COLLAB_REMOVE_COLLABORATOR:
           map:
             category: ['process']
-            type: ['access','deletion']
+            type: ['access','info','change']
         COLLAB_ROLE_CHANGE:
           map:
             category: ['process']
             type: ['access','change']
         COMMENT_CREATE:
           map:
-            category: ['database']
-            type: ['creation']
+            category: ['file']
+            type: ['info']
         COMMENT_DELETE:
           map:
-            category: ['database']
-            type: ['deletion']
+            category: ['file']
+            type: ['info']
         CONTENT_ACCESS:
           map:
             category: ['file']
@@ -137,7 +137,7 @@ processors:
         CONTENT_WORKFLOW_ABNORMAL_DOWNLOAD_ACTIVITY:
           map:
             category: ['process','threat']
-            type: ['access','connection','indicator']
+            type: ['access','indicator']
         CONTENT_WORKFLOW_AUTOMATION_ADD:
           map:
             category: ['process']
@@ -181,7 +181,7 @@ processors:
         DEVICE_TRUST_CHECK_FAILED:
           map:
             category: ['authentication','threat']
-            type: ['denied','indicator']
+            type: ['info','indicator']
         DOWNLOAD:
           map:
             category: ['file']
@@ -213,7 +213,7 @@ processors:
         FAILED_LOGIN:
           map:
             category: ['iam','threat']
-            type: ['denied','indicator']
+            type: ['info','indicator']
         FILE_MARKED_MALICIOUS:
           map:
             category: ['file','threat']
@@ -325,19 +325,19 @@ processors:
         LEGAL_HOLD_ASSIGNMENT_CREATE:
           map:
             category: ['process','database']
-            type: ['creation']
+            type: ['info']
         LEGAL_HOLD_ASSIGNMENT_DELETE:
           map:
             category: ['process','database']
-            type: ['deletion']
+            type: ['change']
         LEGAL_HOLD_POLICY_CREATE:
           map:
             category: ['process','database']
-            type: ['creation']
+            type: ['info']
         LEGAL_HOLD_POLICY_DELETE:
           map:
             category: ['process','database']
-            type: ['deletion']
+            type: ['change']
         LEGAL_HOLD_POLICY_UPDATE:
           map:
             category: ['process','database']
@@ -356,24 +356,24 @@ processors:
             type: ['deletion']
         LOGIN:
           map:
-            category: ['authentication']
-            type: ['access']
+            category: ['session']
+            type: ['start']
         MASTER_INVITE_ACCEPT:
           map:
-            category: ['process']
-            type: ['allowed']
+            category: ['iam']
+            type: ['user']
         MASTER_INVITE_REJECT:
           map:
             category: ['process']
-            type: ['denied']
+            type: ['info']
         METADATA_INSTANCE_CREATE:
           map:
             category: ['database']
-            type: ['creation']
+            type: ['info']
         METADATA_INSTANCE_DELETE:
           map:
             category: ['database']
-            type: ['deletion']
+            type: ['change']
         METADATA_INSTANCE_UPDATE:
           map:
             category: ['database']
@@ -381,11 +381,11 @@ processors:
         METADATA_TEMPLATE_CREATE:
           map:
             category: ['database']
-            type: ['creation']
+            type: ['info']
         METADATA_TEMPLATE_DELETE:
           map:
             category: ['database']
-            type: ['deletion']
+            type: ['change']
         METADATA_TEMPLATE_UPDATE:
           map:
             category: ['database']
@@ -405,11 +405,11 @@ processors:
         REMOVE_DEVICE_ASSOCIATION:
           map:
             category: ['host']
-            type: ['deletion']
+            type: ['end']
         REMOVE_LOGIN_ACTIVITY_DEVICE:
           map:
             category: ['host','session']
-            type: ['deletion']
+            type: ['end']
         RENAME:
           map:
             category: ['file','database']
@@ -417,7 +417,7 @@ processors:
         RETENTION_POLICY_ASSIGNMENT_ADD:
           map:
             category: ['database','process']
-            type: ['creation']
+            type: ['info']
         SHARE:
           map:
             category: ['file','database']
@@ -425,7 +425,7 @@ processors:
         SHARE_EXPIRATION:
           map:
             category: ['process','database']
-            type: ['deletion']
+            type: ['change']
         SHIELD_ALERT:
           map:
             category: ['threat']
@@ -433,23 +433,23 @@ processors:
         SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED:
           map:
             category: ['threat','process']
-            type: ['denied']
+            type: ['access']
         SHIELD_EXTERNAL_COLLAB_ACCESS_BLOCKED_MISSING_JUSTIFICATION:
           map:
             category: ['threat','process']
-            type: ['denied']
+            type: ['access']
         SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED:
           map:
             category: ['threat','process']
-            type: ['denied']
+            type: ['access']
         SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED_MISSING_JUSTIFICATION:
           map:
             category: ['threat','process']
-            type: ['denied']
+            type: ['access']
         SHIELD_JUSTIFICATION_APPROVAL:
           map:
             category: ['threat','process']
-            type: ['admin']
+            type: ['access']
         SIGN_DOCUMENT_ASSIGNED:
           map:
             category: ['process','iam']
@@ -473,7 +473,7 @@ processors:
         SIGN_DOCUMENT_DECLINED:
           map:
             category: ['process','iam']
-            type: ['denied']
+            type: ['info']
         SIGN_DOCUMENT_EXPIRED:
           map:
             category: ['process','iam']
@@ -505,31 +505,31 @@ processors:
         TASK_ASSIGNMENT_CREATE:
           map:
             category: ['process','database']
-            type: ['user','creation']
+            type: ['info']
         TASK_ASSIGNMENT_DELETE:
           map:
             category: ['process','database']
-            type: ['user','deletion']
+            type: ['info']
         TASK_ASSIGNMENT_UPDATE:
           map:
             category: ['process','database']
-            type: ['user','change']
+            type: ['change']
         TASK_CREATE:
           map:
             category: ['process','database']
-            type: ['creation']
+            type: ['info']
         TASK_UPDATE:
           map:
             category: ['process','database']
-            type: ['creation']
+            type: ['change']
         TERMS_OF_SERVICE_ACCEPT:
           map:
             category: ['process','database']
-            type: ['user']
+            type: ['info']
         TERMS_OF_SERVICE_REJECT:
           map:
             category: ['process','database']
-            type: ['user']
+            type: ['info']
         UNDELETE:
           map:
             category: ['file']
@@ -545,7 +545,7 @@ processors:
         UPDATE_COLLABORATION_EXPIRATION:
           map:
             category: ['process','database']
-            type: ['user','change']
+            type: ['change']
         UPDATE_SHARE_EXPIRATION:
           map:
             category: ['process','database']

--- a/packages/box_events/data_stream/events/sample_event.json
+++ b/packages/box_events/data_stream/events/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2019-12-08T08:00:00.000Z",
     "agent": {
-        "ephemeral_id": "764c37eb-8835-4094-ba76-e4a16049d6b9",
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "ephemeral_id": "c9ccc0f9-8d0e-4bfa-b365-1fbb4bc530c6",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "box": {
         "additional_details": {
@@ -60,9 +60,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "snapshot": false,
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "event": {
         "action": "SHIELD_ALERT",
@@ -71,10 +71,10 @@
             "threat",
             "file"
         ],
-        "created": "2023-08-29T15:21:44.833Z",
+        "created": "2023-09-21T01:54:30.945Z",
         "dataset": "box_events.events",
         "id": "97f1b31f-f143-4777-81f8-1b557b39ca33",
-        "ingested": "2023-08-29T15:21:47Z",
+        "ingested": "2023-09-21T01:54:31Z",
         "kind": "alert",
         "risk_score": 77,
         "type": [
@@ -84,20 +84,20 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "c2615f282eb54b57a5bab10d7ee84193",
+        "id": "1de1e3b6561d4ccb9731539ce2f3baf3",
         "ip": [
-            "172.21.0.7"
+            "172.19.0.7"
         ],
         "mac": [
-            "02-42-AC-15-00-07"
+            "02-42-AC-13-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: box_events
 title: Box Events
-version: "1.10.0"
+version: "2.0.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: box_events
 title: Box Events
-version: "1.9.0"
+version: "1.10.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the box_events integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Author notes

- Due to the number of categorization updates, and updates to both `event.category` as well as `event.type`, I set this to a major upgrade.
- I did my best to update these categorization fields as accurately and consistently as possible. Feel free to make suggestions though if you see any issues. 

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
