### PR TITLE
Infoblox_nios: add client geoip and registered_domain processors to dns data

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 1.17.0
   changes:
-    - description: Added parsing for the DNS question and appended the DNS flags as their own fields.
+    - description: Added parsing for the DNS question and appended the DNS flags as their own fields and added GeoIP processing for client.ip.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8107
 - version: 1.16.0

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.17.0
+  changes:
+    - description: Added parsing for the DNS question and appended the DNS flags as their own fields.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8107
 - version: 1.16.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-audit.log-expected.json
@@ -11,7 +11,7 @@
                     "authentication"
                 ],
                 "created": "2023-03-21T09:53:51.000Z",
-                "original": "\u003c29\u003eMar 21 09:53:51 infoblox.localdomain httpd[]: 2022-03-18 13:24:41.705Z [admin]: Logout - - ip=10.50.0.1 group=admin-group trigger_event=Session\\040Expiration",
+                "original": "<29>Mar 21 09:53:51 infoblox.localdomain httpd[]: 2022-03-18 13:24:41.705Z [admin]: Logout - - ip=10.50.0.1 group=admin-group trigger_event=Session\\040Expiration",
                 "type": [
                     "end"
                 ]
@@ -65,7 +65,7 @@
                     "authentication"
                 ],
                 "created": "2023-04-13T22:14:36.000Z",
-                "original": "\u003c141\u003eApr 13 22:14:36  ns1.infoblox.localdomain 10.50.1.227 httpd: 2022-04-13 16:44:36.850Z [fefdn\\040wdbj]: Login_Denied - - to=AdminConnector ip=10.50.0.1 info=Local apparently_via=GUI",
+                "original": "<141>Apr 13 22:14:36  ns1.infoblox.localdomain 10.50.1.227 httpd: 2022-04-13 16:44:36.850Z [fefdn\\040wdbj]: Login_Denied - - to=AdminConnector ip=10.50.0.1 info=Local apparently_via=GUI",
                 "outcome": "failure"
             },
             "host": {
@@ -122,7 +122,7 @@
                     "authentication"
                 ],
                 "created": "2023-03-21T09:53:51.000Z",
