### PR TITLE
[elastic_agent] - Cleanup fields.yml issues

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Modify field mappings to reference ECS fields where possible and remove duplicate field declarations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8079
 - version: "1.13.1"
   changes:
     - description: Fix mapping and description for the `system.process.cpu.{system,user,total}.time.ms` fields.

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -25,7 +25,6 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -46,7 +45,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/agent.yml
@@ -6,36 +6,21 @@
   type: group
   fields:
     - name: account.id
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
+      external: ecs
     - name: availability_zone
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
+      external: ecs
     - name: instance.id
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
+      external: ecs
     - name: instance.name
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
+      external: ecs
     - name: provider
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+      external: ecs
     - name: region
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -46,21 +31,13 @@
   type: group
   fields:
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -68,62 +45,31 @@
   type: group
   fields:
     - name: architecture
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
+      external: ecs
     - name: domain
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      default_field: false
+      external: ecs
     - name: hostname
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
+      external: ecs
     - name: os.kernel
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
+      external: ecs
     - name: os.name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
+      external: ecs
     - name: os.platform
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
+      external: ecs
     - name: os.version
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
+      external: ecs
     - name: type
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -2,15 +2,11 @@
   external: ecs
 - name: decision_id
   type: text
-  title: Decision ID
 - name: input
   type: object
-  title: Decision Input
 - name: result
   type: object
-  title: Decision Result
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -11,7 +11,6 @@
   title: Decision Result
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -1,5 +1,3 @@
-- name: message
-  external: ecs
 - name: decision_id
   type: text
 - name: input

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/agent.yml
@@ -6,36 +6,21 @@
   type: group
   fields:
     - name: account.id
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
+      external: ecs
     - name: availability_zone
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
+      external: ecs
     - name: instance.id
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
+      external: ecs
     - name: instance.name
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
+      external: ecs
     - name: provider
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+      external: ecs
     - name: region
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -46,21 +31,13 @@
   type: group
   fields:
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -68,62 +45,31 @@
   type: group
   fields:
     - name: architecture
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
+      external: ecs
     - name: domain
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      default_field: false
+      external: ecs
     - name: hostname
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
+      external: ecs
     - name: os.kernel
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
+      external: ecs
     - name: os.name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
+      external: ecs
     - name: os.platform
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
+      external: ecs
     - name: os.version
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
+      external: ecs
     - name: type
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -11,7 +11,6 @@
   title: Decision Result
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -31,7 +30,6 @@
       description: Elastic agent version.
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -2,15 +2,11 @@
   external: ecs
 - name: decision_id
   type: text
-  title: Decision ID
 - name: input
   type: object
-  title: Decision Input
 - name: result
   type: object
-  title: Decision Result
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -29,7 +29,6 @@
       type: keyword
       ignore_above: 1024
       description: Elastic agent version.
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -50,7 +49,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -1,5 +1,3 @@
-- name: message
-  external: ecs
 - name: decision_id
   type: text
 - name: input

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/agent.yml
@@ -6,36 +6,21 @@
   type: group
   fields:
     - name: account.id
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
+      external: ecs
     - name: availability_zone
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
+      external: ecs
     - name: instance.id
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
+      external: ecs
     - name: instance.name
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
+      external: ecs
     - name: provider
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
+      external: ecs
     - name: region
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -46,21 +31,13 @@
   type: group
   fields:
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -68,62 +45,31 @@
   type: group
   fields:
     - name: architecture
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
+      external: ecs
     - name: domain
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      default_field: false
+      external: ecs
     - name: hostname
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
+      external: ecs
     - name: os.kernel
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
+      external: ecs
     - name: os.name
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
+      external: ecs
     - name: os.platform
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
+      external: ecs
     - name: os.version
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
+      external: ecs
     - name: type
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard
@@ -55,7 +53,6 @@
       ignore_above: 1024
 - name: unit
   type: group
-  description: Agent unit that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -1,5 +1,4 @@
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: beat

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -175,52 +175,6 @@
               description: >
                 Type of output
 
