### PR TITLE
[integrations][Cisco Meraki] - Removed experimental release tags from data streams

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Removed experimental release tags from data streams.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/8175
 - version: 1.16.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.16.1
+  changes:
+    - description: Removed experimental release tags from data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: 1.16.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/cisco_meraki/data_stream/events/manifest.yml
+++ b/packages/cisco_meraki/data_stream/events/manifest.yml
@@ -1,5 +1,4 @@
 title: Cisco Meraki webhook events
-release: experimental
 type: logs
 streams:
   - input: http_endpoint

--- a/packages/cisco_meraki/data_stream/log/manifest.yml
+++ b/packages/cisco_meraki/data_stream/log/manifest.yml
@@ -1,5 +1,4 @@
 title: Cisco Meraki logs (via Syslog)
-release: experimental
 type: logs
 streams:
   - input: udp

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.16.0"
+version: "1.16.1"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Bug


## Proposed commit message
Removed experimental release tags from data streams. The integration was made GA with 8.4 but the tags remained, which was a bug.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Relates #3859

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
