### PR TITLE
[ECS] Update SEI packages to ECS 8.10 (Part 5)

### DIFF
--- a/packages/entityanalytics_entra_id/_dev/build/build.yml
+++ b/packages/entityanalytics_entra_id/_dev/build/build.yml
@@ -1,3 +1,3 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: "git@v8.10.0"

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.4.0
+  changes:
+    - description: ECS version updated to 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7961
 - version: 0.3.0
   changes:
     - description: "The format_version in the package manifest changed from 2.11.0 to 3.0.0. Removed dotted YAML keys from package manifest. Added 'owner.type: elastic' to package manifest."

--- a/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-users.json-expected.json
+++ b/packages/entityanalytics_entra_id/data_stream/entity/_dev/test/pipeline/test-users.json-expected.json
@@ -15,7 +15,7 @@
                 ]
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user-discovered",
@@ -62,7 +62,7 @@
                 ]
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "user-discovered",

--- a/packages/entityanalytics_entra_id/data_stream/entity/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/entityanalytics_entra_id/data_stream/entity/elasticsearch/ingest_pipeline/default.yml
@@ -3,7 +3,7 @@ description: Pipeline for processing Microsoft Entra ID user entities.
 processors:
 - set:
     field: ecs.version
-    value: "8.9.0"
+    value: "8.10.0"
 
 # Only user documents are currently supported.
 - drop:

--- a/packages/entityanalytics_entra_id/data_stream/entity/sample_event.json
+++ b/packages/entityanalytics_entra_id/data_stream/entity/sample_event.json
@@ -13,7 +13,7 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "a5d370e8-ae36-45f7-adbd-f22b984b979d",

--- a/packages/entityanalytics_entra_id/docs/README.md
+++ b/packages/entityanalytics_entra_id/docs/README.md
@@ -53,7 +53,7 @@ An example event for `entity` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "a5d370e8-ae36-45f7-adbd-f22b984b979d",

--- a/packages/entityanalytics_entra_id/manifest.yml
+++ b/packages/entityanalytics_entra_id/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: entityanalytics_entra_id
 title: "Microsoft Entra ID Entity Analytics"
-version: "0.3.0"
+version: "0.4.0"
 description: "Collect identities from Microsoft Entra ID (formerly Azure Active Directory) with Elastic Agent."
 type: integration
 categories:

--- a/packages/qualys_vmdr/_dev/build/build.yml
+++ b/packages/qualys_vmdr/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: "git@v8.10.0"
     import_mappings: true

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.5.0
+  changes:
+    - description: ECS version updated to 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7961
 - version: 0.4.0
   changes:
     - description: "The format_version in the package manifest changed from 2.11.0 to 3.0.0. Removed dotted YAML keys from package manifest. Added 'owner.type: elastic' to package manifest."

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/_dev/test/pipeline/test-asset-host-detection.log-expected.json
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/_dev/test/pipeline/test-asset-host-detection.log-expected.json
@@ -11,7 +11,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -222,7 +222,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -335,7 +335,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -453,7 +453,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -565,7 +565,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -635,7 +635,7 @@
         },
         {
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -731,7 +731,7 @@
                 }
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/elasticsearch/ingest_pipeline/default.yml
@@ -4,7 +4,7 @@ processors:
   - set:
       field: ecs.version
       tag: set_ecs_version
-      value: 8.9.0
+      value: 8.10.0
   - set:
       field: event.kind
       tag: set_event_kind_1

--- a/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
+++ b/packages/qualys_vmdr/data_stream/asset_host_detection/sample_event.json
@@ -13,7 +13,7 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",

