### PR TITLE
Update cloud_defend codeowners to new team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@
 /packages/cisco_umbrella @elastic/security-external-integrations
 /packages/citrix_adc @elastic/obs-infraobs-integrations
 /packages/citrix_waf @elastic/security-external-integrations
-/packages/cloud_defend @elastic/sec-cloudnative-integrations
+/packages/cloud_defend @elastic/sec-linux-platform
 /packages/cloud_security_posture @elastic/cloud-security-posture
 /packages/cloudflare @elastic/security-external-integrations
 /packages/cloudflare_logpush @elastic/security-external-integrations

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -59,4 +59,4 @@ policy_templates:
                     actions: [alert]
 owner:
   type: elastic
-  github: elastic/sec-cloudnative-integrations
+  github: elastic/sec-linux-platform


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

The github team responsible for cloud-defend has changed, update to the new team name in CODEOWNERS.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #7784 


