### PR TITLE
[ECS] Updating cyberarkpas to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/cyberarkpas/_dev/build/build.yml
+++ b/packages/cyberarkpas/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.16.0"
+  changes:
+    - description: Update package to ECS 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "2.15.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-105-add-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-105-add-file-category.log-expected.json
@@ -25,7 +25,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",
@@ -87,7 +87,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",
@@ -154,7 +154,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",
@@ -222,7 +222,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",
@@ -289,7 +289,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",
@@ -357,7 +357,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add file category",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-106-update-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-106-update-file-category.log-expected.json
@@ -25,7 +25,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",
@@ -87,7 +87,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",
@@ -154,7 +154,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",
@@ -222,7 +222,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",
@@ -290,7 +290,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",
@@ -358,7 +358,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update file category",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-107-delete-file-category.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-107-delete-file-category.log-expected.json
@@ -26,7 +26,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file category",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-124-rename-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-124-rename-file.log-expected.json
@@ -24,7 +24,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "rename file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-125-rename-file-cont.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-125-rename-file-cont.log-expected.json
@@ -24,7 +24,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "rename file (cont.)",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-126-unlock-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-126-unlock-file.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "unlock file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-130-cpm-disable-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-130-cpm-disable-password.log-expected.json
@@ -43,7 +43,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm disable password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-178-get-user-s-details.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-178-get-user-s-details.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "get user's details",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-180-add-user.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-180-add-user.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -95,7 +95,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -173,7 +173,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -251,7 +251,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -329,7 +329,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -407,7 +407,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -485,7 +485,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -564,7 +564,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -643,7 +643,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -722,7 +722,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -801,7 +801,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",
@@ -880,7 +880,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add user",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-181-update-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-181-update-safe.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update safe",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-185-add-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-185-add-safe.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add safe",
@@ -80,7 +80,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add safe",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-187-add-folder.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-187-add-folder.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add folder",
@@ -85,7 +85,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add folder",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-19-full-gateway-connection.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-19-full-gateway-connection.log-expected.json
@@ -25,7 +25,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -107,7 +107,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -198,7 +198,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -289,7 +289,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -370,7 +370,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -462,7 +462,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -554,7 +554,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -637,7 +637,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",
@@ -738,7 +738,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "full gateway connection",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-20-partial-gateway-connection.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-20-partial-gateway-connection.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "partial gateway connection",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-202-old-backup-files-deletion-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-202-old-backup-files-deletion-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "old backup files deletion start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-203-old-backup-files-deletion-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-203-old-backup-files-deletion-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "old backup files deletion end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-22-cpm-verify-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-22-cpm-verify-password.log-expected.json
@@ -44,7 +44,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password",
@@ -150,7 +150,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-23-action-on-closed-safe.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-23-action-on-closed-safe.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "action on closed safe",
@@ -83,7 +83,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "action on closed safe",
@@ -140,7 +140,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "action on closed safe",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-24-cpm-change-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-24-cpm-change-password.log-expected.json
@@ -42,7 +42,7 @@
                 "domain": "radiussrv.cyberark.local"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm change password",
@@ -136,7 +136,7 @@
                 "domain": "components"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm change password",
@@ -239,7 +239,7 @@
                 "domain": "components"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm change password",
@@ -343,7 +343,7 @@
                 "domain": "components"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm change password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-259-add-update-group.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-259-add-update-group.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add/update group",
@@ -79,7 +79,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add/update group",
@@ -141,7 +141,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add/update group",
@@ -203,7 +203,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add/update group",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-265-add-group-member.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-265-add-group-member.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -81,7 +81,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -144,7 +144,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -207,7 +207,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -270,7 +270,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -333,7 +333,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -396,7 +396,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -459,7 +459,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -522,7 +522,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -586,7 +586,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -650,7 +650,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -714,7 +714,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -778,7 +778,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",
@@ -842,7 +842,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add group member",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-266-remove-group-member.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-266-remove-group-member.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "remove group member",
@@ -81,7 +81,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "remove group member",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-273-remove-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-273-remove-owner.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "remove owner",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-278-add-rule.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-278-add-rule.log-expected.json
@@ -21,7 +21,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add rule",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-288-auto-clear-users-history-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-288-auto-clear-users-history-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear users history start",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear users history start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-289-auto-clear-users-history-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-289-auto-clear-users-history-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear users history end",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear users history end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-290-auto-clear-safes-history-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-290-auto-clear-safes-history-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear safes history start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-291-auto-clear-safes-history-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-291-auto-clear-safes-history-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "auto clear safes history end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-294-store-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-294-store-password.log-expected.json
@@ -28,7 +28,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -90,7 +90,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -172,7 +172,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -239,7 +239,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -296,7 +296,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -362,7 +362,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -449,7 +449,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -517,7 +517,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -596,7 +596,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",
@@ -674,7 +674,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-295-retrieve-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-295-retrieve-password.log-expected.json
@@ -36,12 +36,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -51,7 +52,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -134,12 +135,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -149,7 +151,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -219,12 +221,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -234,7 +237,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -324,12 +327,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -339,7 +343,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -410,12 +414,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -425,7 +430,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -510,12 +515,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -525,7 +531,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -600,12 +606,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -615,7 +622,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -694,12 +701,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -709,7 +717,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -803,12 +811,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -818,7 +827,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -889,12 +898,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -904,7 +914,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -979,12 +989,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -994,7 +1005,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -1073,12 +1084,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -1087,7 +1099,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -1169,12 +1181,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "295",
                 "kind": "event",
