### PR TITLE
Added documentation on how to pass in the domain for MSSQL connections

### DIFF
--- a/packages/sql_input/docs/README.md
+++ b/packages/sql_input/docs/README.md
@@ -42,8 +42,12 @@ The following two types of host configurations are supported:
 The supported configuration takes this form
 - `sqlserver://<user>:<password>@<host>`
 
+The supported configuration with Windows Domain takes the form below:
+- `sqlserver://<domain>%5C<user>:<password>@<host>`
+
 Example of supported configurations is as below:
 - `sqlserver://root:test@localhost`
+- `sqlserver://local%5Croot:test@localhost`
 
 #### PostgreSQL: 
 The supported configuration takes this form


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
--> Added documentation on how to pass in the domain for MSSQL connections

## Proposed commit message
Added documentation on how to pass in the domain for MSSQL connections

<!-- Mandatory
Since this is missing in the documentation, and I spent quite a while figuring out how to do it; I have added a few lines describing how one can configure a connection string for MSSQL with the domain of the user.

Please explain:

- WHAT: Amended documentation, on the MSSQL connections part.
- WHY:  To make it easier for future developers consulting the documentation

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [N/A ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ N/A] I have verified that all data streams collect metrics or logs.
- [ Yes] I have added an entry to my package's `changelog.yml` file.
- [ Yes] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Relates [#13364](https://github.com/elastic/beats/issues/13364)
- Relates [#5213](https://github.com/elastic/integrations/issues/5213)

-->

<!-- Optional
Add here screenshots presenting:
Screenshots below proves that I used the configuration and was able to get data.
![image](https://github.com/elastic/integrations/assets/46907347/905546a4-5714-469a-b36f-23e9c699221c)

![image](https://github.com/elastic/integrations/assets/46907347/f001bb72-8825-4fa1-a35b-7b64335e9092)

-->
