### PR TITLE
[SEI] Update 29 packages to format_version 3.0.0

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.22.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.21.0
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: 1password
 title: "1Password"
-version: "1.21.0"
+version: "1.22.0"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:
   - security
   - credential_management
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/1password-signinattempts-screenshot.png
     title: Sign-in attempts
@@ -85,3 +86,4 @@ policy_templates:
             default: false
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/azure_frontdoor/changelog.yml
+++ b/packages/azure_frontdoor/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.4.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.3.2"
   changes:
     - description: Removing unused ECS field declarations.

--- a/packages/azure_frontdoor/manifest.yml
+++ b/packages/azure_frontdoor/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: azure_frontdoor
 title: "Azure Frontdoor"
-version: "1.3.2"
+version: "1.4.0"
 description: "This Elastic integration collects logs from Azure Frontdoor."
 type: integration
 categories:
@@ -10,7 +10,8 @@ categories:
   - security
   - web
 conditions:
-  kibana.version: "^8.6.0"
+  kibana:
+    version: "^8.6.0"
 screenshots:
   - src: /img/azure-frontdoor-overview.png
     title: Azure Frontdoor Overview
@@ -69,3 +70,4 @@ policy_templates:
             show_user: true
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/box_events/changelog.yml
+++ b/packages/box_events/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.1.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.0.0"
   changes:
     - description: Aligned ECS categorization fields and update package to ECS 8.10.0.

--- a/packages/box_events/manifest.yml
+++ b/packages/box_events/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: box_events
 title: Box Events
-version: "2.0.0"
+version: "2.1.0"
 description: "Collect logs from Box with Elastic Agent"
 type: integration
 categories:
   - security
   - productivity_security
 conditions:
-  kibana.version: "^8.7.1"
+  kibana:
+    version: "^8.7.1"
 screenshots:
   - src: /img/box_screenshot.png
     title: "[Logs Box Events Integration] Events Dashboard"
@@ -157,3 +158,4 @@ policy_templates:
             show_user: false
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/carbonblack_edr/changelog.yml
+++ b/packages/carbonblack_edr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.15.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.14.1"
   changes:
     - description: Removing unused ECS field declarations.

--- a/packages/carbonblack_edr/manifest.yml
+++ b/packages/carbonblack_edr/manifest.yml
@@ -1,12 +1,13 @@
 name: carbonblack_edr
 title: VMware Carbon Black EDR
-version: "1.14.1"
+version: "1.15.0"
 description: Collect logs from VMware Carbon Black EDR with Elastic Agent.
 type: integration
-format_version: 2.11.0
+format_version: "3.0.0"
 categories: [security, edr_xdr]
 conditions:
-  kibana.version: ^7.14.0 || ^8.0.0
+  kibana:
+    version: ^7.14.0 || ^8.0.0
 policy_templates:
   - name: log
     title: Carbon Black EDR logs
@@ -31,3 +32,4 @@ icons:
     type: image/svg+xml
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.9.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.8.0
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,15 +1,17 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.8.0"
+version: "1.9.0"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:
   - security
   - network
 conditions:
-  kibana.version: "^8.0.0"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.0.0"
+  elastic:
+    subscription: "basic"
 icons:
   - src: /img/cisco.svg
     title: Cisco
@@ -31,3 +33,4 @@ policy_templates:
         description: Collecting logs from Cisco Aironet via file
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.25.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.24.0"
   changes:
     - description: Extend authenticaton rejection reasons that are accepted.

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -221,8 +221,8 @@
       type: keyword
       description: >-
         The Cisco log message text.
-
     - name: rejection_reason
       type: keyword
       description: >
         Reason for an AAA authentication rejection.
+

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: cisco_asa
 title: Cisco ASA
-version: "2.24.0"
+version: "2.25.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,8 @@ categories:
   - security
   - firewall_security
 conditions:
-  kibana.version: "^8.7.1"
+  kibana:
+    version: "^8.7.1"
 screenshots:
   - src: /img/kibana-cisco-asa.png
     title: kibana cisco asa
@@ -36,3 +37,4 @@ policy_templates:
         description: Collecting logs from Cisco ASA via file
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.18.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.17.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: cisco_ftd
 title: Cisco FTD