@@ -1184,7 +1197,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-300-psm-connect.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-300-psm-connect.log-expected.json
@@ -47,7 +47,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -153,7 +153,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -270,7 +270,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -387,7 +387,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -504,7 +504,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -621,7 +621,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -738,7 +738,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -861,7 +861,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -992,7 +992,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1121,7 +1121,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1250,7 +1250,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1379,7 +1379,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1504,7 +1504,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1629,7 +1629,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1763,7 +1763,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -1897,7 +1897,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",
@@ -2031,7 +2031,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm connect",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-302-psm-disconnect.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-302-psm-disconnect.log-expected.json
@@ -48,7 +48,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -156,7 +156,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -275,7 +275,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -394,7 +394,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -513,7 +513,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -632,7 +632,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -751,7 +751,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -876,7 +876,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1009,7 +1009,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1140,7 +1140,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1271,7 +1271,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1402,7 +1402,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1529,7 +1529,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1656,7 +1656,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1792,7 +1792,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",
@@ -1928,7 +1928,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm disconnect",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-304-psm-upload-recording.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-304-psm-upload-recording.log-expected.json
@@ -31,7 +31,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "psm upload recording",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-308-use-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-308-use-password.log-expected.json
@@ -42,12 +42,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -57,7 +58,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -137,12 +138,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -151,7 +153,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -244,12 +246,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -258,7 +261,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -351,12 +354,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -365,7 +369,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -458,12 +462,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -472,7 +477,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -565,12 +570,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -579,7 +585,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -672,12 +678,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -686,7 +693,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -784,12 +791,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -798,7 +806,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -902,12 +910,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -916,7 +925,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -1025,12 +1034,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -1039,7 +1049,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -1148,12 +1158,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "use password",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "308",
                 "kind": "event",
