### PR TITLE
[HA Proxy ]Corrected incorrect aggregation function used in visualisation and dashboard

### DIFF
--- a/packages/haproxy/changelog.yml
+++ b/packages/haproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.6"
+  changes:
+    - description: Correct the improper aggregation function used in dashboards.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.8.4"
   changes:
     - description: Fix incorrect mapping of `source.address` field from `text` to `keyword` type.

--- a/packages/haproxy/kibana/dashboard/haproxy-0836a4b0-47bd-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-0836a4b0-47bd-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "1",
@@ -29,11 +31,14 @@
                     "y": 20
                 },
                 "panelIndex": "1",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_1",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "2",
@@ -42,11 +47,14 @@
                     "y": 0
                 },
                 "panelIndex": "2",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_2",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "3",
@@ -55,11 +63,14 @@
                     "y": 8
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_3",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "4",
@@ -68,11 +79,14 @@
                     "y": 0
                 },
                 "panelIndex": "4",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_4",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "5",
@@ -81,11 +95,14 @@
                     "y": 20
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_4",
+                "panelRefName": "panel_5",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "6",
@@ -94,11 +111,14 @@
                     "y": 20
                 },
                 "panelIndex": "6",
-                "panelRefName": "panel_5",
+                "panelRefName": "panel_6",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "7",
@@ -107,11 +127,14 @@
                     "y": 0
                 },
                 "panelIndex": "7",
-                "panelRefName": "panel_6",
+                "panelRefName": "panel_7",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "8",
@@ -120,7 +143,8 @@
                     "y": 12
                 },
                 "panelIndex": "8",
-                "panelRefName": "panel_7",
+                "panelRefName": "panel_8",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -128,52 +152,51 @@
         "title": "[Metrics HAProxy] HTTP backend",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-0836a4b0-47bd-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "1:panel_1",
             "type": "visualization"
         },
         {
             "id": "haproxy-794b6cd0-471d-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "2:panel_2",
             "type": "visualization"
         },
         {
             "id": "haproxy-bb0ab500-4735-11e8-bc13-1397384faad3",
-            "name": "panel_2",
+            "name": "3:panel_3",
             "type": "visualization"
         },
         {
             "id": "haproxy-40bed190-473b-11e8-bc13-1397384faad3",
-            "name": "panel_3",
+            "name": "4:panel_4",
             "type": "visualization"
         },
         {
             "id": "haproxy-0751ed00-479c-11e8-bc13-1397384faad3",
-            "name": "panel_4",
+            "name": "5:panel_5",
             "type": "visualization"
         },
         {
             "id": "haproxy-b3463670-47a1-11e8-bc13-1397384faad3",
-            "name": "panel_5",
+            "name": "6:panel_6",
             "type": "visualization"
         },
         {
             "id": "haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3",
-            "name": "panel_6",
+            "name": "7:panel_7",
             "type": "visualization"
         },
         {
             "id": "haproxy-981d1040-47be-11e8-bc13-1397384faad3",
-            "name": "panel_7",
+            "name": "8:panel_8",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/dashboard/haproxy-4b555c30-47dd-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-4b555c30-47dd-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 24,
                     "i": "2",
@@ -29,12 +31,15 @@
                     "y": 8
                 },
                 "panelIndex": "2",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_2",
                 "title": "Servers",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 24,
                     "i": "3",
@@ -43,12 +48,15 @@
                     "y": 8
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_3",
                 "title": "Backends",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 24,
                     "i": "4",
@@ -57,12 +65,15 @@
                     "y": 8
                 },
                 "panelIndex": "4",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_4",
                 "title": "Frontends",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "5",
