### PR TITLE
[ECS][fireeye] Correcting invalid ECS field declarations at root-level

### DIFF
--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.17.0
+  changes:
+    - description: Correct invalid ECS field usages at root-level.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1234
 - version: 1.16.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Correct invalid ECS field usages at root-level.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1234
+      link: https://github.com/elastic/integrations/pull/7969
 - version: 1.16.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
+++ b/packages/fireeye/data_stream/nx/_dev/test/pipeline/test-nx.log-expected.json
@@ -386,15 +386,17 @@
                     "flow_id": 1136872856843530
                 }
             },
-            "interface": {
-                "name": "pether3"
-            },
             "network": {
                 "community_id": "1:YekG1DgBPSO2IV15xvK9ncRxx8c=",
                 "iana_number": "6",
                 "transport": "tcp"
             },
             "observer": {
+                "ingress": {
+                    "interface": {
+                        "name": "pether3"
+                    }
+                },
                 "product": "NX",
                 "vendor": "Fireeye"
             },
@@ -520,9 +522,6 @@
                 },
                 "version": "HTTP/1.1"
             },
-            "interface": {
-                "name": "pether3"
-            },
             "network": {
                 "community_id": "1:I4UBJQqMZJfuPtZwkZDG22mqIBk=",
                 "iana_number": "6",
@@ -530,6 +529,11 @@
                 "transport": "tcp"
             },
             "observer": {
+                "ingress": {
+                    "interface": {
+                        "name": "pether3"
+                    }
+                },
                 "product": "NX",
                 "vendor": "Fireeye"
             },
@@ -609,15 +613,17 @@
                     "flow_id": 206535698492848
                 }
             },
-            "interface": {
-                "name": "pether3"
-            },
             "network": {
                 "community_id": "1:DrM2UXVr/51WHNjvsvUqPj+MU88=",
                 "iana_number": "17",
                 "transport": "udp"
             },
             "observer": {
+                "ingress": {
+                    "interface": {
+                        "name": "pether3"
+                    }
+                },
                 "product": "NX",
                 "vendor": "Fireeye"
             },

--- a/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
+++ b/packages/fireeye/data_stream/nx/elasticsearch/ingest_pipeline/renaming-raws.yml
@@ -220,7 +220,7 @@ processors:
       ignore_missing: true
   - rename:
       field: rawmsg.iface
-      target_field: interface.name
+      target_field: observer.ingress.interface.name
       if: ctx?.event?.type == 'fileinfo'
       ignore_missing: true
   # http event type fields
@@ -271,7 +271,7 @@ processors:
       ignore_missing: true
   - rename:
       field: rawmsg.iface
-      target_field: interface.name
+      target_field: observer.ingress.interface.name
       if: ctx?.event?.type == 'http'
       ignore_missing: true
   # http event type fields
@@ -322,7 +322,7 @@ processors:
       ignore_missing: true
   - rename:
       field: rawmsg.iface
-      target_field: interface.name
+      target_field: observer.ingress.interface.name
       if: ctx?.event?.type == 'http'
       ignore_missing: true
   # dns event type fields
@@ -364,7 +364,7 @@ processors:
       ignore_missing: true
   - rename:
       field: rawmsg.iface
-      target_field: interface.name
+      target_field: observer.ingress.interface.name
       if: ctx?.event?.type == 'dns'
       ignore_missing: true
   # tls event type fields
@@ -455,7 +455,7 @@ processors:
       ignore_missing: true
   - rename:
       field: rawmsg.iface
-      target_field: interface.name
+      target_field: observer.ingress.interface.name
       if: ctx?.event?.type == 'tls'
       ignore_missing: true
 on_failure:

--- a/packages/fireeye/data_stream/nx/fields/ecs.yml
+++ b/packages/fireeye/data_stream/nx/fields/ecs.yml
@@ -121,7 +121,7 @@
 - external: ecs
   name: event.type
 - external: ecs
-  name: interface.name
+  name: observer.ingress.interface.name
 - external: ecs
   name: dns.response_code
 - external: ecs

