### PR TITLE
[ECS] Updating hashicorp_vault to ECS 8.10 & ECS field validation updates

### DIFF
--- a/packages/hashicorp_vault/_dev/build/build.yml
+++ b/packages/hashicorp_vault/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: git@v8.10.0

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Update package to ECS 8.10.0 and align ECS categorization fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7960
 - version: "1.15.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -214,8 +214,6 @@
                 "original": "{\"time\":\"2021-07-19T17:19:00.673898225Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"24ac580b-805a-d9ee-4d0d-7046932f4e05\",\"operation\":\"update\",\"mount_type\":\"pki\",\"client_token\":\"hmac-sha256:db417023d954a03aea8f56a3daf35460aa51920337420c7c22bcbb6b10852f23\",\"namespace\":{\"id\":\"root\"},\"path\":\"internal-ca/issue/internal-server\",\"data\":{\"alt_names\":\"hmac-sha256:9760c514cdbf3ec61fa8d375643f29a78640528ddbbef6a49053ef9de6251eee\",\"common_name\":\"hmac-sha256:bc800a949f7b2fe6401884da3a085de232365d7b508d741198fa2d88815f6d7c\",\"ip_sans\":\"hmac-sha256:b6d902ee3c49cae1cfa8c9172f649716f802a4186c686b813bd344077fe0b5b2\"},\"remote_address\":\"10.6.8.34\"},\"error\":\"permission denied\"}",
                 "outcome": "failure",
                 "type": [
-                    "info",
-                    "info",
                     "info"
                 ]
             },
