### PR TITLE
[Cisco ASA] Fix the processing of the protocol field for 313005

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.25.2
+  changes:
+    - description: Fix the protocol field processing in 313005.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8089
 - version: 2.25.1
   changes:
     - description: Remove redundant regular expression quantifier.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -13,6 +13,7 @@ May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error mess
 May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2(LOCAL\testgroup\testuser) dst dstif:192.168.2.3 (type 3, code 3) on myif interface.  Original IP payload: udp src 192.168.2.2/53 dst 192.168.2.3/10872.
 May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2(LOCAL\testuser) dst dstif:192.168.2.3 (type 3, code 3) on myif interface.  Original IP payload: udp src 192.168.2.2/53 dst 192.168.2.3/10872.
 <188>May  5 17:51:17: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: icmp src 192.168.2.2 dst 192.168.2.3 (type 0, code 0).
+<188>May  5 17:51:17 dev01: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: protocol 51 src 192.168.2.2 dst 192.168.2.3.
 May  5 18:16:21 dev01: %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/0 gaddr 81.2.69.144/2 laddr 10.10.10.10/2 type 8 code 0
 May  5 18:22:35 dev01: %ASA-7-609001: Built local-host net:10.10.10.10
 May  5 18:24:31 dev01: %ASA-7-609002: Teardown local-host identity:10.10.10.10 duration 0:00:00

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -1122,6 +1122,89 @@
             ]
         },
         {
+            "@timestamp": "2023-05-05T17:51:17.000Z",
+            "cisco": {
+                "asa": {
+                    "destination_interface": "dstif",
+                    "icmp_code": 2,
+                    "icmp_type": 3,
+                    "original_iana_number": 51,
+                    "source_interface": "srcif"
+                }
+            },
+            "destination": {
+                "ip": "192.168.2.3"
+            },
+            "ecs": {
+                "version": "8.10.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "313005",
+                "kind": "event",
+                "original": "\u003c188\u003eMay  5 17:51:17 dev01: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: protocol 51 src 192.168.2.2 dst 192.168.2.3.",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 188,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "network": {
+                "community_id": "1:E6cKJx0lLYUlU1tO5oQTlY25dBg=",
+                "iana_number": "1",
+                "transport": "icmp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "dstif"
+                    }
+                },
+                "hostname": "dev01",
+                "ingress": {
+                    "interface": {
+                        "name": "srcif"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "192.168.2.2",
+                    "192.168.2.3"
+                ]
+            },
+            "source": {
+                "ip": "192.168.2.2"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2023-05-05T18:16:21.000Z",
             "cisco": {
                 "asa": {

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -607,6 +607,7 @@ processors:
       description: "313005"
       patterns:
         - "No matching connection for ICMP error message: %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST} dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST} \\(type %{NUMBER:_temp_.cisco.icmp_type}, code %{NUMBER:_temp_.cisco.icmp_code}\\) on %{NOTCOLON} interface.%{SPACE}Original IP payload: %{NOTSPACE:input.type} src %{IPORHOST:source.ip}(/%{NUMBER:source.port})? dst %{IPORHOST:destination.ip}(/%{NUMBER:destination.port})?[.]?"
+        - "No matching connection for ICMP error message: %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST} dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST} \\(type %{NUMBER:_temp_.cisco.icmp_type}, code %{NUMBER:_temp_.cisco.icmp_code}\\) on %{NOTCOLON} interface.%{SPACE}Original IP payload: protocol %{NUMBER:_temp_.cisco.original_iana_number} src %{IPORHOST:source.ip}(/%{NUMBER:source.port})? dst %{IPORHOST:destination.ip}(/%{NUMBER:destination.port})?[.]?"
         - "No matching connection for ICMP error message: %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST}\\(%{NOTCOLON:source.user.domain}\\\\%{NOTSPACE:source.user.group.name}\\\\%{NOTSPACE:source.user.name}\\) dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST} \\(type %{NUMBER:_temp_.cisco.icmp_type}, code %{NUMBER:_temp_.cisco.icmp_code}\\) on %{NOTCOLON} interface.%{SPACE}Original IP payload: %{NOTSPACE:input.type} src %{IPORHOST:source.ip}(/%{NUMBER:source.port})? dst %{IPORHOST:destination.ip}(/%{NUMBER:destination.port})?[.]?"
         - "No matching connection for ICMP error message: %{NOTSPACE:network.transport} src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST}\\(%{NOTCOLON:source.user.domain}\\\\%{NOTSPACE:source.user.name}\\) dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST} \\(type %{NUMBER:_temp_.cisco.icmp_type}, code %{NUMBER:_temp_.cisco.icmp_code}\\) on %{NOTCOLON} interface.%{SPACE}Original IP payload: %{NOTSPACE:input.type} src %{IPORHOST:source.ip}(/%{NUMBER:source.port})? dst %{IPORHOST:destination.ip}(/%{NUMBER:destination.port})?[.]?"
       pattern_definitions:
@@ -1950,6 +1951,15 @@ processors:
   - convert:
       field: _temp_.cisco.icmp_type
       tag: "convert_icmp_type"
+      type: integer
+      ignore_missing: true
+      on_failure:
+        - append:
+            field: error.message
+            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
+  - convert:
+      field: _temp_.cisco.original_iana_number
+      tag: "convert_original_iana_number"
       type: integer
       ignore_missing: true
       on_failure:

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -225,4 +225,8 @@
       type: keyword
       description: >
         Reason for an AAA authentication rejection.
+    - name: original_iana_number
+      type: short
+      description: >
+        IANA Protocol Number of the original IP payload.
 

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -157,6 +157,7 @@ An example event for `log` looks as following:
 | cisco.asa.mapped_source_port | The translated source port. | long |
 | cisco.asa.message | The message associated with SIP and Skinny VoIP events | keyword |
 | cisco.asa.message_id | The Cisco ASA message identifier. | keyword |
+| cisco.asa.original_iana_number | IANA Protocol Number of the original IP payload. | short |
 | cisco.asa.privilege.new | When a users privilege is changed this is the new value | keyword |
 | cisco.asa.privilege.old | When a users privilege is changed this is the old value | keyword |
 | cisco.asa.rejection_reason | Reason for an AAA authentication rejection. | keyword |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_asa
 title: Cisco ASA
-version: "2.25.1"
+version: "2.25.2"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

It fixes the processing of events 313005 with the following format:
```
<188>May 5 17:51:17 dev01: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: protocol 51 src 192.168.2.2 dst 192.168.2.3.
```

which contains a protocol IANA number inside the original IP payload that was not being parsed.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

