### PR TITLE
[oracle_weblogic] Use ECS definition for 'message' field type

### DIFF
--- a/packages/oracle_weblogic/changelog.yml
+++ b/packages/oracle_weblogic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.2"
+  changes:
+    - description: Change the `message` field type to follow the ECS definition.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7971
 - version: "1.0.1"
   changes:
     - description: Add null check and ignore_missing check to the rename processor

--- a/packages/oracle_weblogic/data_stream/admin_server/fields/base-fields.yml
+++ b/packages/oracle_weblogic/data_stream/admin_server/fields/base-fields.yml
@@ -8,8 +8,7 @@
   type: constant_keyword
   description: Data stream type.
 - name: message
-  type: keyword
-  description: A description of the event or condition.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/oracle_weblogic/data_stream/domain/fields/base-fields.yml
+++ b/packages/oracle_weblogic/data_stream/domain/fields/base-fields.yml
@@ -8,8 +8,7 @@
   type: constant_keyword
   description: Data stream type.
 - name: message
-  type: keyword
-  description: A description of the event or condition.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/oracle_weblogic/data_stream/managed_server/fields/base-fields.yml
+++ b/packages/oracle_weblogic/data_stream/managed_server/fields/base-fields.yml
@@ -8,8 +8,7 @@
   type: constant_keyword
   description: Data stream type.
 - name: message
-  type: keyword
-  description: A description of the event or condition.
+  external: ecs
 - name: '@timestamp'
   type: date
   description: Event timestamp.

--- a/packages/oracle_weblogic/docs/README.md
+++ b/packages/oracle_weblogic/docs/README.md
@@ -352,7 +352,7 @@ An example event for `admin_server` looks as following:
 | log.flags | Flags for the log file. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset | Log offset. | long |
-| message | A description of the event or condition. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | oracle_weblogic.admin_server.diagnostic_context_id | Context information to correlate messages coming from a specific request or application. | keyword |
 | oracle_weblogic.admin_server.machine_name | Machine Name is the DNS name of the computer that hosts the server instance. | keyword |
 | oracle_weblogic.admin_server.message_id | A unique identifier for the message. | keyword |
@@ -473,7 +473,7 @@ An example event for `domain` looks as following:
 | log.flags | Flags for the log file. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset | Log offset. | long |
-| message | A description of the event or condition. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | oracle_weblogic.domain.diagnostic_context_id | Context information to correlate messages coming from a specific request or application. | keyword |
 | oracle_weblogic.domain.machine_name | Machine Name is the DNS name of the computer that hosts the server instance. | keyword |
 | oracle_weblogic.domain.message_id | A unique identifier for the message. | keyword |
@@ -590,7 +590,7 @@ An example event for `managed_server` looks as following:
 | log.flags | Flags for the log file. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | log.offset | Log offset. | long |
-| message | A description of the event or condition. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | oracle_weblogic.managed_server.diagnostic_context_id | Context information to correlate messages coming from a specific request or application. | keyword |
 | oracle_weblogic.managed_server.machine_name | Machine Name is the DNS name of the computer that hosts the server instance. | keyword |
 | oracle_weblogic.managed_server.message_id | A unique identifier for the message. | keyword |

--- a/packages/oracle_weblogic/manifest.yml
+++ b/packages/oracle_weblogic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: oracle_weblogic
 title: Oracle WebLogic
-version: "1.0.1"
+version: "1.0.2"
 license: basic
 description: Collect logs and metrics from Oracle WebLogic with Elastic Agent.
 type: integration


### PR DESCRIPTION
## What does this PR do?

The admin_server, domain, and managed_server data streams had the `message` field mapped as a `keyword`. All other integrations use a text-family field type. The field is specified by ECS so this will now reference the ECS definition.

This causes a conflict in the `logs-*` data view.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
