### PR TITLE
[ECS][panw] Correcting invalid ECS field usages at root-level

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
-- version: 3.17.0
+- version: "3.18.0"
+  changes:
+    - description: Correct invalid ECS field usages at root-level.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7984
+- version: "3.17.0"
   changes:
     - description: ECS version updated to 8.10.0.
       type: enhancement

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-decryption-sample.log-expected.json
@@ -180,25 +180,23 @@
                     "not_after": "2022-11-11T15:21:28.000-08:00",
                     "not_before": "2021-11-11T15:21:28.000-08:00",
                     "x509": {
+                        "issuer": {
+                            "common_name": [
+                                "com.example.com"
+                            ]
+                        },
                         "public_key_size": 2048,
                         "serial_number": "ba67e84495b59512",
+                        "subject": {
+                            "common_name": [
+                                "com.example.com"
+                            ]
+                        },
                         "version_number": "V3"
                     }
                 },
                 "version": "1.2",
                 "version_protocol": "tls"
-            },
-            "x509": {
-                "issuer": {
-                    "common_name": [
-                        "com.example.com"
-                    ]
-                },
-                "subject": {
-                    "common_name": [
-                        "com.example.com"
-                    ]
-                }
             }
         },
         {
@@ -382,24 +380,22 @@
                     "not_after": "2022-11-11T15:21:28.000-08:00",
                     "not_before": "2021-11-11T15:21:28.000-08:00",
                     "x509": {
+                        "issuer": {
+                            "common_name": [
+                                "com.example.com"
+                            ]
+                        },
                         "serial_number": "ba67e84495b59512",
+                        "subject": {
+                            "common_name": [
+                                "com.example.com"
+                            ]
+                        },
                         "version_number": "V3"
                     }
                 },
                 "version": "1.2",
                 "version_protocol": "tls"
-            },
-            "x509": {
-                "issuer": {
-                    "common_name": [
-                        "com.example.com"
-                    ]
-                },
-                "subject": {
-                    "common_name": [
-                        "com.example.com"
-                    ]
-                }
             }
         }
     ]

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/decryption.yml
@@ -239,21 +239,21 @@ processors:
       copy_from: panw.panos.source.zone
       ignore_failure: true
   - set:
-      field: x509.subject.common_name
+      field: tls.client.x509.subject.common_name
       copy_from: panw.panos.subject_common_name.value
       ignore_failure: true
   - set:
-      field: x509.subject.common_name
-      value: ['{{{x509.subject.common_name}}}']
-      if: ctx.x509?.subject?.common_name instanceof String
+      field: tls.client.x509.subject.common_name
+      value: ['{{{tls.client.x509.subject.common_name}}}']
+      if: ctx.tls?.client?.x509?.subject?.common_name instanceof String
   - set:
-      field: x509.issuer.common_name
+      field: tls.client.x509.issuer.common_name
       copy_from: panw.panos.issuer_common_name.value
       ignore_failure: true
   - set:
-      field: x509.issuer.common_name
-      value: [ '{{{x509.issuer.common_name}}}' ]
-      if: ctx.x509?.issuer?.common_name instanceof String
+      field: tls.client.x509.issuer.common_name
+      value: [ '{{{tls.client.x509.issuer.common_name}}}' ]
+      if: ctx.tls?.client?.x509?.issuer?.common_name instanceof String
   - set:
       field: rule.uuid
       copy_from: panw.panos.rule_uuid

--- a/packages/panw/data_stream/panos/fields/ecs.yml
+++ b/packages/panw/data_stream/panos/fields/ecs.yml
@@ -245,6 +245,10 @@
 - external: ecs
   name: tls.client.x509.version_number
 - external: ecs
+  name: tls.client.x509.issuer.common_name
+- external: ecs
+  name: tls.client.x509.subject.common_name
+- external: ecs
   name: tls.curve
 - external: ecs
   name: tls.version
@@ -280,7 +284,3 @@
   name: user_agent.os.version
 - external: ecs
   name: user_agent.version
-- external: ecs
-  name: x509.issuer.common_name
-- external: ecs
-  name: x509.subject.common_name

--- a/packages/panw/data_stream/panos/sample_event.json
+++ b/packages/panw/data_stream/panos/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "14270b7f-dcde-4dce-a132-6579ebe118a0",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "3a362c46-abee-4440-bd82-f0e41a651188",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -34,9 +34,9 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "event": {
         "action": "url_filtering",
@@ -48,7 +48,7 @@
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2023-08-07T14:52:26Z",
+        "ingested": "2023-09-26T16:43:58Z",
         "kind": "alert",
         "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -68,7 +68,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.176.4:41606"
+            "address": "192.168.80.7:47488"
         },
         "syslog": {
             "facility": {

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -34,11 +34,11 @@ An example event for `panos` looks as following:
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "14270b7f-dcde-4dce-a132-6579ebe118a0",
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "ephemeral_id": "3a362c46-abee-4440-bd82-f0e41a651188",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -67,9 +67,9 @@ An example event for `panos` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "0a5c1566-c6fd-4e91-b96d-4083445a000e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.9.0"
+        "version": "8.10.1"
     },
     "event": {
         "action": "url_filtering",
@@ -81,7 +81,7 @@ An example event for `panos` looks as following:
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2023-08-07T14:52:26Z",
+        "ingested": "2023-09-26T16:43:58Z",
         "kind": "alert",
         "original": "\u003c14\u003eNov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -101,7 +101,7 @@ An example event for `panos` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.176.4:41606"
+            "address": "192.168.80.7:47488"
         },
         "syslog": {
             "facility": {
@@ -685,8 +685,10 @@ An example event for `panos` looks as following:
 | tls.client.not_after | Date/Time indicating when client certificate is no longer considered valid. | date |
 | tls.client.not_before | Date/Time indicating when client certificate is first considered valid. | date |
 | tls.client.server_name | Also called an SNI, this tells the server which hostname to which the client is attempting to connect to. When this value is available, it should get copied to `destination.domain`. | keyword |
+| tls.client.x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
 | tls.client.x509.public_key_size | The size of the public key space in bits. | long |
 | tls.client.x509.serial_number | Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters. | keyword |
+| tls.client.x509.subject.common_name | List of common names (CN) of subject. | keyword |
 | tls.client.x509.version_number | Version of x509 format. | keyword |
 | tls.curve | String indicating the curve used for the given cipher, when applicable. | keyword |
 | tls.version | Numeric part of the version parsed from the original string. | keyword |
@@ -711,6 +713,4 @@ An example event for `panos` looks as following:
 | user_agent.os.name.text | Multi-field of `user_agent.os.name`. | match_only_text |
 | user_agent.os.version | Operating system version as a raw string. | keyword |
 | user_agent.version | Version of the user agent. | keyword |
-| x509.issuer.common_name | List of common name (CN) of issuing certificate authority. | keyword |
-| x509.subject.common_name | List of common names (CN) of subject. | keyword |
 

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.17.0"
+version: "3.18.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: 2.11.0


### PR DESCRIPTION
## What does this PR do?

Correcting invalid ECS `x509.*` field usages at the root-level

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/7808