--- a/packages/fireeye/data_stream/nx/sample_event.json
+++ b/packages/fireeye/data_stream/nx/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "48b0c5c9-2498-4165-95e7-753c3f489c09",
-        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
+        "ephemeral_id": "dff6c436-37c3-4536-bdf9-08aed3ed94bd",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
@@ -23,9 +23,9 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
-        "snapshot": true,
-        "version": "8.9.0"
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "snapshot": false,
+        "version": "8.10.1"
     },
     "event": {
         "agent_id_status": "verified",
@@ -33,7 +33,7 @@
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2023-06-15T19:10:16Z",
+        "ingested": "2023-09-25T20:05:32Z",
         "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
         "timezone": "+00:00",
         "type": [
@@ -55,20 +55,20 @@
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "85082b6dda81440ab2fd3b084337286f",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.23.0.7"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-17-00-07"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/fireeye/docs/README.md
+++ b/packages/fireeye/docs/README.md
@@ -104,7 +104,6 @@ The `nx` integration ingests network security logs from FireEye NX through TCP/U
 | http.response.status_code | HTTP response status code. | long |
 | http.version | HTTP version. | keyword |
 | input.type | Input type | keyword |
-| interface.name | Interface name as reported by the system. | keyword |
 | log.file.path | Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate. If the event wasn't read from a log file, do not populate this field. | keyword |
 | log.offset | Log offset | long |
 | log.source.address | Logs Source Raw address. | keyword |
@@ -112,6 +111,7 @@ The `nx` integration ingests network security logs from FireEye NX through TCP/U
 | network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | keyword |
 | network.protocol | In the OSI Model this would be the Application Layer protocol. For example, `http`, `dns`, or `ssh`. The field value must be normalized to lowercase for querying. | keyword |
 | network.transport | Same as network.iana_number, but instead using the Keyword name of the transport layer (udp, tcp, ipv6-icmp, etc.) The field value must be normalized to lowercase for querying. | keyword |
+| observer.ingress.interface.name | Interface name as reported by the system. | keyword |
 | observer.product | The product name of the observer. | keyword |
 | observer.vendor | Vendor name of the observer. | keyword |
 | related.hash | All the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search). | keyword |
@@ -175,11 +175,11 @@ An example event for `nx` looks as following:
 {
     "@timestamp": "2020-09-22T08:34:44.991Z",
     "agent": {
-        "ephemeral_id": "48b0c5c9-2498-4165-95e7-753c3f489c09",
-        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
+        "ephemeral_id": "dff6c436-37c3-4536-bdf9-08aed3ed94bd",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "fireeye.nx",
@@ -197,9 +197,9 @@ An example event for `nx` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "8b10c3ab-9f4b-4ca0-b5ad-b6200b7fe65d",
-        "snapshot": true,
-        "version": "8.9.0"
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "snapshot": false,
+        "version": "8.10.1"
     },
     "event": {
         "agent_id_status": "verified",
@@ -207,7 +207,7 @@ An example event for `nx` looks as following:
             "network"
         ],
         "dataset": "fireeye.nx",
-        "ingested": "2023-06-15T19:10:16Z",
+        "ingested": "2023-09-25T20:05:32Z",
         "original": "{\"rawmsg\":\"{\\\"timestamp\\\":\\\"2020-09-22T08:34:44.991339+0000\\\",\\\"flow_id\\\":721570461162990,\\\"event_type\\\":\\\"flow\\\",\\\"src_ip\\\":\\\"fe80:0000:0000:0000:feec:daff:fe31:b706\\\",\\\"src_port\\\":45944,\\\"dest_ip\\\":\\\"ff02:0000:0000:0000:0000:0000:0000:0001\\\",\\\"dest_port\\\":10001,\\\"proto\\\":\\\"UDP\\\",\\\"proto_number\\\":17,\\\"ip_tc\\\":0,\\\"app_proto\\\":\\\"failed\\\",\\\"flow\\\":{\\\"pkts_toserver\\\":8,\\\"pkts_toclient\\\":0,\\\"bytes_toserver\\\":1680,\\\"bytes_toclient\\\":0,\\\"start\\\":\\\"2020-09-22T08:34:12.761326+0000\\\",\\\"end\\\":\\\"2020-09-22T08:34:12.761348+0000\\\",\\\"age\\\":0,\\\"state\\\":\\\"new\\\",\\\"reason\\\":\\\"timeout\\\",\\\"alerted\\\":false}}\\n\",\"meta_sip4\":\"192.168.1.99\",\"meta_oml\":520,\"deviceid\":\"860665216674\",\"meta_cbname\":\"fireeye-7e0de1\"}",
         "timezone": "+00:00",
         "type": [
@@ -229,20 +229,20 @@ An example event for `nx` looks as following:
     },
     "host": {
         "architecture": "x86_64",
-        "containerized": true,
+        "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "85082b6dda81440ab2fd3b084337286f",
+        "id": "28da52b32df94b50aff67dfb8f1be3d6",
         "ip": [
-            "172.23.0.7"
+            "192.168.80.5"
         ],
         "mac": [
-            "02-42-AC-17-00-07"
+            "02-42-C0-A8-50-05"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.10.47-linuxkit",
+            "kernel": "5.10.104-linuxkit",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.11.0
 name: fireeye
 title: "FireEye Network Security"
-version: "1.16.0"
+version: "1.17.0"
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What does this PR do?

Correcting invalid ECS `interface.name` field usage at the root-level

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7808