### PR TITLE
[ECS] Updating okta to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/okta/_dev/build/build.yml
+++ b/packages/okta/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7291
 - version: "2.0.0"
   changes:
     - description: Added Okta Oauth2 support, refactored the UI accordingly & updated stack version to ^8.10.0.

--- a/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
+++ b/packages/okta/data_stream/system/_dev/test/pipeline/test-okta-system-events.log-expected.json
@@ -20,7 +20,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.end",
@@ -34,7 +34,7 @@
                 "outcome": "success",
                 "type": [
                     "end",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -172,7 +172,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.start",
@@ -186,7 +186,7 @@
                 "outcome": "success",
                 "type": [
                     "start",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -324,7 +324,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "policy.evaluate_sign_on",
@@ -489,7 +489,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.end",
@@ -503,7 +503,7 @@
                 "outcome": "success",
                 "type": [
                     "end",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -641,7 +641,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.start",
@@ -655,7 +655,7 @@
                 "outcome": "success",
                 "type": [
                     "start",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -793,7 +793,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "policy.evaluate_sign_on",
@@ -958,7 +958,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.end",
@@ -972,7 +972,7 @@
                 "outcome": "success",
                 "type": [
                     "end",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -1109,7 +1109,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.start",
@@ -1123,7 +1123,7 @@
                 "outcome": "success",
                 "type": [
                     "start",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -1261,7 +1261,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "policy.evaluate_sign_on",
@@ -1425,7 +1425,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.end",
@@ -1439,7 +1439,7 @@
                 "outcome": "success",
                 "type": [
                     "end",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -1558,7 +1558,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.start",
@@ -1572,7 +1572,7 @@
                 "outcome": "success",
                 "type": [
                     "start",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -1692,7 +1692,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "policy.evaluate_sign_on",
@@ -1846,7 +1846,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.session.start",
@@ -1860,7 +1860,7 @@
                 "outcome": "success",
                 "type": [
                     "start",
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -2035,7 +2035,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.verify",
@@ -2210,7 +2210,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.verify",
@@ -2391,7 +2391,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.auth_via_mfa",
@@ -2569,7 +2569,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.auth_via_mfa",
@@ -2755,7 +2755,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.auth_via_mfa",
@@ -2952,7 +2952,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "group.user_membership.add",
@@ -3115,7 +3115,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "app.user_management",
@@ -3214,7 +3214,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.sso",
@@ -3226,7 +3226,7 @@
                 "original": "{\"actor\":{\"alternateId\":\"test.user@test.com\",\"detailEntry\":null,\"displayName\":\"Test User\",\"id\":\"00uk123456abct7\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"idxabcdefg123zA\",\"interface\":null,\"issuer\":null},\"client\":{},\"debugContext\":{},\"device\":{\"device_integrator\":null,\"disk_encryption_type\":\"ALL_INTERNAL_VOLUMES\",\"id\":\"abcdefghijklmnop\",\"jailbreak\":null,\"managed\":false,\"name\":\"MacBookPro14,2\",\"os_platform\":\"OSX\",\"os_version\":\"12.6.6\",\"registered\":true,\"screen_lock_type\":\"PASSCODE\",\"secure_hardware_present\":true},\"displayMessage\":\"User single sign on to app\",\"eventType\":\"user.authentication.sso\",\"legacyEventType\":\"app.auth.sso\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2023-05-23T19:39:49.513Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Lawn Park\",\"country\":\"United States\",\"geolocation\":{\"lat\":47.8907,\"lon\":-87.7908},\"postalCode\":\"999999\",\"state\":\"California\"},\"ip\":\"192.168.1.10\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":7018,\"asOrg\":\"at\u0026t corp.\",\"domain\":\"sbcglobal.net\",\"isProxy\":false,\"isp\":\"att services inc\"},\"severity\":\"INFO\",\"target\":[{\"alternateId\":\"Wiki\",\"detailEntry\":{\"signOnModeType\":\"SAML_2_0\"},\"displayName\":\"An App Server\",\"id\":\"0o123456abcdef1t7\",\"type\":\"AppInstance\"},{\"alternateId\":\"test.user@test.com\",\"detailEntry\":null,\"displayName\":\"Test User\",\"id\":\"0ustyhdhurhjtdrhh1t7\",\"type\":\"AppUser\"}],\"transaction\":{\"detail\":{},\"id\":\"ZGmw\",\"type\":\"WEB\"},\"uuid\":\"2D6FC3CC-3BFB-4AC1-8259-016CF6A5976C\",\"version\":\"0\"}",
                 "outcome": "success",
                 "type": [
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -3343,7 +3343,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.sso",
@@ -3355,7 +3355,7 @@
                 "original": "{\"actor\":{\"alternateId\":\"test.user@test.com\",\"detailEntry\":null,\"displayName\":\"Test User\",\"id\":\"00uk123456abct7\",\"type\":\"User\"},\"authenticationContext\":{\"authenticationProvider\":null,\"authenticationStep\":0,\"credentialProvider\":null,\"credentialType\":null,\"externalSessionId\":\"idxabcdefg123zA\",\"interface\":null,\"issuer\":null},\"client\":{},\"debugContext\":{},\"device\":{\"device_integrator\":\"{\\\"WSC\\\":{},\\\"CROWDSTRIKE\\\":{}}\",\"disk_encryption_type\":\"ALL_INTERNAL_VOLUMES\",\"id\":\"V9YPwc5tnhWcaLs3\",\"jailbreak\":null,\"managed\":false,\"name\":\"MacBookPro18,2\",\"os_platform\":\"OSX\",\"os_version\":\"13.3.1\",\"registered\":true,\"screen_lock_type\":\"BIOMETRIC\",\"secure_hardware_present\":true},\"displayMessage\":\"User single sign on to app\",\"eventType\":\"user.authentication.sso\",\"legacyEventType\":\"app.auth.sso\",\"outcome\":{\"reason\":null,\"result\":\"SUCCESS\"},\"published\":\"2023-05-23T19:39:49.513Z\",\"request\":{\"ipChain\":[{\"geographicalContext\":{\"city\":\"Lawn Park\",\"country\":\"United States\",\"geolocation\":{\"lat\":47.8907,\"lon\":-87.7908},\"postalCode\":\"999999\",\"state\":\"California\"},\"ip\":\"192.168.1.10\",\"source\":null,\"version\":\"V4\"}]},\"securityContext\":{\"asNumber\":7018,\"asOrg\":\"at\u0026t corp.\",\"domain\":\"sbcglobal.net\",\"isProxy\":false,\"isp\":\"att services inc\"},\"severity\":\"INFO\",\"target\":[{\"alternateId\":\"Wiki\",\"detailEntry\":{\"signOnModeType\":\"SAML_2_0\"},\"displayName\":\"An App Server\",\"id\":\"0o123456abcdef1t7\",\"type\":\"AppInstance\"},{\"alternateId\":\"test.user@test.com\",\"detailEntry\":null,\"displayName\":\"Test User\",\"id\":\"0ustyhdhurhjtdrhh1t7\",\"type\":\"AppUser\"}],\"transaction\":{\"detail\":{},\"id\":\"ZGmw\",\"type\":\"WEB\"},\"uuid\":\"2D6FC3CC-3BFB-4AC1-8259-016CF6A5976C\",\"version\":\"0\"}",
                 "outcome": "success",
                 "type": [
-                    "user"
+                    "info"
                 ]
             },
             "okta": {
@@ -3486,7 +3486,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user.authentication.auth_via_mfa",
@@ -3655,7 +3655,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "device.user.add",

--- a/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/okta/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for Okta system logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   # Keep message as event.original.
   # Warn if event.original has already been set. This is most likely due to logstash ecs_compatibility setting.
   - append:
@@ -116,7 +116,7 @@ processors:
       if: '["group.user_membership.add","group.user_membership.remove"].contains(ctx?.okta?.event_type)'
   - append:
       field: event.type
-      value: user
+      value: info
       if: |
         ["user.lifecycle.activate","user.lifecycle.create",
         "user.lifecycle.deactivate","user.lifecycle.suspend",

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,6 +1,6 @@
 name: okta
 title: Okta
-version: "2.0.0"
+version: "2.1.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
 format_version: 2.9.0


### PR DESCRIPTION
## What does this PR do?

- Updates the okta integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
