### PR TITLE
[ECS] Updating proofpoint_tap to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/proofpoint_tap/_dev/build/build.yml
+++ b/packages/proofpoint_tap/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7945
 - version: "1.11.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1234
 - version: "1.11.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/proofpoint_tap/data_stream/clicks_blocked/_dev/test/pipeline/test-clicks-blocked.log-expected.json
+++ b/packages/proofpoint_tap/data_stream/clicks_blocked/_dev/test/pipeline/test-clicks-blocked.log-expected.json
@@ -24,7 +24,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -40,6 +40,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -47,7 +50,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://www.example.com/?name=john\",\"classification\":\"phish\",\"clickTime\":\"2022-03-21T07:52:11.000Z\",\"threatTime\":\"2022-03-18T14:54:20.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36 Edg/99.0.1150.39\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"8760d0fc-1234-1234-1234-2exxfxxxxx1xd\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"123abc@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"x11xxxx1-12f9-111x-x12x-1x1x123456xx\",\"threatID\":\"3xx97xx852c66a7xx761450xxxxxx9f4ffaxxxxxxxxxxxxxxx7a76481xx\",\"threatURL\":\"https://www.example.com/?name=john\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -120,7 +123,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -136,6 +139,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -143,7 +149,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"http://www.example.com/public/download-shares/wwwxxxyyyzzz12345\",\"classification\":\"phish\",\"clickTime\":\"2022-03-30T07:22:52.000Z\",\"threatTime\":\"2022-03-07T01:21:41.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Safari/537.36\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"b80af74a-1234-1234-1234-43xdxxbxxxxx6\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"bd5da771530b11830e6dfd25838b0240@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"bXkXXUrXAXVXWXGXxXrXAXXX-XXXH\",\"threatID\":\"fdxxxxxxxxxxxcc34aff1aefxbx3xx7xb7xfxcxx1xxxxxxxx98780b5xxxexbx5xc32c\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/fdxxxxxxxxa080xxxxxxxxc6bcxxxxxxxxxxxx5aefb37xxxxb5ebxx1234\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -215,7 +221,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -231,6 +237,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -238,7 +247,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://www.example.com/url?q=httpabc12345\",\"classification\":\"spam\",\"clickTime\":\"2022-03-30T07:10:19.000Z\",\"threatTime\":\"2022-03-29T09:27:21.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"85219a90-1234-1234-1234-axx5xx4xxxfxxxx\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"b81458bb9f757994e79a9287b8447622@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"JXXXXaXehXHXzX-XxXhXyXXXXX7\",\"threatID\":\"eaxxxxxxxxxxxx6376xxxxxxxxxxx1cba65xxx9x7xxxxxxxxxxfbbxx4x0\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/eaxxxxxa6597fd3xxxxxxxxx92e4xxxxxxxxxx27c98052fxxxxxxxxxx1234\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -311,7 +320,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -327,6 +336,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -334,7 +346,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://www.example.org/abcdabcd123?query=0\",\"classification\":\"malware\",\"clickTime\":\"2022-03-30T10:11:12.000Z\",\"threatTime\":\"2022-03-21T14:40:31.000Z\",\"userAgent\":\"Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/199.0.427504638 Mobile/15E148 Safari/604.1\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"a5c9f8bb-1234-1234-1234-dxx9xcxxxx8xxxc\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"9c52aa64228824247c48df69b066e5a7@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"XXcXXxXDXVXXXXXXXXXXXX4XXXXX\",\"threatID\":\"502bxxxxxxxxxxx70513b6cxxxxxxxxxxxxebc7fc699xxxxxxxxxxxxxxxxd5f\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/502xxxxxxxxxcebxxxxxxxxxxa04277xxxxx5dxc6xxxxxxxxx5f\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -407,7 +419,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -423,6 +435,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -430,7 +445,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://www.example.org\",\"classification\":\"spam\",\"clickTime\":\"2022-03-30T10:01:01.000Z\",\"threatTime\":\"2022-03-14T05:59:12.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.82 Safari/537.36\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"d35cc5fc-1234-1234-1234-2xxx0xaxbxcxx\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"xyz@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"uHXXXJXTXlXDXmXgXTX3XOXLNXVXNX3XXXHX\",\"threatID\":\"47580xdx0x2x5x2xfx8x3x3x7x7xxxxcx6x7x4x4x1xexcx5cx9x3xfxfxxx1\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/4xxxxd02xxxxxxxxxxxxcacf9da3xxxxxxxxxxx9a947xxxxxxxxxx1\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {

--- a/packages/proofpoint_tap/data_stream/clicks_blocked/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_blocked/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Proofpoint TAP blocked clicks logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - rename:
       field: message
       target_field: event.original
@@ -24,8 +24,12 @@ processors:
       value: email
       ignore_failure: true
   - append:
-      field: event.type
+      field: event.action
       value: denied
+      ignore_failure: true
+  - append:
+      field: event.type
+      value: info
       ignore_failure: true
   - set:
       field: event.kind

