### PR TITLE
[Cloud Security] Bump integration version

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -5,11 +5,8 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.6.0-preview16"
+- version: "1.6.0"
   changes:
-    - description: Add Azure benchmark rule templates
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/8042
     - description: Support multiple installations on the same agent policy
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8043
@@ -19,12 +16,6 @@
     - description: Add support for GCP organizations
       type: enhancement
       link: https://github.com/elastic/integrations/pull/7403
-    - description: Add mapping to CSPM org fields
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/7818
-    - description: Add gcp rule templates
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/8007
 - version: "1.5.2"
   changes:
     - description: Refactor GCP credentials

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.7.x - 8.12.x
 # 1.6.x - 8.11.x
 # 1.5.x - 8.10.x
 # 1.4.x - 8.9.x

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -124,7 +124,7 @@ policy_templates:
             required: true
             show_user: false
             description: A URL to CloudShell for creating a new deployment
-            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.10&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
+            default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.11&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
       - type: cloudbeat/cis_azure
         title: Azure
         description: CIS Benchmark for Microsoft Azure Foundations

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.3.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.6.0-preview16"
+version: "1.6.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Proposed commit message

bumps `cloudshell_git_branch` to `8.11` and removes the `-preview` version suffix

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
