### PR TITLE
[Custom Logs] Implement input parameter exclude_files

### DIFF
--- a/packages/log/agent/input/input.yml.hbs
+++ b/packages/log/agent/input/input.yml.hbs
@@ -3,6 +3,12 @@ paths:
   - {{this}}
 {{/each}}
 
+{{#if exclude_files}}
+exclude_files:
+{{#each exclude_files}}
+  - {{this}}
+{{/each}}
+{{/if}}
 {{#if ignore_older}}
 ignore_older: {{ignore_older}}
 {{/if}}

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose exclude_files option
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/7940
 - version: "2.2.0"
   changes:
     - description: Expose ignore_older option

--- a/packages/log/changelog.yml
+++ b/packages/log/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Expose exclude_files option
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.2.0"
   changes:
     - description: Expose ignore_older option

--- a/packages/log/manifest.yml
+++ b/packages/log/manifest.yml
@@ -4,7 +4,7 @@ title: Custom Logs
 description: >-
   Collect custom logs with Elastic Agent.
 type: input
-version: 2.2.0
+version: 2.3.0
 categories:
   - custom
   - custom_logs
@@ -22,6 +22,13 @@ policy_templates:
         required: true
         title: Log file path
         description: Path to log files to be collected
+        type: text
+        multi: true
+      - name: exclude_files
+        required: false
+        show_user: false
+        title: Exclude files
+        description: Patterns to be ignored
         type: text
         multi: true
       - name: ignore_older


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Expose exclude_files option for the Custom Logs integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. Build package and startup test environment:
```
cd package/log
elastic-package build
elastic-package stack up -v -d
```
2. Add a new "Custom Logs" integration to a policy
3. Verify if the correct logs are collected by the datastream

## Related issues

- Closes #7939 

## Screenshots
![image](https://github.com/elastic/integrations/assets/95880954/866bc753-fe6e-4a1b-a130-0d7d781c5199)

![image](https://github.com/elastic/integrations/assets/95880954/526fc20a-c284-4a7f-833d-e5720f4d449a)