--- a/packages/proofpoint_tap/data_stream/clicks_blocked/sample_event.json
+++ b/packages/proofpoint_tap/data_stream/clicks_blocked/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-03-30T10:11:12.000Z",
     "agent": {
-        "ephemeral_id": "78e894c5-08ce-4680-b2d1-db307a184b72",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "ae779a95-f06b-4c4b-b5ef-85bd0374ec45",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.clicks_blocked",
@@ -34,12 +34,12 @@
         "ip": "89.160.20.112"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "from": {
@@ -55,18 +55,21 @@
         }
     },
     "event": {
+        "action": [
+            "denied"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:31:11.689Z",
+        "created": "2023-09-22T17:31:59.691Z",
         "dataset": "proofpoint_tap.clicks_blocked",
         "id": "a5c9f8bb-1234-1234-1234-dx9xxx2xx9xxx",
-        "ingested": "2023-08-07T18:31:14Z",
+        "ingested": "2023-09-22T17:32:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"ZcxxxxVxyxFxyxLxxxDxVxx4xxxxx\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"malware\",\"clickIP\":\"89.160.20.112\",\"clickTime\":\"2022-03-30T10:11:12.000Z\",\"id\":\"a5c9f8bb-1234-1234-1234-dx9xxx2xx9xxx\",\"messageID\":\"12345678912345.12345.mail@example.com\",\"recipient\":\"9c52aa64228824247c48df69b066e5a7@example.com\",\"sender\":\"abc123@example.com\",\"senderIP\":\"81.2.69.143\",\"threatID\":\"502b7xxxx0x5x1x3xb6xcxexbxxxxxxxcxxexc6xbxxxxxxdx7fxcx6x9xxxx9xdxxxxxxxx5f\",\"threatStatus\":\"active\",\"threatTime\":\"2022-03-21T14:40:31.000Z\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/502xxxxxxxxxcebxxxxxxxxxxa04277xxxxx5dxc6xxxxxxxxx5f\",\"url\":\"https://www.example.com/abcdabcd123?query=0\",\"userAgent\":\"Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/199.0.427504638 Mobile/15E148 Safari/604.1\"}",
         "type": [
-            "denied"
+            "info"
         ]
     },
     "input": {

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-clicks-permitted.log-expected.json
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/_dev/test/pipeline/test-clicks-permitted.log-expected.json
@@ -24,7 +24,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -40,6 +40,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "allowed"
+                ],
                 "category": [
                     "email"
                 ],
@@ -47,7 +50,7 @@
                 "kind": "event",
                 "original": "{\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"MALWARE\",\"clickIP\":\"89.160.20.112\",\"clickTime\":\"2016-06-24T19:17:44.000Z\",\"GUID\":\"x11xxxx1-12f9-111x-x12x-1x1x123XXX6xx\",\"id\":\"a2abc123-1234-1234-1234-babcded1234\",\"messageID\":\"12345678912345.12345.mail@example.com\",\"recipient\":\"example.abc@example.com\",\"sender\":\"abc@example.com\",\"senderIP\":\"81.2.69.143\",\"threatID\":\"61f7622xx1x6x7x1x4xxxxxxxxxxx4xdbaxxxxxxxxxxx5xex3xbxxxxxdxfx5xxxxx0\",\"threatTime\":\"2016-06-24T19:17:46.000Z\",\"threatURL\":\"https://threatinsight.proofpoint.com/#/a2abc123-1234-1234-1234-babcded1234/threat/u/6xxx1xxxfx7x62x2x1x6x7x1x4x4xdxxxbxa5xex5x0xxxxx\",\"threatStatus\":\"active\",\"url\":\"http://example.com/\",\"userAgent\":\"Mozilla/5.0(WindowsNT6.1;WOW64;rv:27.0)Gecko/20100101Firefox/27.0\"}",
                 "type": [
-                    "allowed"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -119,7 +122,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -135,6 +138,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "allowed"
+                ],
                 "category": [
                     "email"
                 ],
@@ -142,7 +148,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://example.com/collab/?id=x4x3x6xsx1xxxx8xEdxexnxxxaxX\",\"classification\":\"phish\",\"clickTime\":\"2022-03-21T20:39:37.000Z\",\"threatTime\":\"2022-03-30T10:05:57.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36 Edg/99.0.1150.46\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"de7eef56-1234-1234-1234-54xxxxx123\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"abc@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"cXXTXpX7jXXXXHXxXBXXkXXXwXXX\",\"threatID\":\"92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "allowed"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -215,7 +221,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -231,6 +237,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "allowed"
+                ],
                 "category": [
                     "email"
                 ],
@@ -238,7 +247,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"http://example.com/ixxxx464xxx6x6xxd_cXxxxT_kxxTuQx_xIhxlx2qxxnxvxPxn\",\"classification\":\"spam\",\"clickTime\":\"2022-03-30T10:51:53.000Z\",\"threatTime\":\"2022-02-26T00:36:25.000Z\",\"userAgent\":\"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"90dd54bc-1234-1234-1234-cxxxxxxxxx4\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"exxxxxxx8x2xxxx2x6x6xxxxx6xxxx5@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"QUWXXxXXJHlYXRXXXXVXUXXk\",\"threatID\":\"xxxxxxbx1cxcxx0xcx5xxxxdx5xex8xbx7xxxeexxxxxxxx9\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/xxxxxxbx1cxcxx0xcx5xxxxdx5xex8xbx7xxxeexxxxxxxx9\",\"threatStatus\":\"cleared\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "allowed"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -310,7 +319,7 @@
                 "ip": "89.160.20.112"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "from": {
@@ -326,6 +335,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "allowed"
+                ],
                 "category": [
                     "email"
                 ],