-            - name: events
-              type: group
-              description: >
-                Event counters
-
-              fields:
-                - name: acked
-                  type: long
-                  description: >
-                    Number of events acknowledged
-
-                - name: active
-                  type: long
-                  description: >
-                    Number of active events
-
-                - name: batches
-                  type: long
-                  description: >
-                    Number of event batches
-
-                - name: dropped
-                  type: long
-                  description: >
-                    Number of events dropped
-
-                - name: duplicates
-                  type: long
-                  description: >
-                    Number of events duplicated
-
-                - name: failed
-                  type: long
-                  description: >
-                    Number of events failed
-
-                - name: toomany
-                  type: long
-                  description: >
-                    Number of too many events
-
-                - name: total
-                  type: long
-                  description: >
-                    Total number of events
-
             - name: read
               type: group
               description: >
@@ -236,20 +190,3 @@
                   type: long
                   description: >
                     Number of read errors
-
-            - name: write
-              type: group
-              description: >
-                Write stats
-
-              fields:
-                - name: bytes
-                  type: long
-                  description: >
-                    Number of bytes written
-
-                - name: errors
-                  type: long
-                  description: >
-                    Number of write errors
-

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/filebeat_input_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_logs/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
@@ -4,8 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
 - name: agent.name
   external: ecs
 - name: agent.type

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: filebeat_input
-  title: Filebeat Input Metric fields
   type: group
   fields:
     # Common static fields for all inputs

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: filebeat_input
   title: Filebeat Input Metric fields
-  description: Fields related to the Filebeat Input Metrics
   type: group
   fields:
     # Common static fields for all inputs

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -25,7 +25,6 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -46,7 +45,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -31,7 +30,6 @@
   description: The policy ID fleet-server is operating on when starting a monitor or similar internal workflow.
 - name: fleet
   title: Fleet Server
-  description: Fleet server annotations.
   type: group
   fields:
     - name: access.apikey.id

--- a/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id
@@ -29,7 +28,6 @@
   ignore_above: 1024
   description: The policy ID fleet-server is operating on when starting a monitor or similar internal workflow.
 - name: fleet
-  title: Fleet Server
   type: group
   fields:
     - name: access.apikey.id

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -30,7 +29,6 @@
   external: ecs
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -27,8 +27,7 @@
       example: 7.11.0
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
-
+  external: ecs
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -49,7 +48,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -25,7 +25,6 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -46,7 +45,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/base-fields.yml
@@ -1,15 +1,11 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: event.dataset
   type: constant_keyword
-  description: Event dataset
+  external: ecs

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -25,7 +25,6 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -46,7 +45,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -25,7 +25,6 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
-
 - name: component
   type: group
   description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
@@ -46,7 +45,6 @@
     - name: dataset
       type: keyword
       ignore_above: 1024
-
 # Metrics currently logged in "Non-zero metrics in the last 30s" logs
 # TODO: Update Agent to move these to the "metrics" data streams
 # Note: none of thes metric_type fields are used on logs data streams

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -2,7 +2,6 @@
   external: ecs
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id
@@ -27,7 +26,6 @@
       example: 7.11.0
 - name: component
   type: group
-  description: Agent component that the log message is about, only available on Elastic Agent 8.6.0+
   fields:
     - name: id
       type: wildcard

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -1,7 +1,6 @@
 - name: message
   external: ecs
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
@@ -1,7 +1,4 @@
 - name: cloud
-  title: Cloud
-  group: 2
-  footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
     - name: account.id
@@ -24,8 +21,6 @@
       type: keyword
       description: Image ID for the cloud instance.
 - name: container
-  title: Container
-  group: 2
   type: group
   fields:
     - name: id
@@ -37,8 +32,6 @@
     - name: name
       external: ecs
 - name: host
-  title: Host
-  group: 2
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
@@ -1,7 +1,6 @@
 - name: cloud
   title: Cloud
   group: 2
-  description: Fields related to the cloud or infrastructure the events are coming from.
   footnote: "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on."
   type: group
   fields:
@@ -27,7 +26,6 @@
 - name: container
   title: Container
   group: 2
-  description: "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime."
   type: group
   fields:
     - name: id
@@ -41,7 +39,6 @@
 - name: host
   title: Host
   group: 2
-  description: "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes."
   type: group
   fields:
     - name: architecture

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/agent.yml
@@ -6,49 +6,21 @@
   type: group
   fields:
     - name: account.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier."