-version: "2.17.0"
+version: "2.18.0"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,8 @@ categories:
   - security
   - firewall_security
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana:
+    version: "^7.16.0 || ^8.0.0"
 icons:
   - src: /img/cisco.svg
     title: cisco
@@ -31,3 +32,4 @@ policy_templates:
         description: Collecting logs from Cisco FTD via file
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.16.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.15.1"
   changes:
     - description: Removing unused ECS field declarations.

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.15.1"
+version: "1.16.0"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:
   - network
   - security
 conditions:
-  kibana.version: ^7.17.0 || ^8.0.0
+  kibana:
+    version: ^7.17.0 || ^8.0.0
 screenshots:
   - src: /img/cisco-meraki-dashboard-1.png
     title: Cisco Meraki Dashboard
@@ -46,3 +47,4 @@ policy_templates:
         description: Collecting events from Cisco Meraki via Webhooks
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.13.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.12.0
   changes:
     - description: Add support for Magic IDS, Firewall DNS and Sinkhole HTTP logs.

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.12.0"
+version: "1.13.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,8 @@ categories:
   - network
   - cdn_security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/cloudflare_logpush-overview1.png
     title: Cloudflare Logpush - Zero Trust Overview
@@ -221,3 +222,4 @@ policy_templates:
             show_user: false
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.22.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.21.0
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,12 +1,13 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.21.0"
+version: "1.22.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
-format_version: 2.11.0
+format_version: "3.0.0"
 categories: [security, edr_xdr]
 conditions:
-  kibana.version: "^8.0.0"
+  kibana:
+    version: "^8.0.0"
 icons:
   - src: /img/logo-integrations-crowdstrike.svg
     title: CrowdStrike
@@ -38,3 +39,4 @@ policy_templates:
         description: "Collecting logs from CrowdStrike Falcon Data Replicator (input: aws-s3)"
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/cyberarkpas/changelog.yml
+++ b/packages/cyberarkpas/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.17.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.16.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/cyberarkpas/manifest.yml
+++ b/packages/cyberarkpas/manifest.yml
@@ -1,12 +1,13 @@
 name: cyberarkpas
 title: CyberArk Privileged Access Security
-version: "2.16.0"
+version: "2.17.0"
 description: Collect logs from CyberArk Privileged Access Security with Elastic Agent.
 type: integration
-format_version: 2.11.0
+format_version: "3.0.0"
 categories: ["security", "iam"]
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/filebeat-cyberarkpas-overview.png
     title: filebeat cyberarkpas overview
@@ -33,3 +34,4 @@ icons:
     type: image/svg+xml
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/fireeye/changelog.yml
+++ b/packages/fireeye/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.18.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.17.0
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/fireeye/manifest.yml
+++ b/packages/fireeye/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: fireeye
 title: "FireEye Network Security"
-version: "1.17.0"
+version: "1.18.0"
 description: Collect logs from FireEye NX with Elastic Agent.
 type: integration
 categories:
   - network
   - security
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana:
+    version: "^7.16.0 || ^8.0.0"
 icons:
   - src: /img/FireEye-logo.svg
     title: Fireeye logo
@@ -30,3 +31,4 @@ policy_templates:
         description: Collecting Fireeye NX logs via TCP
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.17.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.16.1"
   changes:
     - description: Use regular Fleet package fields to create dynamic mappings for prometheus metrics.

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.16.1"
+version: "1.17.0"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:
   - security
   - iam
 conditions:
-  kibana.version: "^8.6.2"
+  kibana:
+    version: "^8.6.2"
 screenshots:
   - src: /img/hashicorp_vault-audit-dashboard.png
     title: Audit Log Dashboard
@@ -39,3 +40,4 @@ policy_templates:
         description: Collect Vault metrics via prometheus.
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.16.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.15.0"
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.15.0"
+version: "1.16.0"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,8 @@ categories:
   - network
   - dns_security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/infoblox-nios-screenshot.png
     title: Infoblox NIOS dashboard screenshot
@@ -106,3 +107,4 @@ policy_templates:
         description: Collecting syslog from Infoblox NIOS via UDP input.
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.9.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.8.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,13 +1,14 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.8.0"
+version: "1.9.0"
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/jamf-compliance-reporter-screenshot.png
     title: Jamf Compliance Reporter Screenshot
