### PR TITLE
[Universal Profiling] Add inputs for collector/symbolizer

### DIFF
--- a/packages/universal_profiling_collector/agent/input/input.yml.hbs
+++ b/packages/universal_profiling_collector/agent/input/input.yml.hbs
@@ -1,5 +1,10 @@
 pf-elastic-collector:
     host: {{host}}
+    verbose: {{verbose}}
+    telemetry: {{telemetry}}
+    {{#if memory_limit}}
+    memory_limit: {{memory_limit}}
+    {{/if}}
     auth:
         secret_token: {{secret_token}}
     ssl:

--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.10.0
+  changes:
+    - description: Add input configuration options for day2 operations
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7962
 - version: 8.9.1-preview
   changes:
     - description: Add input configuration

--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 8.10.0
   changes:
-    - description: Add input configuration options for day2 operations
+    - description: Add input configuration options
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7962
 - version: 8.9.1-preview

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -4,7 +4,7 @@ version: 8.10.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.10.0
+  kibana.version: ^8.10.2
   elastic.subscription: basic
 format_version: 2.8.0
 icons:

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -1,10 +1,10 @@
 name: profiler_collector
 title: Universal Profiling Collector
-version: 8.9.1-preview
+version: 8.10.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.8.0
+  kibana.version: ^8.10.0
   elastic.subscription: basic
 format_version: 2.8.0
 icons:
@@ -25,9 +25,26 @@ policy_templates:
           - name: host
             type: text
             default: localhost:8260
+            description: Network address used to receive incoming traffic from Universal Profiling agents
+          - name: verbose
+            type: bool
+            default: false
+            description: Enable debug logging
+          - name: telemetry
+            type: bool
+            default: true
+            description: Enable metrics
+          - name: memory_limit
+            type: text
+            default: ""
+            description: |
+              Set a soft memory limit for the program. The format for Megabytes is "MB", for Mebibytes is "MiB", etc...
+              The default value ("") does not apply any limits
           - name: secret_token
             type: text
             required: true
+            description: |
+              A sequence of characters used to authenticate the Universal Profiling agents' requests to this component
           - name: tls_enabled
             type: bool
             default: false

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -38,7 +38,7 @@ policy_templates:
             type: text
             default: ""
             description: |
-              Set a soft memory limit for the program. The format for Megabytes is "MB", for Mebibytes is "MiB", etc...
+              Specify a maximum memory allowance for the program. Memory units like 'MB' (Megabytes) or 'MiB' (Mebibytes) are supported.
               The default value ("") applies a memory limit of 25% of the available memory.
           - name: secret_token
             type: text

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -39,7 +39,7 @@ policy_templates:
             default: ""
             description: |
               Set a soft memory limit for the program. The format for Megabytes is "MB", for Mebibytes is "MiB", etc...
-              The default value ("") does not apply any limits
+              The default value ("") applies a memory limit of 25% of the available memory.
           - name: secret_token
             type: text
             required: true

--- a/packages/universal_profiling_symbolizer/agent/input/input.yml.hbs
+++ b/packages/universal_profiling_symbolizer/agent/input/input.yml.hbs
@@ -1,5 +1,13 @@
 pf-elastic-symbolizer:
     host: {{host}}
+    verbose: {{verbose}}
+    telemetry: {{telemetry}}
+    {{#if memory_limit}}
+    memory_limit: {{memory_limit}}
+    {{/if}}
+    {{#if endpoint}}
+    endpoint: {{endpoint}}
+    {{/if}}
     ssl:
         enabled: {{tls_enabled}}
         certificate: {{tls_certificate_path}}

--- a/packages/universal_profiling_symbolizer/changelog.yml
+++ b/packages/universal_profiling_symbolizer/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 8.10.0
   changes:
-    - description: Add input configuration options for day2 operations
+    - description: Add input configuration options
       type: enhancement
       link:
         https://github.com/elastic/integrations/pull/7962

--- a/packages/universal_profiling_symbolizer/changelog.yml
+++ b/packages/universal_profiling_symbolizer/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: 8.10.0
+  changes:
+    - description: Add input configuration options for day2 operations
+      type: enhancement
+      link:
+        https://github.com/elastic/integrations/pull/7962
 - version: 8.9.0-preview
   changes:
     - description: Add input configuration

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -4,7 +4,7 @@ version: 8.10.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.10.0
+  kibana.version: ^8.10.2
   elastic.subscription: basic
 format_version: 2.8.0
 icons:

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -1,10 +1,10 @@
 name: profiler_symbolizer
 title: Universal Profiling Symbolizer
-version: 8.9.0-preview
+version: 8.10.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.9.0
+  kibana.version: ^8.10.0
   elastic.subscription: basic
 format_version: 2.8.0
 icons:
@@ -25,6 +25,27 @@ policy_templates:
           - name: host
             type: text
             default: localhost:8240
+            description: Network address used to serve HTTP endpoint for symbtool
+          - name: verbose
+            type: bool
+            default: false
+            description: Enable debug logging
+          - name: telemetry
+            type: bool
+            default: true
+            description: Enable metrics
+          - name: memory_limit
+            type: text
+            default: ""
+            description: |
+              Set a soft memory limit for the program. The format for Megabytes is "MB", for Mebibytes is "MiB", etc...
+              The default value ("") does not apply any limits
+          - name: endpoint
+            type: text
+            default: ""
+            description: |
+              Set the endpoint for the object storage used to fetch public OS debug symbols; do not set unless you know
+              what you are doing
           - name: tls_enabled
             type: bool
             default: false

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -38,8 +38,8 @@ policy_templates:
             type: text
             default: ""
             description: |
-              Set a soft memory limit for the program. The format for Megabytes is "MB", for Mebibytes is "MiB", etc...
-              The default value ("") does not apply any limits
+              Specify a maximum memory allowance for the program. Memory units like 'MB' (Megabytes) or 'MiB' (Mebibytes) are supported.
+              The default value ("") applies a memory limit of 25% of the available memory.
           - name: endpoint
             type: text
             default: ""

--- a/packages/universal_profiling_symbolizer/manifest.yml
+++ b/packages/universal_profiling_symbolizer/manifest.yml
@@ -44,8 +44,7 @@ policy_templates:
             type: text
             default: ""
             description: |
-              Set the endpoint for the object storage used to fetch public OS debug symbols; do not set unless you know
-              what you are doing
+              This is an expert-only setting. An incorrect endpoint could negatively impact the product's performance. We recommend sticking to the defaults.
           - name: tls_enabled
             type: bool
             default: false


### PR DESCRIPTION
## What does this PR do?

Add configuration options for universal_profiling integrations (collector/symbolizer) to set logging, telemetry and memory limits for the running binaries.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] test the new options are propagated through Fleet

## How to test this PR locally

* Run a local stack with `elastic-stack up` (stack version 8.10 or higher)
* Build an install the new packages in Kibana
* Create an agent policy and enroll an agent locally
* Configure the new `vars`
* Validate they are actually used in the binaries

