### PR TITLE
[ECS] Updating slack to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/slack/_dev/build/build.yml
+++ b/packages/slack/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7946
 - version: "1.11.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/slack/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/slack/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-03-16T15:32:23.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user_login",
@@ -86,7 +86,7 @@
         {
             "@timestamp": "2019-08-19T11:46:32.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user_created",
@@ -168,7 +168,7 @@
         {
             "@timestamp": "2023-05-11T20:17:55.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "file_downloaded",
@@ -179,7 +179,7 @@
                 "kind": "event",
                 "original": "{\"action\":\"file_downloaded\",\"actor\":{\"type\":\"user\",\"user\":{\"email\":\"user.mcuser@abcd.co\",\"id\":\"2f52269c-4f38-4f08-b56d-c2b968681dbd\",\"name\":\"User McUser\",\"team\":\"user-team\"}},\"context\":{\"ip_address\":\"81.2.69.144\",\"location\":{\"domain\":\"domain.tld\",\"id\":\"eedd1a7d-1a92-418d-8b01-51a4c809d0fb\",\"name\":\"The Place\",\"type\":\"workspace\"},\"session_id\":913888259765,\"ua\":\"com.tinyspeck.chatlyio/23.04.40 (iPhone; iOS 1.4.1; Scale/3.00)\"},\"date_create\":1683836275,\"details\":{\"url_private\":\"https://example.com/\"},\"entity\":{\"file\":{\"filetype\":\"image/png\",\"id\":\"7edc4c42-f925-47af-979a-22c10e1fefed\",\"name\":\"image.png\",\"title\":\"image.png\"},\"type\":\"file\"},\"id\":\"2db28060-1659-4b27-ad55-fdba12e3a7b1\"}",
                 "type": [
-                    "allowed"
+                    "access"
                 ]
             },
             "related": {
@@ -249,7 +249,7 @@
         {
             "@timestamp": "2023-01-13T17:40:21.862Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "anomaly",
@@ -335,7 +335,7 @@
         {
             "@timestamp": "2023-07-13T12:01:56.345113Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "anomaly",

--- a/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/slack/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for parsing Slack Audit logs
 processors:
 - set:
     field: ecs.version
-    value: '8.9.0'
+    value: '8.10.0'
 - rename:
     field: message
     target_field: event.original
@@ -348,7 +348,7 @@ processors:
         category:
           - file
         type:
-          - allowed
+          - access
       file_downloaded_blocked:
         category:
           - file

--- a/packages/slack/data_stream/audit/sample_event.json
+++ b/packages/slack/data_stream/audit/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2018-03-16T15:32:23.000Z",
+    "@timestamp": "2023-01-13T17:40:21.862Z",
     "agent": {
-        "ephemeral_id": "09ed6137-cc14-44bf-ae25-3bfb4867008e",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "a3daca3b-553f-45eb-8bfb-8a95e6e5631e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "slack.audit",
@@ -13,30 +13,24 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "event": {
-        "action": "user_login",
+        "action": "anomaly",
         "agent_id_status": "verified",
-        "category": [
-            "authentication",
-            "session"
-        ],
-        "created": "2023-08-07T18:55:53.319Z",
+        "created": "2023-09-22T17:50:16.870Z",
         "dataset": "slack.audit",
-        "id": "0123a45b-6c7d-8900-e12f-3456789gh0i1",
-        "ingested": "2023-08-07T18:55:54Z",
+        "id": "1665fc41-c67c-4cf5-a5c4-d90cb58dd5f9",
+        "ingested": "2023-09-22T17:50:17Z",
         "kind": "event",
-        "original": "{\"action\":\"user_login\",\"actor\":{\"type\":\"user\",\"user\":{\"email\":\"bird@slack.com\",\"id\":\"W123AB456\",\"name\":\"Charlie Parker\"}},\"context\":{\"ip_address\":\"81.2.69.143\",\"location\":{\"domain\":\"birdland\",\"id\":\"E1701NCCA\",\"name\":\"Birdland\",\"type\":\"enterprise\"},\"ua\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36\"},\"date_create\":1521214343,\"entity\":{\"type\":\"user\",\"user\":{\"email\":\"bird@slack.com\",\"id\":\"W123AB456\",\"name\":\"Charlie Parker\"}},\"id\":\"0123a45b-6c7d-8900-e12f-3456789gh0i1\"}",
-        "outcome": "success",
+        "original": "{\"action\":\"anomaly\",\"actor\":{\"type\":\"user\",\"user\":{\"email\":\"aaron@demo.com\",\"id\":\"e65b0f5c\",\"name\":\"roy\"}},\"context\":{\"ip_address\":\"81.2.69.143\",\"location\":{\"domain\":\"Docker\",\"id\":\"e65b11aa\",\"name\":\"Docker\",\"type\":\"workspace\"},\"ua\":\"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:23.0) Gecko/20131011 Firefox/23.0\"},\"date_create\":1683836291,\"details\":{\"action_timestamp\":1673631621862,\"location\":\"England, GB\",\"previous_ip_address\":\"175.16.199.64\",\"previous_ua\":\"\",\"reason\":[\"asn\",\"ip_address\"]},\"entity\":{\"type\":\"user\",\"user\":{\"email\":\"jbob@example.com\",\"id\":\"asdfasdf\",\"name\":\"Joe Bob\",\"team\":\"T234SAH2\"}},\"id\":\"1665fc41-c67c-4cf5-a5c4-d90cb58dd5f9\"}",
         "type": [
-            "info",
-            "start"
+            "info"
         ]
     },
     "input": {
@@ -47,23 +41,32 @@
             "81.2.69.143"
         ],
         "user": [
-            "W123AB456",
-            "bird@slack.com"
+            "e65b0f5c",
+            "aaron@demo.com"
         ]
     },
     "slack": {
         "audit": {
             "context": {
-                "domain": "birdland",
-                "id": "E1701NCCA",
-                "name": "Birdland",
-                "type": "enterprise"
+                "domain": "Docker",
+                "id": "e65b11aa",
+                "name": "Docker",
+                "type": "workspace"
+            },
+            "details": {
+                "location": "England, GB",
+                "previous_ip_address": "175.16.199.64",
+                "reason": [
+                    "asn",
+                    "ip_address"
+                ]
             },
             "entity": {
-                "email": "bird@slack.com",
+                "email": "jbob@example.com",
                 "entity_type": "user",
-                "id": "W123AB456",
-                "name": "Charlie Parker"
+                "id": "asdfasdf",
+                "name": "Joe Bob",
+                "team": "T234SAH2"
             }
         }
     },
@@ -89,21 +92,21 @@
         "preserve_original_event"
     ],
     "user": {
-        "email": "bird@slack.com",
-        "full_name": "Charlie Parker",
-        "id": "W123AB456"
+        "email": "aaron@demo.com",
+        "full_name": "roy",
+        "id": "e65b0f5c"
     },
     "user_agent": {
         "device": {
-            "name": "Mac"
+            "name": "Other"
         },
-        "name": "Chrome",
-        "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+        "name": "Firefox",
+        "original": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:23.0) Gecko/20131011 Firefox/23.0",
         "os": {
-            "full": "Mac OS X 10.12.6",
-            "name": "Mac OS X",
-            "version": "10.12.6"
+            "full": "Windows 7",
+            "name": "Windows",
+            "version": "7"
         },
-        "version": "64.0.3282.186"
+        "version": "23.0."
     }
 }

--- a/packages/slack/docs/README.md
+++ b/packages/slack/docs/README.md
@@ -154,13 +154,13 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2018-03-16T15:32:23.000Z",
+    "@timestamp": "2023-01-13T17:40:21.862Z",
     "agent": {
-        "ephemeral_id": "09ed6137-cc14-44bf-ae25-3bfb4867008e",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "a3daca3b-553f-45eb-8bfb-8a95e6e5631e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "slack.audit",
@@ -168,30 +168,24 @@ An example event for `audit` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "event": {
-        "action": "user_login",
+        "action": "anomaly",
         "agent_id_status": "verified",
-        "category": [
-            "authentication",
-            "session"
-        ],
-        "created": "2023-08-07T18:55:53.319Z",
+        "created": "2023-09-22T17:50:16.870Z",
         "dataset": "slack.audit",
-        "id": "0123a45b-6c7d-8900-e12f-3456789gh0i1",
-        "ingested": "2023-08-07T18:55:54Z",
+        "id": "1665fc41-c67c-4cf5-a5c4-d90cb58dd5f9",
+        "ingested": "2023-09-22T17:50:17Z",
         "kind": "event",
-        "original": "{\"action\":\"user_login\",\"actor\":{\"type\":\"user\",\"user\":{\"email\":\"bird@slack.com\",\"id\":\"W123AB456\",\"name\":\"Charlie Parker\"}},\"context\":{\"ip_address\":\"81.2.69.143\",\"location\":{\"domain\":\"birdland\",\"id\":\"E1701NCCA\",\"name\":\"Birdland\",\"type\":\"enterprise\"},\"ua\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36\"},\"date_create\":1521214343,\"entity\":{\"type\":\"user\",\"user\":{\"email\":\"bird@slack.com\",\"id\":\"W123AB456\",\"name\":\"Charlie Parker\"}},\"id\":\"0123a45b-6c7d-8900-e12f-3456789gh0i1\"}",
-        "outcome": "success",
+        "original": "{\"action\":\"anomaly\",\"actor\":{\"type\":\"user\",\"user\":{\"email\":\"aaron@demo.com\",\"id\":\"e65b0f5c\",\"name\":\"roy\"}},\"context\":{\"ip_address\":\"81.2.69.143\",\"location\":{\"domain\":\"Docker\",\"id\":\"e65b11aa\",\"name\":\"Docker\",\"type\":\"workspace\"},\"ua\":\"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:23.0) Gecko/20131011 Firefox/23.0\"},\"date_create\":1683836291,\"details\":{\"action_timestamp\":1673631621862,\"location\":\"England, GB\",\"previous_ip_address\":\"175.16.199.64\",\"previous_ua\":\"\",\"reason\":[\"asn\",\"ip_address\"]},\"entity\":{\"type\":\"user\",\"user\":{\"email\":\"jbob@example.com\",\"id\":\"asdfasdf\",\"name\":\"Joe Bob\",\"team\":\"T234SAH2\"}},\"id\":\"1665fc41-c67c-4cf5-a5c4-d90cb58dd5f9\"}",
         "type": [
-            "info",
-            "start"
+            "info"
         ]
     },
     "input": {
@@ -202,23 +196,32 @@ An example event for `audit` looks as following:
             "81.2.69.143"
         ],
         "user": [
-            "W123AB456",
-            "bird@slack.com"
+            "e65b0f5c",
+            "aaron@demo.com"
         ]
     },
     "slack": {
         "audit": {
             "context": {
-                "domain": "birdland",
-                "id": "E1701NCCA",
-                "name": "Birdland",
-                "type": "enterprise"
+                "domain": "Docker",
+                "id": "e65b11aa",
+                "name": "Docker",
+                "type": "workspace"
+            },
+            "details": {
+                "location": "England, GB",
+                "previous_ip_address": "175.16.199.64",
+                "reason": [
+                    "asn",
+                    "ip_address"
+                ]
             },
             "entity": {
-                "email": "bird@slack.com",
+                "email": "jbob@example.com",
                 "entity_type": "user",
-                "id": "W123AB456",
-                "name": "Charlie Parker"
+                "id": "asdfasdf",
+                "name": "Joe Bob",
+                "team": "T234SAH2"
             }
         }
     },
@@ -244,22 +247,22 @@ An example event for `audit` looks as following:
         "preserve_original_event"
     ],
     "user": {
-        "email": "bird@slack.com",
-        "full_name": "Charlie Parker",
-        "id": "W123AB456"
+        "email": "aaron@demo.com",
+        "full_name": "roy",
+        "id": "e65b0f5c"
     },
     "user_agent": {
         "device": {
-            "name": "Mac"
+            "name": "Other"
         },
-        "name": "Chrome",
-        "original": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+        "name": "Firefox",
+        "original": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:23.0) Gecko/20131011 Firefox/23.0",
         "os": {
-            "full": "Mac OS X 10.12.6",
-            "name": "Mac OS X",
-            "version": "10.12.6"
+            "full": "Windows 7",
+            "name": "Windows",
+            "version": "7"
         },
-        "version": "64.0.3282.186"
+        "version": "23.0."
     }
 }
 ```

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: slack
 title: "Slack Logs"
-version: "1.11.0"
+version: "1.12.0"
 description: "Slack Logs Integration"
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the slack integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