-                "original": "\u003c29\u003eMar 21 09:53:51 infoblox.localdomain 10.0.0.1 httpd: 2022-03-21 08:53:51.087Z [service_account_test]: Login_Allowed - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=some-Group apparently_via=API",
+                "original": "<29>Mar 21 09:53:51 infoblox.localdomain 10.0.0.1 httpd: 2022-03-21 08:53:51.087Z [service_account_test]: Login_Allowed - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=some-Group apparently_via=API",
                 "outcome": "success",
                 "type": [
                     "start"
@@ -183,7 +183,7 @@
                     "authentication"
                 ],
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 19:48:37.299Z [admin]: Login_Allowed - - to=Serial\\040Console apparently_via=Direct auth=Local group=admin-group",
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 19:48:37.299Z [admin]: Login_Allowed - - to=Serial\\040Console apparently_via=Direct auth=Local group=admin-group",
                 "outcome": "success",
                 "type": [
                     "start"
@@ -238,7 +238,7 @@
                     "authentication"
                 ],
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 14:02:32.750Z [admin]: Login_Denied - - to=Serial\\040Console apparently_via=Direct error=invalid\\040login\\040or\\040password",
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 14:02:32.750Z [admin]: Login_Denied - - to=Serial\\040Console apparently_via=Direct error=invalid\\040login\\040or\\040password",
                 "outcome": "failure"
             },
             "host": {
@@ -286,7 +286,7 @@
             "event": {
                 "action": "first_login",
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login"
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 12:43:47.375Z [user]: First_Login - - to=AdminConnector ip=10.0.0.2 auth=LOCAL group=admin-group apparently_via=GUI\\040first\\040login"
             },
             "host": {
                 "ip": [
@@ -336,7 +336,7 @@
             "event": {
                 "action": "password_reset_error",
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 13:07:33.343Z [user]: Password_Reset_Error - - to=AdminConnector auth=LOCALgroup=admin-group apparently_via=GUI"
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2011-10-19 13:07:33.343Z [user]: Password_Reset_Error - - to=AdminConnector auth=LOCALgroup=admin-group apparently_via=GUI"
             },
             "host": {
                 "ip": [
@@ -383,7 +383,7 @@
             "event": {
                 "action": "modified",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]"
             },
             "host": {
                 "ip": [
@@ -393,7 +393,7 @@
             "infoblox_nios": {
                 "log": {
                     "audit": {
-                        "message": "network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]",
+                        "message": "network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]",
                         "object": {
                             "name": "Network",
                             "value": "192.168.0.0/24"
@@ -408,7 +408,7 @@
                     "priority": 29
                 }
             },
-            "message": "2022-03-21 17:19:02.204Z [admin]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]",
+            "message": "2022-03-21 17:19:02.204Z [admin]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]",
             "related": {
                 "ip": [
                     "10.0.0.1"
@@ -432,7 +432,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:37:29.261Z [admin]: Created Network 192.168.0.0/24 network_view=default: Set extensible_attributes=[],address=\"192.168.2.0\",auto_create_reversezone=False,cidr=24,comment=\"\",common_properties=[domain_name_servers=[],routers=[]],dhcp_members=[[grid_member=Member:infoblox.localdomain]],disabled=False,discovery_member=NULL,enable_discovery=False,enable_immediate_discovery=False,network_view=NetworkView:default,use_basic_polling_settings=False,use_member_enable_discovery=False,vlans=[]"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:37:29.261Z [admin]: Created Network 192.168.0.0/24 network_view=default: Set extensible_attributes=[],address=\"192.168.2.0\",auto_create_reversezone=False,cidr=24,comment=\"\",common_properties=[domain_name_servers=[],routers=[]],dhcp_members=[[grid_member=Member:infoblox.localdomain]],disabled=False,discovery_member=NULL,enable_discovery=False,enable_immediate_discovery=False,network_view=NetworkView:default,use_basic_polling_settings=False,use_member_enable_discovery=False,vlans=[]"
             },
             "host": {
                 "ip": [
@@ -481,7 +481,7 @@
             "event": {
                 "action": "modified",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 11:46:38.877Z [admin]: Modified MemberDhcp infoblox.localdomain: Changed enable_service:False-\u003eTrue"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 11:46:38.877Z [admin]: Modified MemberDhcp infoblox.localdomain: Changed enable_service:False->True"
             },
             "host": {
                 "ip": [
@@ -491,7 +491,7 @@
             "infoblox_nios": {
                 "log": {
                     "audit": {
-                        "message": "Changed enable_service:False-\u003eTrue",
+                        "message": "Changed enable_service:False->True",
                         "object": {
                             "name": "MemberDhcp",
                             "value": "infoblox.localdomain"
@@ -506,7 +506,7 @@
                     "priority": 29
                 }
             },
-            "message": "2022-03-18 11:46:38.877Z [admin]: Modified MemberDhcp infoblox.localdomain: Changed enable_service:False-\u003eTrue",
+            "message": "2022-03-18 11:46:38.877Z [admin]: Modified MemberDhcp infoblox.localdomain: Changed enable_service:False->True",
             "related": {
                 "ip": [
                     "10.0.0.1"
@@ -530,7 +530,7 @@
             "event": {
                 "action": "called",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService: Args services=[\"ALL\"],parents=[],force=True,mode=\"GROUPED\""
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService: Args services=[\"ALL\"],parents=[],force=True,mode=\"GROUPED\""
             },
             "host": {
                 "ip": [
@@ -578,7 +578,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset Block: Set comment=\"\",disabled=True,name=\"Block\",type=\"BLACKLIST\""
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset Block: Set comment=\"\",disabled=True,name=\"Block\",type=\"BLACKLIST\""
             },
             "host": {
                 "ip": [
@@ -627,7 +627,7 @@
             "event": {
                 "action": "called",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:28:24.476Z [admin]: Called - TransferTrafficCapture message=Download\\040Traffic\\040capture\\040file: Args message=\"Download Traffic capture file\",members=[Member:infoblox.localdomain]"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-24 09:28:24.476Z [admin]: Called - TransferTrafficCapture message=Download\\040Traffic\\040capture\\040file: Args message=\"Download Traffic capture file\",members=[Member:infoblox.localdomain]"
             },
             "host": {
                 "ip": [
@@ -675,7 +675,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-21T16:08:08.000Z",
-                "original": "\u003c29\u003eMar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.238Z [service_account_test]: Created HostAddress 10.0.0.1 network_view=default: Set address=\"10.0.0.1\",configure_for_dhcp=False,match_option=\"MAC_ADDRESS\",parent=HostRecord:._default.tld.domain.subdomain.hostrecord"
+                "original": "<29>Mar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.238Z [service_account_test]: Created HostAddress 10.0.0.1 network_view=default: Set address=\"10.0.0.1\",configure_for_dhcp=False,match_option=\"MAC_ADDRESS\",parent=HostRecord:._default.tld.domain.subdomain.hostrecord"
             },
             "host": {
                 "ip": [
@@ -724,7 +724,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-21T16:08:08.000Z",
-                "original": "\u003c29\u003eMar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.239Z [service_account_test]: Created HostRecord somerecord.subdomain.domain.tld DnsView=default alias=somealias.subdomain.domain.tld address=10.0.0.1: Set extensible_attributes=[[name=\"NAC-Policy\",value=\"Host\"]],addresses=[address=\"10.0.0.1\"],aliases=[HostAlias:._default.tld.domain.subdomain.somealias.._default.tld.domain.subdomain.somehostrecord],fqdn=\"somerecord.subdomain.domain.tld\""
+                "original": "<29>Mar 21 16:08:08 10.0.0.1 httpd: 2022-03-21 15:08:08.239Z [service_account_test]: Created HostRecord somerecord.subdomain.domain.tld DnsView=default alias=somealias.subdomain.domain.tld address=10.0.0.1: Set extensible_attributes=[[name=\"NAC-Policy\",value=\"Host\"]],addresses=[address=\"10.0.0.1\"],aliases=[HostAlias:._default.tld.domain.subdomain.somealias.._default.tld.domain.subdomain.somehostrecord],fqdn=\"somerecord.subdomain.domain.tld\""
             },
             "host": {
                 "ip": [
@@ -773,7 +773,7 @@
             "event": {
                 "action": "deleted",
                 "created": "2023-03-21T16:08:48.000Z",
-                "original": "\u003c29\u003eMar 21 16:08:48 10.0.0.1 httpd: 2022-03-21 15:08:48.455Z [service_account_test]: Deleted HostRecord somerecord.subdomain.domain.tld DnsView=default address=10.0.0.0"
+                "original": "<29>Mar 21 16:08:48 10.0.0.1 httpd: 2022-03-21 15:08:48.455Z [service_account_test]: Deleted HostRecord somerecord.subdomain.domain.tld DnsView=default address=10.0.0.0"
             },
             "host": {
                 "ip": [
@@ -822,7 +822,7 @@
             "event": {
                 "action": "deleted",
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Deleted CaaRecord somecaarecord.domain.tld DnsView=default "
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Deleted CaaRecord somecaarecord.domain.tld DnsView=default "
             },
             "host": {
                 "ip": [
@@ -871,7 +871,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Created HostAddress 192.168.0.0 network_view=default: Set address=\"192.168.0.0\",configure_for_dhcp=True,mac_address=\"01:01:01:01:01:01\",match_option=\"MAC_ADDRESS\",network=Network:192.168.0.0/24\\054network_view\\075default,parent=HostRecord:._default.test.test3,reserved_interface=NULL,use_for_ea_inheritance=True"
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Created HostAddress 192.168.0.0 network_view=default: Set address=\"192.168.0.0\",configure_for_dhcp=True,mac_address=\"01:01:01:01:01:01\",match_option=\"MAC_ADDRESS\",network=Network:192.168.0.0/24\\054network_view\\075default,parent=HostRecord:._default.test.test3,reserved_interface=NULL,use_for_ea_inheritance=True"
             },
             "host": {
                 "ip": [
@@ -920,7 +920,7 @@
             "event": {
                 "action": "modified",
                 "created": "2023-03-22T14:26:54.000Z",
-                "original": "\u003c29\u003eMar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]"
+                "original": "<29>Mar 22 14:26:54 10.0.0.1 httpd: 2022-03-22 13:26:54.596Z [some_admin_account]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]"
             },
             "host": {
                 "ip": [
@@ -930,7 +930,7 @@
             "infoblox_nios": {
                 "log": {
                     "audit": {
-                        "message": "network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]",
+                        "message": "network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]",
                         "object": {
                             "name": "Network",
                             "value": "192.168.0.0/24"
@@ -945,7 +945,7 @@
                     "priority": 29
                 }
             },
-            "message": "2022-03-22 13:26:54.596Z [some_admin_account]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]-\u003e[[grid_member=Member:infoblox.localdomain]]",
+            "message": "2022-03-22 13:26:54.596Z [some_admin_account]: Modified Network 192.168.0.0/24 network_view=default: Changed dhcp_members:[]->[[grid_member=Member:infoblox.localdomain]]",
             "related": {
                 "ip": [
                     "10.0.0.1"
@@ -969,7 +969,7 @@
             "event": {
                 "action": "modified",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 12:40:05.241Z [adminuser]: Modified Grid Unibe-DNS-Grid: Changed backup_setting:[password=\"******\",restore_password=\"******\"]-\u003e[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]-\u003e[password=\"******\"],csp_settings:[csp_join_token=\"******\"]-\u003e[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]-\u003e[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]-\u003e[password=\"******\"],http_proxy_server_setting:NULL-\u003e[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]-\u003e[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]-\u003e[[address=\"67.43.156.15\"]]"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-18 12:40:05.241Z [adminuser]: Modified Grid Unibe-DNS-Grid: Changed backup_setting:[password=\"******\",restore_password=\"******\"]->[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]->[password=\"******\"],csp_settings:[csp_join_token=\"******\"]->[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]->[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]->[password=\"******\"],http_proxy_server_setting:NULL->[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]->[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]->[[address=\"67.43.156.15\"]]"
             },
             "host": {
                 "ip": [
@@ -979,7 +979,7 @@
             "infoblox_nios": {
                 "log": {
                     "audit": {
-                        "message": "Changed backup_setting:[password=\"******\",restore_password=\"******\"]-\u003e[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]-\u003e[password=\"******\"],csp_settings:[csp_join_token=\"******\"]-\u003e[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]-\u003e[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]-\u003e[password=\"******\"],http_proxy_server_setting:NULL-\u003e[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]-\u003e[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]-\u003e[[address=\"67.43.156.15\"]]",
+                        "message": "Changed backup_setting:[password=\"******\",restore_password=\"******\"]->[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]->[password=\"******\"],csp_settings:[csp_join_token=\"******\"]->[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]->[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]->[password=\"******\"],http_proxy_server_setting:NULL->[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]->[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]->[[address=\"67.43.156.15\"]]",
                         "object": {
                             "name": "Grid",
                             "value": "Unibe-DNS-Grid"
@@ -994,7 +994,7 @@
                     "priority": 29
                 }
             },
-            "message": "2022-03-18 12:40:05.241Z [adminuser]: Modified Grid Unibe-DNS-Grid: Changed backup_setting:[password=\"******\",restore_password=\"******\"]-\u003e[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]-\u003e[password=\"******\"],csp_settings:[csp_join_token=\"******\"]-\u003e[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]-\u003e[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]-\u003e[password=\"******\"],http_proxy_server_setting:NULL-\u003e[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]-\u003e[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]-\u003e[[address=\"67.43.156.15\"]]",
+            "message": "2022-03-18 12:40:05.241Z [adminuser]: Modified Grid Unibe-DNS-Grid: Changed backup_setting:[password=\"******\",restore_password=\"******\"]->[password=\"******\",restore_password=\"******\"],csp_api_config:[password=\"******\"]->[password=\"******\"],csp_settings:[csp_join_token=\"******\"]->[csp_join_token=\"******\"],download_member_conf:[[interface=\"ANY\",is_online=True,member=\"Member:Grid Master\"]]->[[interface=\"ANY\",is_online=True,member=NULL]],email_setting:[password=\"******\"]->[password=\"******\"],http_proxy_server_setting:NULL->[password=\"******\"],snmp_setting:[snmpv3_queries_users=NULL]->[snmpv3_queries_users=[]],syslog_servers:[[address=\"67.43.156.15\"],[address=\"67.43.156.15\"]]->[[address=\"67.43.156.15\"]]",
             "related": {
                 "ip": [
                     "10.0.0.1"
@@ -1017,7 +1017,7 @@
             },
             "event": {
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 syslog: any random text"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 syslog: any random text"
             },
             "host": {
                 "ip": [
@@ -1052,7 +1052,7 @@
             "event": {
                 "action": "called",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 19:29:20.468Z [admin]: Called - RestartService"
             },
             "host": {
                 "ip": [
@@ -1097,7 +1097,7 @@
             "event": {
                 "action": "modified",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-21 17:19:02.204Z [admin]: Modified Network"
             },
             "host": {
                 "ip": [
@@ -1142,7 +1142,7 @@
             "event": {
                 "action": "created",
                 "created": "2023-03-18T13:40:05.000Z",
-                "original": "\u003c29\u003eMar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset"
+                "original": "<29>Mar 18 13:40:05 10.0.0.1 httpd: 2022-03-29 18:30:58.656Z [admin]: Created Ruleset"
             },
             "host": {
                 "ip": [

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
@@ -1466,6 +1466,18 @@
         {
             "@timestamp": "2023-07-12T15:07:57.000Z",
             "client": {
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
                 "ip": "67.43.156.0",
                 "mac": "9A-DF-6E-F6-1F-23"
             },
@@ -1722,6 +1734,18 @@
         {
             "@timestamp": "2023-07-12T15:10:48.000Z",
             "client": {
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
                 "ip": "67.43.156.0",
                 "mac": "9A-DF-6E-F6-1F-23"
             },
@@ -2796,6 +2820,15 @@
         {
             "@timestamp": "2023-07-12T15:55:55.000Z",
             "client": {
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
                 "ip": "2a02:cf40::",
                 "port": 547
             },
@@ -2844,6 +2877,15 @@
         {
             "@timestamp": "2023-07-12T15:55:55.000Z",
             "client": {
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
                 "ip": "2a02:cf40::"
             },
             "ecs": {
@@ -2892,6 +2934,15 @@
         {
             "@timestamp": "2023-07-12T15:55:55.000Z",
             "client": {
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
                 "ip": "2a02:cf40::",
                 "port": 547
             },
@@ -2942,6 +2993,15 @@
         {
             "@timestamp": "2023-07-12T15:55:55.000Z",
             "client": {
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
                 "ip": "2a02:cf40::",
                 "port": 547
             },
@@ -2986,6 +3046,15 @@
         {
             "@timestamp": "2023-07-12T15:55:55.000Z",
             "client": {
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
                 "ip": "2a02:cf40::",
                 "port": 547
             },

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dhcp.log-expected.json
@@ -12,7 +12,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-04-18T05:02:05.000Z",
-                "original": "\u003c30\u003eApr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via eth3"
+                "original": "<30>Apr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via eth3"
             },
             "host": {
                 "ip": [
@@ -63,7 +63,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-04-18T05:02:05.000Z",
-                "original": "\u003c30\u003eApr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via 192.168.0.2"
+                "original": "<30>Apr 18 05:02:05 10.50.1.227 dhcpd[2301]: DHCPREQUEST for 192.168.0.4 from 00:50:56:81:14:6c via 192.168.0.2"
             },
             "host": {
                 "ip": [
@@ -112,7 +112,7 @@
             "event": {
                 "action": "dhcpdiscover",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID a76ecf84 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID a76ecf84 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -165,7 +165,7 @@
             "event": {
                 "action": "dhcpdiscover",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain 10.0.0.1 dhcpd[7024]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID b5e92c59 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain 10.0.0.1 dhcpd[7024]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID b5e92c59 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain",
@@ -222,7 +222,7 @@
             "event": {
                 "action": "dhcpdiscover",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 10.0.0.1 dhcpd[2750]: DHCPDISCOVER from 00:50:56:83:d0:f6 via eth1 TransID 6214ab45: network 10.50.0.0/20: no free leases"
+                "original": "<30>Mar 27 08:32:59 10.0.0.1 dhcpd[2750]: DHCPDISCOVER from 00:50:56:83:d0:f6 via eth1 TransID 6214ab45: network 10.50.0.0/20: no free leases"
             },
             "host": {
                 "ip": [
@@ -278,7 +278,7 @@
             "event": {
                 "action": "dhcpdiscover",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPDISCOVER from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -328,7 +328,7 @@
             "event": {
                 "action": "dhcpdiscover",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPDISCOVER from 00:00:00:00:00:00 (h000000000000) via 192.168.0.2 TransID 01000000"
+                "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPDISCOVER from 00:00:00:00:00:00 (h000000000000) via 192.168.0.2 TransID 01000000"
             },
             "host": {
                 "domain": "infoblox_localdomain.com"
@@ -380,7 +380,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 119 offered-duration 1800 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 119 offered-duration 1800 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -447,7 +447,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 120 offered-duration 1800"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPOFFER on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 120 offered-duration 1800"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -513,7 +513,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-03-31T15:30:05.000Z",
-                "original": "\u003c30\u003eMar 31 15:30:05 10.0.0.1 dhcpd[15752]: DHCPOFFER on 192.168.0.4 to 26:9a:76:87:8a:06 via eth2 relay 192.168.0.3 lease-duration 1795 uid 01:26:9a:76:87:8a:06"
+                "original": "<30>Mar 31 15:30:05 10.0.0.1 dhcpd[15752]: DHCPOFFER on 192.168.0.4 to 26:9a:76:87:8a:06 via eth2 relay 192.168.0.3 lease-duration 1795 uid 01:26:9a:76:87:8a:06"
             },
             "host": {
                 "ip": [
@@ -576,7 +576,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPOFFER on 192.168.0.4 to 00:00:00:00:00:00 via eth1 relay 192.168.0.3 lease-duration 43137 offered-duration 43200"
+                "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPOFFER on 192.168.0.4 to 00:00:00:00:00:00 via eth1 relay 192.168.0.3 lease-duration 43137 offered-duration 43200"
             },
             "host": {
                 "domain": "infoblox_localdomain.com"
@@ -641,7 +641,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPOFFER on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 120"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPOFFER on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 120"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -703,7 +703,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54737448 uid 01:00:50:56:83:6c:a0 (RENEW)"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54737448 uid 01:00:50:56:83:6c:a0 (RENEW)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -767,7 +767,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 8767dc3c uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 8767dc3c uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -828,7 +828,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54ade258 uid 01:00:50:56:83:6c:a0 (RENEW)"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 54ade258 uid 01:00:50:56:83:6c:a0 (RENEW)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -888,7 +888,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID a18a70a0 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[4495]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID a18a70a0 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -943,7 +943,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[25637]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:d3:83 via eth1 TransID 3ca1e0b7: unknown lease 192.168.0.4."
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[25637]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:d3:83 via eth1 TransID 3ca1e0b7: unknown lease 192.168.0.4."
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1004,7 +1004,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-04-06T10:13:31.000Z",
-                "original": "\u003c30\u003eApr  6 10:13:31 infoblox.localdomain dhcpd[22730]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 542900fa uid 01:00:50:56:83:6c:a0: database update failed"
+                "original": "<30>Apr  6 10:13:31 infoblox.localdomain dhcpd[22730]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 TransID 542900fa uid 01:00:50:56:83:6c:a0: database update failed"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1064,7 +1064,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:50:56:83:6c:a0 via eth3 TransID 748f30ab"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1122,7 +1122,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[30827]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:96:03 via eth1 TransID 9cf7c9e9: ignored (not authoritative)."
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[30827]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:96:03 via eth1 TransID 9cf7c9e9: ignored (not authoritative)."
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1179,7 +1179,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID 2d422d0c"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPREQUEST for 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 TransID 2d422d0c"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1233,7 +1233,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-31T15:30:06.000Z",
-                "original": "\u003c30\u003eMar 31 15:30:06 10.0.0.1 dhcpd[15752]: DHCPREQUEST for 192.168.0.4 from 9a:df:6e:f6:1f:23 via 172.26.0.1 TransID 15ca711f uid 01:9a:df:6e:f6:1f:23 (RENEW)"
+                "original": "<30>Mar 31 15:30:06 10.0.0.1 dhcpd[15752]: DHCPREQUEST for 192.168.0.4 from 9a:df:6e:f6:1f:23 via 172.26.0.1 TransID 15ca711f uid 01:9a:df:6e:f6:1f:23 (RENEW)"
             },
             "host": {
                 "ip": [
@@ -1288,7 +1288,7 @@
             "event": {
                 "action": "dhcprequest",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:00:00:00:00:00 via 192.168.0.3 TransID 01000000 (RENEW)"
+                "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPREQUEST for 192.168.0.4 (192.168.0.1) from 00:00:00:00:00:00 via 192.168.0.3 TransID 01000000 (RENEW)"
             },
             "host": {
                 "domain": "infoblox_localdomain.com"
@@ -1346,7 +1346,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[17530]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 (RENEW) uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[17530]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 (RENEW) uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1411,7 +1411,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1475,7 +1475,7 @@
             "event": {
                 "action": "dhcpoffer",
                 "created": "2023-07-12T15:07:57.000Z",
-                "original": "\u003c30\u003eJul 12 15:07:57 67.43.156.0 dhcpd[8061]: DHCPOFFER on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 40977 offered-duration 43200 uid 01:9a:df:6e:f6:1f:23"
+                "original": "<30>Jul 12 15:07:57 67.43.156.0 dhcpd[8061]: DHCPOFFER on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 40977 offered-duration 43200 uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
                 "ip": [
@@ -1539,7 +1539,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPACK on 192.168.0.4 to 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 relay eth3 lease-duration 1800"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1602,7 +1602,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 10.0.0.1 dhcpd[15752]: DHCPACK on 192.168.0.4 to 9a:df:6e:f6:1f:23 via eth2 relay 192.168.0.3 lease-duration 7257600 (RENEW) uid 01:9a:df:6e:f6:1f:23"
+                "original": "<30>Mar 27 08:32:59 10.0.0.1 dhcpd[15752]: DHCPACK on 192.168.0.4 to 9a:df:6e:f6:1f:23 via eth2 relay 192.168.0.3 lease-duration 7257600 (RENEW) uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
                 "ip": [
@@ -1666,7 +1666,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPACK on 192.168.0.4 to 00:00:00:00:00:00 (h000000000000) via eth1 relay 192.168.0.3 lease-duration 43200 (RENEW)"
+                "original": "<30>Mar 27 08:32:59 infoblox_localdomain.com dhcpd[29258]: DHCPACK on 192.168.0.4 to 00:00:00:00:00:00 (h000000000000) via eth1 relay 192.168.0.3 lease-duration 43200 (RENEW)"
             },
             "host": {
                 "domain": "infoblox_localdomain.com"
@@ -1731,7 +1731,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-07-12T15:10:48.000Z",
-                "original": "\u003c30\u003eJul 12 15:10:48 67.43.156.0 dhcpd[13468]: DHCPACK on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 7257600 (RENEW)"
+                "original": "<30>Jul 12 15:10:48 67.43.156.0 dhcpd[13468]: DHCPACK on 67.43.156.0 to 9a:df:6e:f6:1f:23 via eth2 relay 67.43.156.0 lease-duration 7257600 (RENEW)"
             },
             "host": {
                 "ip": [
@@ -1792,7 +1792,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPACK on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 43200"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPACK on 192.168.0.4 to cc:bb:cc:dd:ee:ff via eth1 relay 192.168.0.3 lease-duration 43200"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1854,7 +1854,7 @@
             "event": {
                 "action": "dhcprelease",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 (found) TransID 0286f3d0 uid 01:00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 (DESKTOP-ABCD) via eth3 (found) TransID 0286f3d0 uid 01:00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1914,7 +1914,7 @@
             "event": {
                 "action": "dhcprelease",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 (not found) TransID 665fd9f1"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[21114]: DHCPRELEASE of 192.168.0.4 from 00:50:56:83:6c:a0 via eth3 (not found) TransID 665fd9f1"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1971,7 +1971,7 @@
             "event": {
                 "action": "dhcpexpire",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPEXPIRE on 192.168.0.4 to 00:50:56:83:6c:a0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPEXPIRE on 192.168.0.4 to 00:50:56:83:6c:a0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2014,7 +2014,7 @@
             "event": {
                 "action": "dhcpinform",
                 "created": "2023-03-18T13:35:15.000Z",
-                "original": "\u003c30\u003eMar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 5713b740"
+                "original": "<30>Mar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 5713b740"
             },
             "host": {
                 "ip": [
@@ -2064,7 +2064,7 @@
             "event": {
                 "action": "dhcpinform",
                 "created": "2023-03-18T13:35:15.000Z",
-                "original": "\u003c30\u003eMar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via eth2 TransID 5713b740"
+                "original": "<30>Mar 18 13:35:15 10.0.0.1 dhcpd[18078]: DHCPINFORM from 192.168.0.4 via eth2 TransID 5713b740"
             },
             "host": {
                 "ip": [
@@ -2117,7 +2117,7 @@
             "event": {
                 "action": "dhcpinform",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 78563412: not authoritative for subnet 10.0.0.0"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPINFORM from 192.168.0.4 via 192.168.0.2 TransID 78563412: not authoritative for subnet 10.0.0.0"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2171,7 +2171,7 @@
             "event": {
                 "action": "dhcpdecline",
                 "created": "2023-03-18T11:44:52.000Z",
-                "original": "\u003c30\u003eMar 18 11:44:52 10.0.0.1 dhcpd[32243]: DHCPDECLINE of 192.168.0.4 from 34:29:8f:71:b8:99 via 10.10.4.1 TransID 00000000: not found"
+                "original": "<30>Mar 18 11:44:52 10.0.0.1 dhcpd[32243]: DHCPDECLINE of 192.168.0.4 from 34:29:8f:71:b8:99 via 10.10.4.1 TransID 00000000: not found"
             },
             "host": {
                 "ip": [
@@ -2225,7 +2225,7 @@
             "event": {
                 "action": "dhcpdecline",
                 "created": "2023-03-07T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 7 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPDECLINE of 192.168.0.4 from 00:c0:dd:07:18:e2 via 192.168.0.2: abandoned\\n"
+                "original": "<30>Mar 7 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPDECLINE of 192.168.0.4 from 00:c0:dd:07:18:e2 via 192.168.0.2: abandoned\\n"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2278,7 +2278,7 @@
             "event": {
                 "action": "dhcpnak",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPNAK on 192.168.0.4 to f4:30:b9:17:ab:0e via 192.168.0.2"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[20397]: DHCPNAK on 192.168.0.4 to f4:30:b9:17:ab:0e via 192.168.0.2"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2327,7 +2327,7 @@
             "event": {
                 "action": "dhcpleasequery",
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPLEASEQUERY from 192.168.0.4: LEASEQUERY not allowed, query ignored"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[6939]: DHCPLEASEQUERY from 192.168.0.4: LEASEQUERY not allowed, query ignored"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2371,7 +2371,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDISCOVER some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2410,7 +2410,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPOFFER some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPOFFER some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2449,7 +2449,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPREQUEST some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPREQUEST some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2488,7 +2488,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPACK some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPACK some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2527,7 +2527,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPRELEASE some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2566,7 +2566,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPEXPIRE some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPEXPIRE some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2605,7 +2605,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPINFORM some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPINFORM some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2644,7 +2644,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDECLINE some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPDECLINE some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2683,7 +2683,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPNAK some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPNAK some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2722,7 +2722,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPLEASEQUERY some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: DHCPLEASEQUERY some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2761,7 +2761,7 @@
             },
             "event": {
                 "created": "2023-03-27T08:32:59.000Z",
-                "original": "\u003c30\u003eMar 27 08:32:59 infoblox.localdomain dhcpd[1761]: some text"
+                "original": "<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[1761]: some text"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -2805,7 +2805,7 @@
             "event": {
                 "action": "encapsulated solicit",
                 "created": "2023-07-12T15:55:55.000Z",
-                "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulated Solicit message from 2a02:cf40:: port 547 from client DUID 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23, transaction ID 0x698AD400"
+                "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulated Solicit message from 2a02:cf40:: port 547 from client DUID 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23, transaction ID 0x698AD400"
             },
             "host": {
                 "ip": [
@@ -2852,7 +2852,7 @@
             "event": {
                 "action": "advertise na",
                 "created": "2023-07-12T15:55:55.000Z",
-                "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Advertise NA: address 2a02:cf40:: to client with duid 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23 iaid = -1620146908 valid for 43200 seconds"
+                "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Advertise NA: address 2a02:cf40:: to client with duid 01:9a:df:6e:f6:1f:23:01:9a:df:6e:f6:1f:23 iaid = -1620146908 valid for 43200 seconds"
             },
             "host": {
                 "ip": [
@@ -2901,7 +2901,7 @@
             "event": {
                 "action": "relay-forward",
                 "created": "2023-07-12T15:55:55.000Z",
-                "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Relay-forward message from 2a02:cf40:: port 547, link address 2a02:cf40::1, peer address 2a02:cf40::2"
+                "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Relay-forward message from 2a02:cf40:: port 547, link address 2a02:cf40::1, peer address 2a02:cf40::2"
             },
             "host": {
                 "ip": [
@@ -2951,7 +2951,7 @@
             "event": {
                 "action": "encapsulating advertise",
                 "created": "2023-07-12T15:55:55.000Z",
-                "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulating Advertise message to send to 2a02:cf40:: port 547"
+                "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Encapsulating Advertise message to send to 2a02:cf40:: port 547"
             },
             "host": {
                 "ip": [
@@ -2995,7 +2995,7 @@
             "event": {
                 "action": "sending relay-reply",
                 "created": "2023-07-12T15:55:55.000Z",
-                "original": "\u003c30\u003eJul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Sending Relay-reply message to 2a02:cf40:: port 547"
+                "original": "<30>Jul 12 15:55:55 67.43.156.0 dhcpdv6[12271]: Sending Relay-reply message to 2a02:cf40:: port 547"
             },
             "host": {
                 "ip": [
@@ -3039,7 +3039,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-28T09:25:49.000Z",
-                "original": "\u003c30\u003eSep 28 09:25:49 infoblox.localdomain 10.0.0.1 dhcpd[25691]: DHCPACK on 192.168.0.4 to 00:50:56:83:96:03 via eth2 relay 192.168.0.4 lease-duration 3600 uid 01:9a:df:6e:f6:1f:23"
+                "original": "<30>Sep 28 09:25:49 infoblox.localdomain 10.0.0.1 dhcpd[25691]: DHCPACK on 192.168.0.4 to 00:50:56:83:96:03 via eth2 relay 192.168.0.4 lease-duration 3600 uid 01:9a:df:6e:f6:1f:23"
             },
             "host": {
                 "domain": "infoblox.localdomain",
@@ -3105,7 +3105,7 @@
             "event": {
                 "action": "release",
                 "created": "2023-09-30T11:27:26.000Z",
-                "original": "\u003c30\u003eSep 30 11:27:26 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: RELEASE on 192.168.0.4 to ce:93:30:8e:db:ac"
+                "original": "<30>Sep 30 11:27:26 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: RELEASE on 192.168.0.4 to ce:93:30:8e:db:ac"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
@@ -3153,7 +3153,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-30T11:30:55.000Z",
-                "original": "\u003c30\u003eSep 30 11:30:55 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK to 192.168.0.4 (9c:ad:97:7a:fd:33) via eth2"
+                "original": "<30>Sep 30 11:30:55 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK to 192.168.0.4 (9c:ad:97:7a:fd:33) via eth2"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
@@ -3208,7 +3208,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-30T11:33:03.000Z",
-                "original": "\u003c30\u003eSep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 uid 01:4a:34:bf:d2:78:24"
+                "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
@@ -3275,7 +3275,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-30T11:33:03.000Z",
-                "original": "\u003c30\u003eSep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
+                "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
@@ -3348,7 +3348,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-30T11:33:03.000Z",
-                "original": "\u003c30\u003eSep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
+                "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW) uid 01:4a:34:bf:d2:78:24"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",
@@ -3419,7 +3419,7 @@
             "event": {
                 "action": "dhcpack",
                 "created": "2023-09-30T11:33:03.000Z",
-                "original": "\u003c30\u003eSep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW)"
+                "original": "<30>Sep 30 11:33:03 anudhcp.anu.edu.au 10.0.0.1 dhcpd[11411]: DHCPACK on 192.168.0.4 to 4a:34:bf:d2:78:24 (my-iPhone) via eth2 relay 67.43.156.0 lease-duration 900 offered-duration 3600 (RENEW)"
             },
             "host": {
                 "domain": "anudhcp.anu.edu.au",

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -29,6 +29,11 @@
                         "A"
                     ]
                 },
+                "flags": {
+                    "dnssec_ok": true,
+                    "edns_opt_record": true,
+                    "recursive": true
+                },
                 "header_flags": [
                     "DO",
                     "RA"
@@ -36,6 +41,9 @@
                 "question": {
                     "class": "IN",
                     "name": "a1.foo.com",
+                    "registered_domain": "foo.com",
+                    "subdomain": "a1",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "NOERROR"
@@ -45,7 +53,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[11042]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a1.foo.com IN A response: NOERROR +ED a1.foo.com 28800 IN A foo.com; a1.foo.com 28800 IN A 0.0.0.0;"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[11042]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a1.foo.com IN A response: NOERROR +ED a1.foo.com 28800 IN A foo.com; a1.foo.com 28800 IN A 0.0.0.0;"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -93,9 +101,14 @@
                 "port": 50565
             },
             "dns": {
+                "flags": {
+                    "recursive": false
+                },
                 "question": {
                     "class": "IN",
                     "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "REFUSED"
@@ -105,7 +118,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c45\u003eMar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#50565 UDP: query: test.com IN A response: REFUSED -"
+                "original": "<45>Mar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#50565 UDP: query: test.com IN A response: REFUSED -"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -168,6 +181,12 @@
                         "A"
                     ]
                 },
+                "flags": {
+                    "authoritive": true,
+                    "dnssec_ok": true,
+                    "edns_opt_record": true,
+                    "recursive": true
+                },
                 "header_flags": [
                     "AA",
                     "DO",
@@ -176,6 +195,9 @@
                 "question": {
                     "class": "IN",
                     "name": "a2.foo.com",
+                    "registered_domain": "foo.com",
+                    "subdomain": "a2",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "NOERROR"
@@ -185,7 +207,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a2.foo.com IN A response: NOERROR +AED a2.foo.com 28800 IN A 192.168.0.3;"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a2.foo.com IN A response: NOERROR +AED a2.foo.com 28800 IN A 192.168.0.3;"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -232,6 +254,11 @@
                 "port": 57398
             },
             "dns": {
+                "flags": {
+                    "dnssec_ok": true,
+                    "edns_opt_record": true,
+                    "recursive": true
+                },
                 "header_flags": [
                     "DO",
                     "RA"
@@ -239,6 +266,9 @@
                 "question": {
                     "class": "IN",
                     "name": "non-exist.foo.com",
+                    "registered_domain": "foo.com",
+                    "subdomain": "non-exist",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "NXDOMAIN"
@@ -248,7 +278,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: non-exist.foo.com IN A response: NXDOMAIN +ED"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: non-exist.foo.com IN A response: NXDOMAIN +ED"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -316,6 +346,11 @@
                         "A"
                     ]
                 },
+                "flags": {
+                    "dnssec_ok": true,
+                    "edns_opt_record": true,
+                    "recursive": true
+                },
                 "header_flags": [
                     "DO",
                     "RA"
@@ -323,6 +358,9 @@
                 "question": {
                     "class": "IN",
                     "name": "a1.foo.com",
+                    "registered_domain": "foo.com",
+                    "subdomain": "a1",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "NOERROR"
@@ -332,7 +370,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c45\u003eMar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a1.foo.com IN A response: NOERROR +ED a1.foo.com 28800 IN A 192.168.0.2; a1.foo.com 28800 IN A 192.168.0.3;"
+                "original": "<45>Mar 11 23:51:31 infoblox.localdomain named[17742]: 07-Apr-2022 08:08:10.043 client 192.168.0.1#57398 UDP: query: a1.foo.com IN A response: NOERROR +ED a1.foo.com 28800 IN A 192.168.0.2; a1.foo.com 28800 IN A 192.168.0.3;"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -384,7 +422,7 @@
             },
             "event": {
                 "created": "2023-03-09T23:59:59.000Z",
-                "original": "\u003c30\u003eMar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query failed (REFUSED) for config.nos-avg.cz/IN/TXT at query.c:10288"
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query failed (REFUSED) for config.nos-avg.cz/IN/TXT at query.c:10288"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -428,12 +466,18 @@
                 "port": 59735
             },
             "dns": {
+                "flags": {
+                    "recursive": true
+                },
                 "header_flags": [
                     "RD"
                 ],
                 "question": {
                     "class": "IN",
                     "name": "config.nos-avg.cz",
+                    "registered_domain": "nos-avg.cz",
+                    "subdomain": "config",
+                    "top_level_domain": "cz",
                     "type": "TXT"
                 }
             },
@@ -442,7 +486,7 @@
             },
             "event": {
                 "created": "2023-03-09T23:59:59.000Z",
-                "original": "\u003c30\u003eMar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query: config.nos-avg.cz IN TXT + (192.168.0.1)"
+                "original": "<30>Mar  9 23:59:59 infoblox.localdomain named[17742]: client @0x7f1dd4114af0 192.168.0.1#59735 (config.nos-avg.cz): query: config.nos-avg.cz IN TXT + (192.168.0.1)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -488,7 +532,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[27014]: rpz: rpz1.com: reload start"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[27014]: rpz: rpz1.com: reload start"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -536,7 +580,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[29914]: client @0x7ff42c168b50 192.168.0.1#50460 (test.com): rewriting query name 'test.com' to 'query123-10-120-20-93.test.com', type A"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[29914]: client @0x7ff42c168b50 192.168.0.1#50460 (test.com): rewriting query name 'test.com' to 'query123-10-120-20-93.test.com', type A"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -581,7 +625,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "test1.com"
+                    "name": "test1.com",
+                    "registered_domain": "test1.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -589,7 +635,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[19204]: client @0x7fec7c11dab0 192.168.0.1#36483: updating zone 'test1.com/IN': adding an RR at 'a6.test1.com' A 192.168.0.2"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[19204]: client @0x7fec7c11dab0 192.168.0.1#36483: updating zone 'test1.com/IN': adding an RR at 'a6.test1.com' A 192.168.0.2"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -644,7 +690,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[28468]: CEF:0|Infoblox|NIOS|8.6.2-49634-e88e9df276a8|RPZ-QNAME|NXDOMAIN|7|app=DNS dst=192.168.0.1 src=192.168.0.1 spt=51424 view=_default qtype=A msg=\"rpz QNAME NXDOMAIN rewrite nxd1.com [A] via nxd1.com.rpz1.com\" CAT=RPZ"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[28468]: CEF:0|Infoblox|NIOS|8.6.2-49634-e88e9df276a8|RPZ-QNAME|NXDOMAIN|7|app=DNS dst=192.168.0.1 src=192.168.0.1 spt=51424 view=_default qtype=A msg=\"rpz QNAME NXDOMAIN rewrite nxd1.com [A] via nxd1.com.rpz1.com\" CAT=RPZ"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -694,7 +740,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "local_7.com"
+                    "name": "local_7.com",
+                    "registered_domain": "local_7.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -702,7 +750,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[7741]: zone local_7.com/IN: notify from 192.168.0.1#46982: zone is up to date"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[7741]: zone local_7.com/IN: notify from 192.168.0.1#46982: zone is up to date"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -749,7 +797,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[7741]: responses: client @0x7fb550117f90 192.168.0.1#46982: received notify for zone 'local_14.com'"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[7741]: responses: client @0x7fb550117f90 192.168.0.1#46982: received notify for zone 'local_14.com'"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -794,7 +842,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "test.com"
+                    "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -802,7 +852,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer status: success"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer status: success"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -847,7 +897,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "test.com"
+                    "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -855,7 +907,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[15242]: transfer of 'test.com/IN' from 192.168.0.1#53: Transfer completed: 1 messages, 9 records, 326 bytes, 0.001 secs (326000 bytes/sec)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -901,7 +953,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "test.com"
+                    "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -909,7 +963,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[56199]: client @0x7f7e6c2809f0 192.168.0.1#57027 (test.com): transfer of 'test.com/IN': AXFR started (serial 3)"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[56199]: client @0x7f7e6c2809f0 192.168.0.1#57027 (test.com): transfer of 'test.com/IN': AXFR started (serial 3)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -955,7 +1009,9 @@
             "dns": {
                 "question": {
                     "class": "IN",
-                    "name": "test.com"
+                    "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com"
                 }
             },
             "ecs": {
@@ -963,7 +1019,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[56199]: client @0x7f7e6c2809f0 192.168.0.1#57027 (test.com): transfer of 'test.com/IN': AXFR ended"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[56199]: client @0x7f7e6c2809f0 192.168.0.1#57027 (test.com): transfer of 'test.com/IN': AXFR ended"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1006,7 +1062,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[30325]: resolver priming query complete"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[30325]: resolver priming query complete"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1043,6 +1099,8 @@
             "dns": {
                 "question": {
                     "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com",
                     "type": "DNSKEY"
                 }
             },
@@ -1051,7 +1109,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[1127]: validating test.com/DNSKEY: unable to find a DNSKEY which verifies the DNSKEY RRset and also matches a trusted key for 'test.com'"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[1127]: validating test.com/DNSKEY: unable to find a DNSKEY which verifies the DNSKEY RRset and also matches a trusted key for 'test.com'"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1089,6 +1147,8 @@
             "dns": {
                 "question": {
                     "name": "test.com",
+                    "registered_domain": "test.com",
+                    "top_level_domain": "com",
                     "type": "NSEC"
                 }
             },
@@ -1097,7 +1157,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[1127]: validating test.com/NSEC: bad cache hit (test.com/DNSKEY)"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[1127]: validating test.com/NSEC: bad cache hit (test.com/DNSKEY)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1135,6 +1195,9 @@
             "dns": {
                 "question": {
                     "name": "hostrec3.test.com",
+                    "registered_domain": "test.com",
+                    "subdomain": "hostrec3",
+                    "top_level_domain": "com",
                     "type": "NSEC"
                 }
             },
@@ -1143,7 +1206,7 @@
             },
             "event": {
                 "created": "2023-03-11T23:51:31.000Z",
-                "original": "\u003c30\u003eMar 11 23:51:31 infoblox.localdomain named[1127]: validating hostrec3.test.com/NSEC: bad cache hit (test.com/DNSKEY)"
+                "original": "<30>Mar 11 23:51:31 infoblox.localdomain named[1127]: validating hostrec3.test.com/NSEC: bad cache hit (test.com/DNSKEY)"
             },
             "host": {
                 "domain": "infoblox.localdomain"
@@ -1183,9 +1246,15 @@
                 "port": 57738
             },
             "dns": {
+                "flags": {
+                    "recursive": false
+                },
                 "question": {
                     "class": "IN",
                     "name": "settings-win.data.microsoft.com",
+                    "registered_domain": "microsoft.com",
+                    "subdomain": "settings-win.data",
+                    "top_level_domain": "com",
                     "type": "A"
                 },
                 "response_code": "REFUSED"
@@ -1195,7 +1264,7 @@
             },
             "event": {
                 "created": "2023-04-14T16:17:20.000Z",
-                "original": "\u003c30\u003eApr 14 16:17:20 10.50.1.227 named[2588]: infoblox-responses: 14-Apr-2022 16:17:20.046 client 192.168.1.90#57738: UDP: query: settings-win.data.microsoft.com IN A response: REFUSED -"
+                "original": "<30>Apr 14 16:17:20 10.50.1.227 named[2588]: infoblox-responses: 14-Apr-2022 16:17:20.046 client 192.168.1.90#57738: UDP: query: settings-win.data.microsoft.com IN A response: REFUSED -"
             },
             "host": {
                 "ip": [
@@ -1245,12 +1314,18 @@
                 "port": 64727
             },
             "dns": {
+                "flags": {
+                    "recursive": true
+                },
                 "header_flags": [
                     "RD"
                 ],
                 "question": {
                     "class": "IN",
                     "name": "ocsp.digicert.com",
+                    "registered_domain": "digicert.com",
+                    "subdomain": "ocsp",
+                    "top_level_domain": "com",
                     "type": "A"
                 }
             },
@@ -1259,7 +1334,7 @@
             },
             "event": {
                 "created": "2023-04-14T16:16:05.000Z",
-                "original": "\u003c30\u003eApr 14 16:16:05 10.50.1.227 named[2588]: queries: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query: ocsp.digicert.com IN A + (192.168.1.10)"
+                "original": "<30>Apr 14 16:16:05 10.50.1.227 named[2588]: queries: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query: ocsp.digicert.com IN A + (192.168.1.10)"
             },
             "host": {
                 "ip": [
@@ -1314,7 +1389,7 @@
             },
             "event": {
                 "created": "2023-04-14T16:16:05.000Z",
-                "original": "\u003c30\u003eApr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288"
+                "original": "<30>Apr 14 16:16:05 10.50.1.227 named[2588]: query-errors: client @0x7f97e40eb500 192.168.1.90#64727 (ocsp.digicert.com): query failed (REFUSED) for ocsp.digicert.com/IN/A at query.c:10288"
             },
             "host": {
                 "ip": [
@@ -1377,12 +1452,18 @@
                         "PTR"
                     ]
                 },
+                "flags": {
+                    "recursive": true
+                },
                 "header_flags": [
                     "RA"
                 ],
                 "question": {
                     "class": "IN",
                     "name": "89.160.20.128.a1.foo.com",
+                    "registered_domain": "foo.com",
+                    "subdomain": "89.160.20.128.a1",
+                    "top_level_domain": "com",
                     "type": "PTR"
                 },
                 "response_code": "NOERROR"
@@ -1392,7 +1473,7 @@
             },
             "event": {
                 "created": "2023-10-04T10:18:07.000Z",
-                "original": "\u003c30\u003eOct 4 10:18:07 a1.foo.com 89.160.20.112 named[10750]: 04-Oct-2022 10:18:07.834 client 89.160.20.128#59605: UDP: query: 89.160.20.128.a1.foo.com IN PTR response: NOERROR + 89.160.20.128.a1.foo.com. 21801 IN PTR 089.160.20.112.a1.foo.com.;"
+                "original": "<30>Oct 4 10:18:07 a1.foo.com 89.160.20.112 named[10750]: 04-Oct-2022 10:18:07.834 client 89.160.20.128#59605: UDP: query: 89.160.20.128.a1.foo.com IN PTR response: NOERROR + 89.160.20.128.a1.foo.com. 21801 IN PTR 089.160.20.112.a1.foo.com.;"
             },
             "host": {
                 "domain": "a1.foo.com",
@@ -1464,12 +1545,18 @@
                         "TXT"
                     ]
                 },
+                "flags": {
+                    "recursive": true
+                },
                 "header_flags": [
                     "RA"
                 ],
                 "question": {
                     "class": "IN",
                     "name": "settings-win.data.microsoft.com",
+                    "registered_domain": "microsoft.com",
+                    "subdomain": "settings-win.data",
+                    "top_level_domain": "com",
                     "type": "TXT"
                 },
                 "response_code": "NOERROR"
@@ -1479,7 +1566,7 @@
             },
             "event": {
                 "created": "2023-05-09T11:54:36.000Z",
-                "original": "\u003c30\u003eMay 9 11:54:36 a1.foo.com 89.160.20.112 named[12261]: 09-May-2023 11:54:36.185 client 89.160.20.128#59605: view 12: UDP: query: settings-win.data.microsoft.com IN TXT response: NOERROR + settings-win.data.microsoft.com. 3600 IN TXT \"k=rsa; p=abc\" \"def\" \"ghi\" \"jkl\" \"AB\";"
+                "original": "<30>May 9 11:54:36 a1.foo.com 89.160.20.112 named[12261]: 09-May-2023 11:54:36.185 client 89.160.20.128#59605: view 12: UDP: query: settings-win.data.microsoft.com IN TXT response: NOERROR + settings-win.data.microsoft.com. 3600 IN TXT \"k=rsa; p=abc\" \"def\" \"ghi\" \"jkl\" \"AB\";"
             },
             "host": {
                 "domain": "a1.foo.com",

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -1431,6 +1431,24 @@
         {
             "@timestamp": "2022-10-04T10:18:07.834Z",
             "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
                 "ip": "89.160.20.128",
                 "port": 59605
             },
@@ -1520,6 +1538,24 @@
         {
             "@timestamp": "2023-05-09T11:54:36.185Z",
             "client": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
                 "ip": "89.160.20.128",
                 "port": 59605
             },

--- a/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/infoblox_nios/data_stream/log/_dev/test/pipeline/test-dns.log-expected.json
@@ -29,11 +29,6 @@
                         "A"
                     ]
                 },
-                "flags": {
-                    "dnssec_ok": true,
-                    "edns_opt_record": true,
-                    "recursive": true
-                },
                 "header_flags": [
                     "DO",
                     "RA"
@@ -101,9 +96,6 @@
                 "port": 50565
             },
             "dns": {
-                "flags": {
-                    "recursive": false
-                },
                 "question": {
                     "class": "IN",
                     "name": "test.com",
@@ -181,12 +173,6 @@
                         "A"
                     ]
                 },
-                "flags": {
-                    "authoritive": true,
-                    "dnssec_ok": true,
-                    "edns_opt_record": true,
-                    "recursive": true
-                },
                 "header_flags": [
                     "AA",
                     "DO",
@@ -254,11 +240,6 @@
                 "port": 57398
             },
             "dns": {
-                "flags": {
-                    "dnssec_ok": true,
-                    "edns_opt_record": true,
-                    "recursive": true
-                },
                 "header_flags": [
                     "DO",
                     "RA"
@@ -345,11 +326,6 @@
                         "A",
                         "A"
                     ]
-                },
-                "flags": {
-                    "dnssec_ok": true,
-                    "edns_opt_record": true,
-                    "recursive": true
                 },
                 "header_flags": [
                     "DO",
@@ -466,9 +442,6 @@
                 "port": 59735
             },
             "dns": {
-                "flags": {
-                    "recursive": true
-                },
                 "header_flags": [
                     "RD"
                 ],
@@ -1246,9 +1219,6 @@
                 "port": 57738
             },
             "dns": {
-                "flags": {
-                    "recursive": false
-                },
                 "question": {
                     "class": "IN",
                     "name": "settings-win.data.microsoft.com",
@@ -1314,9 +1284,6 @@
                 "port": 64727
             },
             "dns": {
-                "flags": {
-                    "recursive": true
-                },
                 "header_flags": [
                     "RD"
                 ],
@@ -1470,9 +1437,6 @@
                         "PTR"
                     ]
                 },
-                "flags": {
-                    "recursive": true
-                },
                 "header_flags": [
                     "RA"
                 ],
@@ -1580,9 +1544,6 @@
                     "type": [
                         "TXT"
                     ]
-                },
-                "flags": {
-                    "recursive": true
                 },
                 "header_flags": [
                     "RA"

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -111,6 +111,30 @@ processors:
       field: event.action
       if: ctx.event?.action != null
       ignore_failure: true
+  - geoip:
+      field: "client.ip"
+      target_field: "client.geo"
+      if: ctx.client?.geo == null && ctx.client?.ip != null
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: client.ip
+      target_field: client.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+      if: ctx.client?.ip != null
+  - rename:
+      field: client.as.asn
+      target_field: client.as.number
+      ignore_missing: true
+      if: ctx?.client?.as?.asn != null
+  - rename:
+      field: client.as.organization_name
+      target_field: client.as.organization.name
+      ignore_missing: true
+      if: ctx?.client?.as?.organization_name != null
   - script:
       description: Drops null/empty values recursively.
       lang: painless

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -129,7 +129,7 @@ processors:
       field: client.as.asn
       target_field: client.as.number
       ignore_missing: true
-      if: ctx?.client?.as?.asn != null
+      if: ctx.client?.as?.asn != null
   - rename:
       field: client.as.organization_name
       target_field: client.as.organization.name

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -134,7 +134,7 @@ processors:
       field: client.as.organization_name
       target_field: client.as.organization.name
       ignore_missing: true
-      if: ctx?.client?.as?.organization_name != null
+      if: ctx.client?.as?.organization_name != null
   - script:
       description: Drops null/empty values recursively.
       lang: painless

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -243,7 +243,7 @@ processors:
   - registered_domain: 
       field: "dns.question.name"
       target_field: "dns.question"
-      if: ctx?.dns?.question != null
+      if: ctx.dns?.question != null
   - set:
       field: dns.flags.recursive
       value: true

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -240,10 +240,47 @@ processors:
         }
         ctx.dns.put('header_flags', hf);
 
+  - registered_domain: 
+      field: "dns.question.name"
+      target_field: "dns.question"
+      if: ctx?.dns?.question != null
+  - set:
+      field: dns.flags.recursive
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('+') ?: false"
+  - set:
+      field: dns.flags.recursive
+      value: false
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('-') ?: false"
+  - set:
+      field: dns.flags.authoritive
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('A') ?: false"
+  - set:
+      field: dns.flags.truncated_response
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('T') ?: false"
+  - set:
+      field: dns.flags.edns_opt_record
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('E') ?: false"
+  - set:
+      field: dns.flags.dnssec_ok
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('D') ?: false"
+  - set:
+      field: dns.flags.dnssec_validated_server
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('V') ?: false"
+  - set:
+      field: dns.flags.dtc_synthetic
+      value: true
+      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('L') ?: false"
   - remove:
       field:
         - timestamp
         - repeat_message
+        - dns.question.domain
       ignore_missing: true
 on_failure:
   - set:

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -244,38 +244,6 @@ processors:
       field: "dns.question.name"
       target_field: "dns.question"
       if: ctx.dns?.question != null
-  - set:
-      field: dns.flags.recursive
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('+') ?: false"
-  - set:
-      field: dns.flags.recursive
-      value: false
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('-') ?: false"
-  - set:
-      field: dns.flags.authoritive
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('A') ?: false"
-  - set:
-      field: dns.flags.truncated_response
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('T') ?: false"
-  - set:
-      field: dns.flags.edns_opt_record
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('E') ?: false"
-  - set:
-      field: dns.flags.dnssec_ok
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('D') ?: false"
-  - set:
-      field: dns.flags.dnssec_validated_server
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('V') ?: false"
-  - set:
-      field: dns.flags.dtc_synthetic
-      value: true
-      if: "ctx?.infoblox_nios?.log?.dns?.header_flags?.contains('L') ?: false"
   - remove:
       field:
         - timestamp

--- a/packages/infoblox_nios/data_stream/log/fields/ecs.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/ecs.yml
@@ -1,6 +1,24 @@
 - external: ecs
   name: client.domain
 - external: ecs
+  name: client.geo.city_name
+- external: ecs
+  name: client.geo.country_name
+- external: ecs
+  name: client.geo.country_iso_code
+- external: ecs
+  name: client.geo.continent_name
+- external: ecs
+  name: client.geo.region_iso_code
+- external: ecs
+  name: client.geo.location
+- external: ecs
+  name: client.geo.region_name
+- external: ecs
+  name: client.as.number
+- external: ecs
+  name: client.as.organization.name
+- external: ecs
   name: client.ip
 - external: ecs
   name: client.mac

--- a/packages/infoblox_nios/data_stream/log/fields/ecs.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/ecs.yml
@@ -23,6 +23,12 @@
 - external: ecs
   name: dns.question.name
 - external: ecs
+  name: dns.question.registered_domain
+- external: ecs
+  name: dns.question.subdomain
+- external: ecs
+  name: dns.question.top_level_domain
+- external: ecs
   name: dns.question.type
 - external: ecs
   name: dns.response_code

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -153,3 +153,7 @@
           type: boolean
         - name: recursive
           type: boolean
+        - name: dnssec_validated_server
+          type: boolean
+        - name: truncated_response
+          type: boolean

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -139,21 +139,3 @@
       type: keyword
     - name: type
       type: keyword
-- name: dns
-  type: group
-  fields:
-    - name: flags
-      type: group
-      fields:
-        - name: authoritive
-          type: boolean
-        - name: dnssec_ok
-          type: boolean
-        - name: edns_opt_record
-          type: boolean
-        - name: recursive
-          type: boolean
-        - name: dnssec_validated_server
-          type: boolean
-        - name: truncated_response
-          type: boolean

--- a/packages/infoblox_nios/data_stream/log/fields/fields.yml
+++ b/packages/infoblox_nios/data_stream/log/fields/fields.yml
@@ -139,3 +139,17 @@
       type: keyword
     - name: type
       type: keyword
+- name: dns
+  type: group
+  fields:
+    - name: flags
+      type: group
+      fields:
+        - name: authoritive
+          type: boolean
+        - name: dnssec_ok
+          type: boolean
+        - name: edns_opt_record
+          type: boolean
+        - name: recursive
+          type: boolean

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -263,9 +263,16 @@ An example event for `log` looks as following:
 | dns.answers.name | The domain name to which this resource record pertains. If a chain of CNAME is being resolved, each answer's `name` should be the one that corresponds with the answer's `data`. It should not simply be the original `question.name` repeated. | keyword |
 | dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | long |
 | dns.answers.type | The type of data contained in this resource record. | keyword |
+| dns.flags.authoritive |  | boolean |
+| dns.flags.dnssec_ok |  | boolean |
+| dns.flags.edns_opt_record |  | boolean |
+| dns.flags.recursive |  | boolean |
 | dns.header_flags | Array of 2 letter DNS header flags. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |
+| dns.question.registered_domain | The highest registered domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
+| dns.question.subdomain | The subdomain is all of the labels under the registered_domain. If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
+| dns.question.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.response_code | The DNS response code. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -273,12 +273,6 @@ An example event for `log` looks as following:
 | dns.answers.name | The domain name to which this resource record pertains. If a chain of CNAME is being resolved, each answer's `name` should be the one that corresponds with the answer's `data`. It should not simply be the original `question.name` repeated. | keyword |
 | dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | long |
 | dns.answers.type | The type of data contained in this resource record. | keyword |
-| dns.flags.authoritive |  | boolean |
-| dns.flags.dnssec_ok |  | boolean |
-| dns.flags.dnssec_validated_server |  | boolean |
-| dns.flags.edns_opt_record |  | boolean |
-| dns.flags.recursive |  | boolean |
-| dns.flags.truncated_response |  | boolean |
 | dns.header_flags | Array of 2 letter DNS header flags. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -238,7 +238,17 @@ An example event for `log` looks as following:
 | Field | Description | Type |
 |---|---|---|
 | @timestamp | Event timestamp. | date |
+| client.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
+| client.as.organization.name | Organization name. | keyword |
+| client.as.organization.name.text | Multi-field of `client.as.organization.name`. | match_only_text |
 | client.domain | The domain name of the client system. This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment. | keyword |
+| client.geo.city_name | City name. | keyword |
+| client.geo.continent_name | Name of the continent. | keyword |
+| client.geo.country_iso_code | Country ISO code. | keyword |
+| client.geo.country_name | Country name. | keyword |
+| client.geo.location | Longitude and latitude. | geo_point |
+| client.geo.region_iso_code | Region ISO code. | keyword |
+| client.geo.region_name | Region name. | keyword |
 | client.ip | IP address of the client (IPv4 or IPv6). | ip |
 | client.mac | MAC address of the client. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | client.port | Port of the client. | long |

--- a/packages/infoblox_nios/docs/README.md
+++ b/packages/infoblox_nios/docs/README.md
@@ -265,8 +265,10 @@ An example event for `log` looks as following:
 | dns.answers.type | The type of data contained in this resource record. | keyword |
 | dns.flags.authoritive |  | boolean |
 | dns.flags.dnssec_ok |  | boolean |
+| dns.flags.dnssec_validated_server |  | boolean |
 | dns.flags.edns_opt_record |  | boolean |
 | dns.flags.recursive |  | boolean |
+| dns.flags.truncated_response |  | boolean |
 | dns.header_flags | Array of 2 letter DNS header flags. | keyword |
 | dns.question.class | The class of records being queried. | keyword |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.16.0"
+version: "1.17.0"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
When looking at the differences between the infoblox NIOS DNS dataset and our `network_packet_capture` dataset I discovered that we are not using `dns.flags` to print out the DNS flags such as: 

```
- = recursion not available
+ = recursion available (from DNS message header)
A = authoritative answer (from DNS message header)
t = truncated response (from DNS message header)
E = EDNS OPT record present (from DNS message header)
D = DNSSEC OK (from EDNS OPT RR)
V = responding server has validated DNSSEC records
L = response contains DTC synthetic record
```

Taken from: [Infoblox DNS](https://docs.infoblox.com/space/NAG8/22252254/Capturing+DNS+Queries+and+Responses)

This is an example taken from our `network packet capture dns` dataset:

```json
"dns": {
      "response_code": "NOERROR",
      "resolved_ip": [
        "34.107.117.83"
      ],
      "question": {
        "registered_domain": "es.io",
        "top_level_domain": "io",
        "etld_plus_one": "es.io",
        "name": "00d0ca5813b840dca7cee7ecebd65591.europe-west3.gcp.cloud.es.io",
        "subdomain": "00d0ca5813b840dca7cee7ecebd65591.europe-west3.gcp.cloud",
        "type": "A",
        "class": "IN"
      },
      "flags": {
        "authoritative": false,
        "truncated_response": false,
        "recursion_desired": true,
        "recursion_available": true,
        "checking_disabled": false,
        "authentic_data": false
      },
```

I added the following:

* ~couple of `set` processors to add the flags~
* registered domain processor to parse out the subdomain, top_level and so on.
* Added geoIP processing for `client.ip`.

I am not sure about the version bump, if this should become 1.17.0 or 2.0.0.

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This adds a `geoip` processor for the `client.ip` field and a `registered_domain` processor for the `dns.question.name` field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

