### PR TITLE
[ECS] Updating keycloak to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/keycloak/_dev/build/build.yml
+++ b/packages/keycloak/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7928
 - version: "1.13.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.14.0"
   changes:
-    - description: Update package to ECS 8.10.0.
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1234
 - version: "1.13.0"

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Update package to ECS 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.13.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2021-10-22T21:01:42.548-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:42,548 INFO  [org.keycloak.services] (ServerService Thread Pool -- 64) KC-SERVICES0009: Added user 'admin' to realm 'master'",
@@ -26,7 +26,7 @@
         {
             "@timestamp": "2021-10-22T21:01:42.667-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:42,667 INFO  [org.jboss.resteasy.resteasy_jaxrs.i18n] (ServerService Thread Pool -- 64) RESTEASY002220: Adding singleton resource org.keycloak.services.resources.admin.AdminRoot from Application class org.keycloak.services.resources.KeycloakApplication",
@@ -49,7 +49,7 @@
         {
             "@timestamp": "2021-10-22T21:01:42.912-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:42,912 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 64) WFLYUT002021-10-22 21: Registered web context: '/auth' for server 'default-server'       ",
@@ -72,7 +72,7 @@
         {
             "@timestamp": "2021-10-22T21:01:43.208-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:43,208 INFO  [org.jboss.as.server] (ServerService Thread Pool -- 46) WFLYSRV0010: Deployed \"keycloak-server.war\" (runtime-name : \"keycloak-server.war\")       ",
@@ -95,7 +95,7 @@
         {
             "@timestamp": "2021-10-22T21:01:43.299-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:43,299 INFO  [org.jboss.as.server] (Controller Boot Thread) WFLYSRV0212: Resuming server",
@@ -118,7 +118,7 @@
         {
             "@timestamp": "2021-10-22T21:01:43.307-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:43,307 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: Keycloak 15.0.2 (WildFly Core 15.0.1.Final) started in 28315ms - Started 692 of 977 services (686 services are lazy, passive or on-demand)",
@@ -141,7 +141,7 @@
         {
             "@timestamp": "2021-10-22T21:01:43.327-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:43,327 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0060: Http management interface listening on http://127.0.0.1:9990/management",
@@ -164,7 +164,7 @@
         {
             "@timestamp": "2021-10-22T21:01:43.327-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "original": "2021-10-22 21:01:43,327 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0051: Admin console listening on http://127.0.0.1:9990",
@@ -187,7 +187,7 @@
         {
             "@timestamp": "2021-10-22T21:01:45.403-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN_ERROR",
@@ -199,8 +199,7 @@
                 "original": "2021-10-22 21:01:45,403 WARN  [org.keycloak.events] (default task-1) type=LOGIN_ERROR, realmId=test, clientId=test, userId=null, ipAddress=172.18.0.1, error=invalid_redirect_uri, redirect_uri=http://localhost:8080",
                 "timezone": "America/Chicago",
                 "type": [
-                    "info",
-                    "denied"
+                    "info"
                 ]
             },
             "keycloak": {
@@ -250,7 +249,7 @@
         {
             "@timestamp": "2021-10-22T21:20:42.120-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN_ERROR",
@@ -262,8 +261,7 @@
                 "original": "2021-10-22 21:20:42,120 WARN  [org.keycloak.events] (default task-2) type=LOGIN_ERROR, realmId=test, clientId=test, userId=cc74404c-de7e-482a-98f7-b271ff3c49be, ipAddress=172.18.0.1, error=invalid_user_credentials, auth_method=openid-connect, auth_type=code, redirect_uri=http://127.0.0.1:8080, code_id=3a76b735-e324-42b1-aa15-7c1f69f22eb8, username=admin, authSessionParentId=3a76b735-e324-42b1-aa15-7c1f69f22eb8, authSessionTabId=oJpF-WjDC04",
                 "timezone": "America/Chicago",
                 "type": [
-                    "info",
-                    "denied"
+                    "info"
                 ]
             },
             "keycloak": {
@@ -325,7 +323,7 @@
         {
             "@timestamp": "2021-10-22T21:24:41.076-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN_ERROR",
@@ -337,8 +335,7 @@
                 "original": "2021-10-22 21:24:41,076 WARN  [org.keycloak.events] (default task-10) type=LOGIN_ERROR, realmId=master, clientId=security-admin-console, userId=null, ipAddress=172.18.0.1, error=user_not_found, auth_method=openid-connect, auth_type=code, redirect_uri=http://127.0.0.1:9090/auth/admin/master/console/, code_id=f9d4300d-d052-4eb6-9aeb-e8fcf642a21f, authSessionParentId=f9d4300d-d052-4eb6-9aeb-e8fcf642a21f, authSessionTabId=C8EtUrcFMsg",
                 "timezone": "America/Chicago",
                 "type": [
-                    "info",
-                    "denied"
+                    "info"
                 ]
             },
             "keycloak": {
@@ -394,7 +391,7 @@
         {
             "@timestamp": "2021-10-22T21:31:31.555-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN_ERROR",
@@ -406,8 +403,7 @@
                 "original": "2021-10-22 21:31:31,555 WARN  [org.keycloak.events] (default task-10) type=LOGIN_ERROR, realmId=test, clientId=test, userId=null, ipAddress=172.18.0.1, error=invalid_redirect_uri, redirect_uri=http://localhost:8080",
                 "timezone": "America/Chicago",
                 "type": [
-                    "info",
-                    "denied"
+                    "info"
                 ]
             },
             "keycloak": {
@@ -457,7 +453,7 @@
         {
             "@timestamp": "2021-10-22T20:58:02.700-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN_ERROR",
@@ -469,8 +465,7 @@
                 "original": "2021-10-22 20:58:02,700 WARN  [org.keycloak.events] (default task-18) type=LOGIN_ERROR, realmId=ABCD TEST, clientId=https://www.example.com/shibboleth, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, error=invalid_user_credentials, auth_method=saml, redirect_uri=https://www.example.com/Shibboleth.sso/SAML2/POST, code_id=cbefe0ca-bc11-48b4-b7fa-f1a59d220980, username=admin, authSessionParentId=cbefe0ca-bc11-48b4-b7fa-f1a59d220980, authSessionTabId=97qImXws36A",
                 "timezone": "America/Chicago",
                 "type": [
-                    "info",
-                    "denied"
+                    "info"
                 ]
             },
             "keycloak": {
@@ -532,7 +527,7 @@
         {
             "@timestamp": "2021-10-22T22:11:31.257-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGIN",
@@ -544,8 +539,7 @@
                 "timezone": "America/Chicago",
                 "type": [
                     "info",
-                    "start",
-                    "allowed"
+                    "start"
                 ]
             },
             "keycloak": {
@@ -608,7 +602,7 @@
         {
             "@timestamp": "2021-10-22T22:11:32.131-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CODE_TO_TOKEN",
@@ -666,7 +660,7 @@
         {
             "@timestamp": "2021-10-22T22:12:09.871-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CREATE-USER",
@@ -734,7 +728,7 @@
         {
             "@timestamp": "2021-10-22T22:12:13.599-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "UPDATE-USER",
@@ -802,7 +796,7 @@
         {
             "@timestamp": "2021-10-22T22:14:29.031-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CREATE-GROUP",
@@ -869,7 +863,7 @@
         {
             "@timestamp": "2021-10-22T22:16:12.150-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CREATE-CLIENT_SCOPE",
@@ -933,7 +927,7 @@
         {
             "@timestamp": "2021-10-22T22:45:12.592-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "LOGOUT",
@@ -1001,7 +995,7 @@
         {
             "@timestamp": "2021-10-22T22:46:14.913-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "DELETE-GROUP",
@@ -1068,7 +1062,7 @@
         {
             "@timestamp": "2021-10-22T23:05:03.371-05:00",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "CREATE-GROUP",

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing keycloak logs
 processors:
 - set:
     field: ecs.version
-    value: '8.9.0'
+    value: '8.10.0'
 - rename:
     field: message
     target_field: event.original

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
@@ -146,13 +146,7 @@ processors:
 - append:
     field: event.type
     value:
-      - denied
-    if: ctx.keycloak?.login?.type == 'LOGIN_ERROR' 
-- append:
-    field: event.type
-    value:
       - start
-      - allowed
     if: ctx.keycloak?.login?.type == 'LOGIN' 
 - append:
     field: event.type

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.13.0"
+version: "1.14.0"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: 2.11.0


### PR DESCRIPTION
## What does this PR do?

- Updates the keycloak integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