@@ -31,3 +32,4 @@ policy_templates:
         description: Collecting Jamf Compliance Reporter logs via TCP.
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/juniper_srx/changelog.yml
+++ b/packages/juniper_srx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.17.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.16.2"
   changes:
     - description: Removing additional unused ECS field declarations.

--- a/packages/juniper_srx/manifest.yml
+++ b/packages/juniper_srx/manifest.yml
@@ -1,12 +1,13 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: juniper_srx
 title: Juniper SRX
-version: "1.16.2"
+version: "1.17.0"
 description: Collect logs from Juniper SRX devices with Elastic Agent.
 categories: ["network", "security", "firewall_security"]
 type: integration
 conditions:
-  kibana.version: ^8.0.0
+  kibana:
+    version: ^8.0.0
 policy_templates:
   - name: juniper
     title: Juniper SRX logs
@@ -28,3 +29,4 @@ icons:
     type: image/svg+xml
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.15.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.14.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,12 +1,13 @@
 name: keycloak
 title: Keycloak
-version: "1.14.0"
+version: "1.15.0"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
-format_version: 2.11.0
+format_version: "3.0.0"
 categories: [security, iam]
 conditions:
-  kibana.version: "^7.16.0 || ^8.0.0"
+  kibana:
+    version: "^7.16.0 || ^8.0.0"
 icons:
   - src: /img/keycloak-logo.svg
     title: Keycloak
@@ -22,3 +23,4 @@ policy_templates:
         description: "Collecting logs from Keycloak"
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/lyve_cloud/changelog.yml
+++ b/packages/lyve_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.9.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.8.0"
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/lyve_cloud/manifest.yml
+++ b/packages/lyve_cloud/manifest.yml
@@ -1,13 +1,14 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: lyve_cloud
 title: Lyve Cloud
-version: "1.8.0"
+version: "1.9.0"
 description: Collect S3 API audit log from Lyve Cloud with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
-  kibana.version: "^8.5.0"
+  kibana:
+    version: "^8.5.0"
 icons:
   - src: /img/LyveCloud-Logo.svg
     title: Seagate-Lyve-Cloud
@@ -27,3 +28,4 @@ policy_templates:
         description: Collecting logs from Lyve Cloud
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.20.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.19.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.19.0"
+version: "2.20.0"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"
   - "edr_xdr"
 type: integration
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 policy_templates:
   - name: microsoft_defender_endpoint
     title: Microsoft Defender for Endpoint
@@ -40,3 +41,4 @@ screenshots:
     type: image/jpg
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/netflow/changelog.yml
+++ b/packages/netflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.16.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.15.2"
   changes:
     - description: Removing additional unused ECS field declarations.

--- a/packages/netflow/manifest.yml
+++ b/packages/netflow/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: netflow
 title: NetFlow Records
-version: "2.15.2"
+version: "2.16.0"
 description: Collect flow records from NetFlow and IPFIX exporters with Elastic Agent.
 type: integration
 categories:
   - network
   - security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/netflow-overview.png
     title: Netflow Overview Dashboard
@@ -35,3 +36,4 @@ policy_templates:
         description: Collecting NetFlow logs using the netflow input
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/okta/changelog.yml
+++ b/packages/okta/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.2.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "2.1.0"
   changes:
     - description: Update package to ECS 8.10.0, align ECS categorization fields, and updated stack version to ^8.10.1 per security fix.

--- a/packages/okta/manifest.yml
+++ b/packages/okta/manifest.yml
@@ -1,12 +1,13 @@
 name: okta
 title: Okta
-version: "2.1.0"
+version: "2.2.0"
 description: Collect and parse event logs from Okta API with Elastic Agent.
 type: integration
-format_version: 2.9.0
+format_version: "3.0.0"
 categories: [security, iam]
 conditions:
-  kibana.version: ^8.10.1
+  kibana:
+    version: ^8.10.1
 icons:
   - src: /img/okta-logo.svg
     title: Okta
@@ -126,3 +127,4 @@ policy_templates:
         description: "Collecting logs from Okta via API"
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 3.19.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "3.18.0"
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,12 +1,13 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.18.0"
+version: "3.19.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
-format_version: 2.11.0
+format_version: "3.0.0"
 categories: [security, network]
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 icons:
   - src: /img/logo-integrations-paloalto-networks.svg
     title: Palo Alto Networks