@@ -71,7 +82,8 @@
                     "y": 0
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_5",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -79,32 +91,31 @@
         "title": "[Metrics HAProxy] Overview",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-4b555c30-47dd-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-79350d50-47db-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "2:panel_2",
             "type": "visualization"
         },
         {
             "id": "haproxy-8c8f0300-47dc-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "3:panel_3",
             "type": "visualization"
         },
         {
             "id": "haproxy-f1e27ed0-47dc-11e8-bc13-1397384faad3",
-            "name": "panel_2",
+            "name": "4:panel_4",
             "type": "visualization"
         },
         {
             "id": "haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3",
-            "name": "panel_3",
+            "name": "5:panel_5",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/dashboard/haproxy-8cc50a50-47e0-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-8cc50a50-47e0-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "5",
@@ -29,11 +31,14 @@
                     "y": 20
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_5",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "6",
@@ -42,11 +47,14 @@
                     "y": 12
                 },
                 "panelIndex": "6",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_6",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "7",
@@ -55,11 +63,14 @@
                     "y": 0
                 },
                 "panelIndex": "7",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_7",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "8",
@@ -68,11 +79,14 @@
                     "y": 12
                 },
                 "panelIndex": "8",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_8",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "10",
@@ -81,11 +95,14 @@
                     "y": 0
                 },
                 "panelIndex": "10",
-                "panelRefName": "panel_4",
+                "panelRefName": "panel_10",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "11",
@@ -94,7 +111,8 @@
                     "y": 20
                 },
                 "panelIndex": "11",
-                "panelRefName": "panel_5",
+                "panelRefName": "panel_11",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -102,42 +120,41 @@
         "title": "[Metrics HAProxy] HTTP server",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-8cc50a50-47e0-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-0751ed00-479c-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "5:panel_5",
             "type": "visualization"
         },
         {
             "id": "haproxy-b3463670-47a1-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "6:panel_6",
             "type": "visualization"
         },
         {
             "id": "haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3",
-            "name": "panel_2",
+            "name": "7:panel_7",
             "type": "visualization"
         },
         {
             "id": "haproxy-981d1040-47be-11e8-bc13-1397384faad3",
-            "name": "panel_3",
+            "name": "8:panel_8",
             "type": "visualization"
         },
         {
             "id": "haproxy-72e84b00-47e1-11e8-bc13-1397384faad3",
-            "name": "panel_4",
+            "name": "10:panel_10",
             "type": "visualization"
         },
         {
             "id": "haproxy-976b0910-47e4-11e8-bc13-1397384faad3",
-            "name": "panel_5",
+            "name": "11:panel_11",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/dashboard/haproxy-9151c900-471d-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-9151c900-471d-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "1",
@@ -29,11 +31,14 @@
                     "y": 0
                 },
                 "panelIndex": "1",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_1",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "2",
@@ -42,11 +47,14 @@
                     "y": 0
                 },
                 "panelIndex": "2",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_2",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 16,
                     "i": "3",
@@ -55,11 +63,14 @@
                     "y": 8
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_3",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "4",
@@ -68,11 +79,14 @@
                     "y": 0
                 },
                 "panelIndex": "4",
-                "panelRefName": "panel_3",
+                "panelRefName": "panel_4",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "5",
@@ -81,11 +95,14 @@
                     "y": 8
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_4",
+                "panelRefName": "panel_5",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 8,
                     "i": "6",
@@ -94,7 +111,8 @@
                     "y": 16
                 },
                 "panelIndex": "6",
-                "panelRefName": "panel_5",
+                "panelRefName": "panel_6",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -102,42 +120,41 @@
         "title": "[Metrics HAProxy] Backend",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-9151c900-471d-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "1:panel_1",
             "type": "visualization"
         },
         {
             "id": "haproxy-794b6cd0-471d-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "2:panel_2",
             "type": "visualization"
         },
         {
             "id": "haproxy-bb0ab500-4735-11e8-bc13-1397384faad3",
-            "name": "panel_2",
+            "name": "3:panel_3",
             "type": "visualization"
         },
         {
             "id": "haproxy-40bed190-473b-11e8-bc13-1397384faad3",
-            "name": "panel_3",
+            "name": "4:panel_4",
             "type": "visualization"
         },
         {
             "id": "haproxy-0751ed00-479c-11e8-bc13-1397384faad3",
-            "name": "panel_4",
+            "name": "5:panel_5",
             "type": "visualization"
         },
         {
             "id": "haproxy-b3463670-47a1-11e8-bc13-1397384faad3",
-            "name": "panel_5",
+            "name": "6:panel_6",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/dashboard/haproxy-d5878d00-47c5-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-d5878d00-47c5-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "2",
@@ -29,11 +31,14 @@
                     "y": 0
                 },
                 "panelIndex": "2",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_2",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "3",
