### PR TITLE
[GCP] Update null checks anf if checks in the rename

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.29.1"
+  changes:
+    - description: Add null checks and ignore_missing checks to the rename processor
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "2.29.0"
   changes:
     - description: Remove GCP CloudSQL deprecated, alpha or beta metrics and fix field types.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null checks and ignore_missing checks to the rename processor
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7934
 - version: "2.29.0"
   changes:
     - description: Remove GCP CloudSQL deprecated, alpha or beta metrics and fix field types.

--- a/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - json:
       field: event.original
       target_field: json

--- a/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/dns/elasticsearch/ingest_pipeline/default.yml
@@ -8,6 +8,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'      
   - json:
       field: event.original
       target_field: json

--- a/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - json:
       field: event.original
       target_field: json

--- a/packages/gcp/data_stream/loadbalancing_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/loadbalancing_logs/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - json:
       field: event.original
       target_field: json

--- a/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/gcp/data_stream/vpcflow/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - json:
       field: event.original
       target_field: json

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.29.0"
+version: "2.29.1"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
- Bug

## What does this PR do?

This PR adds the if check for event.original and the ignore_missing check for the renaming of message to event.original
The packages where the changes are made are as below:

- loadbalancing_logs
- vpcflow
- firewall
- audit
- dns

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/integrations/issues/7822
