### PR TITLE
[ECS][crowdstrike] Correcting invalid ECS field usages at root-level

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.21.0
+  changes:
+    - description: Correct invalid ECS field usages at root-level.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7963
 - version: 1.20.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Correct invalid ECS field usages at root-level.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/7963
+      link: https://github.com/elastic/integrations/pull/7968
 - version: 1.20.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/crowdstrike/data_stream/falcon/sample_event.json
+++ b/packages/crowdstrike/data_stream/falcon/sample_event.json
@@ -1,7 +1,7 @@
 {
     "@timestamp": "2020-02-12T21:29:10.000Z",
     "agent": {
-        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "ephemeral_id": "6b7924ba-f695-422a-a296-d1092ff909e4",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -64,7 +64,7 @@
         ],
         "created": "2020-02-12T21:29:10.710Z",
         "dataset": "crowdstrike.falcon",
-        "ingested": "2023-09-25T19:02:20Z",
+        "ingested": "2023-09-26T13:19:10Z",
         "kind": "event",
         "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success"

--- a/packages/crowdstrike/data_stream/falcon/sample_event.json
+++ b/packages/crowdstrike/data_stream/falcon/sample_event.json
@@ -1,21 +1,43 @@
 {
-    "@timestamp": "2020-02-12T21:39:37.147Z",
+    "@timestamp": "2020-02-12T21:29:10.000Z",
     "agent": {
-        "ephemeral_id": "9fc4b95e-642d-4ce4-b7cc-1fe355c81ef1",
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "crowdstrike": {
         "event": {
-            "OperationName": "twoFactorAuthenticate",
+            "AuditKeyValues": [
+                {
+                    "Key": "APIClientID",
+                    "ValueString": "1234567890abcdefghijklmnopqr"
+                },
+                {
+                    "Key": "partition",
+                    "ValueString": "0"
+                },
+                {
+                    "Key": "offset",
+                    "ValueString": "-1"
+                },
+                {
+                    "Key": "appId",
+                    "ValueString": "siem-connector-v2.0.0"
+                },
+                {
+                    "Key": "eventType",
+                    "ValueString": "[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]"
+                }
+            ],
+            "OperationName": "streamStarted",
             "Success": true
         },
         "metadata": {
             "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
             "eventType": "AuthActivityAuditEvent",
-            "offset": 1,
+            "offset": 0,
             "version": "1.0"
         }
     },
@@ -28,22 +50,23 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": [
-            "twoFactorAuthenticate"
+            "streamStarted"
         ],
         "agent_id_status": "verified",
         "category": [
-            "authentication"
+            "iam"
         ],
+        "created": "2020-02-12T21:29:10.710Z",
         "dataset": "crowdstrike.falcon",
-        "ingested": "2023-06-27T07:42:52Z",
+        "ingested": "2023-09-25T19:02:20Z",
         "kind": "event",
-        "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 1,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581543577147,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"alice@company.com\",\n        \"UserIp\": \"192.168.6.8\",\n        \"OperationName\": \"twoFactorAuthenticate\",\n        \"ServiceName\": \"CrowdStrike Authentication\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581543577147\n    }\n}",
+        "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success"
     },
     "input": {
@@ -56,23 +79,23 @@
         "flags": [
             "multiline"
         ],
-        "offset": 2152
+        "offset": 910
     },
-    "message": "CrowdStrike Authentication",
+    "message": "Crowdstrike Streaming API",
     "observer": {
         "product": "Falcon",
         "vendor": "Crowdstrike"
     },
     "related": {
         "ip": [
-            "192.168.6.8"
+            "10.10.0.8"
         ],
         "user": [
-            "alice@company.com"
+            "api-client-id:1234567890abcdefghijklmnopqrstuvwxyz"
         ]
     },
     "source": {
-        "ip": "192.168.6.8"
+        "ip": "10.10.0.8"
     },
     "tags": [
         "preserve_original_event",
@@ -80,7 +103,6 @@
         "crowdstrike-falcon"
     ],
     "user": {
-        "email": "alice@company.com",
-        "name": "alice@company.com"
+        "name": "api-client-id:1234567890abcdefghijklmnopqrstuvwxyz"
     }
 }

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -61,6 +61,12 @@
                 "version": "1007.4.0013701.1"
             },
             "process": {
+                "args": [
+                    "/bin/sh",
+                    "-s",
+                    "unix:cmd"
+                ],
+                "args_count": 3,
                 "command_line": "/bin/sh -s unix:cmd",
                 "entity_id": "363970027584976556",
                 "executable": "/bin/sh",
@@ -357,6 +363,24 @@
                 "version": "1007.4.0013701.1"
             },
             "process": {
+                "args": [
+                    "ruby",
+                    "--disable-gems",
+                    "sorbet/feature_dependency_plugin.rb",
+                    "--class",
+                    "EmergingAlbertsonsPickupBannerDiscount",
+                    "--method",
+                    "feature_dependency",
+                    "--source",
+                    "feature_dependency",
+                    "Domain::FeatureDependencies::RouletteUserFeature.new(\n",
+                    "feature_name:",
+                    "FEATURE_NAME,\n",
+                    "variants:",
+                    "[FEATURE_VARIANT],\n",
+                    ")"
+                ],
+                "args_count": 15,
                 "command_line": "ruby --disable-gems sorbet/feature_dependency_plugin.rb --class EmergingAlbertsonsPickupBannerDiscount --method feature_dependency --source feature_dependency Domain::FeatureDependencies::RouletteUserFeature.new(\n        feature_name: FEATURE_NAME,\n        variants: [FEATURE_VARIANT],\n      )",
                 "hash": {
                     "sha256": "f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018"
@@ -522,6 +546,11 @@
                 "version": "1007.4.0013701.1"
             },
             "process": {
+                "args": [
+                    "xpcproxy",
+                    "com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000"
+                ],
+                "args_count": 2,
                 "command_line": "xpcproxy com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000",
                 "entity_id": "363276350115996101",
                 "executable": "/usr/libexec/xpcproxy",
@@ -940,6 +969,14 @@
                 "version": "1007.8.0010912.1"
             },
             "process": {
+                "args": [
+                    "pgbackrest",
+                    "--stanza=main",
+                    "archive-get",
+                    "000000020004D51F0000009F",
+                    "pg_wal/RECOVERYXLOG"
+                ],
+                "args_count": 5,
                 "command_line": "pgbackrest --stanza=main archive-get 000000020004D51F0000009F pg_wal/RECOVERYXLOG",
                 "end": "2021-07-07T17:05:35.102Z",
                 "entity_id": "38911778380590",
@@ -3755,6 +3792,13 @@
                 "version": "1007.8.0011308.1"
             },
             "process": {
+                "args": [
+                    "sh",
+                    "-c",
+                    "/usr/lib/erlang/erts-11.1.3/bin/epmd",
+                    "-daemon"
+                ],
+                "args_count": 4,
                 "command_line": "sh -c \"/usr/lib/erlang/erts-11.1.3/bin/epmd\" -daemon",
                 "hash": {
                     "sha256": "64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20"
@@ -4002,6 +4046,27 @@
                 "version": "1007.4.0013701.1"
             },
             "process": {
+                "args": [
+                    "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o",
+                    "-o",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o",
+                    "-index-store-path",
+                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore",
+                    "-index-system-modules"
+                ],
+                "args_count": 18,
                 "command_line": "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules",
                 "entity_id": "365035560818271291",
                 "thread": {
@@ -6963,6 +7028,11 @@
                 "version": "1007.8.0009806.1"
             },
             "process": {
+                "args": [
+                    "uname",
+                    "-a"
+                ],
+                "args_count": 2,
                 "command_line": "uname -a",
                 "end": "2020-11-08T17:04:59.126Z",
                 "entity_id": "321385814512398605",
@@ -7411,6 +7481,11 @@
                 "version": "1007.3.0011603.1"
             },
             "process": {
+                "args": [
+                    "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
+                    "--ps2"
+                ],
+                "args_count": 2,
                 "command_line": "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe --ps2",
                 "entity_id": "583707537390",
                 "executable": "\\Device\\HarddiskVolume2\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
@@ -7686,6 +7761,14 @@
                 "version": "1007.4.0009304.1"
             },
             "process": {
+                "args": [
+                    "/usr/bin/plutil",
+                    "-convert",
+                    "xml1",
+                    "-o",
+                    "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist"
+                ],
+                "args_count": 6,
                 "command_line": "/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist",
                 "entity_id": "311776004953765502",
                 "executable": "/usr/bin/plutil",
@@ -9244,6 +9327,15 @@
                 "version": "1007.3.0011603.1"
             },
             "process": {
+                "args": [
+                    "C:\\WINDOWS\\system32\\svchost.exe",
+                    "-k",
+                    "netsvcs",
+                    "-p",
+                    "-s",
+                    "wlidsvc"
+                ],
+                "args_count": 6,
                 "command_line": "C:\\WINDOWS\\system32\\svchost.exe -k netsvcs -p -s wlidsvc",
                 "entity_id": "955370934902",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
@@ -9554,6 +9646,15 @@
                 "version": "1007.3.0010609.1"
             },
             "process": {
+                "args": [
+                    "C:\\WINDOWS\\System32\\svchost.exe",
+                    "-k",
+                    "netsvcs",
+                    "-p",
+                    "-s",
+                    "NetSetupSvc"
+                ],
+                "args_count": 6,
                 "command_line": "C:\\WINDOWS\\System32\\svchost.exe -k netsvcs -p -s NetSetupSvc",
                 "entity_id": "2882232404222",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
@@ -11098,6 +11199,11 @@
                 "version": "1007.3.0012309.1"
             },
             "process": {
+                "args": [
+                    "C:\\WINDOWS\\system32\\backgroundTaskHost.exe",
+                    "-ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca"
+                ],
+                "args_count": 2,
                 "command_line": "\"C:\\WINDOWS\\system32\\backgroundTaskHost.exe\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca",
                 "entity_id": "2450046082233",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\backgroundTaskHost.exe",
@@ -11787,6 +11893,12 @@
                 "version": "1007.3.0015103.1"
             },
             "process": {
+                "args": [
+                    "C:\\Program Files\\nirsoft\\SoundVolumeView.exe",
+                    "/SetDefault",
+                    "Teradici Virtual Audio Driver\\device\\speakers\" all"
+                ],
+                "args_count": 3,
                 "command_line": "\"C:\\Program Files\\nirsoft\\SoundVolumeView.exe\" /SetDefault \"Teradici Virtual Audio Driver\\device\\speakers\\\" all",
                 "entity_id": "434985669758362104",
                 "executable": "\\Device\\HarddiskVolume3\\Program Files\\NirSoft\\SoundVolumeView.exe",

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -34,6 +34,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -55,16 +60,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
             },
-            "os": {
-                "type": "macos"
-            },
             "process": {
-                "args": [
-                    "/bin/sh",
-                    "-s",
-                    "unix:cmd"
-                ],
-                "args_count": 3,
                 "command_line": "/bin/sh -s unix:cmd",
                 "entity_id": "363970027584976556",
                 "executable": "/bin/sh",
@@ -140,6 +136,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -160,9 +161,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365053603452626914",
@@ -235,6 +233,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "community_id": "1:ZmJm1KFUrdmL4/rYSRwMQ18GXnk=",
                 "direction": "unknown",
@@ -261,9 +264,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365042236081053654"
@@ -330,6 +330,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -351,28 +356,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
             },
-            "os": {
-                "type": "macos"
-            },
             "process": {
-                "args": [
-                    "ruby",
-                    "--disable-gems",
-                    "sorbet/feature_dependency_plugin.rb",
-                    "--class",
-                    "EmergingAlbertsonsPickupBannerDiscount",
-                    "--method",
-                    "feature_dependency",
-                    "--source",
-                    "feature_dependency",
-                    "Domain::FeatureDependencies::RouletteUserFeature.new(\n",
-                    "feature_name:",
-                    "FEATURE_NAME,\n",
-                    "variants:",
-                    "[FEATURE_VARIANT],\n",
-                    ")"
-                ],
-                "args_count": 15,
                 "command_line": "ruby --disable-gems sorbet/feature_dependency_plugin.rb --class EmergingAlbertsonsPickupBannerDiscount --method feature_dependency --source feature_dependency Domain::FeatureDependencies::RouletteUserFeature.new(\n        feature_name: FEATURE_NAME,\n        variants: [FEATURE_VARIANT],\n      )",
                 "hash": {
                     "sha256": "f8bd34d4ac025f862c6fe8f3fd3f170072f94f1f2ec9dc6cb2d7925422b77018"
@@ -433,6 +417,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -453,9 +442,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -509,6 +495,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -530,15 +521,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
             },
-            "os": {
-                "type": "macos"
-            },
             "process": {
-                "args": [
-                    "xpcproxy",
-                    "com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000"
-                ],
-                "args_count": 2,
                 "command_line": "xpcproxy com.apple.mdworker.shared.01000000-0600-0000-0000-000000000000",
                 "entity_id": "363276350115996101",
                 "executable": "/usr/libexec/xpcproxy",
@@ -631,6 +614,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "community_id": "1:urvmigA14TUbvxTimPg744QEiSA=",
                 "direction": "inbound",
@@ -657,9 +645,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "17307488247882"
@@ -726,6 +711,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "17",
@@ -751,9 +741,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "362579458925546303"
@@ -832,6 +819,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "6",
@@ -857,9 +849,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364783686797112486"
@@ -924,6 +913,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -945,18 +939,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.8.0010912.1"
             },
-            "os": {
-                "type": "linux"
-            },
             "process": {
-                "args": [
-                    "pgbackrest",
-                    "--stanza=main",
-                    "archive-get",
-                    "000000020004D51F0000009F",
-                    "pg_wal/RECOVERYXLOG"
-                ],
-                "args_count": 5,
                 "command_line": "pgbackrest --stanza=main archive-get 000000020004D51F0000009F pg_wal/RECOVERYXLOG",
                 "end": "2021-07-07T17:05:35.102Z",
                 "entity_id": "38911778380590",
@@ -1038,6 +1021,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "17",
@@ -1063,9 +1051,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "17307455014463"
@@ -1128,6 +1113,11 @@
                 "path": "/Users/user1/Library/Application Support/Google/DriveFS/110588730849638631570/content_cache/d23/d44/432508",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1148,9 +1138,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365044948432500700",
@@ -1225,6 +1212,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "community_id": "1:XUmTKB40anItSVy47MPGAZ+mJWM=",
                 "direction": "outbound",
@@ -1251,9 +1243,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "12227094573885"
@@ -1316,6 +1305,11 @@
                 "id": "ffffffff-1111-11eb-b7e0-02332cdcc16d",
                 "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1156120155\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"12\",\"ConfigBuild\":\"1007.8.0011611.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV2\",\"id\":\"ffffffff-1111-11eb-b7e0-02332cdcc16d\",\"ErrorCode\":\"0\",\"aid\":\"ffffffff25b14d4aa96de99e24bad2fa\",\"timestamp\":\"1625677493974\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1336,9 +1330,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -1390,6 +1381,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1410,9 +1406,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -1471,6 +1464,11 @@
                 "id": "ffffffff-1111-11eb-8cc5-02c6fb049dd3",
                 "original": "{\"ChannelVersion\":\"0\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"1620585913\",\"ChannelDiffStatus\":\"1\",\"aip\":\"67.43.156.13\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"210\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"ChannelVersionRequiredMacV2\",\"id\":\"ffffffff-1111-11eb-8cc5-02c6fb049dd3\",\"ErrorCode\":\"0\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffff2d7b4778a73b2cf58d327e42\",\"timestamp\":\"1625677480455\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -1491,9 +1489,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -1543,6 +1538,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1563,9 +1563,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -1619,6 +1616,11 @@
                 "path": "/Users/user2/shopper-one/tooling/teams-plugin/build/classes/kotlin/main/com/instacart/shopper/tooling/TeamsPlugin$apply$$inlined$configure$1.class",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1639,9 +1641,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364783686797112486",
@@ -1716,6 +1715,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "6",
@@ -1741,9 +1745,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364796317497854624"
@@ -1809,6 +1810,11 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1829,9 +1835,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364977197365370629",
@@ -1892,6 +1895,11 @@
                 "size": 0,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1912,9 +1920,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365053504406857894",
@@ -1970,6 +1975,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -1990,9 +2000,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -2062,6 +2069,11 @@
                 "path": "/private/var/folders/s8/9c47txv13vj8qx_m7cqtx2w80000gp/T/.LINKS/2F71C2D4-D215-453E-BF4C-D6C037502871",
                 "type": "dir"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2082,9 +2094,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365053555029062046",
@@ -2165,6 +2174,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "community_id": "1:UVftVVD3gVlBx8wJQBdaiJYrD6A=",
                 "direction": "unknown",
@@ -2191,9 +2205,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "84424232977619"
@@ -2289,6 +2300,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2309,9 +2325,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365053546767850587",
@@ -2369,6 +2382,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2389,9 +2407,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -2460,6 +2475,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -2480,9 +2500,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -2562,6 +2579,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2582,9 +2604,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -2656,6 +2675,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "6",
@@ -2681,9 +2705,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364432308748445743"
@@ -2745,6 +2766,11 @@
                 "path": "/Users/user3/Library/Caches/com.tinyspeck.slackmacgap.ShipIt/update.FXKsmFO/Slack.app/Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2765,9 +2791,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364994904864288322",
@@ -2819,6 +2842,11 @@
                 "path": "/private/var/db/powerlog/Library/BatteryLife/Archives/powerlog_2021-07-05_CC5F9FC1.PLSQL.gz",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -2839,9 +2867,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "362897421906895953",
@@ -2896,6 +2921,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -2916,9 +2946,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -2965,6 +2992,11 @@
                     "creation"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -2985,9 +3017,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364938416497226937",
@@ -3045,6 +3074,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3065,9 +3099,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -3140,6 +3171,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "community_id": "1:3WneLMsNfPNapoUBcHO8QHx99mg=",
                 "direction": "unknown",
@@ -3166,9 +3202,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "12241681491990"
@@ -3229,6 +3262,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3249,9 +3287,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -3299,6 +3334,11 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3319,9 +3359,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364839648316192383",
@@ -3378,6 +3415,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3398,9 +3440,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -3475,6 +3514,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3495,9 +3539,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -3544,6 +3585,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3564,9 +3610,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364867547408058681",
@@ -3611,6 +3654,11 @@
                 "id": "ffffffff-1111-11eb-b411-06baeacb7a63",
                 "original": "{\"ChannelVersion\":\"25\",\"event_simpleName\":\"ChannelVersionRequired\",\"ConfigStateHash\":\"3155796140\",\"aip\":\"67.43.156.14\",\"ChannelVersionRequired\":\"0\",\"ChannelId\":\"20\",\"ConfigBuild\":\"1007.8.0011110.1\",\"event_platform\":\"Lin\",\"name\":\"ChannelVersionRequiredLinV1\",\"id\":\"ffffffff-1111-11eb-b411-06baeacb7a63\",\"aid\":\"ffffffff67d54f7daf3d998ffc74d48e\",\"timestamp\":\"1625677507901\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3631,9 +3679,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011110.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -3683,6 +3728,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3704,17 +3754,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
             },
-            "os": {
-                "type": "linux"
-            },
             "process": {
-                "args": [
-                    "sh",
-                    "-c",
-                    "/usr/lib/erlang/erts-11.1.3/bin/epmd",
-                    "-daemon"
-                ],
-                "args_count": 4,
                 "command_line": "sh -c \"/usr/lib/erlang/erts-11.1.3/bin/epmd\" -daemon",
                 "hash": {
                     "sha256": "64e48365207d0c19008ba7d53d75c0de3fcd5a1590e4c40fc69c677663fedc20"
@@ -3778,6 +3818,11 @@
                     "user"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -3798,9 +3843,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -3856,6 +3898,11 @@
                 "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
                 "original": "{\"FeatureVector\":\"000000527b2276223a22312e30222c226e223a352c226c223a3235362c2265223a7b2261223a5b31363737373232332c31363737373232332c31363737373232332c31363737373232332c31363737373232335d7d7d3f48793e3f6837b53f276c8b3ef8d4fe3f036e2f3fdb404f3e361134404d8c7e3df27bb33ef837b53faa57a83e752546402e6b513eb8e2193f5e63203e1446743f295e9e401fb7e93fe010623f90be0e3f6f837b3e7333333f3951833f33afb83e3f62b73e1893753f1b851f3ea752543e9333333ed446743f045a1d40889ba64065d2f2ad9a1b883f573eab3dd773193ed254613f3f3b643eedab9f3f579a6b4082b5dd3f92d42c3e8809d54040fcf83f90a71e40d717593e832ca53e19e83e3b4b295f3f64c2f83f8a9d1f3f27fcb93f088ce73e7333333de944673e81d7dc3f2db22d3e90cb293e2ca57a3e22b6ae3e843fe63f44fdf43f0573eb3ecbc6a83c648e8a3ceb1c433d16c6153c0d4fdf3d0529353e08ce703c2d81ae3f0809d53b69a2c63b7b43d93ded91683ba90cd43e2f9db23b6e28673d646499bb84406c3c0bd6623ea809d53edfb15b3dcc73acbc188d2a3c20cae63d390eaa3d148fda398cfb263b872b023d4d2b2c3a19c60fbc58ec963af9b13139f75bed3f687fcc3f105bc0ae9de3cf3cfb15b53a5dcccfbc2398203c9f40a3ba91e2153d0ec95c3f7e00d23dd048173c13b7d83f3404ea3ef06f69400392643c4dc8753b1f9485bb875d573cdebd903e1a9fbe3be83a113b1528f23c9279143c40053e3b62089e3d06ec183d16e58aba9c7ffe3b30c0273c3cbe623cc9eecc3b1e55c1ba25558f35192b55bcba493d357b1f123422c77e35700fd4349540073385f5c53562b199363180c1bbb5f5f133702cb134553ec134453f1234dfedcabba8e2e3bc4df26734da8f6636e51c133592f7ea34116278be173eabbc11ea79bbb3d4ae3574e4c733a4bbc53046530d34fd74ee330432f8bcf212d7bbaf3e47bc46690534a8a19335420670af1ab38734cdff54338e0e59bd23ad1934a8bd10bd2bb44e3433be90390220d73590265c3481ec3abb7701543b3e1eb437841ede333ede4c31d582ecbc195ee13510b6ab35ab6563b85ae696bcc582563510d9083490265c319cda2abc8327673428415ebba593a3347763df2f713b9cbd14a4d33486ea69bca3ec033d58ec963dc523f63dba7daa3cab9f563d5c67e03e8425af3cdaf8df3f47381d3bab606b3d174e663e6b1c433c4710cb3f04d0143c9691a73e0a233a3bde2ac33d0240b83ee339c13f139c0f3e2fec573df34d6a3d00e6b03df1a9fc3d9fb3fa3b6629953c4100e73d89fe873c0811b23d2d2dcb3ce5de163d0a1dfc3fac816f3f5096bc2e0d65af3df559b43b38ae323cf6555c3d93c3613d78a0903de872b03eb439583e27ef9e3c1689443f7c8b443eb06f694010ce703cff822c3c2d81ae3b0e68e43db5e2043e6b367a3d355ef23d1b089a3c5898b33bd373b03c41d29e3decbfb13d8a0e413bd9dfdb3c2dab9f3d1fddec3dcdd2f23cd10f523ce9ccb83f4b2fec3f7119ce3f276c8b3ee831273f036e2f3fe58adb3e361134404d8c7e3df972473ef837b53faab3683e7f1412402f34d73eb8e2193f62339c3e1446743f2041894013e0df3fe010623f90be0e3f6f837b3e7333333f449ba63f30a3d73e3f62b73e1893753f1b851f3ee240b83e9333333ed446743f03d07d40889ba64065d2f2ad8f49d23f4fd8ae3dd14e3c3edde69b3f3e147b3ee5bc023f579a6b409780343f92d42c3e8809d540435f703f90a71e40d717593e832ca53e19b3d03cc13fd13f6374bc3f8a9d1f3f27fcb93f1cd35b3e7333333de388663e884b5e3f29999a3e90cb293e2305533e2147ae3e843fe63f4d013b3f056d5d3ebe28243c6703b03cf084623d14a4d33c093b7e3d05a7093e087fcc3c304ab63f08c7e33b6ad0c43b8893b83dec22683ba8e2e33e2c56d63b6cd8dc3d637de9bb849cb23c08e79b3ea6dc5d3ee00d1b3dcb923abc1fd36f3c1cf56f3d385c683d134acb398c098e3b872b023d4e075f3a108bd4bc564d7f3b029cfe399cd0863f6958103f10b780ae9e16793cf601793a58523cbc231e7e3c9eecc0ba8398a63d0fba883f7d63883dd254613c14c4483f349ba63ef0b0f24003aa263c49afe23b23d70abb875d573cde3fbc3e1a9fbe3bebcc6c3b19d0203c92641b3c402f303b62d1f23d0366513d1797ccba9f40a33b32c83f3c39a1773ccfe9b83b2276b8ba786f1235192b55bcb890d63573a8ab34a531f734c11ccb3495400732a151a8369df96936179953bbbc1f00340207b734553ec134b523e7352bd356bba8e2e3bc4df26733a7cdeb36e51c1335421b0e3515c299be173eabbc11e647bbb3d4ae328448f533aa5c213046530d357f25dd330432f8bcf290acbbae9ee4bc4669053496f7d534ede333af1ab38733a03ec7346522f2bd23ad19353fd9cfbd2bb44e3392336039250bbe34bb34f73618f0ecbb7701543c50e560356884d0330f9fab31d582ecbc19f5e03510b6ab34e35d66b85ac660bcc582563510d9083490265c3399a707bc84a0e43474d02abba593a3342f209630b98ae7bd11fb4033605e7dbc9e59f33d5f11733dc922533db943183ca5a46a3d5b42463e83bcd33cdd2f1b3f47fcb93bae3a3b3d1ceaf23e6978d53c4836653f03a29c3c9afe1e3e096bba3bde76423cfd4bf13ee1e4f73f1418933e2ee6323df1a9fc3cfe1da83df0d8453d9e7ea63b69f6a93c4083123d8a7c5b3c0266773d2e147b3ce978d53d08ce703facf41f3f510cb32e0d9dfa3df2b0213b2bd5dc3cf77af63d94ee393d782d383de978d53eb404ea3e288ce73c2209ab3f7c91d13eb0d8454010e2193cfc65413c2e53653b0ede553db674d13e6ae7d53d361bb03d1c23b83c579d0a3bd3176a3c4447c33dea161e3d8a67623bd477bc3c2f4f0e3d1e6eeb3dd07c853cd4e8fb3cded2893f42de013f6d4fdf3f276c8b3ee1e4f73f036e2f3fe58adb3e361134404d8c7e3df837b53ef18fc53faa57a83e781d7e402d53263eb8e2193f62339c3e1b089a3f204189400eb9f53fe010623f9395813f6a233a3e81ff2e3f41a9fc3f3013a93e2666663e17dbf53f1b851f3ec666663e9333333ed446743f0e560440889ba64065d2f2ad9a1b883f573eab3dd7a7873edde69b3f3f3b643eed42c43f6a30554087f62b3f92d42c3e83958140435f703f90a71e40d717593e832ca53e19ce073cd0917d3f6374bc3f8a9d1f3f26e9793f088ce73e7333333df34d6a3e8710cb3f34f7663ea20c4a3e1a02753e23bcd33e843fe63f3a36e33f0573eb3ec84b5e3c6685db3cef0ae53d17acc53c0b32cf3d05681f3e0831273c2ff6d33f0a29c73b6a9e6f3b88c60d3deecbfb3baa53fc3e2d91683b6c636b3d66d9bebb8533b13c0a0d353ea91d153ee275253dcc9d9dbc159e623c1d27c43d3ad18d3d145b6c3982b47b3b88051d3d4fe9b83a12e7cfbc579d0a3af0a5f0390a9f2b3f69db233f10b780ae9e5a073cfc26573a5a6b1bbc247ed03c9d7343ba9bb6aa3d0f66a53f7d49523dd35a863c151c5c3f35b5743ef1d14e40047f243c4d9e843b24095fbb87b99d3cdd82fd3e1c28f63beeae9f3b14812c3c91a75d3c40ad043b613f4b3d033c603d195033ba9d8c6d3b307d0b3c3d12453cd234ec3b25375dba904f6e35181195bcba493d35a2674934a531f7352bda363522229033be54dc337b157336151dabbbb5f5f1340207b7345d30d93421b49d34c2b91cbba8e2e3bc4df26733a7cdeb369116e13592f7ea34116278be173eabbc11e647bbb3d4ae328448f533b7f4153046530d359e3e2233d006d8bcf2cf96bbad9ad8bc466905351da01436249e38af17834033a03ec7346522f2bd1ddc1e35d36497bd2bb44e33bf0a47390220d734c2822235531fdebb73ba773c1888f8356884d0330f9fab31d533c2bc195ee135adf23935ab6563b85b06ccbcc84b5e3510d9083490265c33e590e6bc81450f33ce498bbba593a334d1f8602f713b9cbd1930be33605e7dbca3ec033d5d249e3dc85b183dbc115e3ca858793d5c33723e83afb83cdcc63f3f4916873bab47413d1cb6853e6b9f563c49320e3f03eab33c9afe1e3e0aa64c3bdfd6953cfac1d33ee3e4263f14af4f3e2f69443df3b6463cfeda663df2b0213d9faebc3b50678c3c4250723d8c00543c0151a43d2d0e563ce4f7663d0701113fad2bd43f5075f72e0e19d33df5f6fd3b2eb80f3cf487fd3d92e72e3d7842313de944673eb50b0f3e295e9e3c1fd36f3f7d6a163eb15b57401159b43d000a7c3c2d2dcb3b0ecd8e3db4e11e3e6c3c9f3d3adc0a3d1bb0603c52dcb13bd338f83c4100e73de9e1b13d8b53503bd6ece13c2cd9e83d201cd63dd1b7173cda12303cdc725c3f48793e3f6ded293f276c8b3f036e2f3f036e2f3fea0f913e361134404d8c7e3e0189373ef837b53fabc3613e7f62b7403012063eb79a6b3f5e63203e0d4fdf3f204189400de9e23fe010623f90be0e3f6a233a3e81ff2e3f3951833f30902e3e4275253e18793e3f1b851f3ee0f9093e9333333ed446743f045a1d40889ba64065d2f2ad9d19253f573eab3dc692f73ece21963f3f3b643eee2eb23f579a6b407e76c93f92d42c3e83958140435f703f90a71e40d717593e832ca53e25aee63cb7e9103f64c2f83f8a9d1f3f27fcb93f06a7f03e676c8b3de147ae3e884b5e3f27bb303e90cb293e3295ea3e21e4f73e81205c3f3fec573f0573eb3ebec56d3c633eff3cf1800a3d1389b53c0ac1903d0587943e06dc5d3c2efb2b3f095e9e3b67ddca3b80303c3dec8b443ba782903e30068e3b6bcc6c3d619b91bb836eb53c0bf7f03ea60aa63ee00d1b3dcc447cbc28c1553c1d55e73d36e2eb3d132b56399063903b8776813d4d7f0f3a15a1bdbc55cfab3b06f04a39c25a833f68f5c33f107c85ae9e10d83cf9335d3a594a8abc2276b83c9f16b1ba66e57d3d0e0c9e3f7dbf483dd1b7173c1435ad3f34bc6a3ef096bc4003689d3c49afe23b22fcf0bb87a8d63cde939f3e1aee633bedbb5a3b14f69d3c91e6473c402f303b64217d3d06cca33d183516ba9fe8683b33d4ae3c38f9b13cced9173b288f00ba5a42d7356eda97bcb9628d356e0c6f341b95cf341f3c6534ad5b0a32a151a8337b157335b2c72cbbb2852334900adf34553ec1346e5ee5347ab7febba8e2e3bc4df26733a7cdeb35cf19143592f7ea34c9a612be173eabbc11e647bbb3d4ae35219fff33b7f4153046530d348b7aa434677fadbcf290acbbaf2d80bc46690535a6b2cc3206f2a8af17834033a03ec7338e0e59bd1e83e435857ac3bd2bb44e33043df73927249d34bb34f735906b14bb780dc33c50e560361e0a98336f92c2320a0eb4bc19b2c435adf23935ab6563b85a4586bcc56d5d3510d9083490265c3399a707bc811b1e34cde3d7bba593a334aec0612fb676c6bd13be2333605e7dbca3ec033d59be4d3dc9667b3db83cf33ca7ef9e3d5c09813e8361133cdba0a53f485f073ba023213d191bc53e69fbe73c4059213f04dd2f3c9835163e0865953be38a7e3d0385c63ee1b08a3f142c3d3e2f9db23df0068e3cff6d333df06f693d9e7ea63b68fb013c4250723d8a4d2b3c0b007a3d2e924f3cea209b3d094c443faccccd3f50ded32e0d9dfa3df41f213b2dab9f3cf95d4f3d94a4d33d7991bc3de809d53eb532613e28db8c3c1afe1e3f7cd9e83eb0ff974010f0d83cfc3b4f3c2e53653b0ede553db6c3763e6bb98c3d35f1bf3d1a95423c53d85a3bcedd483c46bce83ded5cfb3d8ac0833bd0edc43c319a413d1e30013dd07c853cdcf0303ce243573f4ded293f69c77a3f13d70a3f036e2f3f036e2f3feaa3053e361134404d8c7e3df5c28f3ef02de03faa57a83e70d845402f5dcc3eb8e2193f62339c3df0068e3f204189400de9e23fe010623f90be0e3f6a233a3e7333333f4a85883f3318fc3e4000003e063f143f1b851f3ecb5dcc3e9333333ed446743f0e560440889ba64065d2f2ad8f49d23f573eab3dbeff193ed7f62b3f3f3b643eedab9f3f57d567409780343f9292a33e8395814041158c3f90a71e40d717593e832ca53e1a511a3c74c6e73f64c2f83f832cf93f26e9793f03a92a3e6872b03df34d6a3e884b5e3f3381d83ea20c4a3e1a02753e2353f83e825aee3f4d013b3f041f213ec240b83c6a4a8c3cf3a14d3d15b5743c091e213d059c8d3e08ce703c2f78ff3f0837b53b6a7ce13b815e393ded91683ba9cdc43e2d42c43b73dc053d6147aebb8438093c0a61173ea72b023edf559b3dcaff6dbc1bd4063c21fd153d39ffd63d128e0d398d4bad3b894c443d4f18013a195aafbc5773193af57f7339ce41413f6851ec3f0fec57ae9dfa533cfa58f73a5a0d27bc21943a3ca1dfb9ba5471063d0e56043f7dd2f23dd1b7173c14b3813f33dd983ef013a9400347d83c4ca2db3b245d42bb8733663ce243573e1b22d13bf47b673b0f32383c928e0d3c4059213b6304473d05143c3d176ddbba9aed573b3220793c3c6a7f3ccc4ef93b267621ba298e0334f8d6f4bcba493d35461af9342ca85e34c11ccb352222903385f5c5368e9b3935b2c72cbbb75ea6344cfa3134553ec134b523e734c2b91cbba8e2e3bc4df26734d636243705eeb9351ad56535332082be173eabbc11ea79bbb3d4ae35a82cc133a943c13046530d34fd74ee34677fadbcf27bb3bbad8a11bc4669053496f7d53580f4d6af1848493405e546338e0e59bd23ad193400bddcbd2bb44e33bf0a473927249d34c2822235531fdebb73ba773c626d4836cf4407330f9fab31d582ecbc1a027535b8af0035d13ed5b85ad11cbcc582563573cb0735d499d3319cda2abc8548aa3474d02abba593a3351ccb0c2f713b9cbd14a4d333605e7dbca3ec033d6108c43dc9e4503dba34443ca454de3d5a511a3e84816f3cdc09813f4773193bac3a863d1945b73e6b1c433c48de2b3f03e4263c9a415f3e08b4393bd8ba413d0073583ee1cac13f13a92a3e2e48e93df318fc3d0216c63df212d73d9d7dbf3b627e0f3c44ef893d8ba1f53c03e8573d2c9afe3ce5f30e3d0846203fac710d3f50c49c2e0d4f2a3df487fd3b306c443cf837b53d96ffc13d795d4f3de8db8c3eb4bc6a3e28a71e3c1fba453f7c56d63eb07c854010c63f3cfeb0753c3170503b0e68e43db977853e6bb98c3d3c7f783d19a4163c55f99c3bd1e96c3c4669053debb98c3d8a6ca03bde43ee3c2efb2b3d2007dd3dce075f3cdbb59e3ce75793b01aa501\",\"event_simpleName\":\"DeliverLocalFXToCloud\",\"ConfigStateHash\":\"1620585913\",\"aip\":\"67.43.156.14\",\"ModelPrediction\":\"1436899696705536\",\"SHA256HashData\":\"c89caf538788e6524bf4ae93194051f3389eecbc71e4793f12a2dc0368211cc2\",\"Malicious\":\"0\",\"ConfigBuild\":\"1007.4.0013701.1\",\"FeatureExtractionVersion\":\"2\",\"event_platform\":\"Mac\",\"FXFileSize\":\"502032\",\"Entitlements\":\"15\",\"name\":\"DeliverLocalFXToCloudMacV4\",\"PupAdwareDecisionValue\":\"12384657383358464\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"PupAdwareConfidence\":\"0\",\"EffectiveTransmissionClass\":\"1\",\"aid\":\"ffffffff45d647e6ae0ba8764a4bd570\",\"MLModelVersion\":\"4\",\"timestamp\":\"1625677489052\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3876,9 +3923,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -3931,6 +3975,11 @@
                 "path": "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -3952,31 +4001,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
             },
-            "os": {
-                "type": "macos"
-            },
             "process": {
-                "args": [
-                    "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o",
-                    "-o",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o",
-                    "-index-store-path",
-                    "/Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore",
-                    "-index-system-modules"
-                ],
-                "args_count": 18,
                 "command_line": "t.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/CategorySurfaceViewController.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationActionView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationAddressView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationErrorView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationHeaderView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationLoadingView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationPostalCodeView.o -o /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Build/Intermediates.noindex/Instacart.build/Debug-iphonesimulator/Carrot.build/Objects-normal/x86_64/ChangeLocationViewController.o -index-store-path /Users/user4/Library/Developer/Xcode/DerivedData/Instacart-ceioektzbmfzbcgtsioovgzlzmnt/Index/DataStore -index-system-modules",
                 "entity_id": "365035560818271291",
                 "thread": {
@@ -4034,6 +4059,11 @@
                 "path": "/private/var/folders/pt/s9pzbbwd07q_0fxqvfhc513r0000gp/T/com.microsoft.Excel/Content.MSO/mso6ACABA95",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -4054,9 +4084,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364156540965623394",
@@ -4103,6 +4130,11 @@
                 "id": "ffffffff-1111-11eb-9dc2-029257dbe83b",
                 "original": "{\"event_simpleName\":\"GroupIdentity\",\"GID\":\"242\",\"AuthenticationUuidAsString\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"ConfigStateHash\":\"3967242894\",\"aip\":\"67.43.156.13\",\"AuthenticationId\":\"1119489580471877843\",\"UserPrincipal\":\"user2@dom1\",\"UserSid\":\"S-1-5-21-3852557355-3178143607-2040168074-1485\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"GroupIdentityMacV2\",\"id\":\"ffffffff-1111-11eb-9dc2-029257dbe83b\",\"EffectiveTransmissionClass\":\"2\",\"aid\":\"ffffffff44564c2f8d76394cb25c31ab\",\"AuthenticationUuid\":\"ABCDEFAB-CDEF-ABCD-EFAB-CDEF000000F2\",\"timestamp\":\"1625677478379\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -4123,9 +4155,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -4196,6 +4225,11 @@
                 "size": 0,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -4216,9 +4250,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364938429384226082",
@@ -4281,6 +4312,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "6",
@@ -4306,9 +4342,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364938390018585510"
@@ -4486,6 +4519,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -4506,9 +4544,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -4565,6 +4600,11 @@
                 "size": 596224,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -4585,9 +4625,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "362208380891022165",
@@ -4771,6 +4808,11 @@
                 "size": 3876424,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -4791,9 +4833,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -4833,6 +4872,11 @@
                 "id": "ffffffff-1111-11eb-b44e-069a02b0ad6b",
                 "original": "{\"event_simpleName\":\"LightningLatencyInfo\",\"LightningLatencyState\":\"3\",\"ConfigStateHash\":\"3090255842\",\"aip\":\"67.43.156.14\",\"ConfigBuild\":\"1007.4.0013701.1\",\"event_platform\":\"Mac\",\"Entitlements\":\"15\",\"name\":\"LightningLatencyInfoMacV1\",\"id\":\"ffffffff-1111-11eb-b44e-069a02b0ad6b\",\"EffectiveTransmissionClass\":\"0\",\"aid\":\"ffffffffd452449b8d1eb7d85b146650\",\"timestamp\":\"1625677453146\",\"cid\":\"ffffffff15754bcfb5f9152ec7ac90ac\"}"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -4853,9 +4897,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -4938,6 +4979,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -4958,9 +5004,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -5014,6 +5057,11 @@
                 "path": "/Users/user6/Library/Developer/CoreSimulator/Devices/BCE6B46B-E863-4151-AA9D-D71C79438C47/data/Containers/Data/Application/1249A061-F246-4338-AE56-4373E918C9B4/Library/Application Support/com.instacart.instashopper/LogCache/2021-07-06T23:44:46.133Z.zip",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5034,9 +5082,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365039419134863763",
@@ -5121,7 +5166,10 @@
             },
             "host": {
                 "hostname": "comp2",
-                "name": "comp2"
+                "name": "comp2",
+                "os": {
+                    "type": "macos"
+                }
             },
             "observer": {
                 "address": [
@@ -5143,9 +5191,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "6.24.13701.0"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -5200,6 +5245,11 @@
                 "path": "/private/var/db/dslocal/nodes/Default/users/daemon.plist",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5220,9 +5270,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365053399098988534",
@@ -5286,6 +5333,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos",
+                    "version": "Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5306,10 +5359,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "6.24.13701.0"
-            },
-            "os": {
-                "type": "macos",
-                "version": "Darwin Kernel Version 19.6.0: Tue Jan 12 22:13:05 PST 2021; root:xnu-6153.141.16~1/RELEASE_X86_64"
             },
             "related": {
                 "hash": [
@@ -5372,6 +5421,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5392,9 +5446,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0010912.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -5444,6 +5495,11 @@
                 "path": "KernelModuleArchiveExt11611",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5464,9 +5520,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011611.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "related": {
                 "hash": [
@@ -5533,6 +5586,11 @@
                 "path": "/Users/user7/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/cache/database_cleaner-1.8.5.gem",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5553,9 +5611,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "365049009681176519",
@@ -5620,6 +5675,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5640,9 +5700,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -5694,6 +5751,11 @@
                 "path": "C-00000503-00000000-00000001.sys",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5714,9 +5776,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -5784,6 +5843,11 @@
                 "path": "/System/Library/AssetsV2/com_apple_MobileAsset_MacSoftwareUpdate/5968e4faeba359dd5270ac282340cc4bd94d348c.asset/AssetData/payloadv2/ecc_data/System/Library/Spotlight/SystemPrefs.mdimporter/Contents/MacOS/SystemPrefs",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5804,9 +5868,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364936256754041721",
@@ -5859,6 +5920,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5879,9 +5945,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0010912.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "130732827553316",
@@ -5935,6 +5998,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -5955,9 +6023,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6007,6 +6072,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6027,9 +6097,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6085,6 +6152,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "6",
@@ -6110,9 +6182,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0011308.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "328911864662804336"
@@ -6173,6 +6242,11 @@
                 "size": 38798952,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6193,9 +6267,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "363122200934575406",
@@ -6264,6 +6335,12 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux",
+                    "version": "Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6284,10 +6361,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "6.19.11611.0"
-            },
-            "os": {
-                "type": "linux",
-                "version": "Linux localhost 4.14.232-176.381.amzn2.x86_64 #1 SMP Wed May 19 00:31:54 UTC 2021 x86_64"
             },
             "related": {
                 "hash": [
@@ -6342,6 +6415,11 @@
                 "path": "/private/var/db/dslocal/nodes/Default/users/user9.plist/",
                 "type": "dir"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -6362,9 +6440,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364849347227309005",
@@ -6429,6 +6504,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6449,9 +6529,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6507,6 +6584,11 @@
                 "size": 8052,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6527,9 +6609,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013806.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "364952259879648742",
@@ -6597,6 +6676,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -6617,9 +6701,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6671,6 +6752,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6691,9 +6777,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6758,6 +6841,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -6778,9 +6866,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0013701.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -6851,6 +6936,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -6872,15 +6962,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.8.0009806.1"
             },
-            "os": {
-                "type": "linux"
-            },
             "process": {
-                "args": [
-                    "uname",
-                    "-a"
-                ],
-                "args_count": 2,
                 "command_line": "uname -a",
                 "end": "2020-11-08T17:04:59.126Z",
                 "entity_id": "321385814512398605",
@@ -6964,6 +7046,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -6984,9 +7071,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "317713210176499254",
@@ -7098,6 +7182,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -7118,9 +7207,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "3100508103359",
@@ -7199,6 +7285,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -7219,9 +7310,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0009304.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "311775981885093125",
@@ -7296,6 +7384,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -7317,15 +7410,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
             },
-            "os": {
-                "type": "windows"
-            },
             "process": {
-                "args": [
-                    "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
-                    "--ps2"
-                ],
-                "args_count": 2,
                 "command_line": "D:\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe --ps2",
                 "entity_id": "583707537390",
                 "executable": "\\Device\\HarddiskVolume2\\projects\\splunk-forwarder\\bin\\splunk-powershell.exe",
@@ -7399,6 +7484,11 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -7419,9 +7509,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "259090530891",
@@ -7479,6 +7566,11 @@
                 "path": "/etc/shadow",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "linux"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -7499,9 +7591,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.8.0009806.1"
-            },
-            "os": {
-                "type": "linux"
             },
             "process": {
                 "entity_id": "321385820045701199",
@@ -7570,6 +7659,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -7591,18 +7685,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.4.0009304.1"
             },
-            "os": {
-                "type": "macos"
-            },
             "process": {
-                "args": [
-                    "/usr/bin/plutil",
-                    "-convert",
-                    "xml1",
-                    "-o",
-                    "/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist"
-                ],
-                "args_count": 6,
                 "command_line": "/usr/bin/plutil -convert xml1 -o - /Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/tvOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/DiagnosticExtensions.framework/PlugIns/com.apple.DiagnosticExtensions.CrashLogs.appex/Info.plist",
                 "entity_id": "311776004953765502",
                 "executable": "/usr/bin/plutil",
@@ -7689,6 +7772,11 @@
                 "path": "\\Device\\HarddiskVolume4\\Windows\\Temp\\__PSScriptPolicyTest_dvkjnbka.apn.ps1",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -7709,9 +7797,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1546527409909",
@@ -7785,6 +7870,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "inbound",
                 "iana_number": "6",
@@ -7810,9 +7900,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0012205.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "321275232072440993"
@@ -7893,6 +7980,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "network": {
                 "community_id": "1:gnQhhn0wJhJU+wrHlczmnm7THKs=",
                 "direction": "outbound",
@@ -7919,9 +8011,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "223442259384"
@@ -7997,6 +8086,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8017,9 +8111,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "816054990879",
@@ -8106,6 +8197,11 @@
                 "size": 6144,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8126,9 +8222,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "4415814628770",
@@ -8193,6 +8286,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8213,9 +8311,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "related": {
                 "hash": [
@@ -8292,6 +8387,11 @@
                 "path": "\\Device\\HarddiskVolume4\\Program Files\\Snow Software\\Inventory\\Agent\\cloudmeteringhost.exe",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8312,9 +8412,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "635780922149",
@@ -8376,6 +8473,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "6",
@@ -8401,9 +8503,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "50714198593318",
@@ -8486,6 +8585,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8506,9 +8610,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "7073822473144",
@@ -8583,6 +8684,11 @@
                 "path": "\\Device\\HarddiskVolume3\\Program Files\\WindowsApps\\Deleted\\Microsoft.Getstarted_9.10.32461.0_x64__8wekyb3d8bbweacf6b996-01b3-402c-bd01-a67529f94699\\clrcompression.dll",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8603,9 +8709,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1838383212125",
@@ -8671,6 +8774,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -8691,9 +8799,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0009202.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "318137549555284836",
@@ -8752,6 +8857,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -8772,9 +8882,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "683078218537",
@@ -8833,6 +8940,11 @@
                 "path": "C-00000013-00000000-00000408.sys",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -8853,9 +8965,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "related": {
                 "hash": [
@@ -8930,6 +9039,11 @@
                 "path": "\\Device\\HarddiskVolume3\\Windows\\assembly\\temp\\EKA0UARWWK\\Microsoft.WSMan.Management.ni.dll",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -8950,9 +9064,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "2071361595421",
@@ -9022,6 +9133,11 @@
                 "path": "\\Device\\HarddiskVolume3\\Windows\\CbsTemp\\30848497_1904507751\\FodWU",
                 "type": "dir"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -9042,9 +9158,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "66601077523",
@@ -9104,6 +9217,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -9125,19 +9243,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
             },
-            "os": {
-                "type": "windows"
-            },
             "process": {
-                "args": [
-                    "C:\\WINDOWS\\system32\\svchost.exe",
-                    "-k",
-                    "netsvcs",
-                    "-p",
-                    "-s",
-                    "wlidsvc"
-                ],
-                "args_count": 6,
                 "command_line": "C:\\WINDOWS\\system32\\svchost.exe -k netsvcs -p -s wlidsvc",
                 "entity_id": "955370934902",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
@@ -9204,6 +9310,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "6",
@@ -9229,9 +9340,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "319255017313886870"
@@ -9303,6 +9411,11 @@
                     "user"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -9323,9 +9436,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "30254389526587",
@@ -9417,6 +9527,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -9438,19 +9553,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.3.0010609.1"
             },
-            "os": {
-                "type": "windows"
-            },
             "process": {
-                "args": [
-                    "C:\\WINDOWS\\System32\\svchost.exe",
-                    "-k",
-                    "netsvcs",
-                    "-p",
-                    "-s",
-                    "NetSetupSvc"
-                ],
-                "args_count": 6,
                 "command_line": "C:\\WINDOWS\\System32\\svchost.exe -k netsvcs -p -s NetSetupSvc",
                 "entity_id": "2882232404222",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\svchost.exe",
@@ -9533,6 +9636,11 @@
                 "path": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads\\file.pptx",
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -9553,9 +9661,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1016182570608",
@@ -9661,6 +9766,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -9681,9 +9791,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0010609.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1741732942772",
@@ -9767,6 +9874,11 @@
                 "size": 223989,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -9787,9 +9899,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1786917081743",
@@ -9851,6 +9960,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "network": {
                 "direction": "unknown",
                 "iana_number": "6",
@@ -9876,9 +9990,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "439029805661",
@@ -9959,6 +10070,11 @@
                 "size": 29646,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -9979,9 +10095,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "321365562189152025",
@@ -10035,6 +10148,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -10055,9 +10173,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "2932136",
@@ -10136,6 +10251,11 @@
                     "connection"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "network": {
                 "community_id": "1:H+oCOL0YBAZDUBNuLG0b/Xuke3g=",
                 "direction": "outbound",
@@ -10162,9 +10282,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "56042872298"
@@ -10240,6 +10357,11 @@
                 "size": 165,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -10260,9 +10382,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "321382909294815631",
@@ -10324,6 +10443,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "6",
@@ -10349,9 +10473,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "321367236803434269"
@@ -10411,6 +10532,11 @@
                     "protocol"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -10431,9 +10557,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1611521722601",
@@ -10499,6 +10622,11 @@
             "file": {
                 "device": "PCI\\VEN_8086\u0026DEV_31E3\u0026SUBSYS_080C1028\u0026REV_03\\3\u002611583659\u00260\u002690"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -10519,9 +10647,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "100.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "4492535979973",
@@ -10579,6 +10704,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "network": {
                 "direction": "outbound",
                 "iana_number": "6",
@@ -10604,9 +10734,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "321210562584146513"
@@ -10673,6 +10800,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -10693,9 +10825,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "224116976578",
@@ -10754,6 +10883,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -10774,9 +10908,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "661455186053",
@@ -10846,6 +10977,11 @@
                 "size": 288041,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -10866,9 +11002,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1091372257857",
@@ -10938,6 +11071,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -10959,15 +11097,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.3.0012309.1"
             },
-            "os": {
-                "type": "windows"
-            },
             "process": {
-                "args": [
-                    "C:\\WINDOWS\\system32\\backgroundTaskHost.exe",
-                    "-ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca"
-                ],
-                "args_count": 2,
                 "command_line": "\"C:\\WINDOWS\\system32\\backgroundTaskHost.exe\" -ServerName:App.AppXnme9zjyebb2xnyygh6q9ev6p5d234br2.mca",
                 "entity_id": "2450046082233",
                 "executable": "\\Device\\HarddiskVolume3\\Windows\\System32\\backgroundTaskHost.exe",
@@ -11037,6 +11167,11 @@
                     "user"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -11057,9 +11192,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0011104.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "related": {
                 "hash": [
@@ -11120,6 +11252,11 @@
                     "info"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -11140,9 +11277,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "related": {
                 "hash": [
@@ -11200,6 +11334,11 @@
                 "size": 517029,
                 "type": "file"
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -11220,9 +11359,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1161025471861",
@@ -11281,6 +11417,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -11301,9 +11442,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1717987648455",
@@ -11355,6 +11493,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "macos"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.14"
@@ -11375,9 +11518,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.4.0009906.1"
-            },
-            "os": {
-                "type": "macos"
             },
             "process": {
                 "entity_id": "66426035996442255"
@@ -11434,7 +11574,11 @@
                     "timezone": "America/Los_Angeles"
                 },
                 "hostname": "mac1",
-                "name": "mac1"
+                "name": "mac1",
+                "os": {
+                    "type": "macos",
+                    "version": "Big Sur (11.0)"
+                }
             },
             "observer": {
                 "address": [
@@ -11456,10 +11600,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "6.31.14404.0"
-            },
-            "os": {
-                "type": "macos",
-                "version": "Big Sur (11.0)"
             },
             "related": {
                 "hosts": [
@@ -11515,6 +11655,11 @@
                     "end"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -11535,9 +11680,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "related": {
                 "hash": [
@@ -11615,6 +11757,11 @@
                     "start"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "89.160.20.120"
@@ -11639,16 +11786,7 @@
                 "vendor": "crowdstrike",
                 "version": "1007.3.0015103.1"
             },
-            "os": {
-                "type": "windows"
-            },
             "process": {
-                "args": [
-                    "C:\\Program Files\\nirsoft\\SoundVolumeView.exe",
-                    "/SetDefault",
-                    "Teradici Virtual Audio Driver\\device\\speakers\" all"
-                ],
-                "args_count": 3,
                 "command_line": "\"C:\\Program Files\\nirsoft\\SoundVolumeView.exe\" /SetDefault \"Teradici Virtual Audio Driver\\device\\speakers\\\" all",
                 "entity_id": "434985669758362104",
                 "executable": "\\Device\\HarddiskVolume3\\Program Files\\NirSoft\\SoundVolumeView.exe",
@@ -11716,6 +11854,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -11736,9 +11879,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1717987648455",
@@ -11884,6 +12024,11 @@
                     "change"
                 ]
             },
+            "host": {
+                "os": {
+                    "type": "windows"
+                }
+            },
             "observer": {
                 "address": [
                     "67.43.156.13"
@@ -11904,9 +12049,6 @@
                 "type": "agent",
                 "vendor": "crowdstrike",
                 "version": "1007.3.0011603.1"
-            },
-            "os": {
-                "type": "windows"
             },
             "process": {
                 "entity_id": "1717987648455",

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1513,25 +1513,25 @@ processors:
   
   ## OS fields.
   - set:
-      field: os.type
+      field: host.os.type
       value: linux
       if: ctx.crowdstrike?.event_platform != null && ctx.crowdstrike?.event_platform == "Lin"
   - set:
-      field: os.type
+      field: host.os.type
       value: macos
       if: ctx.crowdstrike?.event_platform != null && ctx.crowdstrike?.event_platform == "Mac"
   - set:
-      field: os.type
+      field: host.os.type
       value: windows
       if: ctx.crowdstrike?.event_platform != null && ctx.crowdstrike?.event_platform == "Win"
   - rename:
       field: crowdstrike.OSVersionString
-      target_field: os.version
+      target_field: host.os.version
       ignore_missing: true
       ignore_failure: true
   - rename:
       field: crowdstrike.Version
-      target_field: os.version
+      target_field: host.os.version
       ignore_missing: true
       ignore_failure: true
 
@@ -2426,7 +2426,7 @@ processors:
       field: crowdstrike.event_platform
       ignore_missing: true
       ignore_failure: true
-      if: ctx.os?.type != null
+      if: ctx.host?.os?.type != null
   - remove:
       field:
         - _temp

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -1544,7 +1544,7 @@ processors:
       tag: split-command-line
       description: Implements Windows-like SplitCommandLine
       lang: painless
-      if: ctx.process?.command_line != null && ctx.process.command_line != "" && ctx.os?.type != null
+      if: ctx.process?.command_line != null && ctx.process.command_line != "" && ctx.host?.os?.type != null
       source: |-
         // appendBSBytes appends n '\\' bytes to b and returns the resulting slice.
         def appendBSBytes(StringBuilder b, int n) {

--- a/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
+++ b/packages/crowdstrike/data_stream/fdr/fields/ecs.yml
@@ -119,9 +119,9 @@
 - external: ecs
   name: observer.version
 - external: ecs
-  name: os.type
+  name: host.os.type
 - external: ecs
-  name: os.version
+  name: host.os.version
 - external: ecs
   name: process.args
 - external: ecs

--- a/packages/crowdstrike/data_stream/fdr/sample_event.json
+++ b/packages/crowdstrike/data_stream/fdr/sample_event.json
@@ -1,7 +1,7 @@
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "ephemeral_id": "6b7924ba-f695-422a-a296-d1092ff909e4",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -47,7 +47,7 @@
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2023-09-25T19:03:21Z",
+        "ingested": "2023-09-26T13:20:10Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",

--- a/packages/crowdstrike/data_stream/fdr/sample_event.json
+++ b/packages/crowdstrike/data_stream/fdr/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "9fc4b95e-642d-4ce4-b7cc-1fe355c81ef1",
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "crowdstrike": {
         "ConfigStateHash": "1763245019",
@@ -34,9 +34,9 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": "RansomwareOpenFile",
@@ -47,7 +47,7 @@
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2023-06-27T07:43:18Z",
+        "ingested": "2023-09-25T19:03:21Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",
@@ -63,6 +63,11 @@
         "name": "file.pptx",
         "path": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads\\file.pptx",
         "type": "file"
+    },
+    "host": {
+        "os": {
+            "type": "windows"
+        }
     },
     "input": {
         "type": "log"
@@ -93,9 +98,6 @@
         "type": "agent",
         "vendor": "crowdstrike",
         "version": "1007.3.0011603.1"
-    },
-    "os": {
-        "type": "windows"
     },
     "process": {
         "entity_id": "1016182570608",

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -346,23 +346,45 @@ An example event for `falcon` looks as following:
 
 ```json
 {
-    "@timestamp": "2020-02-12T21:39:37.147Z",
+    "@timestamp": "2020-02-12T21:29:10.000Z",
     "agent": {
-        "ephemeral_id": "9fc4b95e-642d-4ce4-b7cc-1fe355c81ef1",
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "crowdstrike": {
         "event": {
-            "OperationName": "twoFactorAuthenticate",
+            "AuditKeyValues": [
+                {
+                    "Key": "APIClientID",
+                    "ValueString": "1234567890abcdefghijklmnopqr"
+                },
+                {
+                    "Key": "partition",
+                    "ValueString": "0"
+                },
+                {
+                    "Key": "offset",
+                    "ValueString": "-1"
+                },
+                {
+                    "Key": "appId",
+                    "ValueString": "siem-connector-v2.0.0"
+                },
+                {
+                    "Key": "eventType",
+                    "ValueString": "[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]"
+                }
+            ],
+            "OperationName": "streamStarted",
             "Success": true
         },
         "metadata": {
             "customerIDString": "8f69fe9e-b995-4204-95ad-44f9bcf75b6b",
             "eventType": "AuthActivityAuditEvent",
-            "offset": 1,
+            "offset": 0,
             "version": "1.0"
         }
     },
@@ -375,22 +397,23 @@ An example event for `falcon` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": [
-            "twoFactorAuthenticate"
+            "streamStarted"
         ],
         "agent_id_status": "verified",
         "category": [
-            "authentication"
+            "iam"
         ],
+        "created": "2020-02-12T21:29:10.710Z",
         "dataset": "crowdstrike.falcon",
-        "ingested": "2023-06-27T07:42:52Z",
+        "ingested": "2023-09-25T19:02:20Z",
         "kind": "event",
-        "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 1,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581543577147,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"alice@company.com\",\n        \"UserIp\": \"192.168.6.8\",\n        \"OperationName\": \"twoFactorAuthenticate\",\n        \"ServiceName\": \"CrowdStrike Authentication\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581543577147\n    }\n}",
+        "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success"
     },
     "input": {
@@ -403,23 +426,23 @@ An example event for `falcon` looks as following:
         "flags": [
             "multiline"
         ],
-        "offset": 2152
+        "offset": 910
     },
-    "message": "CrowdStrike Authentication",
+    "message": "Crowdstrike Streaming API",
     "observer": {
         "product": "Falcon",
         "vendor": "Crowdstrike"
     },
     "related": {
         "ip": [
-            "192.168.6.8"
+            "10.10.0.8"
         ],
         "user": [
-            "alice@company.com"
+            "api-client-id:1234567890abcdefghijklmnopqrstuvwxyz"
         ]
     },
     "source": {
-        "ip": "192.168.6.8"
+        "ip": "10.10.0.8"
     },
     "tags": [
         "preserve_original_event",
@@ -427,8 +450,7 @@ An example event for `falcon` looks as following:
         "crowdstrike-falcon"
     ],
     "user": {
-        "email": "alice@company.com",
-        "name": "alice@company.com"
+        "name": "api-client-id:1234567890abcdefghijklmnopqrstuvwxyz"
     }
 }
 ```
@@ -984,6 +1006,8 @@ and/or `session_token`.
 | host.geo.timezone | The time zone of the location, such as IANA time zone name. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
+| host.os.version | Operating system version as a raw string. | keyword |
 | input.type |  | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.offset |  | long |
@@ -1004,8 +1028,6 @@ and/or `session_token`.
 | observer.type | The type of the observer the data is coming from. There is no predefined list of observer types. Some examples are `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`. | keyword |
 | observer.vendor | Vendor name of the observer. | keyword |
 | observer.version | Observer version. | keyword |
-| os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
-| os.version | Operating system version as a raw string. | keyword |
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | wildcard |
@@ -1078,11 +1100,11 @@ An example event for `fdr` looks as following:
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "9fc4b95e-642d-4ce4-b7cc-1fe355c81ef1",
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "crowdstrike": {
         "ConfigStateHash": "1763245019",
@@ -1111,9 +1133,9 @@ An example event for `fdr` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "62b999a7-d53a-460e-b8cb-bcccb4e5fbd5",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.6.2"
+        "version": "8.10.1"
     },
     "event": {
         "action": "RansomwareOpenFile",
@@ -1124,7 +1146,7 @@ An example event for `fdr` looks as following:
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2023-06-27T07:43:18Z",
+        "ingested": "2023-09-25T19:03:21Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",
@@ -1140,6 +1162,11 @@ An example event for `fdr` looks as following:
         "name": "file.pptx",
         "path": "\\Device\\HarddiskVolume3\\Users\\user11\\Downloads\\file.pptx",
         "type": "file"
+    },
+    "host": {
+        "os": {
+            "type": "windows"
+        }
     },
     "input": {
         "type": "log"
@@ -1170,9 +1197,6 @@ An example event for `fdr` looks as following:
         "type": "agent",
         "vendor": "crowdstrike",
         "version": "1007.3.0011603.1"
-    },
-    "os": {
-        "type": "windows"
     },
     "process": {
         "entity_id": "1016182570608",

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -348,7 +348,7 @@ An example event for `falcon` looks as following:
 {
     "@timestamp": "2020-02-12T21:29:10.000Z",
     "agent": {
-        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "ephemeral_id": "6b7924ba-f695-422a-a296-d1092ff909e4",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -411,7 +411,7 @@ An example event for `falcon` looks as following:
         ],
         "created": "2020-02-12T21:29:10.710Z",
         "dataset": "crowdstrike.falcon",
-        "ingested": "2023-09-25T19:02:20Z",
+        "ingested": "2023-09-26T13:19:10Z",
         "kind": "event",
         "original": "{\n    \"metadata\": {\n        \"customerIDString\": \"8f69fe9e-b995-4204-95ad-44f9bcf75b6b\",\n        \"offset\": 0,\n        \"eventType\": \"AuthActivityAuditEvent\",\n        \"eventCreationTime\": 1581542950710,\n        \"version\": \"1.0\"\n    },\n    \"event\": {\n        \"UserId\": \"api-client-id:1234567890abcdefghijklmnopqrstuvwxyz\",\n        \"UserIp\": \"10.10.0.8\",\n        \"OperationName\": \"streamStarted\",\n        \"ServiceName\": \"Crowdstrike Streaming API\",\n        \"Success\": true,\n        \"UTCTimestamp\": 1581542950,\n        \"AuditKeyValues\": [\n            {\n                \"Key\": \"APIClientID\",\n                \"ValueString\": \"1234567890abcdefghijklmnopqr\"\n            },\n            {\n                \"Key\": \"partition\",\n                \"ValueString\": \"0\"\n            },\n            {\n                \"Key\": \"offset\",\n                \"ValueString\": \"-1\"\n            },\n            {\n                \"Key\": \"appId\",\n                \"ValueString\": \"siem-connector-v2.0.0\"\n            },\n            {\n                \"Key\": \"eventType\",\n                \"ValueString\": \"[UserActivityAuditEvent HashSpreadingEvent RemoteResponseSessionStartEvent RemoteResponseSessionEndEvent DetectionSummaryEvent AuthActivityAuditEvent]\"\n            }\n        ]\n    }\n}",
         "outcome": "success"
@@ -1100,7 +1100,7 @@ An example event for `fdr` looks as following:
 {
     "@timestamp": "2020-11-08T09:58:32.519Z",
     "agent": {
-        "ephemeral_id": "a59d59e8-e79f-499e-9540-4427e14af39c",
+        "ephemeral_id": "6b7924ba-f695-422a-a296-d1092ff909e4",
         "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -1146,7 +1146,7 @@ An example event for `fdr` looks as following:
         "created": "2020-11-08T17:07:22.091Z",
         "dataset": "crowdstrike.fdr",
         "id": "ffffffff-1111-11eb-9756-06fe7f8f682f",
-        "ingested": "2023-09-25T19:03:21Z",
+        "ingested": "2023-09-26T13:20:10Z",
         "kind": "alert",
         "original": "{\"ConfigBuild\":\"1007.3.0011603.1\",\"ConfigStateHash\":\"1763245019\",\"ContextProcessId\":\"1016182570608\",\"ContextThreadId\":\"37343520154472\",\"ContextTimeStamp\":\"1604829512.519\",\"DesiredAccess\":\"1179785\",\"EffectiveTransmissionClass\":\"3\",\"Entitlements\":\"15\",\"FileAttributes\":\"0\",\"FileIdentifier\":\"7a9c1c1610045d45a54bd6643ac12ea767a5020000000c00\",\"FileObject\":\"18446670458156489088\",\"Information\":\"1\",\"IrpFlags\":\"2180\",\"MajorFunction\":\"0\",\"MinorFunction\":\"0\",\"OperationFlags\":\"0\",\"Options\":\"16777312\",\"ShareAccess\":\"5\",\"Status\":\"0\",\"TargetFileName\":\"\\\\Device\\\\HarddiskVolume3\\\\Users\\\\user11\\\\Downloads\\\\file.pptx\",\"aid\":\"ffffffffac4148947ed68497e89f3308\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022d\",\"event_platform\":\"Win\",\"event_simpleName\":\"RansomwareOpenFile\",\"id\":\"ffffffff-1111-11eb-9756-06fe7f8f682f\",\"name\":\"RansomwareOpenFileV4\",\"timestamp\":\"1604855242091\"}",
         "outcome": "success",

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.20.0"
+version: "1.21.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: 2.11.0


### PR DESCRIPTION
## What does this PR do?

Correcting invalid ECS `os.*` field usage at the root-level

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7808