--- a/packages/qualys_vmdr/data_stream/knowledge_base/_dev/test/pipeline/test-knowledge-base.log-expected.json
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/_dev/test/pipeline/test-knowledge-base.log-expected.json
@@ -3,7 +3,7 @@
         {
             "@timestamp": "2023-06-06T06:02:45.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [
@@ -209,7 +209,7 @@
         {
             "@timestamp": "2023-06-06T06:02:45.000Z",
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "category": [

--- a/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/elasticsearch/ingest_pipeline/default.yml
@@ -4,7 +4,7 @@ processors:
   - set:
       field: ecs.version
       tag: set_ecs_version
-      value: 8.9.0
+      value: 8.10.0
   - set:
       field: event.kind
       tag: set_event_kind_1

--- a/packages/qualys_vmdr/data_stream/knowledge_base/sample_event.json
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/sample_event.json
@@ -13,7 +13,7 @@
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",

--- a/packages/qualys_vmdr/docs/README.md
+++ b/packages/qualys_vmdr/docs/README.md
@@ -102,7 +102,7 @@ An example event for `asset_host_detection` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",
@@ -303,7 +303,7 @@ An example event for `knowledge_base` looks as following:
         "type": "logs"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "elastic_agent": {
         "id": "6b293533-5b3c-4cb2-a00c-b2b25ba9edec",

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "0.4.0"
+version: "0.5.0"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:

--- a/packages/trellix_edr_cloud/_dev/build/build.yml
+++ b/packages/trellix_edr_cloud/_dev/build/build.yml
@@ -1,4 +1,4 @@
 dependencies:
   ecs:
-    reference: git@v8.9.0
+    reference: "git@v8.10.0"
     import_mappings: true

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.4.0
+  changes:
+    - description: ECS version updated to 8.10.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7961
 - version: 0.3.0
   changes:
     - description: "The format_version in the package manifest changed from 2.11.0 to 3.0.0. Removed dotted YAML keys from package manifest. Added 'owner.type: elastic' to package manifest."

--- a/packages/trellix_edr_cloud/data_stream/event/_dev/test/pipeline/test-event.log-expected.json
+++ b/packages/trellix_edr_cloud/data_stream/event/_dev/test/pipeline/test-event.log-expected.json
@@ -10,7 +10,7 @@
                 "id": "D435435b0-BB33-4625-891E-XXXXXXX"
             },
             "ecs": {
-                "version": "8.9.0"
+                "version": "8.10.0"
             },
             "event": {
                 "action": "added",

--- a/packages/trellix_edr_cloud/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/trellix_edr_cloud/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -4,7 +4,7 @@ processors:
   - set:
       field: ecs.version
       tag: set_ecs_version
-      value: 8.9.0
+      value: 8.10.0
   - set:
       field: event.kind
       tag: set_event_kind

--- a/packages/trellix_edr_cloud/data_stream/event/sample_event.json
+++ b/packages/trellix_edr_cloud/data_stream/event/sample_event.json
@@ -8,7 +8,7 @@
         "id": "D435435b0-BB33-4625-891E-XXXXXXX"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "event": {
         "action": "added",

--- a/packages/trellix_edr_cloud/docs/README.md
+++ b/packages/trellix_edr_cloud/docs/README.md
@@ -129,7 +129,7 @@ An example event for `event` looks as following:
         "id": "D435435b0-BB33-4625-891E-XXXXXXX"
     },
     "ecs": {
-        "version": "8.9.0"
+        "version": "8.10.0"
     },
     "event": {
         "action": "added",

--- a/packages/trellix_edr_cloud/manifest.yml
+++ b/packages/trellix_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: trellix_edr_cloud
 title: Trellix EDR Cloud
-version: "0.3.0"
+version: "0.4.0"
 description: Collect logs from Trellix EDR Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Updates the following SEI packages to ECS version 8.10:

- entityanalytics_entra_id
- qualys_vmdr
- trellix_edr_cloud

Changes generated by:
```
go install github.com/andrewkroh/go-examples/elastic-package-changelog@main
go run github.com/andrewkroh/go-examples/ecs-update@main -owner elastic/security-external-integrations -ecs-version=8.10.0 -ecs-git-ref=v8.10.0 -pr 7961 packages/<PACKAGE>
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/integrations/issues/7480