@@ -42,7 +47,8 @@
                     "y": 0
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_3",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -50,22 +56,21 @@
         "title": "[Metrics HAProxy] Frontend",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-d5878d00-47c5-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "2:panel_2",
             "type": "visualization"
         },
         {
             "id": "haproxy-86159190-47c5-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "3:panel_3",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/dashboard/haproxy-e9057ae0-47c5-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/dashboard/haproxy-e9057ae0-47c5-11e8-bc13-1397384faad3.json
@@ -20,7 +20,9 @@
         },
         "panelsJSON": [
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "3",
@@ -29,11 +31,14 @@
                     "y": 12
                 },
                 "panelIndex": "3",
-                "panelRefName": "panel_0",
+                "panelRefName": "panel_3",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "4",
@@ -42,11 +47,14 @@
                     "y": 0
                 },
                 "panelIndex": "4",
-                "panelRefName": "panel_1",
+                "panelRefName": "panel_4",
+                "type": "visualization",
                 "version": "7.3.0"
             },
             {
-                "embeddableConfig": {},
+                "embeddableConfig": {
+                    "enhancements": {}
+                },
                 "gridData": {
                     "h": 12,
                     "i": "5",
@@ -55,7 +63,8 @@
                     "y": 12
                 },
                 "panelIndex": "5",
-                "panelRefName": "panel_2",
+                "panelRefName": "panel_5",
+                "type": "visualization",
                 "version": "7.3.0"
             }
         ],
@@ -63,27 +72,26 @@
         "title": "[Metrics HAProxy] HTTP frontend",
         "version": 1
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-e9057ae0-47c5-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "dashboard": "7.3.0"
+        "dashboard": "8.7.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [
         {
             "id": "haproxy-86159190-47c5-11e8-bc13-1397384faad3",
-            "name": "panel_0",
+            "name": "3:panel_3",
             "type": "visualization"
         },
         {
             "id": "haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3",
-            "name": "panel_1",
+            "name": "4:panel_4",
             "type": "visualization"
         },
         {
             "id": "haproxy-30956d00-47d7-11e8-bc13-1397384faad3",
-            "name": "panel_2",
+            "name": "5:panel_5",
             "type": "visualization"
         }
     ],

--- a/packages/haproxy/kibana/visualization/haproxy-0751ed00-479c-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-0751ed00-479c-11e8-bc13-1397384faad3.json
@@ -12,6 +12,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -66,19 +67,19 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "HAProxy average connection time",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-0751ed00-479c-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-30956d00-47d7-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-30956d00-47d7-11e8-bc13-1397384faad3.json
@@ -12,6 +12,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -122,19 +123,19 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "HAProxy requests",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-30956d00-47d7-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-40bed190-473b-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-40bed190-473b-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Downtime seconds [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,18 +18,22 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "background_color_rules": [
                     {
                         "id": "c86b8e00-4739-11e8-8953-55bbe33e1362"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "haproxy.stat.component_type:1"
                 },
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -38,7 +48,7 @@
                             {
                                 "field": "haproxy.stat.downtime",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "avg"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -59,25 +69,29 @@
                         "split_mode": "terms",
                         "stacked": "none",
                         "terms_field": "haproxy.stat.proxy.name",
+                        "time_range_mode": "entire_time_range",
                         "value_template": "{{value}}s"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "metric",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy downtime seconds",
+            "title": "Downtime seconds [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:45:14.182Z",
     "id": "haproxy-40bed190-473b-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-72e84b00-47e1-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-72e84b00-47e1-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Number of server connections [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,9 +18,13 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -33,7 +43,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -53,25 +63,29 @@
                         "split_color_mode": "gradient",
                         "split_mode": "terms",
                         "stacked": "none",
-                        "terms_field": "haproxy.stat.service_name"
+                        "terms_field": "haproxy.stat.service_name",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy number of server connections",
+            "title": "Number of server connections [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:38:56.548Z",
     "id": "haproxy-72e84b00-47e1-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-79350d50-47db-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-79350d50-47db-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Servers per connection [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,18 +18,22 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "bar_color_rules": [
                     {
                         "id": "50830800-47d9-11e8-9db9-274c7a5e25e4"
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/haproxy-8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:kuery,query:'haproxy.stat.service_name:\"{{ key }}\"'))",
+                "drop_last_bucket": 1,
                 "filter": "",
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "ignore_global_filter": 0,
                 "index_pattern": "metrics-*",
                 "interval": "auto",
                 "markdown": "{{#each _all}}\n{{ label }}\n\n{{/each}}",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -42,7 +52,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             }
                         ],
                         "point_size": 1,