-      example: 666777888999
+      external: ecs
     - name: availability_zone
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Availability zone in which this host is running.
-      example: us-east-1c
+      external: ecs
     - name: instance.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance ID of the host machine.
-      example: i-1234567890abcdef0
+      external: ecs
     - name: instance.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Instance name of the host machine.
+      external: ecs
     - name: machine.type
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Machine type of the host machine.
-      example: t2.medium
+      external: ecs
     - name: provider
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.
-      example: aws
+      external: ecs
     - name: region
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Region in which this host is running.
-      example: us-east-1
+      external: ecs
     - name: project.id
-      type: keyword
-      description: Name of the project in Google Cloud.
+      external: ecs
     - name: image.id
       type: keyword
       description: Image ID for the cloud instance.
@@ -59,25 +31,13 @@
   type: group
   fields:
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique container id.
+      external: ecs
     - name: image.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Name of the image the container was built on.
+      external: ecs
     - name: labels
-      level: extended
-      type: object
-      object_type: keyword
-      description: Image labels.
+      external: ecs
     - name: name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Container name.
+      external: ecs
 - name: host
   title: Host
   group: 2
@@ -85,82 +45,31 @@
   type: group
   fields:
     - name: architecture
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Operating system architecture.
-      example: x86_64
+      external: ecs
     - name: domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider."
-      example: CONTOSO
-      default_field: false
+      external: ecs
     - name: hostname
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine."
+      external: ecs
     - name: id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`."
+      external: ecs
     - name: ip
-      level: core
-      type: ip
-      description: Host ip addresses.
+      external: ecs
     - name: mac
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Host mac addresses.
+      external: ecs
     - name: name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use."
+      external: ecs
     - name: os.family
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: OS family (such as redhat, debian, freebsd, windows).
-      example: debian
+      external: ecs
     - name: os.kernel
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system kernel version as a raw string.
-      example: 4.4.0-112-generic
+      external: ecs
     - name: os.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: text
-          norms: false
-          default_field: false
-      description: Operating system name, without the version.
-      example: Mac OS X
+      external: ecs
     - name: os.platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system platform (such centos, ubuntu, windows).
-      example: darwin
+      external: ecs
     - name: os.version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Operating system version as a raw string.
-      example: 10.14.1
+      external: ecs
     - name: type
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment."
+      external: ecs
     - name: containerized
       type: boolean
       description: >

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs
 - name: "@timestamp"
-  type: date
-  description: Event timestamp.
+  external: ecs

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
@@ -1,5 +1,5 @@
 - name: beat.type
-  descripion: Beat type.
+  description: Beat type.
   type: keyword
 - name: beat.stats
   type: group

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/beat-fields.yml
@@ -2,7 +2,6 @@
   descripion: Beat type.
   type: keyword
 - name: beat.stats
-  description: Beat stats
   type: group
   fields:
     - name: libbeat

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -1,6 +1,5 @@
 - name: elastic_agent
   title: Elastic Agent
-  description: Fields related to the Elastic Agents
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -1,5 +1,4 @@
 - name: elastic_agent
-  title: Elastic Agent
   type: group
   fields:
     - name: id

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -7,7 +7,8 @@ format_version: 1.0.0
 license: basic
 categories: ["elastic_stack"]
 conditions:
-  kibana.version: "^8.9.0"
+  kibana:
+    version: "^8.9.0"
 owner:
   github: elastic/elastic-agent
 icons:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.13.1
+version: 1.14.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

This fixes most of the issues necessary to upgrade this package to `format_version: 3.0.0` and does some general housekeeping.

For fields that exist in ECS use 'external: ecs' in the field definition.

Remove attributes from field definitions that have no purpose (like footnote, level, title, etc).

Fix typo for description attribute in some field definitions.

Remove duplicate definitions of fields within the same data stream.

Fix dotted YAML key in manifest.yml.

```
[git-generate]
cd packages/elastic_agent
go run github.com/andrewkroh/fydler@90f7b627e -fix -a useecs,invalidattribute,unknownattribute **/fields/*.yml
perl -p -i -e 's/descripion:/description:/g' **/fields/*.yml
elastic-package format
elastic-package changelog add --link https://github.com/elastic/integrations/pull/8079 --type enhancement --next minor --description "Modified the field definitions to reference ECS where possible and remove invalid field attributes."
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