@@ -1162,7 +1173,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-309-undefined-user-logon.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-309-undefined-user-logon.log-expected.json
@@ -21,7 +21,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -34,7 +34,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {
@@ -95,7 +95,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -108,7 +108,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {
@@ -165,7 +165,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -178,7 +178,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {
@@ -254,7 +254,7 @@
                 "ip": "67.43.156.13"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -267,7 +267,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {
@@ -338,7 +338,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -351,7 +351,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-31-cpm-reconcile-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-31-cpm-reconcile-password.log-expected.json
@@ -44,7 +44,7 @@
                 "domain": "dbserver.cyberark.local"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-310-monitor-dr-replication-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-310-monitor-dr-replication-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor dr replication start",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor dr replication start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-311-monitor-dr-replication-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-311-monitor-dr-replication-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor dr replication end",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor dr replication end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-316-reset-user-password-detailed-information.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-316-reset-user-password-detailed-information.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "reset user password detailed information",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-317-reset-user-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-317-reset-user-password.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "reset user password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-32-add-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-32-add-owner.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -99,7 +99,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -179,7 +179,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -260,7 +260,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -341,7 +341,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -422,7 +422,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -503,7 +503,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -584,7 +584,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -665,7 +665,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -746,7 +746,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -827,7 +827,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -908,7 +908,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -989,7 +989,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -1070,7 +1070,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -1151,7 +1151,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",
@@ -1232,7 +1232,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "add owner",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-326-cpm-auto-detection-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-326-cpm-auto-detection-start.log-expected.json
@@ -25,7 +25,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm auto-detection start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-327-cpm-auto-detection-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-327-cpm-auto-detection-end.log-expected.json
@@ -25,7 +25,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm auto-detection end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-33-update-owner.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-33-update-owner.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -99,7 +99,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -180,7 +180,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -261,7 +261,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -342,7 +342,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -423,7 +423,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",
@@ -505,7 +505,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update owner",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-355-monitor-license-expiration-date-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-355-monitor-license-expiration-date-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor license expiration date start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-356-monitor-license-expiration-date-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-356-monitor-license-expiration-date-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor license expiration date end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-357-monitor-fw-rules-start.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-357-monitor-fw-rules-start.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor fw rules start",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor fw rules start",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-358-monitor-fw-rules-end.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-358-monitor-fw-rules-end.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor fw rules end",
@@ -66,7 +66,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "monitor fw rules end",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-359-sql-command.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-359-sql-command.log-expected.json
@@ -58,7 +58,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -176,7 +176,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -294,7 +294,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -412,7 +412,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -530,7 +530,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -648,7 +648,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -766,7 +766,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -884,7 +884,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -1002,7 +1002,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",
@@ -1120,7 +1120,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "sql command",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-361-keystroke-logging.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-361-keystroke-logging.log-expected.json
@@ -50,7 +50,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -164,7 +164,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -295,7 +295,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -426,7 +426,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -557,7 +557,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -693,7 +693,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",
@@ -829,7 +829,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-38-cpm-verify-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-38-cpm-verify-password-failed.log-expected.json
@@ -57,7 +57,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -71,7 +71,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -176,7 +177,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -190,7 +191,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The network name cannot be found. (winRc=67). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -294,7 +296,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -308,7 +310,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC.local\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -413,7 +416,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -427,7 +430,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC.local\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -532,7 +536,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -546,7 +550,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC.local\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -640,7 +645,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -654,7 +659,8 @@
                 "reason": "Error when verifypass to User root on Server 10.0.1.20. State: IM002 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -749,7 +755,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -763,7 +769,8 @@
                 "reason": "Error when verifypass to User root on Server . State: IM014 Native error: 0 Message: [Microsoft][ODBC Driver Manager] The specified DSN contains an architecture mismatch between the Driver and Application",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -858,7 +865,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -872,7 +879,8 @@
                 "reason": "Error when verifypass to User root on Server . State: HY090 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Invalid string or buffer length",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -967,7 +975,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -981,7 +989,8 @@
                 "reason": "Error when verifypass to User root on Server . State: HY090 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Invalid string or buffer length",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1076,7 +1085,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1090,7 +1099,8 @@
                 "reason": "Error when verifypass to User root on Server 127.0.0.1. State: IM002 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1188,7 +1198,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1202,7 +1212,8 @@
                 "reason": "Error when verifypass to User root on Server . State: IM002 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1300,7 +1311,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1314,7 +1325,8 @@
                 "reason": "Error when verifypass to User root on Server . State: HY090 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Invalid string or buffer length",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1412,7 +1424,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1426,7 +1438,8 @@
                 "reason": "Error when verifypass to User root on Server . State: IM002 Native error: 0 Message: [Microsoft][ODBC Driver Manager] Data source name not found and no default driver specified",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1527,7 +1540,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1541,7 +1554,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC.local\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {
@@ -1646,7 +1660,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify password failed",
@@ -1660,7 +1674,8 @@
                 "reason": "Error in verifypass to user 67.43.156.15\\ELASTIC.local\\bart on domain 67.43.156.15(\\\\67.43.156.15). Reason: The specified username is invalid. (winRc=2202). ",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "admin",
+                    "info"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-385-blservice-audit-record.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-385-blservice-audit-record.log-expected.json
@@ -23,7 +23,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "blservice audit record",
@@ -86,7 +86,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "blservice audit record",
@@ -149,7 +149,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "blservice audit record",
@@ -212,7 +212,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "blservice audit record",
@@ -275,7 +275,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "blservice audit record",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-4-user-authentication.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-4-user-authentication.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -29,7 +29,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {
@@ -96,7 +96,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_failure",
@@ -109,7 +109,7 @@
                 "outcome": "failure",
                 "severity": 7,
                 "type": [
-                    "error"
+                    "start"
                 ]
             },
             "host": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-411-window-title.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-411-window-title.log-expected.json
@@ -56,7 +56,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "window title",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-412-keystroke-logging.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-412-keystroke-logging.log-expected.json
@@ -57,7 +57,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "keystroke logging",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-414-cpm-verify-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-414-cpm-verify-ssh-key.log-expected.json
@@ -53,7 +53,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm verify ssh key",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-427-store-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-427-store-ssh-key.log-expected.json
@@ -24,7 +24,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store ssh key",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-428-retrieve-ssh-key.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-428-retrieve-ssh-key.log-expected.json
@@ -53,12 +53,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve ssh key",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "428",
                 "kind": "event",
@@ -68,7 +69,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -172,12 +173,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve ssh key",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "428",
                 "kind": "event",
@@ -187,7 +189,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {
@@ -287,12 +289,13 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve ssh key",
                 "category": [
-                    "iam"
+                    "iam",
+                    "authentication"
                 ],
                 "code": "428",
                 "kind": "event",
@@ -302,7 +305,7 @@
                 "severity": 2,
                 "type": [
                     "admin",
-                    "access"
+                    "start"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-449-create-discovery-succeeded.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-449-create-discovery-succeeded.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create discovery succeeded",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-459-general-audit.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-459-general-audit.log-expected.json
@@ -42,7 +42,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "general audit",
@@ -123,7 +123,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "general audit",
@@ -205,7 +205,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "general audit",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-467-the-component-public-key-for-jwt-authentication-was-updated.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-467-the-component-public-key-for-jwt-authentication-was-updated.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "the component public key for jwt authentication was updated",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-479-security-warning-the-signature-hash-algorithm-of-the-vault-certificate-is-sha1.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-479-security-warning-the-signature-hash-algorithm-of-the-vault-certificate-is-sha1.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "security warning - the signature hash algorithm of the vault certificate is sha1.",
@@ -69,7 +69,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "security warning - the signature hash algorithm of the vault certificate is sha1.",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-482-update-existing-add-account-bulk-operation-succeeded.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-482-update-existing-add-account-bulk-operation-succeeded.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update existing add account bulk operation succeeded",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-50-store-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-50-store-file.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",
@@ -75,7 +75,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",
@@ -141,7 +141,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",
@@ -198,7 +198,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",
@@ -265,7 +265,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",
@@ -337,7 +337,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "store file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-51-retrieve-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-51-retrieve-file.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve file",
@@ -75,7 +75,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve file",
@@ -137,7 +137,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-52-delete-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-52-delete-file.log-expected.json
@@ -31,7 +31,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -106,7 +106,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -167,7 +167,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -225,7 +225,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -301,7 +301,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -372,7 +372,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -445,7 +445,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -518,7 +518,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -595,7 +595,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",
@@ -672,7 +672,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "delete file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-57-cpm-change-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-57-cpm-change-password-failed.log-expected.json
@@ -54,7 +54,7 @@
                 "domain": "rhel7.cybr.com"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm change password failed",
@@ -69,8 +69,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-59-clear-safe-history.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-59-clear-safe-history.log-expected.json
@@ -17,7 +17,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "clear safe history",
@@ -68,7 +68,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "clear safe history",
@@ -116,7 +116,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "clear safe history",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-60-cpm-reconcile-password-failed.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-60-cpm-reconcile-password-failed.log-expected.json
@@ -54,7 +54,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -69,8 +69,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -172,7 +171,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -187,8 +186,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -288,7 +286,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -303,8 +301,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -406,7 +403,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -421,8 +418,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -524,7 +520,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -539,8 +535,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -641,7 +636,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -656,8 +651,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -760,7 +754,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -775,8 +769,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -877,7 +870,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -892,8 +885,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {
@@ -997,7 +989,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "cpm reconcile password failed",
@@ -1012,8 +1004,7 @@
                 "severity": 7,
                 "type": [
                     "user",
-                    "change",
-                    "error"
+                    "change"
                 ]
             },
             "file": {

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-62-create-file-version.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-62-create-file-version.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -84,7 +84,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -150,7 +150,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -216,7 +216,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -283,7 +283,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -341,7 +341,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -413,7 +413,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",
@@ -474,7 +474,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "create file version",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-7-logon.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-7-logon.log-expected.json
@@ -21,7 +21,7 @@
                 "ip": "10.2.0.3"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -82,7 +82,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -148,7 +148,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -214,7 +214,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -280,7 +280,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -346,7 +346,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -417,7 +417,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -492,7 +492,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -576,7 +576,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -655,7 +655,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -730,7 +730,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -805,7 +805,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-8-logoff.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-8-logoff.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -82,7 +82,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -148,7 +148,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -214,7 +214,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -280,7 +280,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -346,7 +346,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -412,7 +412,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -487,7 +487,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -562,7 +562,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -637,7 +637,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -727,7 +727,7 @@
                 "ip": "67.43.156.13"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -812,7 +812,7 @@
                 "ip": "67.43.156.13"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -883,7 +883,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -959,7 +959,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",
@@ -1049,7 +1049,7 @@
                 "ip": "67.43.156.15"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "logoff",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-88-set-password.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-88-set-password.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -68,7 +68,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -118,7 +118,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -165,7 +165,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -217,7 +217,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -269,7 +269,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -330,7 +330,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -391,7 +391,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -452,7 +452,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -513,7 +513,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -574,7 +574,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -635,7 +635,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -697,7 +697,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -759,7 +759,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -821,7 +821,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -883,7 +883,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -945,7 +945,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",
@@ -1007,7 +1007,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "set password",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-98-open-file-write-only.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-98-open-file-write-only.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "open file (write only)",
@@ -75,7 +75,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "open file (write only)",
@@ -141,7 +141,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "open file (write only)",
@@ -213,7 +213,7 @@
                 "ip": "10.0.1.20"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "open file (write only)",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-99-open-file.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-99-open-file.log-expected.json
@@ -18,7 +18,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "open file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-legacysyslog.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-legacysyslog.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve file",

--- a/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-rfc5424syslog.log-expected.json
+++ b/packages/cyberarkpas/data_stream/audit/_dev/test/pipeline/test-rfc5424syslog.log-expected.json
@@ -16,7 +16,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -82,7 +82,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",
@@ -150,7 +150,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "retrieve file",
@@ -205,7 +205,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "authentication_success",

--- a/packages/cyberarkpas/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cyberarkpas/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
   #
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
 
   #
   # Set event.original from message, unless reindexing.
@@ -426,7 +426,7 @@ processors:
           - set: event.category
             value: ["authentication"]
           - set: event.type
-            value: ["error"]
+            value: ["start"]
           - set: event.action
             value:  "authentication_failure"
           - set: event.outcome
@@ -583,7 +583,7 @@ processors:
           - set: event.category
             value: ["iam"]
           - set: event.type
-            value: ["error"]
+            value: ["admin", "info"]
 
         # 50 - Store File
         #
@@ -606,7 +606,7 @@ processors:
           - set: event.category
             value: ["iam"]
           - set: event.type
-            value: ["user", "change", "error"]
+            value: ["user", "change"]
           - set: event.reason
             from: cyberarkpas.audit.ca_properties.cpm_error_details
 
@@ -623,7 +623,7 @@ processors:
           - set: event.category
             value: ["iam"]
           - set: event.type
-            value: ["user", "change", "error"]
+            value: ["user", "change"]
           - set: event.reason
             from: cyberarkpas.audit.ca_properties.cpm_error_details
 
@@ -721,9 +721,9 @@ processors:
           - set: user.name
             from: cyberarkpas.audit.issuer
           - set: event.category
-            value: ["iam"]
+            value: ["iam", "authentication"]
           - set: event.type
-            value: ["admin", "access"]
+            value: ["admin", "start"]
           - set: event.outcome
             value: "success"
           - set: event.reason
@@ -784,9 +784,9 @@ processors:
           - set: user.name
             from: cyberarkpas.audit.issuer
           - set: event.category
-            value: ["iam"]
+            value: ["iam", "authentication"]
           - set: event.type
-            value: ["admin", "access"]
+            value: ["admin", "start"]
           - set: event.outcome
             from: cyberarkpas.audit.ca_properties.cpm_status
           - set: event.reason
@@ -800,7 +800,7 @@ processors:
           - set: event.category
             value: ["authentication"]
           - set: event.type
-            value: ["error"]
+            value: ["start"]
           - set: event.action
             value:  "authentication_failure"
           - set: event.outcome
@@ -919,9 +919,9 @@ processors:
           - set: user.name
             from: cyberarkpas.audit.issuer
           - set: event.category
-            value: ["iam"]
+            value: ["iam", "authentication"]
           - set: event.type
-            value: ["admin", "access"]
+            value: ["admin", "start"]
           - set: event.outcome
             value: "success"
           - set: event.reason

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,6 +1,6 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: "2.15.0"
+version: "2.16.0"
 description: Collect logs from CyberArk Privileged Access Security with Elastic Agent.
 type: integration
 format_version: 2.11.0


### PR DESCRIPTION
## What does this PR do?

- Updates the cyberarkpas integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