@@ -272,8 +270,6 @@
                 "original": "{\"time\":\"2021-07-19T17:19:00.674663552Z\",\"type\":\"response\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"24ac580b-805a-d9ee-4d0d-7046932f4e05\",\"operation\":\"update\",\"mount_type\":\"pki\",\"client_token\":\"hmac-sha256:db417023d954a03aea8f56a3daf35460aa51920337420c7c22bcbb6b10852f23\",\"namespace\":{\"id\":\"root\"},\"path\":\"internal-ca/issue/internal-server\",\"data\":{\"alt_names\":\"hmac-sha256:9760c514cdbf3ec61fa8d375643f29a78640528ddbbef6a49053ef9de6251eee\",\"common_name\":\"hmac-sha256:bc800a949f7b2fe6401884da3a085de232365d7b508d741198fa2d88815f6d7c\",\"ip_sans\":\"hmac-sha256:b6d902ee3c49cae1cfa8c9172f649716f802a4186c686b813bd344077fe0b5b2\"},\"remote_address\":\"10.6.8.34\"},\"response\":{\"mount_type\":\"pki\",\"data\":{\"error\":\"hmac-sha256:409ef1533baffc8e15cd4424780c9aba5d10f168b8d641f111da43e7955451fa\"}},\"error\":\"1 error occurred:\\n\\t* permission denied\\n\\n\"}",
                 "outcome": "failure",
                 "type": [
-                    "info",
-                    "info",
                     "info"
                 ]
             },

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2020-12-01T20:29:04.356Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -15,7 +15,7 @@
                 "original": "{\"time\":\"2020-12-01T20:29:04.356625452Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:9cc3baa3c2bd7a4b233ca1fdcf69df91c8f2a9f14ddda54a4039190f581dd327\",\"accessor\":\"hmac-sha256:eb605bd7f8a5ceb951b9ab42cae6d6c3f12f203cb2c2a78e33e899f77dceb931\",\"display_name\":\"oidc-12349999999999999999\",\"policies\":[\"default\",\"group-admin\"],\"token_policies\":[\"default\",\"group-admin\"],\"metadata\":{\"account_id\":\"12349999999999999999\",\"email\":\"example@gmail.com\",\"role\":\"gmail\"},\"entity_id\":\"e4f5c67a-6f7e-789d-ae56-a1fe3ae23046\",\"token_type\":\"service\",\"token_ttl\":3600,\"token_issue_time\":\"2020-12-01T20:28:40Z\"},\"request\":{\"id\":\"cd09708b-11cc-2985-648b-cfe262cf7e50\",\"operation\":\"update\",\"mount_type\":\"system\",\"client_token\":\"hmac-sha256:9cc3baa3c2bd7a4b233ca1fdcf69df91c8f2a9f14ddda54a4039190f581dd327\",\"client_token_accessor\":\"hmac-sha256:eb605bd7f8a5ceb951b9ab42cae6d6c3f12f203cb2c2a78e33e899f77dceb931\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/capabilities-self\",\"data\":{\"paths\":[\"hmac-sha256:fd04b28916cb60f622b1ebce308b339b468f5da93fa735f985f4435049627a27\"]},\"remote_address\":\"67.43.156.13\"}}",
                 "outcome": "success",
                 "type": [
-                    "change"
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -93,7 +93,7 @@
         {
             "@timestamp": "2020-12-01T20:29:04.360Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -105,7 +105,7 @@
                 "original": "{\"time\":\"2020-12-01T20:29:04.36089379Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:9cc3baa3c2bd7a4b233ca1fdcf69df91c8f2a9f14ddda54a4039190f581dd327\",\"accessor\":\"hmac-sha256:eb605bd7f8a5ceb951b9ab42cae6d6c3f12f203cb2c2a78e33e899f77dceb931\",\"display_name\":\"oidc-12349999999999999999\",\"policies\":[\"default\",\"group-admin\"],\"token_policies\":[\"default\",\"group-admin\"],\"metadata\":{\"account_id\":\"12349999999999999999\",\"email\":\"example@gmail.com\",\"role\":\"gmail\"},\"entity_id\":\"e4f5c67a-6f7e-789d-ae56-a1fe3ae23046\",\"token_type\":\"service\",\"token_ttl\":3600,\"token_issue_time\":\"2020-12-01T20:28:40Z\"},\"request\":{\"id\":\"cd09708b-11cc-2985-648b-cfe262cf7e50\",\"operation\":\"update\",\"mount_type\":\"system\",\"client_token\":\"hmac-sha256:9cc3baa3c2bd7a4b233ca1fdcf69df91c8f2a9f14ddda54a4039190f581dd327\",\"client_token_accessor\":\"hmac-sha256:eb605bd7f8a5ceb951b9ab42cae6d6c3f12f203cb2c2a78e33e899f77dceb931\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/capabilities-self\",\"data\":{\"paths\":[\"hmac-sha256:fd04b28916cb60f622b1ebce308b339b468f5da93fa735f985f4435049627a27\"]},\"remote_address\":\"67.43.156.13\"},\"response\":{\"mount_type\":\"system\",\"data\":{\"capabilities\":[\"hmac-sha256:b77b79078c7bad1402a1ec74613454fd85efa203f1aa557fd2a9718cfd4ef367\",\"hmac-sha256:8d0bb80a69f442489908170e1831503c65b2f9d45a3250eac21fc16840416e5a\",\"hmac-sha256:c5086738f6225235066f69681e94111d94a45a268e9f0c64c6105073e32e8176\",\"hmac-sha256:3d439b7d92cbd8123fda8462716af05ae15710c8e2905eaba8d5452fccbad2f2\",\"hmac-sha256:5622a2d8fedf53e4671d6f371c59e40f3379030815fd4bb4126fdedce5fc87bb\"],\"secret/metadata/apps/github-runner/ca-cert\":[\"hmac-sha256:b77b79078c7bad1402a1ec74613454fd85efa203f1aa557fd2a9718cfd4ef367\",\"hmac-sha256:8d0bb80a69f442489908170e1831503c65b2f9d45a3250eac21fc16840416e5a\",\"hmac-sha256:c5086738f6225235066f69681e94111d94a45a268e9f0c64c6105073e32e8176\",\"hmac-sha256:3d439b7d92cbd8123fda8462716af05ae15710c8e2905eaba8d5452fccbad2f2\",\"hmac-sha256:5622a2d8fedf53e4671d6f371c59e40f3379030815fd4bb4126fdedce5fc87bb\"]}}}",
                 "outcome": "success",
                 "type": [
-                    "change"
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -202,7 +202,7 @@
         {
             "@timestamp": "2021-07-19T17:19:00.673Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -214,9 +214,10 @@
                 "original": "{\"time\":\"2021-07-19T17:19:00.673898225Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"24ac580b-805a-d9ee-4d0d-7046932f4e05\",\"operation\":\"update\",\"mount_type\":\"pki\",\"client_token\":\"hmac-sha256:db417023d954a03aea8f56a3daf35460aa51920337420c7c22bcbb6b10852f23\",\"namespace\":{\"id\":\"root\"},\"path\":\"internal-ca/issue/internal-server\",\"data\":{\"alt_names\":\"hmac-sha256:9760c514cdbf3ec61fa8d375643f29a78640528ddbbef6a49053ef9de6251eee\",\"common_name\":\"hmac-sha256:bc800a949f7b2fe6401884da3a085de232365d7b508d741198fa2d88815f6d7c\",\"ip_sans\":\"hmac-sha256:b6d902ee3c49cae1cfa8c9172f649716f802a4186c686b813bd344077fe0b5b2\"},\"remote_address\":\"10.6.8.34\"},\"error\":\"permission denied\"}",
                 "outcome": "failure",
                 "type": [
-                    "change",
-                    "error",
-                    "denied"
+                    "info",
+                    "info",
+                    "end",
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -260,7 +261,7 @@
         {
             "@timestamp": "2021-07-19T17:19:00.674Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -272,9 +273,10 @@
                 "original": "{\"time\":\"2021-07-19T17:19:00.674663552Z\",\"type\":\"response\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"24ac580b-805a-d9ee-4d0d-7046932f4e05\",\"operation\":\"update\",\"mount_type\":\"pki\",\"client_token\":\"hmac-sha256:db417023d954a03aea8f56a3daf35460aa51920337420c7c22bcbb6b10852f23\",\"namespace\":{\"id\":\"root\"},\"path\":\"internal-ca/issue/internal-server\",\"data\":{\"alt_names\":\"hmac-sha256:9760c514cdbf3ec61fa8d375643f29a78640528ddbbef6a49053ef9de6251eee\",\"common_name\":\"hmac-sha256:bc800a949f7b2fe6401884da3a085de232365d7b508d741198fa2d88815f6d7c\",\"ip_sans\":\"hmac-sha256:b6d902ee3c49cae1cfa8c9172f649716f802a4186c686b813bd344077fe0b5b2\"},\"remote_address\":\"10.6.8.34\"},\"response\":{\"mount_type\":\"pki\",\"data\":{\"error\":\"hmac-sha256:409ef1533baffc8e15cd4424780c9aba5d10f168b8d641f111da43e7955451fa\"}},\"error\":\"1 error occurred:\\n\\t* permission denied\\n\\n\"}",
                 "outcome": "failure",
                 "type": [
-                    "change",
-                    "error",
-                    "denied"
+                    "info",
+                    "info",
+                    "end",
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -324,7 +326,7 @@
         {
             "@timestamp": "2021-06-29T17:26:11.402Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -336,7 +338,8 @@
                 "original": "{\"time\":\"2021-06-29T17:26:11.402530449Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:95b624915ff8dd55a4028bb57d1af8c6d487a99033b507b99a5a6e943b4933ef\",\"accessor\":\"hmac-sha256:8fa4f7f3d1fd812064950025cde2b1565829a9dc5075253399e5ede8f8a1d98e\",\"display_name\":\"token-375f9cb3-4355-42c7-eab5-029f8a310ca7-runner\",\"policies\":[\"app-continuous-delivery\",\"app-github-runner\",\"default\"],\"token_policies\":[\"app-continuous-delivery\",\"app-github-runner\",\"default\"],\"metadata\":{\"AllocationID\":\"375f9cb3-4355-42c7-eab5-029f8a310ca7\",\"Namespace\":\"\",\"NodeID\":\"b70676cb-731b-976b-edc4-a5b1bb963fe4\",\"Task\":\"runner\"},\"token_type\":\"service\",\"token_ttl\":259200,\"token_issue_time\":\"2021-04-29T21:53:46Z\"},\"request\":{\"id\":\"0042ad1b-1400-7eb7-5e25-1dfc898c1998\",\"operation\":\"read\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:95b624915ff8dd55a4028bb57d1af8c6d487a99033b507b99a5a6e943b4933ef\",\"client_token_accessor\":\"hmac-sha256:8fa4f7f3d1fd812064950025cde2b1565829a9dc5075253399e5ede8f8a1d98e\",\"namespace\":{\"id\":\"root\"},\"path\":\"secret/data/apps/continuous-delivery/aws-bucket-sse-c\",\"remote_address\":\"10.6.8.36\"}}",
                 "outcome": "success",
                 "type": [
-                    "access"
+                    "info",
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -407,7 +410,7 @@
         {
             "@timestamp": "2021-06-29T17:26:11.409Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -419,7 +422,8 @@
                 "original": "{\"time\":\"2021-06-29T17:26:11.409840527Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:95b624915ff8dd55a4028bb57d1af8c6d487a99033b507b99a5a6e943b4933ef\",\"accessor\":\"hmac-sha256:8fa4f7f3d1fd812064950025cde2b1565829a9dc5075253399e5ede8f8a1d98e\",\"display_name\":\"token-375f9cb3-4355-42c7-eab5-029f8a310ca7-runner\",\"policies\":[\"app-continuous-delivery\",\"app-github-runner\",\"default\"],\"token_policies\":[\"app-continuous-delivery\",\"app-github-runner\",\"default\"],\"metadata\":{\"AllocationID\":\"375f9cb3-4355-42c7-eab5-029f8a310ca7\",\"Namespace\":\"\",\"NodeID\":\"b70676cb-731b-976b-edc4-a5b1bb963fe4\",\"Task\":\"runner\"},\"token_type\":\"service\",\"token_ttl\":259200,\"token_issue_time\":\"2021-04-29T21:53:46Z\"},\"request\":{\"id\":\"0042ad1b-1400-7eb7-5e25-1dfc898c1998\",\"operation\":\"read\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:95b624915ff8dd55a4028bb57d1af8c6d487a99033b507b99a5a6e943b4933ef\",\"client_token_accessor\":\"hmac-sha256:8fa4f7f3d1fd812064950025cde2b1565829a9dc5075253399e5ede8f8a1d98e\",\"namespace\":{\"id\":\"root\"},\"path\":\"secret/data/apps/continuous-delivery/aws-bucket-sse-c\",\"remote_address\":\"10.6.8.36\"},\"response\":{\"mount_type\":\"kv\",\"data\":{\"data\":{\"customer_key\":\"hmac-sha256:85d3c6e705ea04f49772b92cc7335e34c53f0264a6d75bba3ab95bad22ca5bd1\"},\"metadata\":{\"created_time\":\"hmac-sha256:9c910646d7399704ee015b4247b374bfb950282339d902a221b1ff4c83b13ee7\",\"deletion_time\":\"hmac-sha256:17a84bc5c1c7ee851af0069663ab9de3c879107724470fa34fc0b5418fb653db\",\"destroyed\":false,\"version\":1}}}}",
                 "outcome": "success",
                 "type": [
-                    "access"
+                    "info",
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -504,7 +508,7 @@
         {
             "@timestamp": "2021-06-29T18:01:29.545Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -516,7 +520,8 @@
                 "original": "{\"time\":\"2021-06-29T18:01:29.545476939Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:f69c28fde8609df2a0ec6a316c0293179fa922a8a3a660a314859e6cff8e5fef\",\"accessor\":\"hmac-sha256:2ee197e25b333d83ba45d0c40aca153e0ad6c9e42b04b6de6a5b5b575de58771\",\"display_name\":\"token-c1d6c089-2f46-ff11-5988-38636bddf8d9-homeassistant\",\"policies\":[\"app-home-assistant\",\"default\"],\"token_policies\":[\"app-home-assistant\",\"default\"],\"metadata\":{\"AllocationID\":\"c1d6c089-2f46-ff11-5988-38636bddf8d9\",\"Namespace\":\"\",\"NodeID\":\"a28cef3a-f9e6-ad7d-bc5f-2c5ac27eec51\",\"Task\":\"homeassistant\"},\"token_type\":\"service\",\"token_ttl\":259200,\"token_issue_time\":\"2021-06-24T21:22:03Z\"},\"request\":{\"id\":\"3aa3f349-b55a-53e3-a795-dd4137d64299\",\"operation\":\"read\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:f69c28fde8609df2a0ec6a316c0293179fa922a8a3a660a314859e6cff8e5fef\",\"client_token_accessor\":\"hmac-sha256:2ee197e25b333d83ba45d0c40aca153e0ad6c9e42b04b6de6a5b5b575de58771\",\"namespace\":{\"id\":\"root\"},\"path\":\"secret/data/apps/home-assistant/secrets_yaml\",\"remote_address\":\"10.6.8.34\"}}",
                 "outcome": "success",
                 "type": [
-                    "access"
+                    "info",
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -585,7 +590,7 @@
         {
             "@timestamp": "2021-06-29T18:01:29.547Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -597,7 +602,8 @@
                 "original": "{\"time\":\"2021-06-29T18:01:29.547355273Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:f69c28fde8609df2a0ec6a316c0293179fa922a8a3a660a314859e6cff8e5fef\",\"accessor\":\"hmac-sha256:2ee197e25b333d83ba45d0c40aca153e0ad6c9e42b04b6de6a5b5b575de58771\",\"display_name\":\"token-c1d6c089-2f46-ff11-5988-38636bddf8d9-homeassistant\",\"policies\":[\"app-home-assistant\",\"default\"],\"token_policies\":[\"app-home-assistant\",\"default\"],\"metadata\":{\"AllocationID\":\"c1d6c089-2f46-ff11-5988-38636bddf8d9\",\"Namespace\":\"\",\"NodeID\":\"a28cef3a-f9e6-ad7d-bc5f-2c5ac27eec51\",\"Task\":\"homeassistant\"},\"token_type\":\"service\",\"token_ttl\":259200,\"token_issue_time\":\"2021-06-24T21:22:03Z\"},\"request\":{\"id\":\"3aa3f349-b55a-53e3-a795-dd4137d64299\",\"operation\":\"read\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:f69c28fde8609df2a0ec6a316c0293179fa922a8a3a660a314859e6cff8e5fef\",\"client_token_accessor\":\"hmac-sha256:2ee197e25b333d83ba45d0c40aca153e0ad6c9e42b04b6de6a5b5b575de58771\",\"namespace\":{\"id\":\"root\"},\"path\":\"secret/data/apps/home-assistant/secrets_yaml\",\"remote_address\":\"10.6.8.34\"},\"response\":{\"mount_type\":\"kv\",\"data\":{\"data\":{\"aladdin_connect_password\":\"hmac-sha256:f3a85a98373fa879041a438606e38773fdfaca9d99e2a1ee08183a2cb8fc9a17\",\"aladdin_connect_username\":\"hmac-sha256:b3c982a71d17164325f4ef6a9831a132e1bb789833fc6d1ecab5d36bc71df112\",\"elasticsearch_password\":\"hmac-sha256:8d2328e2c80428977858c0a80c6624c7910dd7da0b74c8d33e4d8d22fc0e9ad1\",\"elasticsearch_url\":\"hmac-sha256:c63aa2b5d15069aa9ff53eb1b6f4418a21a87c4fe508655d7f396b4bdf73492c\",\"elasticsearch_username\":\"hmac-sha256:bb7bdfaa02957aaf85efd2ea4585e05aa1ccb4594eb6820078bf8df46d123133\",\"rest_notify_cisco_phone_csrc_token\":\"hmac-sha256:b2120f2e905e41167ea380586d9f1bb13772873bb3e35aba28daca747921faad\",\"rest_notify_cisco_phone_password\":\"hmac-sha256:a4c3451df78d28825309c3b25fefb6fdb9314350da1169b012923325929d2b5d\",\"rest_notify_cisco_phone_username\":\"hmac-sha256:1229909bcdaa7acf6894ebfa51daff701b9f026f7bfff5525fe7ddfcf8469af6\",\"smtp_host\":\"hmac-sha256:bf4e6e6f4b1af3beb385006278b7e2da94eb4b243af8738727ba5e82375138c5\",\"smtp_password\":\"hmac-sha256:7b8a462d76578b0e4ddf162d9a244eb5a736d3d04b21d9ed399ad7f44032743e\",\"smtp_port\":587,\"smtp_username\":\"hmac-sha256:d97eb233a52d67e2fb16b43950b8537659b69a13e03aa58a771d8e82379354e4\",\"twilio_account_sid\":\"hmac-sha256:509150eeaf7657a069a37df450fe5821b307a882a2634230edf0b8b172f2fca8\",\"twilio_auth_token\":\"hmac-sha256:09cf3ffa023a5b5750d0aaff696f767b5a00c1af430b297abdc84d53dd4d139e\",\"cam_backyard_rtsp_url\":\"hmac-sha256:bcac97c20cdc641ca7ba4d1e4c80246961f6f116670ce6ae32be1a01be36fed1\",\"cam_backyard_url\":\"hmac-sha256:5a9348e779c7260e4375a734a4947506e97f86098e45db8d63ba800698d26c34\",\"cam_basement_door_rtsp_url\":\"hmac-sha256:ffd1f989ed0632e542f760ae8e683852e6d4b22acb24b5eae94e1568e977b007\",\"cam_basement_door_url\":\"hmac-sha256:550f62496448494a4a30a4c8499903ea58ea7ab43102a56103020c122795861b\",\"cam_driveway_rtsp_url\":\"hmac-sha256:7b732f13b417be1d8387dc9c517087cd2f9a854898f8bd50922ae39c9123cf5f\",\"cam_driveway_url\":\"hmac-sha256:aef04b9fc7c345e7cb49f3833fbe0d56c8d8c6c6d922152250019f83bfc38acc\",\"cam_front_door_rtsp_url\":\"hmac-sha256:db5ef5a052e6d09fee199dede89f5178afd5f642843268aa5bb43e755785f916\",\"cam_front_door_url\":\"hmac-sha256:6b5129afbd2e43f8ac8fe25a0b7c27f69c19d8713a95ac98ebfa65c8e51fd089\",\"cam_garage_rtsp_url\":\"hmac-sha256:10aa878ec26fdfa5e3a486ead013c693425f5c6bd3315b9365132a0c963c30f6\",\"cam_garage_url\":\"hmac-sha256:80d5c5b1080b12ed3681806bcc560f2ff0f53a43549df72396b14f41d1871dbf\",\"cam_mechanical_room_rtsp_url\":\"hmac-sha256:e343a772988cbc3262c6256df08c0c9f1a0f50e3bcefe3f39febc7cb135e2132\",\"cam_mechanical_room_url\":\"hmac-sha256:fd1f4d286bebd86234c474580cc2a74fdb79b16d936e4b8562e5cc13d82fbf7b\",\"cam_os_password\":\"hmac-sha256:b428f7bdeb97348f2553143030dfb1ac3b714436b59ed74e3320af2e13b5919f\",\"cam_os_username\":\"hmac-sha256:ff23e0d8782523b6a57c1bc1d21f88ef451359d7acefb032864e7a2715ba4185\",\"yale_lock_code_andrew\":\"hmac-sha256:545bca27b7805c8f17433693e8a07dab5c8b9d07a9a0e99ba04d73917c882956\",\"yale_lock_code_neva\":\"hmac-sha256:954080fe6c36dddfecea03fe20c91fa75d1c54488c1c706c988650dd0c45647e\",\"zwave_network_key\":\"hmac-sha256:382cc81146b9b71dc62135d6fb97246c74818857f3a73b03e7f7367ea53a8336\"},\"metadata\":{\"created_time\":\"hmac-sha256:be77f81a3338087479da238bf04ab23998c11375bc830cdeca8e30c24ab8a095\",\"deletion_time\":\"hmac-sha256:17a84bc5c1c7ee851af0069663ab9de3c879107724470fa34fc0b5418fb653db\",\"destroyed\":false,\"version\":6}}}}",
                 "outcome": "success",
                 "type": [
-                    "access"
+                    "info",
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -710,7 +716,7 @@
         {
             "@timestamp": "2021-12-30T17:11:12.468Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "help",

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-audit.log-expected.json
@@ -216,7 +216,6 @@
                 "type": [
                     "info",
                     "info",
-                    "end",
                     "info"
                 ]
             },
@@ -275,7 +274,6 @@
                 "type": [
                     "info",
                     "info",
-                    "end",
                     "info"
                 ]
             },

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
@@ -17,8 +17,7 @@
                 "type": [
                     "info",
                     "start",
-                    "info",
-                    "end"
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -85,8 +84,7 @@
                 "type": [
                     "info",
                     "start",
-                    "info",
-                    "end"
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -180,8 +178,7 @@
                 "outcome": "failure",
                 "type": [
                     "info",
-                    "info",
-                    "end"
+                    "info"
                 ]
             },
             "hashicorp_vault": {
@@ -270,8 +267,7 @@
                 "outcome": "failure",
                 "type": [
                     "info",
-                    "info",
-                    "end"
+                    "info"
                 ]
             },
             "hashicorp_vault": {

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2018-04-09T21:04:29.640Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -15,8 +15,10 @@
                 "original": "{\"time\":\"2018-04-09T21:04:29.6406536Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:eb3da855a3fb8b1c3574064f7edd080a97c4ebcf4a8e6674126710915fe464ae\",\"accessor\":\"hmac-sha256:f5a8798113bb65c0676abb3eef5ca5482c0c7daac38da36d402282a5414fcf3d\",\"display_name\":\"token\",\"policies\":[\"default\",\"sudo\",\"surf-admin\"],\"metadata\":{\"loglevel\":\"raw\",\"remote\":\"false\",\"surf\":\"moderate\"},\"entity_id\":\"\"},\"request\":{\"id\":\"b2f72168-6cba-1bab-808a-72d9304b82f8\",\"operation\":\"read\",\"client_token\":\"hmac-sha256:eb3da855a3fb8b1c3574064f7edd080a97c4ebcf4a8e6674126710915fe464ae\",\"client_token_accessor\":\"hmac-sha256:f5a8798113bb65c0676abb3eef5ca5482c0c7daac38da36d402282a5414fcf3d\",\"path\":\"auth/token/lookup-self\",\"data\":null,\"policy_override\":false,\"remote_address\":\"172.17.0.1\",\"wrap_ttl\":0,\"headers\":{}},\"error\":\"\"}",
                 "outcome": "failure",
                 "type": [
-                    "access",
-                    "error"
+                    "info",
+                    "start",
+                    "info",
+                    "end"
                 ]
             },
             "hashicorp_vault": {
@@ -69,7 +71,7 @@
         {
             "@timestamp": "2018-04-09T21:04:29.642Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "read",
@@ -81,8 +83,10 @@
                 "original": "{\"time\":\"2018-04-09T21:04:29.6420203Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:eb3da855a3fb8b1c3574064f7edd080a97c4ebcf4a8e6674126710915fe464ae\",\"accessor\":\"hmac-sha256:f5a8798113bb65c0676abb3eef5ca5482c0c7daac38da36d402282a5414fcf3d\",\"display_name\":\"token\",\"policies\":[\"default\",\"sudo\",\"surf-admin\"],\"metadata\":{\"loglevel\":\"raw\",\"remote\":\"false\",\"surf\":\"moderate\"},\"entity_id\":\"\"},\"request\":{\"id\":\"b2f72168-6cba-1bab-808a-72d9304b82f8\",\"operation\":\"read\",\"client_token\":\"hmac-sha256:eb3da855a3fb8b1c3574064f7edd080a97c4ebcf4a8e6674126710915fe464ae\",\"client_token_accessor\":\"hmac-sha256:f5a8798113bb65c0676abb3eef5ca5482c0c7daac38da36d402282a5414fcf3d\",\"path\":\"auth/token/lookup-self\",\"data\":null,\"policy_override\":false,\"remote_address\":\"172.17.0.1\",\"wrap_ttl\":0,\"headers\":{}},\"response\":{\"data\":{\"accessor\":\"hmac-sha256:f5a8798113bb65c0676abb3eef5ca5482c0c7daac38da36d402282a5414fcf3d\",\"creation_time\":1523307682,\"creation_ttl\":180000000,\"display_name\":\"hmac-sha256:e38035c165f0076d9288ba0363eb36733379cc5d370bec5e82f11632519c26a8\",\"entity_id\":\"hmac-sha256:2fced7e2c77266f5079d733bea71dc8c8413d3838584ca9d0f4867271df7a220\",\"expire_time\":\"2023-12-23T05:01:22.8929692Z\",\"explicit_max_ttl\":0,\"id\":\"hmac-sha256:eb3da855a3fb8b1c3574064f7edd080a97c4ebcf4a8e6674126710915fe464ae\",\"issue_time\":\"2018-04-09T21:01:22.8929624Z\",\"meta\":{\"loglevel\":\"hmac-sha256:eac4a7deb2df94609ab14ae48b9edea81d91de51be1dd59df6ca6852537227c5\",\"remote\":\"hmac-sha256:aa2d1dd64d4468bbd9c6b0ca275cdffb7473a2d91b5f42a047161620245fcc79\",\"surf\":\"hmac-sha256:8b29af9294da23c72de8d8d847ccebd450d978af5565807d0c9922b6b2e92988\"},\"num_uses\":0,\"orphan\":false,\"path\":\"hmac-sha256:36ea987a227a2c7aefe055a98f99751383f601955e9f1925bd3c2d6f9931a025\",\"policies\":[\"hmac-sha256:451623ebbe12fb9b1b3f444ceb5a5a46102452e46d640925c7b0dcb93a65a99a\",\"hmac-sha256:9a76c609b073848f2d9cb4a7fcddfc2103c0063480b87a9ee585e9e072e901d9\",\"hmac-sha256:8924f876eca967c68bbc8ac138e9f876f2144e300c08b1898224fc76902c1fe3\"],\"renewable\":true,\"ttl\":179999812}},\"error\":\"\"}",
                 "outcome": "failure",
                 "type": [
-                    "access",
-                    "error"
+                    "info",
+                    "start",
+                    "info",
+                    "end"
                 ]
             },
             "hashicorp_vault": {
@@ -163,7 +167,7 @@
         {
             "@timestamp": "2021-07-21T12:37:50.936Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -175,8 +179,9 @@
                 "original": "{\"time\":\"2021-07-21T12:37:50.93608Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"remaining_uses\":5,\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"request\":{\"id\":\"002c8225-e859-44a0-9ccb-471c3655dbd8\",\"operation\":\"update\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:e890f27c5ee11e26bda7c8e6ec218af451a6b1e35f9fe6d0676f1b29889b406c\",\"client_token_accessor\":\"35e2f256-0fc3-4eea-9405-3e212435b6c7\",\"namespace\":{\"id\":\"root\"},\"path\":\"secrets/foo\",\"data\":{\"data\":\"hmac-sha256:46c0fd3146d89ff602279417df7ac9267ce58fa3c6d2535d2d9050a5323c21ec\"},\"policy_override\":true,\"remote_address\":\"127.0.0.1\",\"wrap_ttl\":3600,\"headers\":{\"foo\":[\"bar\"]}},\"error\":\"this is an error\"}",
                 "outcome": "failure",
                 "type": [
-                    "change",
-                    "error"
+                    "info",
+                    "info",
+                    "end"
                 ]
             },
             "hashicorp_vault": {
@@ -252,7 +257,7 @@
         {
             "@timestamp": "2021-07-21T12:37:50.936Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "update",
@@ -264,8 +269,9 @@
                 "original": "{\"time\":\"2021-07-21T12:37:50.936443Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"remaining_uses\":5,\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"request\":{\"id\":\"002c8225-e859-44a0-9ccb-471c3655dbd8\",\"operation\":\"update\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:e890f27c5ee11e26bda7c8e6ec218af451a6b1e35f9fe6d0676f1b29889b406c\",\"client_token_accessor\":\"35e2f256-0fc3-4eea-9405-3e212435b6c7\",\"namespace\":{\"id\":\"root\"},\"path\":\"secrets/foo\",\"data\":{\"data\":\"hmac-sha256:46c0fd3146d89ff602279417df7ac9267ce58fa3c6d2535d2d9050a5323c21ec\"},\"policy_override\":true,\"remote_address\":\"127.0.0.1\",\"wrap_ttl\":3600,\"headers\":{\"foo\":[\"bar\"]}},\"response\":{\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"mount_type\":\"kv\",\"data\":{\"certificate\":\"hmac-sha256:cb232c6394c9149b7f06f85e8ed9fcc55b7d1db82dd0ec1d321d0a83a7adda01\"},\"redirect\":\"redirect\",\"wrap_info\":{\"ttl\":3600,\"token\":\"hmac-sha256:09dff0fdb8db56293383d7d0347afdf64ceb672cb9aea2c66edd802bcd714094\",\"accessor\":\"xzW2I9CMqcALsllhYvqtlsvq\",\"creation_time\":\"2020-05-28T18:40:18Z\",\"creation_path\":\"auth/token/create\",\"wrapped_accessor\":\"Bh57rT8zuhspG9APjXpGpiAJ\"},\"headers\":{\"Extra-Extra\":[\"read\"]}},\"error\":\"this is an error\"}",
                 "outcome": "failure",
                 "type": [
-                    "change",
-                    "error"
+                    "info",
+                    "info",
+                    "end"
                 ]
             },
             "hashicorp_vault": {

--- a/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/audit/_dev/test/pipeline/test-faked-all-fields.log-expected.json
@@ -16,8 +16,7 @@
                 "outcome": "failure",
                 "type": [
                     "info",
-                    "start",
-                    "info"
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -83,8 +82,7 @@
                 "outcome": "failure",
                 "type": [
                     "info",
-                    "start",
-                    "info"
+                    "start"
                 ]
             },
             "hashicorp_vault": {
@@ -177,7 +175,6 @@
                 "original": "{\"time\":\"2021-07-21T12:37:50.93608Z\",\"type\":\"request\",\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"remaining_uses\":5,\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"request\":{\"id\":\"002c8225-e859-44a0-9ccb-471c3655dbd8\",\"operation\":\"update\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:e890f27c5ee11e26bda7c8e6ec218af451a6b1e35f9fe6d0676f1b29889b406c\",\"client_token_accessor\":\"35e2f256-0fc3-4eea-9405-3e212435b6c7\",\"namespace\":{\"id\":\"root\"},\"path\":\"secrets/foo\",\"data\":{\"data\":\"hmac-sha256:46c0fd3146d89ff602279417df7ac9267ce58fa3c6d2535d2d9050a5323c21ec\"},\"policy_override\":true,\"remote_address\":\"127.0.0.1\",\"wrap_ttl\":3600,\"headers\":{\"foo\":[\"bar\"]}},\"error\":\"this is an error\"}",
                 "outcome": "failure",
                 "type": [
-                    "info",
                     "info"
                 ]
             },
@@ -266,7 +263,6 @@
                 "original": "{\"time\":\"2021-07-21T12:37:50.936443Z\",\"type\":\"response\",\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"remaining_uses\":5,\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"request\":{\"id\":\"002c8225-e859-44a0-9ccb-471c3655dbd8\",\"operation\":\"update\",\"mount_type\":\"kv\",\"client_token\":\"hmac-sha256:e890f27c5ee11e26bda7c8e6ec218af451a6b1e35f9fe6d0676f1b29889b406c\",\"client_token_accessor\":\"35e2f256-0fc3-4eea-9405-3e212435b6c7\",\"namespace\":{\"id\":\"root\"},\"path\":\"secrets/foo\",\"data\":{\"data\":\"hmac-sha256:46c0fd3146d89ff602279417df7ac9267ce58fa3c6d2535d2d9050a5323c21ec\"},\"policy_override\":true,\"remote_address\":\"127.0.0.1\",\"wrap_ttl\":3600,\"headers\":{\"foo\":[\"bar\"]}},\"response\":{\"auth\":{\"client_token\":\"hmac-sha256:3aae134b7843218bf089cd9b01a55ec417346a242b5383a7fac2ab49692f403a\",\"accessor\":\"bar\",\"display_name\":\"testtoken\",\"policies\":[\"root\"],\"token_policies\":[\"web\"],\"identity_policies\":[\"ident1\",\"ident2\"],\"external_namespace_policies\":{\"ns1\":[\"baz\"]},\"no_default_policy\":true,\"metadata\":{\"id\":\"007\"},\"entity_id\":\"foobarentity\",\"token_type\":\"service\",\"token_ttl\":14400,\"token_issue_time\":\"2020-05-28T13:40:18-05:00\"},\"mount_type\":\"kv\",\"data\":{\"certificate\":\"hmac-sha256:cb232c6394c9149b7f06f85e8ed9fcc55b7d1db82dd0ec1d321d0a83a7adda01\"},\"redirect\":\"redirect\",\"wrap_info\":{\"ttl\":3600,\"token\":\"hmac-sha256:09dff0fdb8db56293383d7d0347afdf64ceb672cb9aea2c66edd802bcd714094\",\"accessor\":\"xzW2I9CMqcALsllhYvqtlsvq\",\"creation_time\":\"2020-05-28T18:40:18Z\",\"creation_path\":\"auth/token/create\",\"wrapped_accessor\":\"Bh57rT8zuhspG9APjXpGpiAJ\"},\"headers\":{\"Extra-Extra\":[\"read\"]}},\"error\":\"this is an error\"}",
                 "outcome": "failure",
                 "type": [
-                    "info",
                     "info"
                 ]
             },

--- a/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -40,23 +40,28 @@ processors:
       if: ctx?.hashicorp_vault?.audit?.request?.operation == 'delete'
       field: event.type
       value: [info, end]
+      allow_duplicates: false
   - append:
       if: ctx?.hashicorp_vault?.audit?.request?.operation == 'update'
       field: event.type
       value: info
+      allow_duplicates: false
   - append:
       if: >
         ['read', 'list', 'create'].contains(ctx.hashicorp_vault?.audit?.request?.operation)
       field: event.type
       value: [info, start]
+      allow_duplicates: false
   - append:
       if: ctx?.hashicorp_vault?.audit?.error != null
       field: event.type
       value: info
+      allow_duplicates: false
   - append:
       if: ctx?.hashicorp_vault?.audit?.error != null && ctx.hashicorp_vault.audit.error.contains("denied")
       field: event.type
       value: info
+      allow_duplicates: false
   - set:
       field: event.action
       copy_from: hashicorp_vault.audit.request.operation

--- a/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for processing Hashicorp Vault audit logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - rename:
       field: message
       target_field: event.original
@@ -37,29 +37,28 @@ processors:
       value: authentication
   # Request operation can be: create, delete, list, read, update.
   - append:
-      if: ctx?.hashicorp_vault?.audit?.request?.operation == 'create'
-      field: event.type
-      value: creation
-  - append:
       if: ctx?.hashicorp_vault?.audit?.request?.operation == 'delete'
       field: event.type
-      value: deletion
+      value: [info, end]
   - append:
       if: ctx?.hashicorp_vault?.audit?.request?.operation == 'update'
       field: event.type
-      value: change
+      value: info
   - append:
-      if: ctx?.hashicorp_vault?.audit?.request?.operation == 'read' || ctx?.hashicorp_vault?.audit?.request?.operation == 'list'
+      if: >
+        ctx?.hashicorp_vault?.audit?.request?.operation == 'read' || 
+        ctx?.hashicorp_vault?.audit?.request?.operation == 'list' ||
+        ctx?.hashicorp_vault?.audit?.request?.operation == 'create'
       field: event.type
-      value: access
+      value: [info, start]
   - append:
       if: ctx?.hashicorp_vault?.audit?.error != null
       field: event.type
-      value: error
+      value: info
   - append:
       if: ctx?.hashicorp_vault?.audit?.error != null && ctx.hashicorp_vault.audit.error.contains("denied")
       field: event.type
-      value: denied
+      value: info
   - set:
       field: event.action
       copy_from: hashicorp_vault.audit.request.operation

--- a/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hashicorp_vault/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -46,9 +46,7 @@ processors:
       value: info
   - append:
       if: >
-        ctx?.hashicorp_vault?.audit?.request?.operation == 'read' || 
-        ctx?.hashicorp_vault?.audit?.request?.operation == 'list' ||
-        ctx?.hashicorp_vault?.audit?.request?.operation == 'create'
+        ['read', 'list', 'create'].contains(ctx.hashicorp_vault?.audit?.request?.operation)
       field: event.type
       value: [info, start]
   - append:

--- a/packages/hashicorp_vault/data_stream/audit/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/audit/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-07-20T13:39:22.108Z",
+    "@timestamp": "2023-09-25T13:24:07.923Z",
     "agent": {
-        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.audit",
@@ -13,12 +13,12 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": "update",
@@ -27,13 +27,13 @@
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
-        "ingested": "2023-07-20T13:39:50Z",
+        "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
+        "ingested": "2023-09-25T13:24:32Z",
         "kind": "event",
-        "original": "{\"time\":\"2023-07-20T13:39:22.1089946Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"07b55e76-c58c-7911-f1a2-a19692c37e43\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-09-25T13:24:07.923269575Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"f8b3b3d3-8e8d-6a88-0d45-326f841b19b5\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
-            "change"
+            "info"
         ]
     },
     "hashicorp_vault": {
@@ -42,7 +42,7 @@
                 "token_type": "default"
             },
             "request": {
-                "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
+                "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
                 "namespace": {
                     "id": "root"
                 },
@@ -54,20 +54,20 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "f61391496aaa43bb94736676494450c5",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.22.0.10"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/hashicorp_vault/data_stream/audit/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/audit/sample_event.json
@@ -1,7 +1,7 @@
 {
-    "@timestamp": "2023-09-25T13:24:07.923Z",
+    "@timestamp": "2023-09-26T13:07:49.743Z",
     "agent": {
-        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "ephemeral_id": "5bbd86cc-8032-432d-be82-fae8f624ed98",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -27,10 +27,10 @@
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
-        "ingested": "2023-09-25T13:24:32Z",
+        "id": "0b1b9013-da54-633d-da69-8575e6794ed3",
+        "ingested": "2023-09-26T13:08:15Z",
         "kind": "event",
-        "original": "{\"time\":\"2023-09-25T13:24:07.923269575Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"f8b3b3d3-8e8d-6a88-0d45-326f841b19b5\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-09-26T13:07:49.743284857Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"0b1b9013-da54-633d-da69-8575e6794ed3\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
             "info"
@@ -42,7 +42,7 @@
                 "token_type": "default"
             },
             "request": {
-                "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
+                "id": "0b1b9013-da54-633d-da69-8575e6794ed3",
                 "namespace": {
                     "id": "root"
                 },

--- a/packages/hashicorp_vault/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/hashicorp_vault/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2021-07-16T06:30:48.194Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -27,7 +27,7 @@
         {
             "@timestamp": "2021-07-16T06:33:08.867Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -50,7 +50,7 @@
         {
             "@timestamp": "2021-07-09T17:20:27.184Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -77,7 +77,7 @@
         {
             "@timestamp": "2021-07-09T17:20:27.190Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -100,7 +100,7 @@
         {
             "@timestamp": "2021-07-09T17:20:27.182Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -127,7 +127,7 @@
         {
             "@timestamp": "2021-07-09T17:20:27.212Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -151,7 +151,7 @@
         {
             "@timestamp": "2021-07-09T17:04:06.945Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -175,7 +175,7 @@
         {
             "@timestamp": "2021-07-16T19:05:02.795Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -198,7 +198,7 @@
         {
             "@timestamp": "2021-07-09T17:01:42.203Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -222,7 +222,7 @@
         {
             "@timestamp": "2021-07-22T17:33:20.689Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -245,7 +245,7 @@
         {
             "@timestamp": "2021-07-22T17:33:20.689Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",
@@ -272,7 +272,7 @@
         {
             "@timestamp": "2021-07-22T17:33:20.691Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "kind": "event",

--- a/packages/hashicorp_vault/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hashicorp_vault/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for processing Hashicorp Vault operational logs.
 processors:
   - set:
       field: ecs.version
-      value: '8.9.0'
+      value: '8.10.0'
   - set:
       field: event.kind
       value: event

--- a/packages/hashicorp_vault/data_stream/log/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/log/sample_event.json
@@ -1,7 +1,7 @@
 {
-    "@timestamp": "2023-09-25T13:25:23.306Z",
+    "@timestamp": "2023-09-26T13:09:08.587Z",
     "agent": {
-        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "ephemeral_id": "5bbd86cc-8032-432d-be82-fae8f624ed98",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -23,9 +23,9 @@
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2023-09-25T13:25:48Z",
+        "ingested": "2023-09-26T13:09:35Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-25T13:25:23.306351Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-26T13:09:08.587324Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {

--- a/packages/hashicorp_vault/data_stream/log/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-07-20T13:40:29.312Z",
+    "@timestamp": "2023-09-25T13:25:23.306Z",
     "agent": {
-        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.log",
@@ -13,19 +13,19 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2023-07-20T13:40:57Z",
+        "ingested": "2023-09-25T13:25:48Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-07-20T13:40:29.312131Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-25T13:25:23.306351Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {
@@ -36,20 +36,20 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "f61391496aaa43bb94736676494450c5",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.22.0.10"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/hashicorp_vault/data_stream/metrics/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/metrics/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-07-20T13:42:02.506Z",
+    "@timestamp": "2023-09-25T13:27:19.655Z",
     "agent": {
-        "ephemeral_id": "08f3f73e-194c-4c7b-b9a9-5de2971266e7",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "9839521e-7998-4af2-9684-9a7088210694",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.metrics",
@@ -16,39 +16,40 @@
         "version": "8.9.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "event": {
         "agent_id_status": "verified",
-        "duration": 8463400,
-        "ingested": "2023-07-20T13:42:03Z",
+        "duration": 3137729,
+        "ingested": "2023-09-25T13:27:22Z",
         "kind": "metric"
     },
     "hashicorp_vault": {
         "metrics": {
-            "vault_barrier_get": {
-                "value": 0.06210000067949295
+            "vault_barrier_estimated_encryptions": {
+                "counter": 48,
+                "rate": 0
             }
         }
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "f61391496aaa43bb94736676494450c5",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.22.0.10"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -59,7 +60,7 @@
         "host": "hashicorp_vault",
         "instance": "hashicorp_vault:8200",
         "job": "hashicorp_vault",
-        "quantile": "0.9"
+        "term": "1"
     },
     "metricset": {
         "period": 5000

--- a/packages/hashicorp_vault/data_stream/metrics/sample_event.json
+++ b/packages/hashicorp_vault/data_stream/metrics/sample_event.json
@@ -1,7 +1,7 @@
 {
-    "@timestamp": "2023-09-25T13:27:19.655Z",
+    "@timestamp": "2023-09-26T13:11:06.913Z",
     "agent": {
-        "ephemeral_id": "9839521e-7998-4af2-9684-9a7088210694",
+        "ephemeral_id": "3de3cc3a-6b9f-46c0-a268-200ac7dda214",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
@@ -22,8 +22,8 @@
     },
     "event": {
         "agent_id_status": "verified",
-        "duration": 3137729,
-        "ingested": "2023-09-25T13:27:22Z",
+        "duration": 4669007,
+        "ingested": "2023-09-26T13:11:09Z",
         "kind": "metric"
     },
     "hashicorp_vault": {

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -83,9 +83,9 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-09-25T13:24:07.923Z",
+    "@timestamp": "2023-09-26T13:07:49.743Z",
     "agent": {
-        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "ephemeral_id": "5bbd86cc-8032-432d-be82-fae8f624ed98",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -111,10 +111,10 @@ An example event for `audit` looks as following:
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
-        "ingested": "2023-09-25T13:24:32Z",
+        "id": "0b1b9013-da54-633d-da69-8575e6794ed3",
+        "ingested": "2023-09-26T13:08:15Z",
         "kind": "event",
-        "original": "{\"time\":\"2023-09-25T13:24:07.923269575Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"f8b3b3d3-8e8d-6a88-0d45-326f841b19b5\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-09-26T13:07:49.743284857Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"0b1b9013-da54-633d-da69-8575e6794ed3\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
             "info"
@@ -126,7 +126,7 @@ An example event for `audit` looks as following:
                 "token_type": "default"
             },
             "request": {
-                "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
+                "id": "0b1b9013-da54-633d-da69-8575e6794ed3",
                 "namespace": {
                     "id": "root"
                 },
@@ -317,9 +317,9 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-09-25T13:25:23.306Z",
+    "@timestamp": "2023-09-26T13:09:08.587Z",
     "agent": {
-        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "ephemeral_id": "5bbd86cc-8032-432d-be82-fae8f624ed98",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -341,9 +341,9 @@ An example event for `log` looks as following:
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2023-09-25T13:25:48Z",
+        "ingested": "2023-09-26T13:09:35Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-25T13:25:23.306351Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-26T13:09:08.587324Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {

--- a/packages/hashicorp_vault/docs/README.md
+++ b/packages/hashicorp_vault/docs/README.md
@@ -83,13 +83,13 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-07-20T13:39:22.108Z",
+    "@timestamp": "2023-09-25T13:24:07.923Z",
     "agent": {
-        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.audit",
@@ -97,12 +97,12 @@ An example event for `audit` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": "update",
@@ -111,13 +111,13 @@ An example event for `audit` looks as following:
             "authentication"
         ],
         "dataset": "hashicorp_vault.audit",
-        "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
-        "ingested": "2023-07-20T13:39:50Z",
+        "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
+        "ingested": "2023-09-25T13:24:32Z",
         "kind": "event",
-        "original": "{\"time\":\"2023-07-20T13:39:22.1089946Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"07b55e76-c58c-7911-f1a2-a19692c37e43\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
+        "original": "{\"time\":\"2023-09-25T13:24:07.923269575Z\",\"type\":\"request\",\"auth\":{\"token_type\":\"default\"},\"request\":{\"id\":\"f8b3b3d3-8e8d-6a88-0d45-326f841b19b5\",\"operation\":\"update\",\"namespace\":{\"id\":\"root\"},\"path\":\"sys/audit/test\"}}",
         "outcome": "success",
         "type": [
-            "change"
+            "info"
         ]
     },
     "hashicorp_vault": {
@@ -126,7 +126,7 @@ An example event for `audit` looks as following:
                 "token_type": "default"
             },
             "request": {
-                "id": "07b55e76-c58c-7911-f1a2-a19692c37e43",
+                "id": "f8b3b3d3-8e8d-6a88-0d45-326f841b19b5",
                 "namespace": {
                     "id": "root"
                 },
@@ -138,20 +138,20 @@ An example event for `audit` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "f61391496aaa43bb94736676494450c5",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.22.0.10"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -317,13 +317,13 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-07-20T13:40:29.312Z",
+    "@timestamp": "2023-09-25T13:25:23.306Z",
     "agent": {
-        "ephemeral_id": "a7c83396-040f-439b-a855-c30ecdf1e604",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "77db3422-e708-426e-96d5-10e9003825de",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "hashicorp_vault.log",
@@ -331,19 +331,19 @@ An example event for `log` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.10.1"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "hashicorp_vault.log",
-        "ingested": "2023-07-20T13:40:57Z",
+        "ingested": "2023-09-25T13:25:48Z",
         "kind": "event",
-        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-07-20T13:40:29.312131Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
+        "original": "{\"@level\":\"info\",\"@message\":\"proxy environment\",\"@timestamp\":\"2023-09-25T13:25:23.306351Z\",\"http_proxy\":\"\",\"https_proxy\":\"\",\"no_proxy\":\"\"}"
     },
     "hashicorp_vault": {
         "log": {
@@ -354,20 +354,20 @@ An example event for `log` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "f61391496aaa43bb94736676494450c5",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.22.0.10"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-16-00-0A"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.15.0"
+version: "1.16.0"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

- Updates the hashicorp_vault integration to ECS 8.10
- Correcting ECS categorization fields for validation as a result of https://github.com/elastic/elastic-package/issues/1439

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7480
- Relates https://github.com/elastic/elastic-package/issues/1439
