### PR TITLE
[O11y][Apache Spark] Update MBean for driver datastream

### DIFF
--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.6.4"
   changes:
-    - description: Update MBean for driver datastream.
+    - description: Fix the metric type of input_rate field for driver datastream.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/8061
 - version: "0.6.3"

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update MBean for driver datastream.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/8061
 - version: "0.6.3"
   changes:
     - description: Update Apache Spark logo.

--- a/packages/apache_spark/changelog.yml
+++ b/packages/apache_spark/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.4"
+  changes:
+    - description: Update MBean for driver datastream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.6.3"
   changes:
     - description: Update Apache Spark logo.

--- a/packages/apache_spark/data_stream/driver/agent/stream/stream.yml.hbs
+++ b/packages/apache_spark/data_stream/driver/agent/stream/stream.yml.hbs
@@ -283,7 +283,7 @@ jmx.mappings:
     attributes:
     - attr: Value
       field: driver.spark.streaming.event_time.watermark
-  - mbean: 'metrics:name=*.driver.spark.streaming.*.inputRate-total,type=gauge'
+  - mbean: 'metrics:name=*.driver.spark.streaming.*.inputRate-total,type=gauges'
     attributes:
     - attr: Value
       field: driver.spark.streaming.input_rate.total

--- a/packages/apache_spark/manifest.yml
+++ b/packages/apache_spark/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache_spark
 title: Apache Spark
-version: "0.6.3"
+version: "0.6.4"
 license: basic
 description: Collect metrics from Apache Spark with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Bugfix
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:

- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do

- Fix typo error for MBean `metrics:name=.driver.spark.streaming..inputRate-total,type=gauge` whose data is not being collected.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #8060