### PR TITLE
[ECS] Updating cisco_ftd to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/cisco_ftd/_dev/build/build.yml
+++ b/packages/cisco_ftd/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.17.0"
   changes:
-    - description: Update package to ECS 8.10.0.
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7908
 - version: "2.16.0"

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.17.0"
+  changes:
+    - description: Update package to ECS 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "2.16.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to ECS 8.10.0.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7908
 - version: "2.16.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -17,7 +17,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -103,7 +103,7 @@
                 "ip": "10.123.123.123"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -179,7 +179,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -250,7 +250,7 @@
                 "port": 57621
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -325,7 +325,7 @@
                 "ip": "10.123.123.123"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -385,7 +385,7 @@
                 "ip": "10.10.10.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-creation",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
@@ -14,7 +14,7 @@
                 "port": 8256
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -98,7 +98,7 @@
                 "port": 1772
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -178,7 +178,7 @@
                 "port": 1758
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -264,7 +264,7 @@
                 "port": 1757
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -350,7 +350,7 @@
                 "port": 1755
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -436,7 +436,7 @@
                 "port": 1754
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -522,7 +522,7 @@
                 "port": 1752
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -608,7 +608,7 @@
                 "port": 1749
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -694,7 +694,7 @@
                 "port": 1750
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -780,7 +780,7 @@
                 "port": 1747
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -866,7 +866,7 @@
                 "port": 1742
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -952,7 +952,7 @@
                 "port": 1741
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1038,7 +1038,7 @@
                 "port": 1739
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1124,7 +1124,7 @@
                 "port": 1740
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1210,7 +1210,7 @@
                 "port": 1738
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1296,7 +1296,7 @@
                 "port": 1756
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1382,7 +1382,7 @@
                 "port": 1737
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1468,7 +1468,7 @@
                 "port": 1736
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1554,7 +1554,7 @@
                 "port": 1765
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1639,7 +1639,7 @@
                 "port": 1188
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1723,7 +1723,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1803,7 +1803,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1892,7 +1892,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1972,7 +1972,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2056,7 +2056,7 @@
                 "port": 8257
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2140,7 +2140,7 @@
                 "port": 1773
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2219,7 +2219,7 @@
                 "port": 8258
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2303,7 +2303,7 @@
                 "port": 1774
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2387,7 +2387,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2471,7 +2471,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2551,7 +2551,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2636,7 +2636,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -2720,7 +2720,7 @@
                 "port": 8259
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2804,7 +2804,7 @@
                 "port": 1775
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2883,7 +2883,7 @@
                 "port": 1189
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2967,7 +2967,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3051,7 +3051,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3131,7 +3131,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3216,7 +3216,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3300,7 +3300,7 @@
                 "port": 8265
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3384,7 +3384,7 @@
                 "port": 1452
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3468,7 +3468,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3552,7 +3552,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3632,7 +3632,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3717,7 +3717,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3801,7 +3801,7 @@
                 "port": 8266
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3885,7 +3885,7 @@
                 "port": 1453
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3965,7 +3965,7 @@
                 "port": 1453
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4055,7 +4055,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4135,7 +4135,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4220,7 +4220,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4304,7 +4304,7 @@
                 "port": 8267
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4388,7 +4388,7 @@
                 "port": 1454
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4467,7 +4467,7 @@
                 "port": 8268
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4551,7 +4551,7 @@
                 "port": 1455
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4630,7 +4630,7 @@
                 "port": 8269
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4714,7 +4714,7 @@
                 "port": 1456
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4798,7 +4798,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4878,7 +4878,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -4962,7 +4962,7 @@
                 "port": 8270
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5046,7 +5046,7 @@
                 "port": 1457
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5125,7 +5125,7 @@
                 "port": 8271
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5209,7 +5209,7 @@
                 "port": 1458
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5293,7 +5293,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5373,7 +5373,7 @@
                 "port": 1457
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5458,7 +5458,7 @@
                 "port": 8272
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5542,7 +5542,7 @@
                 "port": 1459
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5622,7 +5622,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5706,7 +5706,7 @@
                 "port": 8273
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5790,7 +5790,7 @@
                 "port": 1460
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5869,7 +5869,7 @@
                 "port": 8267
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -5952,7 +5952,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6036,7 +6036,7 @@
                 "port": 1385
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6115,7 +6115,7 @@
                 "port": 8268
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6198,7 +6198,7 @@
                 "port": 8269
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6281,7 +6281,7 @@
                 "port": 8270
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6364,7 +6364,7 @@
                 "port": 8271
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6447,7 +6447,7 @@
                 "port": 8272
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6530,7 +6530,7 @@
                 "port": 8273
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6614,7 +6614,7 @@
                 "port": 1382
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6700,7 +6700,7 @@
                 "port": 1385
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -6785,7 +6785,7 @@
                 "port": 8278
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6869,7 +6869,7 @@
                 "port": 1386
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -6949,7 +6949,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7031,7 +7031,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7113,7 +7113,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7195,7 +7195,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7277,7 +7277,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7359,7 +7359,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7441,7 +7441,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7523,7 +7523,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7605,7 +7605,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7687,7 +7687,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7769,7 +7769,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7851,7 +7851,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -7933,7 +7933,7 @@
                 "port": 8277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8014,7 +8014,7 @@
                 "port": 8279
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8098,7 +8098,7 @@
                 "port": 1275
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8177,7 +8177,7 @@
                 "port": 1190
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8261,7 +8261,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8341,7 +8341,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -8430,7 +8430,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8510,7 +8510,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -8594,7 +8594,7 @@
                 "port": 8280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8678,7 +8678,7 @@
                 "port": 1276
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8757,7 +8757,7 @@
                 "port": 8281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8841,7 +8841,7 @@
                 "port": 1277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -8921,7 +8921,7 @@
                 "port": 1276
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9006,7 +9006,7 @@
                 "port": 8282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9090,7 +9090,7 @@
                 "port": 1278
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9170,7 +9170,7 @@
                 "port": 1277
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9255,7 +9255,7 @@
                 "port": 8283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9339,7 +9339,7 @@
                 "port": 1279
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9419,7 +9419,7 @@
                 "port": 1278
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9505,7 +9505,7 @@
                 "port": 1279
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9590,7 +9590,7 @@
                 "port": 8284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9674,7 +9674,7 @@
                 "port": 1280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9754,7 +9754,7 @@
                 "port": 1280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -9839,7 +9839,7 @@
                 "port": 8285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -9923,7 +9923,7 @@
                 "port": 1281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10002,7 +10002,7 @@
                 "port": 8286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10086,7 +10086,7 @@
                 "port": 1282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10165,7 +10165,7 @@
                 "port": 8287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10249,7 +10249,7 @@
                 "port": 1283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10328,7 +10328,7 @@
                 "port": 8288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10412,7 +10412,7 @@
                 "port": 1284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10492,7 +10492,7 @@
                 "port": 1281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10578,7 +10578,7 @@
                 "port": 1282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10664,7 +10664,7 @@
                 "port": 1283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -10749,7 +10749,7 @@
                 "port": 8289
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10833,7 +10833,7 @@
                 "port": 1285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10912,7 +10912,7 @@
                 "port": 8290
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -10996,7 +10996,7 @@
                 "port": 1286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11076,7 +11076,7 @@
                 "port": 1284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11161,7 +11161,7 @@
                 "port": 8291
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11245,7 +11245,7 @@
                 "port": 1287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11325,7 +11325,7 @@
                 "port": 1285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11411,7 +11411,7 @@
                 "port": 1286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11501,7 +11501,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11580,7 +11580,7 @@
                 "port": 8292
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11664,7 +11664,7 @@
                 "port": 1288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11744,7 +11744,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11833,7 +11833,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -11913,7 +11913,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -11997,7 +11997,7 @@
                 "port": 8293
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12081,7 +12081,7 @@
                 "port": 1289
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12161,7 +12161,7 @@
                 "port": 1288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12247,7 +12247,7 @@
                 "port": 1287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12337,7 +12337,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12417,7 +12417,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12501,7 +12501,7 @@
                 "port": 8294
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12585,7 +12585,7 @@
                 "port": 1290
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12665,7 +12665,7 @@
                 "port": 68
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12749,7 +12749,7 @@
                 "port": 8276
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -12837,7 +12837,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -12921,7 +12921,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13001,7 +13001,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13090,7 +13090,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13170,7 +13170,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13255,7 +13255,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13344,7 +13344,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13424,7 +13424,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13508,7 +13508,7 @@
                 "port": 8295
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13592,7 +13592,7 @@
                 "port": 1291
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13676,7 +13676,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13756,7 +13756,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -13840,7 +13840,7 @@
                 "port": 8296
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -13924,7 +13924,7 @@
                 "port": 1292
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14003,7 +14003,7 @@
                 "port": 8297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14087,7 +14087,7 @@
                 "port": 1293
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14166,7 +14166,7 @@
                 "port": 8298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14250,7 +14250,7 @@
                 "port": 1294
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14330,7 +14330,7 @@
                 "port": 1293
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14415,7 +14415,7 @@
                 "port": 8299
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14499,7 +14499,7 @@
                 "port": 1295
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14578,7 +14578,7 @@
                 "port": 8300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14662,7 +14662,7 @@
                 "port": 1296
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -14742,7 +14742,7 @@
                 "port": 1294
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14828,7 +14828,7 @@
                 "port": 1295
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14914,7 +14914,7 @@
                 "port": 1296
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -14999,7 +14999,7 @@
                 "port": 8301
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15083,7 +15083,7 @@
                 "port": 1297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15162,7 +15162,7 @@
                 "port": 8302
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15246,7 +15246,7 @@
                 "port": 1298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15330,7 +15330,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15410,7 +15410,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15495,7 +15495,7 @@
                 "port": 1297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15580,7 +15580,7 @@
                 "port": 8303
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15664,7 +15664,7 @@
                 "port": 1299
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15743,7 +15743,7 @@
                 "port": 8304
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15827,7 +15827,7 @@
                 "port": 1300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -15907,7 +15907,7 @@
                 "port": 1298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -15993,7 +15993,7 @@
                 "port": 1300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16078,7 +16078,7 @@
                 "port": 8305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16162,7 +16162,7 @@
                 "port": 1301
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16241,7 +16241,7 @@
                 "port": 8306
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16325,7 +16325,7 @@
                 "port": 1302
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -16404,7 +16404,7 @@
                 "port": 8280
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16487,7 +16487,7 @@
                 "port": 8281
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16570,7 +16570,7 @@
                 "port": 8282
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16653,7 +16653,7 @@
                 "port": 8283
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16736,7 +16736,7 @@
                 "port": 8284
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16819,7 +16819,7 @@
                 "port": 8285
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16902,7 +16902,7 @@
                 "port": 8286
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -16985,7 +16985,7 @@
                 "port": 8287
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17068,7 +17068,7 @@
                 "port": 8288
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17151,7 +17151,7 @@
                 "port": 8289
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17234,7 +17234,7 @@
                 "port": 8290
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17317,7 +17317,7 @@
                 "port": 8291
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17400,7 +17400,7 @@
                 "port": 8292
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17483,7 +17483,7 @@
                 "port": 8297
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17566,7 +17566,7 @@
                 "port": 8298
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17649,7 +17649,7 @@
                 "port": 8308
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -17733,7 +17733,7 @@
                 "port": 1304
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -17812,7 +17812,7 @@
                 "port": 8299
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17895,7 +17895,7 @@
                 "port": 8300
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -17983,7 +17983,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18067,7 +18067,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18147,7 +18147,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18232,7 +18232,7 @@
                 "port": 56132
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18316,7 +18316,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18400,7 +18400,7 @@
                 "port": 1305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -18479,7 +18479,7 @@
                 "port": 8301
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18562,7 +18562,7 @@
                 "port": 8302
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18645,7 +18645,7 @@
                 "port": 8303
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18728,7 +18728,7 @@
                 "port": 8304
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18811,7 +18811,7 @@
                 "port": 8305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18894,7 +18894,7 @@
                 "port": 8306
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -18977,7 +18977,7 @@
                 "port": 8307
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -19061,7 +19061,7 @@
                 "port": 1305
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -19147,7 +19147,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19229,7 +19229,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19311,7 +19311,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19392,7 +19392,7 @@
                 "port": 8310
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19476,7 +19476,7 @@
                 "port": 1306
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19556,7 +19556,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19638,7 +19638,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19720,7 +19720,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19802,7 +19802,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19884,7 +19884,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -19966,7 +19966,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20048,7 +20048,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20130,7 +20130,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20212,7 +20212,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20294,7 +20294,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20376,7 +20376,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20458,7 +20458,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20540,7 +20540,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20622,7 +20622,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20704,7 +20704,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20786,7 +20786,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20868,7 +20868,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -20950,7 +20950,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21032,7 +21032,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21114,7 +21114,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21196,7 +21196,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21278,7 +21278,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21360,7 +21360,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21442,7 +21442,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21524,7 +21524,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21606,7 +21606,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21688,7 +21688,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21770,7 +21770,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21852,7 +21852,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -21934,7 +21934,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22016,7 +22016,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22098,7 +22098,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -22180,7 +22180,7 @@
                 "port": 8309
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -68,7 +68,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -214,7 +214,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -358,7 +358,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -505,7 +505,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -650,7 +650,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -794,7 +794,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -941,7 +941,7 @@
                 "response_code": "NXDOMAIN"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1085,7 +1085,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1230,7 +1230,7 @@
                 "response_code": "SERVFAIL"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1376,7 +1376,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1520,7 +1520,7 @@
                 "response_code": "REFUSED"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1656,7 +1656,7 @@
                 "response_code": "SERVFAIL"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1802,7 +1802,7 @@
                 "response_code": "NXDOMAIN"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1947,7 +1947,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2093,7 +2093,7 @@
                 "response_code": "NXDOMAIN"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2239,7 +2239,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2383,7 +2383,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2527,7 +2527,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2671,7 +2671,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2811,7 +2811,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2957,7 +2957,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2019-01-01T01:00:27.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -47,7 +47,7 @@
         {
             "@timestamp": "2019-01-01T01:00:30.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-firepower-management.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-firepower-management.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2019-08-14T13:56:30.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:56:30 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
@@ -40,7 +40,7 @@
         {
             "@timestamp": "2019-08-14T13:57:19.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:57:19 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=Banner, Page View\u0000x0a\u0000x00",
@@ -77,7 +77,7 @@
         {
             "@timestamp": "2019-08-14T13:57:26.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:57:26 ChangeReconciliation.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/ChangeReconciliation.cgi, Page View\u0000x0a\u0000x00",
@@ -114,7 +114,7 @@
         {
             "@timestamp": "2019-08-14T13:57:34.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:57:34 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=IntrusionPolicyPrefs, Page View\u0000x0a\u0000x00",
@@ -151,7 +151,7 @@
         {
             "@timestamp": "2019-08-14T13:57:43.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:57:43 lights_out_mgmt.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /admin/lights_out_mgmt.cgi, Page View\u0000x0a\u0000x00",
@@ -188,7 +188,7 @@
         {
             "@timestamp": "2019-08-14T13:58:02.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:02 mojo_server.pl: siem-management: admin@10.0.255.31, Cloud Services, View url filtering settings\u0000x0a\u0000x00",
@@ -225,7 +225,7 @@
         {
             "@timestamp": "2019-08-14T13:58:02.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:02 mojo_server.pl: siem-management: admin@10.0.255.31, Cloud Services, View amp settings\u0000x0a\u0000x00",
@@ -262,7 +262,7 @@
         {
             "@timestamp": "2019-08-14T13:58:20.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:20 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00",
@@ -299,7 +299,7 @@
         {
             "@timestamp": "2019-08-14T13:58:41.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:41 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management, Page View\u0000x0a\u0000x00",
@@ -336,7 +336,7 @@
         {
             "@timestamp": "2019-08-14T13:58:47.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:47 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Interfaces, Page View\u0000x0a\u0000x00",
@@ -373,7 +373,7 @@
         {
             "@timestamp": "2019-08-14T13:58:52.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:52 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00",
@@ -410,7 +410,7 @@
         {
             "@timestamp": "2019-08-14T13:58:54.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:58:54 mojo_server.pl: siem-management: admin@10.0.255.31, Devices \u003e Device Management \u003e NGFW Device Summary, Page View\u0000x0a\u0000x00",
@@ -447,7 +447,7 @@
         {
             "@timestamp": "2019-08-14T13:59:10.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:59:10 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings, Page View\u0000x0a\u0000x00",
@@ -484,7 +484,7 @@
         {
             "@timestamp": "2019-08-14T13:59:15.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 13:59:15 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -521,7 +521,7 @@
         {
             "@timestamp": "2019-08-14T14:00:37.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
@@ -558,7 +558,7 @@
         {
             "@timestamp": "2019-08-14T14:00:37.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
@@ -595,7 +595,7 @@
         {
             "@timestamp": "2019-08-14T14:00:37.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:00:37 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -632,7 +632,7 @@
         {
             "@timestamp": "2019-08-14T14:01:12.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:12 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Save Policy ftd-policy\u0000x0a\u0000x00",
@@ -669,7 +669,7 @@
         {
             "@timestamp": "2019-08-14T14:01:12.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:12 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Modified: Syslog\u0000x0a\u0000x00",
@@ -706,7 +706,7 @@
         {
             "@timestamp": "2019-08-14T14:01:13.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:13 sfdccsm: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Platform Settings Editor, Page View\u0000x0a\u0000x00",
@@ -743,7 +743,7 @@
         {
             "@timestamp": "2019-08-14T14:01:20.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:20 sfdccsm: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -780,7 +780,7 @@
         {
             "@timestamp": "2019-08-14T14:01:31.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:31 ActionQueueScrape.pl: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -817,7 +817,7 @@
         {
             "@timestamp": "2019-08-14T14:01:31.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:31 ActionQueueScrape.pl: siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Global Configuration Generation\u0000x0a\u0000x00",
@@ -854,7 +854,7 @@
         {
             "@timestamp": "2019-08-14T14:01:35.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:35 ActionQueueScrape.pl: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -891,7 +891,7 @@
         {
             "@timestamp": "2019-08-14T14:01:36.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:36 ActionQueueScrape.pl: siem-management: admin@localhost, Task Queue, Successful task completion : Pre-deploy Device Configuration for siem-ftd\u0000x0a\u0000x00",
@@ -928,7 +928,7 @@
         {
             "@timestamp": "2019-08-14T14:01:55.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:55 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00",
@@ -965,7 +965,7 @@
         {
             "@timestamp": "2019-08-14T14:01:56.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:56 sfdccsm: siem-management: admin@localhost, Task Queue, Policy Deployment to siem-ftd - SUCCESS\u0000x0a\u0000x00",
@@ -1002,7 +1002,7 @@
         {
             "@timestamp": "2019-08-14T14:01:57.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:01:57 sfdccsm: siem-management: csm_processes@Default User IP, Login, Login Success\u0000x0a\u0000x00",
@@ -1039,7 +1039,7 @@
         {
             "@timestamp": "2019-08-14T14:02:03.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:02:03 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Syslog, Page View\u0000x0a\u0000x00",
@@ -1076,7 +1076,7 @@
         {
             "@timestamp": "2019-08-14T14:02:11.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:02:11 index.cgi: siem-management: admin@10.0.255.31, System \u003e Monitoring \u003e Audit, Page View\u0000x0a\u0000x00",
@@ -1113,7 +1113,7 @@
         {
             "@timestamp": "2019-08-14T14:02:19.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:02:19 mojo_server.pl: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration, Page View\u0000x0a\u0000x00",
@@ -1150,7 +1150,7 @@
         {
             "@timestamp": "2019-08-14T14:02:31.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:02:31 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, System \u003e Configuration \u003e Configuration \u003e /platinum/platformSettingEdit.cgi?type=AuditLog, Page View\u0000x0a\u0000x00",
@@ -1187,7 +1187,7 @@
         {
             "@timestamp": "2019-08-14T14:02:38.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14\u003eAug 14 2019 14:02:38 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Local System Configuration, Save Local System Configuration\u0000x0a\u0000x00",
@@ -1223,7 +1223,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "\u003c14.2\u003eAug 14 2019 14:02:38 platformSettingEdit.cgi: siem-management: admin@10.0.255.31, Devices \u003e Platform Settings \u003e Audit Log Settings \u003e  Modified: Send Audit Log to Syslog enabled \u003e Disabled",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-endpoint-profile.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-endpoint-profile.log-expected.json
@@ -47,7 +47,7 @@
                 "manufacturer": "Microsoft"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -173,7 +173,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -299,7 +299,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -425,7 +425,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -551,7 +551,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -677,7 +677,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -806,7 +806,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -935,7 +935,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1064,7 +1064,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1193,7 +1193,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1322,7 +1322,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1451,7 +1451,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1574,7 +1574,7 @@
                 "manufacturer": "Konica"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1697,7 +1697,7 @@
                 "manufacturer": "Android"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1817,7 +1817,7 @@
                 "manufacturer": "Android"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1940,7 +1940,7 @@
                 "manufacturer": "Android"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2063,7 +2063,7 @@
                 "manufacturer": "Android"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2186,7 +2186,7 @@
                 "manufacturer": "Android"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2312,7 +2312,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2438,7 +2438,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2564,7 +2564,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2693,7 +2693,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2819,7 +2819,7 @@
                 "manufacturer": "Apple"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -2939,7 +2939,7 @@
                 "manufacturer": "Apple"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3062,7 +3062,7 @@
                 "manufacturer": "Apple"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3185,7 +3185,7 @@
                 "manufacturer": "Apple"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3311,7 +3311,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3437,7 +3437,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3560,7 +3560,7 @@
                 "manufacturer": "Cisco"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3683,7 +3683,7 @@
                 "manufacturer": "Cisco"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3806,7 +3806,7 @@
                 "manufacturer": "Cisco"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -3932,7 +3932,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4055,7 +4055,7 @@
                 "manufacturer": "Google"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4178,7 +4178,7 @@
                 "manufacturer": "RaspberryPi"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4298,7 +4298,7 @@
                 "manufacturer": "Intel"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4418,7 +4418,7 @@
                 "manufacturer": "HP"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4535,7 +4535,7 @@
                 "port": 631
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4655,7 +4655,7 @@
                 "manufacturer": "Nortel"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4775,7 +4775,7 @@
                 "manufacturer": "Dell"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -4895,7 +4895,7 @@
                 "manufacturer": "ChromeBook"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5021,7 +5021,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5144,7 +5144,7 @@
                 "manufacturer": "American Power Conversion"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5264,7 +5264,7 @@
                 "manufacturer": "Microsoft"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5390,7 +5390,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5513,7 +5513,7 @@
                 "manufacturer": "RICOH"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -5633,7 +5633,7 @@
                 "port": 631
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -12,7 +12,7 @@
                 "ip": "192.168.0.38"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "created",
@@ -81,7 +81,7 @@
                 "ip": "192.168.0.139"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "deleted",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-fix.log-expected.json
@@ -96,8 +96,7 @@
                 "timezone": "UTC",
                 "type": [
                     "info",
-                    "deletion",
-                    "user",
+                    "end",
                     "allowed"
                 ]
             },

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-inbound-outbound.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-inbound-outbound.log-expected.json
@@ -37,7 +37,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -168,7 +168,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -267,7 +267,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -384,7 +384,7 @@
                 "port": 443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-intrusion.log-expected.json
@@ -41,7 +41,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -154,7 +154,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -265,7 +265,7 @@
                 "port": 39114
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -374,7 +374,7 @@
                 "port": 40740
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-no-type-id.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-no-type-id.log-expected.json
@@ -18,7 +18,7 @@
                 "ip": "10.8.12.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -83,7 +83,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -141,7 +141,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -212,7 +212,7 @@
                 "port": 64311
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -27,7 +27,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -105,7 +105,7 @@
                 "ip": "172.24.177.29"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -178,7 +178,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -15,7 +15,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -86,7 +86,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -158,7 +158,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -228,7 +228,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -306,7 +306,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -383,7 +383,7 @@
                 "port": 12834
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -459,7 +459,7 @@
                 "port": 4952
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -527,7 +527,7 @@
                 "port": 25882
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -603,7 +603,7 @@
                 "port": 52925
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -675,7 +675,7 @@
                 "port": 45392
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -752,7 +752,7 @@
                 "port": 4953
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -822,7 +822,7 @@
                 "port": 52925
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -901,7 +901,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -982,7 +982,7 @@
                 "ip": "172.24.177.29"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -1047,7 +1047,7 @@
                 "port": 10879
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1124,7 +1124,7 @@
                 "port": 4954
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1187,7 +1187,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1249,7 +1249,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1320,7 +1320,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1391,7 +1391,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1462,7 +1462,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1533,7 +1533,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1604,7 +1604,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1675,7 +1675,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1746,7 +1746,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1817,7 +1817,7 @@
                 "port": 25
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1888,7 +1888,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -1957,7 +1957,7 @@
                 "port": 137
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2016,7 +2016,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2078,7 +2078,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2149,7 +2149,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2220,7 +2220,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2291,7 +2291,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2362,7 +2362,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2433,7 +2433,7 @@
                 "port": 8111
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2504,7 +2504,7 @@
                 "port": 8111
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2575,7 +2575,7 @@
                 "port": 40443
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2646,7 +2646,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2718,7 +2718,7 @@
                 "port": 2000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2792,7 +2792,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2868,7 +2868,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -2946,7 +2946,7 @@
                 "port": 53
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3028,7 +3028,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3107,7 +3107,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3182,7 +3182,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3264,7 +3264,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3346,7 +3346,7 @@
                 "port": 5678
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3426,7 +3426,7 @@
                 "port": 5679
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3497,7 +3497,7 @@
                 "port": 5679
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3570,7 +3570,7 @@
                 "port": 5000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3652,7 +3652,7 @@
                 "port": 65000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3732,7 +3732,7 @@
                 "port": 65000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -3808,7 +3808,7 @@
                 "port": 1235
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3890,7 +3890,7 @@
                 "port": 500
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "flow-expiration",
@@ -3961,7 +3961,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4025,7 +4025,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4089,7 +4089,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4153,7 +4153,7 @@
                 "ip": "192.168.99.47"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4217,7 +4217,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4281,7 +4281,7 @@
                 "ip": "192.168.99.57"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4345,7 +4345,7 @@
                 "ip": "192.168.1.255"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4409,7 +4409,7 @@
                 "ip": "192.168.1.255"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4476,7 +4476,7 @@
                 "port": 25
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4549,7 +4549,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4617,7 +4617,7 @@
                 "ip": "172.16.1.10"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4687,7 +4687,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4778,7 +4778,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4863,7 +4863,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4930,7 +4930,7 @@
                 "ip": "192.168.2.1"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -4981,7 +4981,7 @@
                 "ip": "192.168.2.32"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5038,7 +5038,7 @@
                 "ip": "192.168.0.19"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5125,7 +5125,7 @@
                 "port": 1433
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "firewall-rule",
@@ -5191,7 +5191,7 @@
                 "ip": "192.168.0.8"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -5245,7 +5245,7 @@
         {
             "@timestamp": "2023-03-03T08:50:32.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logged-in",
@@ -5301,7 +5301,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logon-failed",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-connection.log-expected.json
@@ -42,7 +42,7 @@
                 "packets": 0
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -157,7 +157,7 @@
                 "packets": 1
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -299,7 +299,7 @@
                 "response_code": "NOERROR"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -439,7 +439,7 @@
                 "response_code": "NXDOMAIN"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -568,7 +568,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -701,7 +701,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -848,7 +848,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -980,7 +980,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1111,7 +1111,7 @@
                 "packets": 0
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",
@@ -1232,7 +1232,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1377,7 +1377,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1498,7 +1498,7 @@
                 "port": 7680
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1610,7 +1610,7 @@
                 "port": 8193
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",
@@ -1727,7 +1727,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "intrusion-detected",
@@ -1847,7 +1847,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-started",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-file-malware.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-file-malware.log-expected.json
@@ -31,7 +31,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -130,7 +130,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -229,7 +229,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -328,7 +328,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -431,7 +431,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -541,7 +541,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file-detected",
@@ -655,7 +655,7 @@
                 "port": 8000
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",
@@ -780,7 +780,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",
@@ -893,7 +893,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",
@@ -1018,7 +1018,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",
@@ -1146,7 +1146,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "malware-detected",

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-security-malware-site.log-expected.json
@@ -64,7 +64,7 @@
                 "port": 80
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "connection-finished",

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
       ignore_missing: true
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   #
   # Parse the syslog header
   #

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2167,30 +2167,29 @@ processors:
             - network
           type:
             - info
-            - change
         error:
           kind: event
           outcome: failure
           category:
             - network
           type:
-            - error
+            - info
+            - end
         deleted:
           kind: event
           category:
             - network
           type:
             - info
-            - deletion
-            - user
+            - end
         creation:
           kind: event
           category:
             - network
           type:
             - info
-            - creation
-            - user
+            - connection
+            - start
       source: >-
         if (ctx?.event?.action == null || !params.containsKey(ctx.event.action)) {
           return;

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: cisco_ftd
 title: Cisco FTD
-version: "2.16.0"
+version: "2.17.0"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the cisco_ftd integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
