### PR TITLE
o365: fix mappings for dynamically mapped fields

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.24.1
+  changes:
+    - description: Fix mappings for dynamically mapped fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 1.24.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/o365/data_stream/audit/fields/fields.yml
+++ b/packages/o365/data_stream/audit/fields/fields.yml
@@ -34,6 +34,9 @@
       type: keyword
     - name: ExchangeMetaData.*
       type: object
+      # This object can also contain date fields, but we cannot express multiple dynamic mapping types here.
+      object_type: long
+      object_type_mapping_type: long
     - name: Category
       type: keyword
     - name: ClientAppId
@@ -68,8 +71,14 @@
       type: keyword
     - name: ExceptionInfo.*
       type: object
+      # This should be boolean→boolean falling back to *→keyword, but this is
+      # not expressible here; object_type_mapping_type cannot be 'boolean'.
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: ExtendedProperties.*
       type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: ExternalAccess
       type: boolean
     - name: FileSizeBytes
@@ -90,8 +99,12 @@
       type: keyword
     - name: Item.*
       type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: Item.*.*
       type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: ItemName
       type: keyword
     - name: ItemType
@@ -118,10 +131,10 @@
       type: keyword
     - name: Members
       type: flattened
-    - name: Members.*
-      type: object
     - name: ModifiedProperties.*.*
       type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: Name
       type: keyword
     - name: NewValue
@@ -138,6 +151,8 @@
       type: keyword
     - name: Parameters.*
       type: object
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: PolicyDetails
       type: flattened
     - name: PolicyId
@@ -150,6 +165,9 @@
       type: boolean
     - name: SharePointMetaData.*
       type: object
+      # This object may contain date formatted fields, but we do not ensure validity, so leave as keyword.
+      object_type: keyword
+      object_type_mapping_type: '*'
     - name: SessionId
       type: keyword
     - name: Severity

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -279,7 +279,6 @@ An example event for `audit` looks as following:
 | o365.audit.MailboxOwnerSid |  | keyword |
 | o365.audit.MailboxOwnerUPN |  | keyword |
 | o365.audit.Members |  | flattened |
-| o365.audit.Members.\* |  | object |
 | o365.audit.ModifiedProperties.\*.\* |  | object |
 | o365.audit.Name |  | keyword |
 | o365.audit.NewValue |  | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.24.0"
+version: "1.24.1"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR.
-->

- `o365.audit.ExchangeMetaData.*`
- `o365.audit.ExceptionInfo.*`
- `o365.audit.ExtendedProperties.*`
- `o365.audit.Item.*`
- `o365.audit.Item.*.*`
- `o365.audit.ModifiedProperties.*.*`
- `o365.audit.Parameters.*`
- `o365.audit.SharePointMetaData.*`

Remove `o365.audit.Members.*`; `o365.audit.Members` is already defined as a flattened field.

After this change the dynamic mappings are:
```
      "dynamic_templates": [
        {
          "container.labels": {
            "path_match": "container.labels.*",
            "match_mapping_type": "string",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.ExchangeMetaData.*": {
            "path_match": "o365.audit.ExchangeMetaData.*",
            "match_mapping_type": "long",
            "mapping": {
              "type": "long"
            }
          }
        },
        {
          "o365.audit.ExceptionInfo.*": {
            "path_match": "o365.audit.ExceptionInfo.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.ExtendedProperties.*": {
            "path_match": "o365.audit.ExtendedProperties.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.Item.*.*": {
            "path_match": "o365.audit.Item.*.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.ModifiedProperties.*.*": {
            "path_match": "o365.audit.ModifiedProperties.*.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.Parameters.*": {
            "path_match": "o365.audit.Parameters.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "o365.audit.SharePointMetaData.*": {
            "path_match": "o365.audit.SharePointMetaData.*",
            "mapping": {
              "type": "keyword"
            }
          }
        },
        {
          "strings_as_keyword": {
            "match_mapping_type": "string",
            "mapping": {
              "ignore_above": 1024,
              "type": "keyword"
            }
          }
        }
      ],
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #7975

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
