### PR TITLE
microsoft_sqlserver: Bump minimum `kibana.version`

### DIFF
--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Bump minimum kibana version for fetch_from_all_databases feature
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8019
 - version: "2.2.1"
   changes:
     - description: Add null check and ignore_missing check to the rename processor

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -10,7 +10,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: "^8.10.0"
+  kibana.version: "^8.10.2"
 screenshots:
   - src: /img/sqlserver-dashboard.png
     title: Microsoft SQL Server Dashboard

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "2.2.1"
+version: "2.2.2"
 license: basic
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
@@ -10,7 +10,7 @@ categories:
   - security
 release: ga
 conditions:
-  kibana.version: "^8.8.0"
+  kibana.version: "^8.10.0"
 screenshots:
   - src: /img/sqlserver-dashboard.png
     title: Microsoft SQL Server Dashboard


### PR DESCRIPTION
## What does this PR do?

Bumps the minimum `kibana.version` in manifest.yml to make it mandatory to use ^8.10.2 stack for the new `fetch_from_all_databases` feature which was not enforced earlier.

Based on a conversation with @ishleenk17 and also referring to https://github.com/elastic/integrations/blob/faef732498b4749407af54b6ee0d75c4f904eb1d/docs/tips_for_building_integrations.md?plain=1#L110 made a decision to bump the `kibana.version`.

> Update: Upgrading the stack to ^8.10.2 as 8.10.0 and 8.10.1 have security flaws and it is recommended to use ^8.10.2

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Relates https://github.com/elastic/integrations/pull/7500