### PR TITLE
[docker] Fix 'message' data type to align with ECS

### DIFF
--- a/packages/docker/changelog.yml
+++ b/packages/docker/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.2"
+  changes:
+    - description: Fix mapping for `message` to align with ECS.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7964
 - version: "2.8.1"
   changes:
     - description: Remove confusing documentation about Windows support.

--- a/packages/docker/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/docker/data_stream/container_logs/fields/base-fields.yml
@@ -32,6 +32,4 @@
   release: ga
   description: Container log stream
 - name: message
-  type: keyword
-  release: ga
-  description: Container log message
+  external: ecs

--- a/packages/docker/docs/README.md
+++ b/packages/docker/docs/README.md
@@ -1151,7 +1151,7 @@ The Docker `container_logs` data stream collects container logs.
 | input.type | Type of Filebeat input. | keyword |
 | log.file.path | Path to the log file. | keyword |
 | log.offset | Offset of the entry in the log file. | long |
-| message | Container log message | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
 | stream | Container log stream | keyword |

--- a/packages/docker/manifest.yml
+++ b/packages/docker/manifest.yml
@@ -1,6 +1,6 @@
 name: docker
 title: Docker
-version: 2.8.1
+version: 2.8.2
 release: ga
 description: Collect metrics and logs from Docker instances with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The docker integration has the `message` field mapped as a keyword while every other integration uses `match_only_text` (ECS) or `text`.

Fixes: #5679

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #5679