@@ -333,7 +345,7 @@
                 "kind": "event",
                 "original": "{\"url\":\"https://xyz123456789.support.com#xyz@example.com\",\"classification\":\"phish\",\"clickTime\":\"2022-03-30T00:56:14.000Z\",\"threatTime\":\"2022-03-30T00:53:43.000Z\",\"userAgent\":\"Mozilla/5.0 (Linux; Android 12; SM-N976U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.88 Mobile Safari/537.36\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"id\":\"4b4ae949-1234-1234-1234-6axxxxx9xxxxx3\",\"clickIP\":\"89.160.20.112\",\"sender\":\"abc123@example.com\",\"recipient\":\"f3xxxx0x2xcx3xaxbxcx2xaxxxcxxxx2@example.com\",\"senderIP\":\"81.2.69.143\",\"GUID\":\"VXXhXiXyXBXlXdXXfXXXXXWXLXXX\",\"threatID\":\"xxxdxxdx6x7x6xxxxx5xxx837ex4x4xcx8xcxxxexxx2xxxxxx5\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/xxxdxxdx6x7x6xxxxx5xxx837ex4x4xcx8xcxxxexxx2xxxxxx5\",\"threatStatus\":\"active\",\"messageID\":\"12345678912345.12345.mail@example.com\"}",
                 "type": [
-                    "allowed"
+                    "info"
                 ]
             },
             "proofpoint_tap": {

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Proofpoint TAP permitted clicks logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - rename:
       field: message
       target_field: event.original
@@ -24,8 +24,12 @@ processors:
       value: email
       ignore_failure: true
   - append:
-      field: event.type
+      field: event.action
       value: allowed
+      ignore_failure: true
+  - append:
+      field: event.type
+      value: info
       ignore_failure: true
   - set:
       field: event.kind

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/sample_event.json
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-03-21T20:39:37.000Z",
     "agent": {
-        "ephemeral_id": "7d9f81b5-089b-48e9-8588-08a722332bf1",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "9ed6d678-8adf-4976-bd88-2df7b0511246",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.clicks_permitted",
@@ -34,12 +34,12 @@
         "ip": "89.160.20.112"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "from": {
@@ -55,18 +55,21 @@
         }
     },
     "event": {
+        "action": [
+            "allowed"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:32:06.666Z",
+        "created": "2023-09-22T17:32:59.985Z",
         "dataset": "proofpoint_tap.clicks_permitted",
         "id": "de7eef56-1234-1234-1234-5xxfx7xxxdxxxx",
-        "ingested": "2023-08-07T18:32:09Z",
+        "ingested": "2023-09-22T17:33:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"cTxxxxxxzx7xxxxxxxxxx8x4xwxx\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"phish\",\"clickIP\":\"89.160.20.112\",\"clickTime\":\"2022-03-21T20:39:37.000Z\",\"id\":\"de7eef56-1234-1234-1234-5xxfx7xxxdxxxx\",\"messageID\":\"12345678912345.12345.mail@example.com\",\"recipient\":\"abc@example.com\",\"sender\":\"abc123@example.com\",\"senderIP\":\"81.2.69.143\",\"threatID\":\"92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"threatStatus\":\"active\",\"threatTime\":\"2022-03-30T10:05:57.000Z\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"url\":\"https://example.com/collab/?id=x4x3x6xsx1xxxx8xEdxexnxxxaxX\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36 Edg/99.0.1150.46\"}",
         "type": [
-            "allowed"
+            "info"
         ]
     },
     "input": {

--- a/packages/proofpoint_tap/data_stream/message_blocked/_dev/test/pipeline/test-message-blocked.log-expected.json
+++ b/packages/proofpoint_tap/data_stream/message_blocked/_dev/test/pipeline/test-message-blocked.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2022-01-01T00:45:55.050Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -37,6 +37,9 @@
                 "x_mailer": "Microsoft Outlook 16.0"
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -44,7 +47,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":0,\"phishScore\":0,\"threatsInfoMap\":[{\"threatID\":\"dhgonvjabcdefghijkabcdefghijkabcdefghijkabcdefghijkhlonvjdsabcdefgh\",\"threatStatus\":\"active\",\"classification\":\"malware\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhgon-vjdsd-efghjikhlon-abcdefghij/threat/email/792e8d28448xxxxxxxxxxxxxxxxx8448c792xxxxx1af132onvjdsvsbnvjd\",\"threatTime\":\"2022-01-01T02:03:40.050Z\",\"threat\":\"example.com/xyz/\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T00:45:55.050Z\",\"impostorScore\":0.0,\"malwareScore\":100,\"cluster\":\"pharmtech_hosted\",\"subject\":\"Re: Delayed Mail (still being retried)\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\"],\"modulesRun\":[\"av\",\"zerohour\",\"dkimv\",\"spf\",\"spam\",\"dmarc\",\"pdr\"],\"messageSize\":3102,\"headerFrom\":\"\u003cinfo@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"info@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mailer-daemon@example.com\"],\"xmailer\":\"Microsoft Outlook 16.0\",\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"}],\"completelyRewritten\":false,\"id\":\"401ccabc-1234-123-1234-babc74fce1a4\",\"QID\":\"3XXXXgaXXX-1\",\"GUID\":\"qxxlnx-xxxxxNxXGxQxWxPxxxxx0\",\"sender\":\"info@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"1.128.3.4\",\"messageID\":\"\u003c3f208x0sga-1@m0116781.example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -125,7 +128,7 @@
         {
             "@timestamp": "2022-01-01T01:25:59.059Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -159,6 +162,9 @@
                 "x_mailer": "Microsoft Outlook 16.0"
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -166,7 +172,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":0,\"phishScore\":0,\"threatsInfoMap\":[{\"threatID\":\"8defghjikhlonvjdsvsbdhgonvjdsdefghjikhlonvjdsvsbnvjdsvsbvjdsvsb8\",\"threatStatus\":\"active\",\"classification\":\"malware\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhgo-nvjdsdef-ghjikhlonv-abcdefghij/threat/email/848c79xxxxxxxxxxxxxxxxbdadkh79xxxxxxxxxxxxxx1aa6a88fdbdadkh217b1af8\",\"threatTime\":\"2022-01-01T10:10:02.020Z\",\"threat\":\"example.com/xyz/\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T01:25:59.059Z\",\"impostorScore\":0.0,\"malwareScore\":100,\"cluster\":\"pharmtech_hosted\",\"subject\":\"Re: Undelivered Mail Returned to Sender\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\"],\"modulesRun\":[\"av\",\"zerohour\",\"spf\",\"spam\",\"dmarc\",\"pdr\"],\"messageSize\":2278,\"headerFrom\":\"\u003ccontact@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"contact@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mailer-daemon@example.com\"],\"xmailer\":\"Microsoft Outlook 16.0\",\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"}],\"completelyRewritten\":false,\"id\":\"443bacb2-1234-1234-1234-8abcaaa28260\",\"QID\":\"3XXfXX2X1XXX\",\"GUID\":\"LQxxx9xNxcxxx_xjxexLrxxnxQx9xdxx3xx\",\"sender\":\"contact@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"1.128.3.4\",\"messageID\":\"\u003c20220329151120.AAAB383797@example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -246,7 +252,7 @@
         {
             "@timestamp": "2022-01-01T04:51:56.269Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -280,6 +286,9 @@
                 "x_mailer": "Microsoft Outlook 16.0"
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -287,7 +296,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":0,\"phishScore\":0,\"threatsInfoMap\":[{\"threatID\":\"6abcdefghijkabcdefghijkabcdefghijk7503ddcabcdefghijkabcdefghijk\",\"threatStatus\":\"active\",\"classification\":\"malware\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhg-onvjdsdefgh-jikhlonvjdsv-abcdefghij/threat/email/6d748c7921afxxxxxxxxxxxxxxxxxhc7921af13xxxxxxxxxxxxxxxxxxxxxd267a\",\"threatTime\":\"2022-01-01T11:06:50.580Z\",\"threat\":\"example.com/xyz/\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T04:51:56.269Z\",\"impostorScore\":0.0,\"malwareScore\":100,\"cluster\":\"pharmtech_hosted\",\"subject\":\"Re: Undelivered Mail Returned to Sender [BACKSCATTER DETECTED]\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\"],\"modulesRun\":[\"av\",\"zerohour\",\"dkimv\",\"spf\",\"spam\",\"dmarc\",\"pdr\"],\"messageSize\":2755,\"headerFrom\":\"\u003cnoreply@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"noreply@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mailer-daemon@example.com\"],\"xmailer\":\"Microsoft Outlook 16.0\",\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"}],\"completelyRewritten\":false,\"id\":\"0c8eabc5-1234-1234-1234-cabcb7b41c86\",\"QID\":\"XXsXXX-XXX1XX\",\"GUID\":\"6xxxx6xmxxxfxcxTxAxExxDxxxxx2\",\"sender\":\"noreply@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"175.16.199.1\",\"messageID\":\"\u003c3f21wvrsws-1@example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -374,7 +383,7 @@
         {
             "@timestamp": "2022-01-01T00:25:20.010Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -449,6 +458,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -456,7 +468,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":100,\"phishScore\":100,\"threatsInfoMap\":[{\"threatID\":\"cfdhgondhgonvjdsdefghjikhlonvjdsvsbnvjd56546ghjikhlonvjdsvsbnvjd\",\"threatStatus\":\"active\",\"classification\":\"phish\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhgon-vjdsdef-ghjikhlonv-abcdefghij/threat/email/7921af132d1aa6a88fdbdadkhlonvj1a8xxxxxxxxxxxxxxxxxxxxxdkhlonvj1\",\"threatTime\":\"2022-01-01T05:02:48.832Z\",\"threat\":\"https://example.com/\",\"campaignID\":null,\"threatType\":\"url\"},{\"threatID\":\"124563bcdefghijkabcdefghi201256abcdefghijk201256aswe20abc\",\"threatStatus\":\"active\",\"classification\":\"phish\",\"threatUrl\":\"https://threatinsight.proofpoint.com/abcdefgh-1234-1234-1234-1234-abcdefgh/threat/email/85738a8x9x7x1x04x5329xaadc9x425925abdf84089wcwe3x022xx4x19x123\",\"threatTime\":\"2022-01-01T00:00:00.000Z\",\"threat\":\"example.com\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T00:25:20.010Z\",\"impostorScore\":0.0,\"malwareScore\":0,\"cluster\":\"pharmtech_hosted\",\"subject\":\"Statement From (Trinity Groundwater)\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\",\"allow_relay\"],\"modulesRun\":[\"av\",\"zerohour\",\"dkimv\",\"spf\",\"spam\",\"dmarc\"],\"messageSize\":111091,\"headerFrom\":\"Laura Schumacher \u003cabc@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"abc@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mail@example.com\",\"abc@example.com\"],\"xmailer\":null,\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"},{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.txt\",\"sandboxStatus\":null,\"oContentType\":\"text/plain\",\"contentType\":\"text/plain\"},{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.txt\",\"sandboxStatus\":null,\"oContentType\":\"text/plain\",\"contentType\":\"text/plain\"},{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"},{\"disposition\":\"attached\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"image001.png\",\"sandboxStatus\":null,\"oContentType\":\"image/png\",\"contentType\":\"image/png\"}],\"completelyRewritten\":false,\"id\":\"8f12300-f387-1234-xxxx-a4abcd12347\",\"QID\":\"0XX0XXXXaX3XXX-X1\",\"GUID\":\"_pxxxxOxQxxXxx4wxjxtx2xxxTxxxYxxx\",\"sender\":\"abc@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"175.16.199.1\",\"messageID\":\"\u003c77F0EA74-7D6F-453A-AB7F-31B192481AE8@example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -571,7 +583,7 @@
         {
             "@timestamp": "2022-01-01T00:00:00.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -604,6 +616,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -611,7 +626,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":100,\"phishScore\":100,\"threatsInfoMap\":[{\"threatID\":\"9dhgabcdefghijkhgonvjdsdefghjikhlonvjdsvsbnvjdvjdsdefghjikhlonv\",\"threatStatus\":\"active\",\"classification\":\"phish\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhgon-vjdsdefghj-ikhlonvj-abcdefghij/threat/email/97921af132d1aa6a88fdbdadkhlonvjbc9fxxxxxxxxxxxxxxxxxxxxxbdadkhlonvjd\",\"threatTime\":\"2022-01-01T03:02:25.092Z\",\"threat\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T00:00:00.000Z\",\"impostorScore\":0.0,\"malwareScore\":0,\"cluster\":\"pharmtech_hosted\",\"subject\":\"(1) VOICE MAIL MESSSAGE\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\"],\"modulesRun\":[\"av\",\"zerohour\",\"dkimv\",\"spf\",\"spam\",\"dmarc\",\"pdr\"],\"messageSize\":5776,\"headerFrom\":\"VOICE MAIL\u003cman.web@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"man.web@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mailer-daemon@example.com\"],\"xmailer\":null,\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"}],\"completelyRewritten\":false,\"id\":\"ee212323-1234-1234-1234-0f0abcd123456\",\"QID\":\"3XXXf1XaXX-X1XX\",\"GUID\":\"gxxxxxgxx3xcx-MxZxixxoxxxxxAxxx2\",\"sender\":\"man.web@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"175.16.199.1\",\"messageID\":\"\u003c20220327194933.12463F24B8AC1B73@example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {
