### PR TITLE
[ECS] Updating cisco_asa to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/cisco_asa/_dev/build/build.yml
+++ b/packages/cisco_asa/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.23.0"
   changes:
-    - description: Update package to ECS 8.10.0.
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7907
 - version: "2.22.0"

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.23.0"
+  changes:
+    - description: Update package to ECS 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "2.22.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -22,7 +22,7 @@
                 "port": 53500
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -110,7 +110,7 @@
                 "port": 53500
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -190,7 +190,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -252,7 +252,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -313,7 +313,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -377,7 +377,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -453,7 +453,7 @@
                 "port": 111
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -537,7 +537,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -611,7 +611,7 @@
                 "port": 67
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -688,7 +688,7 @@
                 "port": 21
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -753,7 +753,7 @@
         {
             "@timestamp": "2023-05-05T17:51:17.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -805,7 +805,7 @@
                 "port": 10872
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -883,7 +883,7 @@
                 "port": 10872
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -972,7 +972,7 @@
                 "port": 10872
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1057,7 +1057,7 @@
                 "ip": "192.168.2.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1135,7 +1135,7 @@
                 "ip": "192.168.2.2"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1198,7 +1198,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1256,7 +1256,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1321,7 +1321,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -1389,7 +1389,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -1458,7 +1458,7 @@
                 "port": 55225
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1547,7 +1547,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1627,7 +1627,7 @@
                 "port": 54230
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1705,7 +1705,7 @@
                 "ip": "192.168.2.2"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1776,7 +1776,7 @@
                 "port": 57006
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1850,7 +1850,7 @@
                 "port": 14322
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1924,7 +1924,7 @@
                 "port": 53356
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2011,7 +2011,7 @@
                 "port": 161
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2099,7 +2099,7 @@
                 "port": 161
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2180,7 +2180,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2255,7 +2255,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2324,7 +2324,7 @@
                 "port": 65020
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2396,7 +2396,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2467,7 +2467,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2538,7 +2538,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2610,7 +2610,7 @@
                 "port": 10051
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2685,7 +2685,7 @@
                 "port": 10051
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2760,7 +2760,7 @@
                 "port": 10051
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2834,7 +2834,7 @@
                 "port": 10051
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2914,7 +2914,7 @@
                 "port": 39222
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2988,7 +2988,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3041,7 +3041,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3101,7 +3101,7 @@
                 "port": 3452
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3179,7 +3179,7 @@
                 "port": 6007
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3245,7 +3245,7 @@
         {
             "@timestamp": "2023-05-05T19:02:26.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3285,7 +3285,7 @@
         {
             "@timestamp": "2023-05-05T19:02:26.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3335,7 +3335,7 @@
                 "port": 1985
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3396,7 +3396,7 @@
         {
             "@timestamp": "2023-05-05T19:02:26.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3436,7 +3436,7 @@
         {
             "@timestamp": "2023-05-05T19:02:26.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3486,7 +3486,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3564,7 +3564,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3615,7 +3615,7 @@
                 "port": 2
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3691,7 +3691,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3759,7 +3759,7 @@
                 "ip": "10.20.30.40"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3818,7 +3818,7 @@
                 "ip": "10.20.30.40"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3877,7 +3877,7 @@
                 "ip": "10.20.30.40"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3936,7 +3936,7 @@
                 "ip": "10.20.30.40"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4015,7 +4015,7 @@
                 "port": 9101
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4108,7 +4108,7 @@
                 "port": 51635
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4186,7 +4186,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4251,7 +4251,7 @@
         {
             "@timestamp": "2023-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4302,7 +4302,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4365,7 +4365,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4422,7 +4422,7 @@
                 "ip": "10.10.1.254"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -4488,7 +4488,7 @@
         {
             "@timestamp": "2023-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -4555,7 +4555,7 @@
                 "ip": "10.10.1.254"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4620,7 +4620,7 @@
         {
             "@timestamp": "2023-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -4678,7 +4678,7 @@
         {
             "@timestamp": "2023-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4759,7 +4759,7 @@
                 "ip": "81.2.69.144"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-disconnected",
@@ -4824,7 +4824,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4887,7 +4887,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4960,7 +4960,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5024,7 +5024,7 @@
                 "port": 23
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5108,7 +5108,7 @@
                 "port": 123123
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "bypass",
@@ -5194,7 +5194,7 @@
                 "port": 514514
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "drop",
@@ -5272,7 +5272,7 @@
                 "port": 123412
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5355,7 +5355,7 @@
                 "port": 514514
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5439,7 +5439,7 @@
                 "ip": "192.168.2.2"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "created",
@@ -5512,7 +5512,7 @@
                 "ip": "192.168.2.2"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "deleted",
@@ -5589,7 +5589,7 @@
                 "port": 7777
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -5663,7 +5663,7 @@
                 "port": 7777
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "error",
@@ -5731,7 +5731,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5781,7 +5781,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5829,7 +5829,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "error",
@@ -5878,7 +5878,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "error",
@@ -5920,7 +5920,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5961,7 +5961,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "error",
@@ -6003,7 +6003,7 @@
         {
             "@timestamp": "2020-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "error",
@@ -6052,7 +6052,7 @@
         {
             "@timestamp": "2023-04-27T02:03:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6128,7 +6128,7 @@
                 "ip": "172.31.98.44"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6224,7 +6224,7 @@
                 "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6324,7 +6324,7 @@
                 "port": 500
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6418,7 +6418,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6471,7 +6471,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6524,7 +6524,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6577,7 +6577,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6638,7 +6638,7 @@
                 "ip": "81.2.69.144"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -6713,7 +6713,7 @@
                 "ip": "81.2.69.144"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -6783,7 +6783,7 @@
                 "ip": "81.2.69.144"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -6840,7 +6840,7 @@
         {
             "@timestamp": "2023-05-05T19:02:25.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -6891,7 +6891,7 @@
         {
             "@timestamp": "2023-05-05T19:02:25.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -6947,7 +6947,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -7006,7 +7006,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -7065,7 +7065,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -7129,7 +7129,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -7197,7 +7197,7 @@
                 "ip": "192.168.0.8"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -7260,7 +7260,7 @@
         {
             "@timestamp": "2023-03-03T08:50:32.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -7325,7 +7325,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -7397,7 +7397,7 @@
                 "ip": "10.1.2.0"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -5122,8 +5122,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info",
-                    "change"
+                    "info"
                 ]
             },
             "host": {
@@ -5528,8 +5527,7 @@
                 "timezone": "UTC",
                 "type": [
                     "info",
-                    "deletion",
-                    "user"
+                    "end"
                 ]
             },
             "host": {
@@ -5679,7 +5677,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "error"
+                    "info"
                 ]
             },
             "host": {
@@ -5846,7 +5844,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "error"
+                    "info"
                 ]
             },
             "host": {
@@ -5895,7 +5893,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "error"
+                    "info"
                 ]
             },
             "host": {
@@ -5978,7 +5976,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "error"
+                    "info"
                 ]
             },
             "host": {
@@ -6020,7 +6018,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "error"
+                    "info"
                 ]
             },
             "host": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -76,7 +76,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -149,7 +149,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -222,7 +222,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -295,7 +295,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -368,7 +368,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -441,7 +441,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -514,7 +514,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -587,7 +587,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -632,7 +632,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -705,7 +705,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-connected",
@@ -779,7 +779,7 @@
         {
             "@timestamp": "2018-10-10T12:34:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-error",
@@ -831,7 +831,7 @@
         {
             "@timestamp": "2022-06-22T13:29:11.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-connected",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
@@ -17,7 +17,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -91,7 +90,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -165,7 +163,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -239,7 +236,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -313,7 +309,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -387,7 +382,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -461,7 +455,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -535,7 +528,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -609,7 +601,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -655,7 +646,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },
@@ -803,7 +793,6 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "error",
                     "denied"
                 ]
             },

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -17,7 +17,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -103,7 +103,7 @@
                 "ip": "10.123.123.123"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -179,7 +179,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -250,7 +250,7 @@
                 "port": 57621
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -325,7 +325,7 @@
                 "ip": "10.123.123.123"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -381,7 +381,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -455,7 +455,7 @@
                 "port": 0
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -526,7 +526,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -597,7 +597,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -669,7 +669,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -758,7 +758,7 @@
                 "port": 8080
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -860,7 +860,7 @@
                 "port": 9803
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -972,7 +972,7 @@
                 "port": 9803
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1090,7 +1090,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -25,7 +25,7 @@
                 "ip": "67.43.156.12"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-disconnected",
@@ -100,7 +100,7 @@
                 "ip": "67.43.156.12"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-disconnected",
@@ -153,7 +153,7 @@
         {
             "@timestamp": "2019-10-20T15:42:54.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -215,7 +215,7 @@
         {
             "@timestamp": "2020-08-06T11:01:37.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -270,7 +270,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -331,7 +331,7 @@
         {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -381,7 +381,7 @@
         {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -434,7 +434,7 @@
         {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -487,7 +487,7 @@
         {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -540,7 +540,7 @@
         {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
@@ -14,7 +14,7 @@
                 "port": 8256
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -98,7 +98,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -179,7 +179,7 @@
                 "port": 1758
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -265,7 +265,7 @@
                 "port": 1757
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -351,7 +351,7 @@
                 "port": 1755
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -437,7 +437,7 @@
                 "port": 1754
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -523,7 +523,7 @@
                 "port": 1752
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -609,7 +609,7 @@
                 "port": 1749
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -695,7 +695,7 @@
                 "port": 1750
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -781,7 +781,7 @@
                 "port": 1747
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -867,7 +867,7 @@
                 "port": 1742
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -953,7 +953,7 @@
                 "port": 1741
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1039,7 +1039,7 @@
                 "port": 1739
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1125,7 +1125,7 @@
                 "port": 1740
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1211,7 +1211,7 @@
                 "port": 1738
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1297,7 +1297,7 @@
                 "port": 1756
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1383,7 +1383,7 @@
                 "port": 1737
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1469,7 +1469,7 @@
                 "port": 1736
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1555,7 +1555,7 @@
                 "port": 1765
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1640,7 +1640,7 @@
                 "port": 1188
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1724,7 +1724,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1805,7 +1805,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1894,7 +1894,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1975,7 +1975,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2059,7 +2059,7 @@
                 "port": 8257
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2143,7 +2143,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2223,7 +2223,7 @@
                 "port": 8258
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2307,7 +2307,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2392,7 +2392,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2477,7 +2477,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2558,7 +2558,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2643,7 +2643,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2727,7 +2727,7 @@
                 "port": 8259
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2811,7 +2811,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2891,7 +2891,7 @@
                 "port": 1189
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2975,7 +2975,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3060,7 +3060,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3141,7 +3141,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3226,7 +3226,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3310,7 +3310,7 @@
                 "port": 8265
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3394,7 +3394,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3479,7 +3479,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3564,7 +3564,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3645,7 +3645,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3730,7 +3730,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3814,7 +3814,7 @@
                 "port": 8266
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3898,7 +3898,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3979,7 +3979,7 @@
                 "port": 1453
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4069,7 +4069,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4150,7 +4150,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4235,7 +4235,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4319,7 +4319,7 @@
                 "port": 8267
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4403,7 +4403,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4483,7 +4483,7 @@
                 "port": 8268
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4567,7 +4567,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4647,7 +4647,7 @@
                 "port": 8269
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4731,7 +4731,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4816,7 +4816,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4897,7 +4897,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4981,7 +4981,7 @@
                 "port": 8270
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5065,7 +5065,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5145,7 +5145,7 @@
                 "port": 8271
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5229,7 +5229,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5314,7 +5314,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5395,7 +5395,7 @@
                 "port": 1457
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5480,7 +5480,7 @@
                 "port": 8272
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5564,7 +5564,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5645,7 +5645,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5729,7 +5729,7 @@
                 "port": 8273
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5813,7 +5813,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5893,7 +5893,7 @@
                 "port": 8267
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5976,7 +5976,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6060,7 +6060,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6140,7 +6140,7 @@
                 "port": 8268
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6223,7 +6223,7 @@
                 "port": 8269
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6306,7 +6306,7 @@
                 "port": 8270
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6389,7 +6389,7 @@
                 "port": 8271
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6472,7 +6472,7 @@
                 "port": 8272
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6555,7 +6555,7 @@
                 "port": 8273
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6639,7 +6639,7 @@
                 "port": 1382
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6725,7 +6725,7 @@
                 "port": 1385
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6810,7 +6810,7 @@
                 "port": 8278
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6894,7 +6894,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6975,7 +6975,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7057,7 +7057,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7139,7 +7139,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7221,7 +7221,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7303,7 +7303,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7385,7 +7385,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7467,7 +7467,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7549,7 +7549,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7631,7 +7631,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7713,7 +7713,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7795,7 +7795,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7877,7 +7877,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7959,7 +7959,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8040,7 +8040,7 @@
                 "port": 8279
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8124,7 +8124,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8204,7 +8204,7 @@
                 "port": 1190
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8288,7 +8288,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8369,7 +8369,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -8458,7 +8458,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8539,7 +8539,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -8623,7 +8623,7 @@
                 "port": 8280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8707,7 +8707,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8787,7 +8787,7 @@
                 "port": 8281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8871,7 +8871,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8952,7 +8952,7 @@
                 "port": 1276
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9037,7 +9037,7 @@
                 "port": 8282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9121,7 +9121,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9202,7 +9202,7 @@
                 "port": 1277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9287,7 +9287,7 @@
                 "port": 8283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9371,7 +9371,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9452,7 +9452,7 @@
                 "port": 1278
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9538,7 +9538,7 @@
                 "port": 1279
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9623,7 +9623,7 @@
                 "port": 8284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9707,7 +9707,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9788,7 +9788,7 @@
                 "port": 1280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9873,7 +9873,7 @@
                 "port": 8285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9957,7 +9957,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10037,7 +10037,7 @@
                 "port": 8286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10121,7 +10121,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10201,7 +10201,7 @@
                 "port": 8287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10285,7 +10285,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10365,7 +10365,7 @@
                 "port": 8288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10449,7 +10449,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10530,7 +10530,7 @@
                 "port": 1281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10616,7 +10616,7 @@
                 "port": 1282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10702,7 +10702,7 @@
                 "port": 1283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10787,7 +10787,7 @@
                 "port": 8289
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10871,7 +10871,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10951,7 +10951,7 @@
                 "port": 8290
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11035,7 +11035,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11116,7 +11116,7 @@
                 "port": 1284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11201,7 +11201,7 @@
                 "port": 8291
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11285,7 +11285,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11366,7 +11366,7 @@
                 "port": 1285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11452,7 +11452,7 @@
                 "port": 1286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11542,7 +11542,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11622,7 +11622,7 @@
                 "port": 8292
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11706,7 +11706,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11787,7 +11787,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11876,7 +11876,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11957,7 +11957,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12041,7 +12041,7 @@
                 "port": 8293
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12125,7 +12125,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12206,7 +12206,7 @@
                 "port": 1288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12292,7 +12292,7 @@
                 "port": 1287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12382,7 +12382,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12463,7 +12463,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12547,7 +12547,7 @@
                 "port": 8294
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12631,7 +12631,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12712,7 +12712,7 @@
                 "port": 68
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12796,7 +12796,7 @@
                 "port": 8276
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12884,7 +12884,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12969,7 +12969,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13050,7 +13050,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13139,7 +13139,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13220,7 +13220,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13305,7 +13305,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13394,7 +13394,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13475,7 +13475,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13559,7 +13559,7 @@
                 "port": 8295
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13643,7 +13643,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13728,7 +13728,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13809,7 +13809,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13893,7 +13893,7 @@
                 "port": 8296
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13977,7 +13977,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14057,7 +14057,7 @@
                 "port": 8297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14141,7 +14141,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14221,7 +14221,7 @@
                 "port": 8298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14305,7 +14305,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14386,7 +14386,7 @@
                 "port": 1293
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14471,7 +14471,7 @@
                 "port": 8299
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14555,7 +14555,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14635,7 +14635,7 @@
                 "port": 8300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14719,7 +14719,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14800,7 +14800,7 @@
                 "port": 1294
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14886,7 +14886,7 @@
                 "port": 1295
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14972,7 +14972,7 @@
                 "port": 1296
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15057,7 +15057,7 @@
                 "port": 8301
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15141,7 +15141,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15221,7 +15221,7 @@
                 "port": 8302
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15305,7 +15305,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15390,7 +15390,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15471,7 +15471,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15556,7 +15556,7 @@
                 "port": 1297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15641,7 +15641,7 @@
                 "port": 8303
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15725,7 +15725,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15805,7 +15805,7 @@
                 "port": 8304
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15889,7 +15889,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15970,7 +15970,7 @@
                 "port": 1298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16056,7 +16056,7 @@
                 "port": 1300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16141,7 +16141,7 @@
                 "port": 8305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16225,7 +16225,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16305,7 +16305,7 @@
                 "port": 8306
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16389,7 +16389,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16469,7 +16469,7 @@
                 "port": 8280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16552,7 +16552,7 @@
                 "port": 8281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16635,7 +16635,7 @@
                 "port": 8282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16718,7 +16718,7 @@
                 "port": 8283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16801,7 +16801,7 @@
                 "port": 8284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16884,7 +16884,7 @@
                 "port": 8285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16967,7 +16967,7 @@
                 "port": 8286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17050,7 +17050,7 @@
                 "port": 8287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17133,7 +17133,7 @@
                 "port": 8288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17216,7 +17216,7 @@
                 "port": 8289
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17299,7 +17299,7 @@
                 "port": 8290
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17382,7 +17382,7 @@
                 "port": 8291
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17465,7 +17465,7 @@
                 "port": 8292
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17548,7 +17548,7 @@
                 "port": 8297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17631,7 +17631,7 @@
                 "port": 8298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17714,7 +17714,7 @@
                 "port": 8308
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -17798,7 +17798,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -17878,7 +17878,7 @@
                 "port": 8299
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17961,7 +17961,7 @@
                 "port": 8300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18049,7 +18049,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18134,7 +18134,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18215,7 +18215,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18300,7 +18300,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18384,7 +18384,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18468,7 +18468,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18548,7 +18548,7 @@
                 "port": 8301
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18631,7 +18631,7 @@
                 "port": 8302
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18714,7 +18714,7 @@
                 "port": 8303
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18797,7 +18797,7 @@
                 "port": 8304
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18880,7 +18880,7 @@
                 "port": 8305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18963,7 +18963,7 @@
                 "port": 8306
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -19046,7 +19046,7 @@
                 "port": 8307
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -19130,7 +19130,7 @@
                 "port": 1305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -19216,7 +19216,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19298,7 +19298,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19380,7 +19380,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19461,7 +19461,7 @@
                 "port": 8310
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19545,7 +19545,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19626,7 +19626,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19708,7 +19708,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19790,7 +19790,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19872,7 +19872,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19954,7 +19954,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20036,7 +20036,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20118,7 +20118,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20200,7 +20200,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20282,7 +20282,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20364,7 +20364,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20446,7 +20446,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20528,7 +20528,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20610,7 +20610,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20692,7 +20692,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20774,7 +20774,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20856,7 +20856,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20938,7 +20938,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21020,7 +21020,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21102,7 +21102,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21184,7 +21184,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21266,7 +21266,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21348,7 +21348,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21430,7 +21430,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21512,7 +21512,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21594,7 +21594,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21676,7 +21676,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21758,7 +21758,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21840,7 +21840,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21922,7 +21922,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22004,7 +22004,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22086,7 +22086,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22168,7 +22168,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22250,7 +22250,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22336,7 +22336,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-dap-records.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-dap-records.log-expected.json
@@ -12,7 +12,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2023-01-01T01:00:27.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -47,7 +47,7 @@
         {
             "@timestamp": "2023-01-01T01:00:30.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -98,7 +98,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-hostnames.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-hostnames.log-expected.json
@@ -11,7 +11,7 @@
                 "domain": "target.destination.hostname.local"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -78,7 +78,7 @@
                 "ip": "192.168.2.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -19,7 +19,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -99,7 +99,7 @@
                 "port": 10050
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -183,7 +183,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -267,7 +267,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -345,7 +345,7 @@
                 "port": 54703
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -415,7 +415,7 @@
                 "port": 25
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -516,7 +516,7 @@
                 "port": 62409
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -606,7 +606,7 @@
                 "port": 56421
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -696,7 +696,7 @@
                 "port": 50578
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -782,7 +782,7 @@
                 "port": 56570
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -875,7 +875,7 @@
                 "port": 2511
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -970,7 +970,7 @@
                 "port": 2511
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1045,7 +1045,7 @@
                 "domain": "eth0_fw"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -1120,7 +1120,7 @@
                 "domain": "eth0_fw"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -1195,7 +1195,7 @@
                 "domain": "eth0_fw"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1270,7 +1270,7 @@
                 "domain": "eth0_fw"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1335,7 +1335,7 @@
         {
             "@timestamp": "2023-07-15T12:18:51.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-connected",
@@ -1410,7 +1410,7 @@
         {
             "@timestamp": "2023-07-01T09:27:13.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "client-vpn-connected",
@@ -1486,7 +1486,7 @@
                 "domain": "mirror"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1558,7 +1558,7 @@
                 "ip": "81.2.69.142"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",
@@ -1649,7 +1649,7 @@
                 "ip": "81.2.69.144"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -27,7 +27,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -105,7 +105,7 @@
                 "ip": "172.24.177.29"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -178,7 +178,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -15,7 +15,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -86,7 +86,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -158,7 +158,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -228,7 +228,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -306,7 +306,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -383,7 +383,7 @@
                 "port": 12834
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -456,7 +456,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -528,7 +528,7 @@
                 "port": 25882
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -604,7 +604,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -677,7 +677,7 @@
                 "port": 45392
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -750,7 +750,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -825,7 +825,7 @@
                 "port": 52925
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -904,7 +904,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -985,7 +985,7 @@
                 "ip": "172.24.177.29"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1050,7 +1050,7 @@
                 "port": 10879
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1123,7 +1123,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1191,7 +1191,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1254,7 +1254,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1325,7 +1325,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1396,7 +1396,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1467,7 +1467,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1538,7 +1538,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1609,7 +1609,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1680,7 +1680,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1751,7 +1751,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1822,7 +1822,7 @@
                 "port": 25
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1893,7 +1893,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1962,7 +1962,7 @@
                 "port": 137
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2022,7 +2022,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2085,7 +2085,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2156,7 +2156,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2227,7 +2227,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2298,7 +2298,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2369,7 +2369,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2440,7 +2440,7 @@
                 "port": 8111
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2511,7 +2511,7 @@
                 "port": 8111
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2582,7 +2582,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2653,7 +2653,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2725,7 +2725,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2799,7 +2799,7 @@
                 "port": 11180
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2872,7 +2872,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2946,7 +2946,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3024,7 +3024,7 @@
                 "port": 1234
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3102,7 +3102,7 @@
                 "port": 1234
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3176,7 +3176,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3254,7 +3254,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3332,7 +3332,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3408,7 +3408,7 @@
                 "port": 5679
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3475,7 +3475,7 @@
                 "port": 5679
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3544,7 +3544,7 @@
                 "port": 5000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3622,7 +3622,7 @@
                 "port": 1234
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3699,7 +3699,7 @@
                 "port": 1234
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3772,7 +3772,7 @@
                 "port": 1235
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3850,7 +3850,7 @@
                 "port": 500
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3921,7 +3921,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3985,7 +3985,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4049,7 +4049,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4113,7 +4113,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4177,7 +4177,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4241,7 +4241,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4305,7 +4305,7 @@
                 "ip": "192.168.1.255"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4369,7 +4369,7 @@
                 "ip": "192.168.1.255"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4436,7 +4436,7 @@
                 "port": 25
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4509,7 +4509,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4577,7 +4577,7 @@
                 "ip": "172.16.1.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4647,7 +4647,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4735,7 +4735,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4816,7 +4816,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4883,7 +4883,7 @@
                 "ip": "192.168.2.1"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4934,7 +4934,7 @@
                 "ip": "192.168.2.32"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4992,7 +4992,7 @@
                 "ip": "192.168.0.19"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5077,7 +5077,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5148,7 +5148,7 @@
                 "ip": "172.17.6.211"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5234,7 +5234,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5345,7 +5345,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5458,7 +5458,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -5554,7 +5554,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -5654,7 +5654,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",
@@ -5748,7 +5748,7 @@
                 "port": 18449
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5826,7 +5826,7 @@
                 "ip": "ff02::1"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5899,7 +5899,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5989,7 +5989,7 @@
                 "port": 50120
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6093,7 +6093,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6196,7 +6196,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6294,7 +6294,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6402,7 +6402,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6507,7 +6507,7 @@
                 "ip": "81.2.69.193"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "deleted",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -6522,8 +6522,7 @@
                 "timezone": "UTC",
                 "type": [
                     "info",
-                    "deletion",
-                    "user"
+                    "end"
                 ]
             },
             "log": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sip.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sip.log-expected.json
@@ -16,7 +16,7 @@
                 "port": 5060
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -84,7 +84,7 @@
                 "port": 5060
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -152,7 +152,7 @@
                 "port": 5060
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -220,7 +220,7 @@
                 "port": 5060
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2340,30 +2340,27 @@ processors:
             - network
           type:
             - info
-            - change
         error:
           kind: event
           outcome: failure
           category:
             - network
           type:
-            - error
+            - info
         deleted:
           kind: event
           category:
             - network
           type:
             - info
-            - deletion
-            - user
+            - end
         creation:
           kind: event
           category:
             - network
           type:
             - info
-            - creation
-            - user
+            - access
         client-vpn-connected:
           kind: event
           category:
@@ -2378,7 +2375,6 @@ processors:
             - network
           type:
             - connection
-            - error
             - denied
         client-vpn-disconnected:
           kind: event

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,7 @@ processors:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   #
   # Parse the syslog header
   #

--- a/packages/cisco_asa/data_stream/log/sample_event.json
+++ b/packages/cisco_asa/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "bf92e689-48fb-4249-92c2-e3a34105ed72",
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "ephemeral_id": "9ee676bb-6135-4b55-b398-3316bd6865ad",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "cisco": {
         "asa": {
@@ -28,9 +28,9 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "snapshot": false,
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "event": {
         "action": "firewall-rule",
@@ -40,7 +40,7 @@
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2023-08-29T16:16:14Z",
+        "ingested": "2023-09-21T02:17:20Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -58,7 +58,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.21.0.4:41604"
+            "address": "172.19.0.4:60534"
         }
     },
     "network": {

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -17,11 +17,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "bf92e689-48fb-4249-92c2-e3a34105ed72",
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "ephemeral_id": "9ee676bb-6135-4b55-b398-3316bd6865ad",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "cisco": {
         "asa": {
@@ -44,9 +44,9 @@ An example event for `log` looks as following:
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "5607d6f4-6e45-4c33-a087-2e07de5f0082",
+        "id": "a4d1a8b2-b45c-4d97-a37a-bd371f13111b",
         "snapshot": false,
-        "version": "8.9.1"
+        "version": "8.8.1"
     },
     "event": {
         "action": "firewall-rule",
@@ -56,7 +56,7 @@ An example event for `log` looks as following:
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2023-08-29T16:16:14Z",
+        "ingested": "2023-09-21T02:17:20Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
@@ -74,7 +74,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.21.0.4:41604"
+            "address": "172.19.0.4:60534"
         }
     },
     "network": {

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: cisco_asa
 title: Cisco ASA
-version: "2.22.0"
+version: "2.23.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the cisco_asa integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
