### PR TITLE
[Github] Fix docs for Audit log permissions

### DIFF
--- a/packages/github/_dev/build/docs/README.md
+++ b/packages/github/_dev/build/docs/README.md
@@ -11,7 +11,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 To use this integration, the following prerequisites must be met:
  - You must be an organization owner.
  - You must be using Github Enterprise Cloud.
- - You must use an Personal Access Token with `read:audit_log` scope.
+ - You must use a Personal Access Token with `read:audit_log` scope.
 
 *This integration is not compatible with GitHub Enterprise server.*
 

--- a/packages/github/_dev/build/docs/README.md
+++ b/packages/github/_dev/build/docs/README.md
@@ -11,7 +11,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 To use this integration, the following prerequisites must be met:
  - You must be an organization owner.
  - You must be using Github Enterprise Cloud.
- - You must use an Personal Access Token with the `admin:org` and `read:audit_log` scope.
+ - You must use an Personal Access Token with `read:audit_log` scope.
 
 *This integration is not compatible with GitHub Enterprise server.*
 

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.23.1
+  changes:
+    - description: Fix docs for Github Audit log permissions
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7954
 - version: 1.23.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/github/data_stream/audit/manifest.yml
+++ b/packages/github/data_stream/audit/manifest.yml
@@ -6,7 +6,7 @@ streams:
       - name: access_token
         type: text
         title: Personal Access Token
-        description: the GitHub Personal Access Token.  Requires the 'admin:org' scope
+        description: the GitHub Personal Access Token. Requires `read:audit_log` scope
         multi: false
         required: true
         show_user: true

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -11,7 +11,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 To use this integration, the following prerequisites must be met:
  - You must be an organization owner.
  - You must be using Github Enterprise Cloud.
- - You must use an Personal Access Token with `read:audit_log` scope.
+ - You must use a Personal Access Token with `read:audit_log` scope.
 
 *This integration is not compatible with GitHub Enterprise server.*
 

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -11,7 +11,7 @@ The GitHub audit log records all events related to the GitHub organization. See 
 To use this integration, the following prerequisites must be met:
  - You must be an organization owner.
  - You must be using Github Enterprise Cloud.
- - You must use an Personal Access Token with the `admin:org` and `read:audit_log` scope.
+ - You must use an Personal Access Token with `read:audit_log` scope.
 
 *This integration is not compatible with GitHub Enterprise server.*
 

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "1.23.0"
+version: "1.23.1"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Github token doesn't require `admin:org` scope in order to fetch the audit logs of an organization. This PR removes that scope from the token permissions.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fix docs

