### PR TITLE
[ECS][cisco_aironet] Correcting invalid ECS field usages at root-level

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.8.0
+  changes:
+    - description: Correct invalid ECS field usages at root-level.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7966
 - version: 1.7.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -471,9 +471,6 @@
             "host": {
                 "name": "WLC001"
             },
-            "interface": {
-                "id": "3"
-            },
             "log": {
                 "level": "error",
                 "syslog": {
@@ -487,6 +484,13 @@
                 }
             },
             "message": "Port 3 Admin Mode is Disable!",
+            "observer": {
+                "ingress": {
+                    "interface": {
+                        "id": "3"
+                    }
+                }
+            },
             "process": {
                 "name": "emWeb"
             },

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -113,7 +113,7 @@ processors:
       field: message
       if: ctx._temp_?.reason == 'NIM-3-ADMIN_MODE_DISABLE'
       patterns:
-        - "Port %{INT:interface.id}"
+        - "Port %{INT:observer.ingress.interface.id}"
       ignore_failure: false
   ###
   - grok:

--- a/packages/cisco_aironet/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_aironet/data_stream/log/fields/ecs.yml
@@ -51,4 +51,4 @@
 - external: ecs
   name: threat.indicator.type
 - external: ecs
-  name: interface.id
+  name: observer.ingress.interface.id

--- a/packages/cisco_aironet/data_stream/log/sample_event.json
+++ b/packages/cisco_aironet/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2023-08-20T11:25:50.157Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "94e446a1-23f6-4982-887b-d3d087059aaa",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.10.1"
     },
     "cisco": {
         "interface": {
@@ -24,15 +24,15 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "snapshot": false,
+        "version": "8.10.1"
     },
     "event": {
         "action": "ENTRY_DELETED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "ingested": "2023-01-13T12:03:05Z",
+        "ingested": "2023-09-25T17:34:47Z",
         "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
         "severity": "6",
@@ -47,7 +47,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.27.0.4:33146"
+            "address": "192.168.80.7:42857"
         },
         "syslog": {
             "facility": {

--- a/packages/cisco_aironet/docs/README.md
+++ b/packages/cisco_aironet/docs/README.md
@@ -18,11 +18,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2023-08-20T11:25:50.157Z",
     "agent": {
-        "ephemeral_id": "88645c33-21f7-47a1-a1e6-b4a53f32ec43",
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
+        "ephemeral_id": "94e446a1-23f6-4982-887b-d3d087059aaa",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.0"
+        "version": "8.10.1"
     },
     "cisco": {
         "interface": {
@@ -41,15 +41,15 @@ An example event for `log` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "94011a8e-8b26-4bce-a627-d54316798b52",
-        "snapshot": true,
-        "version": "8.6.0"
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "snapshot": false,
+        "version": "8.10.1"
     },
     "event": {
         "action": "ENTRY_DELETED",
         "agent_id_status": "verified",
         "dataset": "cisco_aironet.log",
-        "ingested": "2023-01-13T12:03:05Z",
+        "ingested": "2023-09-25T17:34:47Z",
         "original": "\u003c134\u003eWLC001: *SISF BT Process: Aug 20 11:25:50.157: %SISF-6-ENTRY_DELETED: sisf_shim_utils.c:482 Entry deleted A=fe80::aee2:d3ff:feba:56a4 V=0 I=wired:1 P=0000 M=",
         "provider": "SISF",
         "severity": "6",
@@ -64,7 +64,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.27.0.4:33146"
+            "address": "192.168.80.7:42857"
         },
         "syslog": {
             "facility": {
@@ -122,7 +122,6 @@ An example event for `log` looks as following:
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | input.type | Input type. | keyword |
-| interface.id | Interface ID as reported by an observer (typically SNMP interface ID). | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset |  | long |
@@ -131,6 +130,7 @@ An example event for `log` looks as following:
 | log.syslog.priority | Syslog numeric priority of the event, if available. According to RFCs 5424 and 3164, the priority is 8 \* facility + severity. This number is therefore expected to contain a value between 0 and 191. | long |
 | log.syslog.severity.code | The Syslog numeric severity of the log event, if available. If the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
+| observer.ingress.interface.id | Interface ID as reported by an observer (typically SNMP interface ID). | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.name.text | Multi-field of `process.name`. | match_only_text |
 | server.ip | IP address of the server (IPv4 or IPv6). | ip |

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.7.0"
+version: "1.8.0"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Correcting invalid ECS `interface.id` field usage at the root-level

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7808