@@ -53,25 +63,29 @@
                         "terms_field": "haproxy.stat.service_name",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
                         "terms_size": "20",
+                        "time_range_mode": "entire_time_range",
                         "var_name": ""
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy servers per connection",
+            "title": "Servers per connection [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:59:12.528Z",
     "id": "haproxy-79350d50-47db-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-794b6cd0-471d-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-794b6cd0-471d-11e8-bc13-1397384faad3.json
@@ -18,6 +18,12 @@
                         "id": "1ec0dde0-471d-11e8-9876-09cc6c85f5f2",
                         "operator": "lte",
                         "value": 0
+                    },
+                    {
+                        "color": "rgba(255,0,6,1)",
+                        "id": "f77c4efa-14d0-4ee6-a9f5-8dcf6a20fdb7",
+                        "operator": "empty",
+                        "value": null
                     }
                 ],
                 "bar_color_rules": [
@@ -25,6 +31,7 @@
                         "id": "297160c0-471d-11e8-9876-09cc6c85f5f2"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "haproxy.stat.component_type:(2 OR 3)"
@@ -42,12 +49,20 @@
                         "id": "f8458a80-4721-11e8-b854-2f6d2b452362",
                         "operator": "lte",
                         "value": 0.5
+                    },
+                    {
+                        "gauge": "rgba(255,0,5,1)",
+                        "id": "67570cae-b216-43f7-9227-23773c95d5fe",
+                        "operator": "empty",
+                        "text": null,
+                        "value": null
                     }
                 ],
                 "gauge_inner_width": 10,
                 "gauge_max": "1",
                 "gauge_style": "half",
                 "gauge_width": 10,
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -121,19 +136,19 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "metric"
+                "type": "metric",
+                "use_kibana_indexes": false
             },
             "title": "HAProxy active servers in backend",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-794b6cd0-471d-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-86159190-47c5-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-86159190-47c5-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Traffic volume [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,15 +18,19 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
                         "chart_type": "line",
-                        "color": "rgba(164,221,0,1)",
-                        "fill": "0.5",
+                        "color": "rgba(84,179,153,1)",
+                        "fill": "0.3",
                         "formatter": "bytes",
                         "id": "61ca57f1-469d-11e7-af02-69e470af7417",
                         "label": "Incoming",
@@ -29,7 +39,7 @@
                             {
                                 "field": "haproxy.stat.in.bytes",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -42,13 +52,14 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
                         "chart_type": "line",
-                        "color": "rgba(25,77,51,1)",
-                        "fill": "0.5",
+                        "color": "rgba(96,146,192,1)",
+                        "fill": "0.1",
                         "formatter": "bytes",
                         "id": "c89d1520-47c4-11e8-994c-81d2daeb7c86",
                         "label": "Outgoing",
@@ -71,25 +82,29 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy traffic volume",
+            "title": "Traffic volume [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:48:18.542Z",
     "id": "haproxy-86159190-47c5-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-8c8f0300-47dc-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-8c8f0300-47dc-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Backends per connection [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,15 +18,19 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "bar_color_rules": [
                     {
                         "id": "4aeddd40-47dc-11e8-9db9-274c7a5e25e4"
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/haproxy-0836a4b0-47bd-11e8-bc13-1397384faad3?_a=(query:(language:kuery,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))",
+                "drop_last_bucket": 1,
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -39,7 +49,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             }
                         ],
                         "point_size": 1,
@@ -49,25 +59,29 @@
                         "stacked": "none",
                         "terms_field": "haproxy.stat.proxy.name",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "20"
+                        "terms_size": "20",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy backends per connection",
+            "title": "Backends per connection [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:23:12.198Z",
     "id": "haproxy-8c8f0300-47dc-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-976b0910-47e4-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-976b0910-47e4-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Healthcheck [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,9 +18,12 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -29,7 +38,7 @@
                             {
                                 "field": "haproxy.stat.downtime",
                                 "id": "198f56e1-47e4-11e8-b45e-f10c3845381c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "198f56e1-47e4-11e8-b45e-f10c3845381c",
@@ -61,7 +70,8 @@
                         "seperate_axis": 1,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -83,25 +93,29 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy healthcheck",
+            "title": "Healthcheck [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:18:30.908Z",
     "id": "haproxy-976b0910-47e4-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-981d1040-47be-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-981d1040-47be-11e8-bc13-1397384faad3.json
@@ -12,6 +12,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
@@ -43,19 +44,19 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
             "title": "HAProxy average response time",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:00:11.844Z",
     "id": "haproxy-981d1040-47be-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Connections [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,6 +18,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "background_color_rules": [
                     {
                         "id": "4e35d500-471b-11e8-a520-3f46123ab5eb"
@@ -22,6 +29,7 @@
                         "id": "69899960-4719-11e8-a520-3f46123ab5eb"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "haproxy.stat.component_type:(0 OR 1)"
@@ -37,6 +45,7 @@
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -52,7 +61,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -79,25 +88,29 @@
                         ],
                         "split_mode": "terms",
                         "stacked": "none",
-                        "terms_field": "haproxy.stat.proxy.name"
+                        "terms_field": "haproxy.stat.proxy.name",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy connections",
+            "title": "Connections [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T05:44:17.504Z",
     "id": "haproxy-a64b4fd0-471c-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-b3463670-47a1-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-b3463670-47a1-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Average time in queue [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,9 +18,12 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -42,19 +51,21 @@
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy average time in queue",
+            "title": "Average time in queue [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:39:38.890Z",
     "id": "haproxy-b3463670-47a1-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-bb0ab500-4735-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-bb0ab500-4735-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Connections per server [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,19 +18,23 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "bar_color_rules": [
                     {
                         "id": "978f2660-4735-11e8-b619-8f82b8185e96"
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/haproxy-8cc50a50-47e0-11e8-bc13-1397384faad3?_a=(query:(language:kuery,query:'haproxy.stat.service_name:\"{{ key }}\"'))",
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "haproxy.stat.component_type:(2 OR 3)"
                 },
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -39,7 +49,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "avg"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -53,25 +63,29 @@
                         "split_color_mode": "gradient",
                         "split_mode": "terms",
                         "stacked": "none",
-                        "terms_field": "haproxy.stat.service_name"
+                        "terms_field": "haproxy.stat.service_name",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy connections per server",
+            "title": "Connections per server [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:26:14.022Z",
     "id": "haproxy-bb0ab500-4735-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-f1e27ed0-47dc-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-f1e27ed0-47dc-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Frontends per connection [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,15 +18,19 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "bar_color_rules": [
                     {
                         "id": "b81d8640-47dc-11e8-9a25-99b107967d82"
                     }
                 ],
                 "drilldown_url": "../app/kibana#/dashboard/haproxy-e9057ae0-47c5-11e8-bc13-1397384faad3?_a=(query:(language:kuery,query:'haproxy.stat.proxy.name:\"{{ key }}\"'))",
+                "drop_last_bucket": 1,
+                "hide_last_value_indicator": true,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -39,7 +49,7 @@
                             {
                                 "field": "haproxy.stat.connection.total",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             }
                         ],
                         "point_size": 1,