@@ -698,7 +713,7 @@
         {
             "@timestamp": "2022-01-01T05:00:02.010Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -731,6 +746,9 @@
                 }
             },
             "event": {
+                "action": [
+                    "denied"
+                ],
                 "category": [
                     "email"
                 ],
@@ -738,7 +756,7 @@
                 "kind": "event",
                 "original": "{\"spamScore\":100,\"phishScore\":100,\"threatsInfoMap\":[{\"threatID\":\"abcdefghijkabcdefghijkabcdefghijkefghjikhlonvjdsvsbnvjd\",\"threatStatus\":\"active\",\"classification\":\"phish\",\"threatUrl\":\"https://threatinsight.proofpoint.com/adhgonvj-dsdefgh-jikhlon-abcdefghij/threat/email/7921af132xxxxxxxxxxxxxxxxxxviuerhvuie35abcdefghabcdefghijk\",\"threatTime\":\"2022-01-01T00:00:00.000Z\",\"threat\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"campaignID\":null,\"threatType\":\"url\"}],\"messageTime\":\"2022-01-01T05:00:02.010Z\",\"impostorScore\":0.0,\"malwareScore\":0,\"cluster\":\"pharmtech_hosted\",\"subject\":\"(1) VOICE MAIL MESSSAGE\",\"quarantineFolder\":null,\"quarantineRule\":null,\"policyRoutes\":[\"default_inbound\"],\"modulesRun\":[\"av\",\"zerohour\",\"dkimv\",\"spf\",\"spam\",\"dmarc\",\"pdr\"],\"messageSize\":5776,\"headerFrom\":\"VOICE MAIL\u003cman.web@example.com\u003e\",\"headerReplyTo\":null,\"fromAddress\":[\"man.web@example.com\"],\"ccAddresses\":[],\"replyToAddress\":[],\"toAddresses\":[\"mailer-daemon@example.com\"],\"xmailer\":null,\"messageParts\":[{\"disposition\":\"inline\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"filename\":\"text.html\",\"sandboxStatus\":null,\"oContentType\":\"text/html\",\"contentType\":\"text/html\"}],\"completelyRewritten\":false,\"id\":\"ee212323-1234-1234-1234-0f0abcd123456\",\"QID\":\"3XXfXabXcXXXX1\",\"GUID\":\"gxxxxgx3xcx-xMx7xPxxZxxxxoxAx2xxxxx\",\"sender\":\"man.web@example.com\",\"recipient\":[\"mailer-daemon@example.com\"],\"senderIP\":\"89.160.20.112\",\"messageID\":\"\u003c20220327194933.12463F24B8AC1B73@example.com\u003e\"}",
                 "type": [
-                    "denied"
+                    "info"
                 ]
             },
             "proofpoint_tap": {

--- a/packages/proofpoint_tap/data_stream/message_blocked/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/message_blocked/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Proofpoint TAP blocked message logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - rename:
       field: message
       target_field: event.original
@@ -32,8 +32,12 @@ processors:
       value: email
       ignore_failure: true
   - append:
-      field: event.type
+      field: event.action
       value: denied
+      ignore_failure: true
+  - append:
+      field: event.type
+      value: info
       ignore_failure: true
   - set:
       field: event.kind

--- a/packages/proofpoint_tap/data_stream/message_blocked/sample_event.json
+++ b/packages/proofpoint_tap/data_stream/message_blocked/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2021-11-25T09:10:00.050Z",
     "agent": {
-        "ephemeral_id": "1ac91299-2df1-4476-ab43-293b76348bf8",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "c84bcbe5-ed0f-4c89-a9c4-8b21738f93d2",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.message_blocked",
@@ -13,12 +13,12 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "attachments": [
@@ -68,17 +68,20 @@
         "x_mailer": "Spambot v2.5"
     },
     "event": {
+        "action": [
+            "denied"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:33:01.901Z",
+        "created": "2023-09-22T17:33:59.847Z",
         "dataset": "proofpoint_tap.message_blocked",
-        "ingested": "2023-08-07T18:33:04Z",
+        "ingested": "2023-09-22T17:34:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"x11xxxx1-12f9-111x-x12x-1x1x123456xx\",\"QID\":\"x2XXxXXX111111\",\"ccAddresses\":[\"abc@example.com\"],\"clusterId\":\"pharmtech_hosted\",\"completelyRewritten\":\"true\",\"fromAddress\":\"abc@example.com\",\"headerCC\":\"\\\"Example Abc\\\" \\u003cabc@example.com\\u003e\",\"headerFrom\":\"\\\"A. Bc\\\" \\u003cabc@example.com\\u003e\",\"headerReplyTo\":null,\"headerTo\":\"\\\"Aa Bb\\\" \\u003caa.bb@example.com\\u003e; \\\"Hey Hello\\\" \\u003chey.hello@example.com\\u003e\",\"impostorScore\":0,\"malwareScore\":100,\"messageID\":\"12345678912345.12345.mail@example.com\",\"messageParts\":[{\"contentType\":\"text/plain\",\"disposition\":\"inline\",\"filename\":\"text.txt\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"oContentType\":\"text/plain\",\"sandboxStatus\":\"unsupported\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\"},{\"contentType\":\"application/pdf\",\"disposition\":\"attached\",\"filename\":\"text.pdf\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"oContentType\":\"application/pdf\",\"sandboxStatus\":\"threat\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\"}],\"messageTime\":\"2021-11-25T09:10:00.050Z\",\"modulesRun\":[\"pdr\",\"sandbox\",\"spam\",\"urldefense\"],\"phishScore\":46,\"policyRoutes\":[\"default_inbound\",\"executives\"],\"quarantineFolder\":\"Attachment Defense\",\"quarantineRule\":\"module.sandbox.threat\",\"recipient\":[\"example.abc@example.com\",\"hey.hello@example.com\"],\"replyToAddress\":null,\"sender\":\"x99x7x5580193x6x51x597xx2x0210@example.com\",\"senderIP\":\"175.16.199.1\",\"spamScore\":4,\"subject\":\"Please find a totally safe invoice attached.\",\"threatsInfoMap\":[{\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"MALWARE\",\"threat\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"threatId\":\"2xxx740f143fc1aa4c1cd0146d334x5593b1428x6x062b2c406e5efe8xxx95xx\",\"threatStatus\":\"active\",\"threatTime\":\"2021-11-25T09:10:00.050Z\",\"threatType\":\"ATTACHMENT\",\"threatUrl\":\"https://www.example.com/?name=john\"},{\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"MALWARE\",\"threat\":\"example.com\",\"threatId\":\"3xx97xx852c66a7xx761450xxxxxx9f4ffab74715b591294f78b5e37a76481xx\",\"threatTime\":\"2021-07-20T05:00:00.050Z\",\"threatType\":\"URL\",\"threatUrl\":\"https://www.example.com/?name=john\"}],\"toAddresses\":[\"example.abc@example.com\",\"hey.hello@example.com\"],\"xmailer\":\"Spambot v2.5\"}",
         "type": [
-            "denied"
+            "info"
         ]
     },
     "input": {

--- a/packages/proofpoint_tap/data_stream/message_delivered/_dev/test/pipeline/test-message-delivered.log-expected.json
+++ b/packages/proofpoint_tap/data_stream/message_delivered/_dev/test/pipeline/test-message-delivered.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2022-01-05T10:05:56.020Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "delivery_timestamp": "2022-01-05T10:05:56.020Z",
@@ -90,7 +90,7 @@
         {
             "@timestamp": "2022-01-01T00:00:00.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "delivery_timestamp": "2022-01-01T00:00:00.000Z",
@@ -160,7 +160,7 @@
         {
             "@timestamp": "2022-01-01T00:00:00.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "delivery_timestamp": "2022-01-01T00:00:00.000Z",
@@ -236,7 +236,7 @@
         {
             "@timestamp": "2022-01-01T00:00:00.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "delivery_timestamp": "2022-01-01T00:00:00.000Z",
@@ -312,7 +312,7 @@
         {
             "@timestamp": "2022-03-15T15:00:20.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -460,7 +460,7 @@
         {
             "@timestamp": "2021-09-28T16:28:59.490Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -615,7 +615,7 @@
         {
             "@timestamp": "2022-08-17T18:00:22.060Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [
@@ -764,7 +764,7 @@
         {
             "@timestamp": "2022-03-24T13:24:57.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "email": {
                 "attachments": [

--- a/packages/proofpoint_tap/data_stream/message_delivered/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/proofpoint_tap/data_stream/message_delivered/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Proofpoint TAP delivered message logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - rename:
       field: message
       target_field: event.original

--- a/packages/proofpoint_tap/data_stream/message_delivered/sample_event.json
+++ b/packages/proofpoint_tap/data_stream/message_delivered/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2022-01-01T00:00:00.000Z",
     "agent": {
-        "ephemeral_id": "5966500d-85d6-408f-91f5-1a2fabd4fd8e",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "f01ebff4-ea3a-4827-ac33-e7af925ed197",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.message_delivered",
@@ -13,12 +13,12 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "delivery_timestamp": "2022-01-01T00:00:00.000Z",
@@ -33,10 +33,10 @@
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:33:57.755Z",
+        "created": "2023-09-22T17:35:00.037Z",
         "dataset": "proofpoint_tap.message_delivered",
         "id": "2hsvbU-i8abc123-12345-xxxxx12",
-        "ingested": "2023-08-07T18:34:00Z",
+        "ingested": "2023-09-22T17:35:03Z",
         "kind": "event",
         "original": "{\"GUID\":\"NxxxsxvxbxUxixcx2xxxxx5x6xWxBxOxxxxxjxx\",\"QID\":null,\"ccAddresses\":null,\"cluster\":\"pharmtech_hosted\",\"completelyRewritten\":true,\"fromAddress\":null,\"headerFrom\":null,\"headerReplyTo\":null,\"id\":\"2hsvbU-i8abc123-12345-xxxxx12\",\"impostorScore\":0,\"malwareScore\":0,\"messageID\":\"\",\"messageParts\":null,\"messageSize\":0,\"messageTime\":\"2022-01-01T00:00:00.000Z\",\"modulesRun\":null,\"phishScore\":0,\"policyRoutes\":null,\"quarantineFolder\":null,\"quarantineRule\":null,\"recipient\":[\"fxxxxhxsxxvxbcx2xx5xxx6x3xx26@example.com\"],\"replyToAddress\":null,\"sender\":\"\",\"senderIP\":\"89.160.20.112\",\"spamScore\":0,\"subject\":null,\"threatsInfoMap\":[{\"campaignID\":null,\"classification\":\"spam\",\"threat\":\"http://zbcd123456x0.example.com\",\"threatID\":\"b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\",\"threatStatus\":\"active\",\"threatTime\":\"2021-11-25T13:02:58.640Z\",\"threatType\":\"url\",\"threatUrl\":\"https://threatinsight.proofpoint.com/aaabcdef-1234-b1abcdefghe/threat/email/b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\"},{\"campaignID\":null,\"classification\":\"phish\",\"threat\":\"http://zbcd123456x0.example.com\",\"threatID\":\"aaabcdefg123456f009971a9c193abcdefg123456bf5abcdefg1234566\",\"threatStatus\":\"active\",\"threatTime\":\"2021-07-19T10:28:15.100Z\",\"threatType\":\"url\",\"threatUrl\":\"https://threatinsight.proofpoint.com/aaabcdef-1234-b1abcdefghe/threat/email/b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\"}],\"toAddresses\":null,\"xmailer\":null}",
         "type": [

--- a/packages/proofpoint_tap/docs/README.md
+++ b/packages/proofpoint_tap/docs/README.md
@@ -31,11 +31,11 @@ An example event for `clicks_blocked` looks as following:
 {
     "@timestamp": "2022-03-30T10:11:12.000Z",
     "agent": {
-        "ephemeral_id": "78e894c5-08ce-4680-b2d1-db307a184b72",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "ae779a95-f06b-4c4b-b5ef-85bd0374ec45",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.clicks_blocked",
@@ -64,12 +64,12 @@ An example event for `clicks_blocked` looks as following:
         "ip": "89.160.20.112"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "from": {
@@ -85,18 +85,21 @@ An example event for `clicks_blocked` looks as following:
         }
     },
     "event": {
+        "action": [
+            "denied"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:31:11.689Z",
+        "created": "2023-09-22T17:31:59.691Z",
         "dataset": "proofpoint_tap.clicks_blocked",
         "id": "a5c9f8bb-1234-1234-1234-dx9xxx2xx9xxx",
-        "ingested": "2023-08-07T18:31:14Z",
+        "ingested": "2023-09-22T17:32:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"ZcxxxxVxyxFxyxLxxxDxVxx4xxxxx\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"malware\",\"clickIP\":\"89.160.20.112\",\"clickTime\":\"2022-03-30T10:11:12.000Z\",\"id\":\"a5c9f8bb-1234-1234-1234-dx9xxx2xx9xxx\",\"messageID\":\"12345678912345.12345.mail@example.com\",\"recipient\":\"9c52aa64228824247c48df69b066e5a7@example.com\",\"sender\":\"abc123@example.com\",\"senderIP\":\"81.2.69.143\",\"threatID\":\"502b7xxxx0x5x1x3xb6xcxexbxxxxxxxcxxexc6xbxxxxxxdx7fxcx6x9xxxx9xdxxxxxxxx5f\",\"threatStatus\":\"active\",\"threatTime\":\"2022-03-21T14:40:31.000Z\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/502xxxxxxxxxcebxxxxxxxxxxa04277xxxxx5dxc6xxxxxxxxx5f\",\"url\":\"https://www.example.com/abcdabcd123?query=0\",\"userAgent\":\"Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/199.0.427504638 Mobile/15E148 Safari/604.1\"}",
         "type": [
-            "denied"
+            "info"
         ]
     },
     "input": {
@@ -263,11 +266,11 @@ An example event for `clicks_permitted` looks as following:
 {
     "@timestamp": "2022-03-21T20:39:37.000Z",
     "agent": {
-        "ephemeral_id": "7d9f81b5-089b-48e9-8588-08a722332bf1",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "9ed6d678-8adf-4976-bd88-2df7b0511246",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.clicks_permitted",
@@ -296,12 +299,12 @@ An example event for `clicks_permitted` looks as following:
         "ip": "89.160.20.112"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "from": {
@@ -317,18 +320,21 @@ An example event for `clicks_permitted` looks as following:
         }
     },
     "event": {
+        "action": [
+            "allowed"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:32:06.666Z",
+        "created": "2023-09-22T17:32:59.985Z",
         "dataset": "proofpoint_tap.clicks_permitted",
         "id": "de7eef56-1234-1234-1234-5xxfx7xxxdxxxx",
-        "ingested": "2023-08-07T18:32:09Z",
+        "ingested": "2023-09-22T17:33:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"cTxxxxxxzx7xxxxxxxxxx8x4xwxx\",\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"phish\",\"clickIP\":\"89.160.20.112\",\"clickTime\":\"2022-03-21T20:39:37.000Z\",\"id\":\"de7eef56-1234-1234-1234-5xxfx7xxxdxxxx\",\"messageID\":\"12345678912345.12345.mail@example.com\",\"recipient\":\"abc@example.com\",\"sender\":\"abc123@example.com\",\"senderIP\":\"81.2.69.143\",\"threatID\":\"92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"threatStatus\":\"active\",\"threatTime\":\"2022-03-30T10:05:57.000Z\",\"threatURL\":\"https://threatinsight.proofpoint.com/a2abc123-1234-1234-1234-babcded1234/threat/email/92c17aaxxxxxxxxxx07xx7xxxx9xexcx3x3xxxxxx8xx3xxxx\",\"url\":\"https://example.com/collab/?id=x4x3x6xsx1xxxx8xEdxexnxxxaxX\",\"userAgent\":\"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.74 Safari/537.36 Edg/99.0.1150.46\"}",
         "type": [
-            "allowed"
+            "info"
         ]
     },
     "input": {
@@ -493,11 +499,11 @@ An example event for `message_blocked` looks as following:
 {
     "@timestamp": "2021-11-25T09:10:00.050Z",
     "agent": {
-        "ephemeral_id": "1ac91299-2df1-4476-ab43-293b76348bf8",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "c84bcbe5-ed0f-4c89-a9c4-8b21738f93d2",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.message_blocked",
@@ -505,12 +511,12 @@ An example event for `message_blocked` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "attachments": [
@@ -560,17 +566,20 @@ An example event for `message_blocked` looks as following:
         "x_mailer": "Spambot v2.5"
     },
     "event": {
+        "action": [
+            "denied"
+        ],
         "agent_id_status": "verified",
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:33:01.901Z",
+        "created": "2023-09-22T17:33:59.847Z",
         "dataset": "proofpoint_tap.message_blocked",
-        "ingested": "2023-08-07T18:33:04Z",
+        "ingested": "2023-09-22T17:34:02Z",
         "kind": "event",
         "original": "{\"GUID\":\"x11xxxx1-12f9-111x-x12x-1x1x123456xx\",\"QID\":\"x2XXxXXX111111\",\"ccAddresses\":[\"abc@example.com\"],\"clusterId\":\"pharmtech_hosted\",\"completelyRewritten\":\"true\",\"fromAddress\":\"abc@example.com\",\"headerCC\":\"\\\"Example Abc\\\" \\u003cabc@example.com\\u003e\",\"headerFrom\":\"\\\"A. Bc\\\" \\u003cabc@example.com\\u003e\",\"headerReplyTo\":null,\"headerTo\":\"\\\"Aa Bb\\\" \\u003caa.bb@example.com\\u003e; \\\"Hey Hello\\\" \\u003chey.hello@example.com\\u003e\",\"impostorScore\":0,\"malwareScore\":100,\"messageID\":\"12345678912345.12345.mail@example.com\",\"messageParts\":[{\"contentType\":\"text/plain\",\"disposition\":\"inline\",\"filename\":\"text.txt\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"oContentType\":\"text/plain\",\"sandboxStatus\":\"unsupported\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\"},{\"contentType\":\"application/pdf\",\"disposition\":\"attached\",\"filename\":\"text.pdf\",\"md5\":\"b10a8db164e0754105b7a99be72e3fe5\",\"oContentType\":\"application/pdf\",\"sandboxStatus\":\"threat\",\"sha256\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\"}],\"messageTime\":\"2021-11-25T09:10:00.050Z\",\"modulesRun\":[\"pdr\",\"sandbox\",\"spam\",\"urldefense\"],\"phishScore\":46,\"policyRoutes\":[\"default_inbound\",\"executives\"],\"quarantineFolder\":\"Attachment Defense\",\"quarantineRule\":\"module.sandbox.threat\",\"recipient\":[\"example.abc@example.com\",\"hey.hello@example.com\"],\"replyToAddress\":null,\"sender\":\"x99x7x5580193x6x51x597xx2x0210@example.com\",\"senderIP\":\"175.16.199.1\",\"spamScore\":4,\"subject\":\"Please find a totally safe invoice attached.\",\"threatsInfoMap\":[{\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"MALWARE\",\"threat\":\"a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e\",\"threatId\":\"2xxx740f143fc1aa4c1cd0146d334x5593b1428x6x062b2c406e5efe8xxx95xx\",\"threatStatus\":\"active\",\"threatTime\":\"2021-11-25T09:10:00.050Z\",\"threatType\":\"ATTACHMENT\",\"threatUrl\":\"https://www.example.com/?name=john\"},{\"campaignId\":\"46x01x8x-x899-404x-xxx9-111xx393d1x7\",\"classification\":\"MALWARE\",\"threat\":\"example.com\",\"threatId\":\"3xx97xx852c66a7xx761450xxxxxx9f4ffab74715b591294f78b5e37a76481xx\",\"threatTime\":\"2021-07-20T05:00:00.050Z\",\"threatType\":\"URL\",\"threatUrl\":\"https://www.example.com/?name=john\"}],\"toAddresses\":[\"example.abc@example.com\",\"hey.hello@example.com\"],\"xmailer\":\"Spambot v2.5\"}",
         "type": [
-            "denied"
+            "info"
         ]
     },
     "input": {
@@ -803,11 +812,11 @@ An example event for `message_delivered` looks as following:
 {
     "@timestamp": "2022-01-01T00:00:00.000Z",
     "agent": {
-        "ephemeral_id": "5966500d-85d6-408f-91f5-1a2fabd4fd8e",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "f01ebff4-ea3a-4827-ac33-e7af925ed197",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "proofpoint_tap.message_delivered",
@@ -815,12 +824,12 @@ An example event for `message_delivered` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "email": {
         "delivery_timestamp": "2022-01-01T00:00:00.000Z",
@@ -835,10 +844,10 @@ An example event for `message_delivered` looks as following:
         "category": [
             "email"
         ],
-        "created": "2023-08-07T18:33:57.755Z",
+        "created": "2023-09-22T17:35:00.037Z",
         "dataset": "proofpoint_tap.message_delivered",
         "id": "2hsvbU-i8abc123-12345-xxxxx12",
-        "ingested": "2023-08-07T18:34:00Z",
+        "ingested": "2023-09-22T17:35:03Z",
         "kind": "event",
         "original": "{\"GUID\":\"NxxxsxvxbxUxixcx2xxxxx5x6xWxBxOxxxxxjxx\",\"QID\":null,\"ccAddresses\":null,\"cluster\":\"pharmtech_hosted\",\"completelyRewritten\":true,\"fromAddress\":null,\"headerFrom\":null,\"headerReplyTo\":null,\"id\":\"2hsvbU-i8abc123-12345-xxxxx12\",\"impostorScore\":0,\"malwareScore\":0,\"messageID\":\"\",\"messageParts\":null,\"messageSize\":0,\"messageTime\":\"2022-01-01T00:00:00.000Z\",\"modulesRun\":null,\"phishScore\":0,\"policyRoutes\":null,\"quarantineFolder\":null,\"quarantineRule\":null,\"recipient\":[\"fxxxxhxsxxvxbcx2xx5xxx6x3xx26@example.com\"],\"replyToAddress\":null,\"sender\":\"\",\"senderIP\":\"89.160.20.112\",\"spamScore\":0,\"subject\":null,\"threatsInfoMap\":[{\"campaignID\":null,\"classification\":\"spam\",\"threat\":\"http://zbcd123456x0.example.com\",\"threatID\":\"b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\",\"threatStatus\":\"active\",\"threatTime\":\"2021-11-25T13:02:58.640Z\",\"threatType\":\"url\",\"threatUrl\":\"https://threatinsight.proofpoint.com/aaabcdef-1234-b1abcdefghe/threat/email/b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\"},{\"campaignID\":null,\"classification\":\"phish\",\"threat\":\"http://zbcd123456x0.example.com\",\"threatID\":\"aaabcdefg123456f009971a9c193abcdefg123456bf5abcdefg1234566\",\"threatStatus\":\"active\",\"threatTime\":\"2021-07-19T10:28:15.100Z\",\"threatType\":\"url\",\"threatUrl\":\"https://threatinsight.proofpoint.com/aaabcdef-1234-b1abcdefghe/threat/email/b7exxxxxxxx0d10xxxxxxe2xxxxxxxxxxxx81cxxxxxx034ac9cxxxxxxxxxxxxb\"}],\"toAddresses\":null,\"xmailer\":null}",
         "type": [

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the proofpoint_tap integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
