### PR TITLE
[Azure][Storage_account] Enable TSDB

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Enable time series data streams for the storage_account metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8064
 - version: "1.1.1"
   changes:
     - description: Add metric_type metadata to the `storage_account` datastream

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.0"
+  changes:
+    - description: Enable time series data streams for the storage_account metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: tba
 - version: "1.1.1"
   changes:
     - description: Add metric_type metadata to the `storage_account` datastream

--- a/packages/azure_metrics/data_stream/storage_account/manifest.yml
+++ b/packages/azure_metrics/data_stream/storage_account/manifest.yml
@@ -32,3 +32,5 @@ streams:
         show_user: true
     title: Storage Account
     description: Collect Storage Account metrics
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.1.1
+version: 1.2.0
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement

## Proposed commit message

Enable time series data streams for the storage_account metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.

The changes have been validated using the `TSDB migration test kit`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




- Closes #7215 

## Screenshots

Refer #7215 