@@ -49,25 +59,29 @@
                         "stacked": "none",
                         "terms_field": "haproxy.stat.proxy.name",
                         "terms_order_by": "61ca57f2-469d-11e7-af02-69e470af7417",
-                        "terms_size": "20"
+                        "terms_size": "20",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "top_n"
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "top_n",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy frontends per connection",
+            "title": "Frontends per connection [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:27:53.755Z",
     "id": "haproxy-f1e27ed0-47dc-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/kibana/visualization/haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3.json
+++ b/packages/haproxy/kibana/visualization/haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3.json
@@ -2,7 +2,13 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "HTTP response codes [Metrics HAProxy]",
         "uiStateJSON": {},
@@ -12,9 +18,12 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
+                "drop_last_bucket": 1,
                 "id": "61ca57f0-469d-11e7-af02-69e470af7417",
                 "index_pattern": "metrics-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
@@ -29,7 +38,7 @@
                             {
                                 "field": "haproxy.stat.response.http.2xx",
                                 "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "61ca57f2-469d-11e7-af02-69e470af7417",
@@ -48,7 +57,8 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -63,7 +73,7 @@
                             {
                                 "field": "haproxy.stat.response.http.3xx",
                                 "id": "aafd05e1-47bd-11e8-b7ab-dff70b15977c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "aafd05e1-47bd-11e8-b7ab-dff70b15977c",
@@ -76,7 +86,8 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -91,7 +102,7 @@
                             {
                                 "field": "haproxy.stat.response.http.4xx",
                                 "id": "c77191a1-47bd-11e8-b7ab-dff70b15977c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "c77191a1-47bd-11e8-b7ab-dff70b15977c",
@@ -104,7 +115,8 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -119,7 +131,7 @@
                             {
                                 "field": "haproxy.stat.response.http.5xx",
                                 "id": "d574e901-47bd-11e8-b7ab-dff70b15977c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "d574e901-47bd-11e8-b7ab-dff70b15977c",
@@ -132,7 +144,8 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -147,7 +160,7 @@
                             {
                                 "field": "haproxy.stat.response.http.other",
                                 "id": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "e3b8a4c1-47bd-11e8-b7ab-dff70b15977c",
@@ -160,7 +173,8 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     },
                     {
                         "axis_position": "right",
@@ -175,7 +189,7 @@
                             {
                                 "field": "haproxy.stat.response.errors",
                                 "id": "f9217d41-47be-11e8-b7ab-dff70b15977c",
-                                "type": "sum"
+                                "type": "max"
                             },
                             {
                                 "field": "f9217d41-47be-11e8-b7ab-dff70b15977c",
@@ -188,25 +202,29 @@
                         "seperate_axis": 0,
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
-                        "stacked": "none"
+                        "stacked": "none",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
                 "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
-                "type": "timeseries"
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
+                "type": "timeseries",
+                "use_kibana_indexes": false
             },
-            "title": "HAProxy HTTP response codes",
+            "title": "HTTP response codes [Metrics HAProxy]",
             "type": "metrics"
         }
     },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2023-10-16T06:37:09.263Z",
     "id": "haproxy-fcbdfa60-47bd-11e8-bc13-1397384faad3",
     "migrationVersion": {
-        "visualization": "7.8.0"
+        "visualization": "8.5.0"
     },
-    "namespaces": [
-        "default"
-    ],
     "references": [],
     "type": "visualization"
 }

--- a/packages/haproxy/manifest.yml
+++ b/packages/haproxy/manifest.yml
@@ -1,6 +1,6 @@
 name: haproxy
 title: HAProxy
-version: "1.8.4"
+version: "1.8.6"
 description: Collect logs and metrics from HAProxy servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

- Bug


## Proposed commit message

HAProxy dashboard uses incorrect aggregation functions in multiple dashboards and visualisation.
Correct aggregation function is used as part of this PR.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