@@ -46,3 +47,4 @@ policy_templates:
               - /var/log/pan-os.log
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.15.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.14.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.14.0"
+version: "1.15.0"
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration
 icons:
@@ -8,13 +8,14 @@ icons:
     title: pfsense
     size: 512x143
     type: image/svg+xml
-format_version: 2.11.0
+format_version: "3.0.0"
 categories:
   - network
   - security
   - firewall_security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/firewall.png
     title: pfSense Firewall Dashboard
@@ -41,3 +42,4 @@ policy_templates:
         description: "Collecting logs from pfSense systems (input: tcp)"
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.10.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.9.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: ping_one
 title: PingOne
-version: "1.9.0"
+version: "1.10.0"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:
   - security
   - iam
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/ping-one-dashboard.png
     title: PingOne Audit Dashboard Screenshot
@@ -144,3 +145,4 @@ policy_templates:
               #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.13.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.12.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.12.0"
+version: "1.13.0"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:
   - security
   - email_security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/proofpoint_tap-screenshot.png
     title: Proofpoint TAP blocked clicks dashboard screenshot
@@ -88,3 +89,4 @@ policy_templates:
               #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.16.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.15.0"
   changes:
     - description: Correct invalid ECS field usages at root-level.

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: sentinel_one
 title: SentinelOne
-version: "1.15.0"
+version: "1.16.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:
   - security
   - edr_xdr
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/sentinel-one-screenshot.png
     title: SentinelOne Threat Dashboard Screenshot
@@ -83,3 +84,4 @@ policy_templates:
               #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.13.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.12.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: slack
 title: "Slack Logs"
-version: "1.12.0"
+version: "1.13.0"
 description: "Slack Logs Integration"
 type: integration
 categories:
   - productivity
   - security
 conditions:
-  kibana.version: "^8.7.1"
+  kibana:
+    version: "^8.7.1"
 icons:
   - src: /img/slack.svg
     title: Slack logo
@@ -61,3 +62,4 @@ policy_templates:
             default: 60s
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.17.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: "1.16.0"
   changes:
     - description: Update package to ECS 8.10.0 and align ECS categorization fields.

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -1,15 +1,16 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: tenable_sc
 title: Tenable.sc
 # The version must be updated in the pipeline as well. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "1.16.0"
+version: "1.17.0"
 description: |
   Collect logs from Tenable.sc with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/tenable_sc-screenshot.png
     title: Tenable.sc vulnerability dashboard screenshot
@@ -113,3 +114,4 @@ policy_templates:
         description: Collect Tenable.sc Vulnerability, Asset, and Plugin logs.
 owner:
   github: elastic/security-external-integrations
+  type: elastic

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.12.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8025
 - version: 1.11.0
   changes:
     - description: Handle detection documents that have a requests array instead of a request field.

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,14 +1,15 @@
-format_version: 2.11.0
+format_version: "3.0.0"
 name: trend_micro_vision_one
 title: Trend Micro Vision One
-version: "1.11.0"
+version: "1.12.0"
 description: Collect logs from Trend Micro Vision One with Elastic Agent.
 type: integration
 categories:
   - security
   - edr_xdr
 conditions:
-  kibana.version: ^8.7.1
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/trend-micro-vision-one-alert-dashboard-screenshot.png
     title: Trend Micro Vision One Dashboard Screenshot
@@ -83,3 +84,4 @@ policy_templates:
               #    -----END CERTIFICATE-----
 owner:
   github: elastic/security-external-integrations
+  type: elastic


### PR DESCRIPTION
## Proposed commit message

Update the remaining packages owned by elastic/security-external-integration (SEI) to format_version 3.0.0. The changes are modifying `format_version`, replacing the dotted `kibana.version` and `elastic.subscription` YAML keys, and adding `owner.type: elastic`.

Relates: #7810

```
[git-generate]

zsh
setopt extendedglob
go run github.com/andrewkroh/go-examples/ecs-update@v0.0.0-20230926022833-8e5b97998cc0  \
  -format-version=3.0.0 \
  -fix-dotted-yaml-keys \
  -add-owner-type \
  -owner elastic/security-external-integrations \
  -pr=7810 \
  packages/*~packages/cylance~packages/fortinet_forticlient~packages/imperva~packages/netscout~packages/radware~packages/squid
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #7810
