### PR TITLE
[salesforce] Update package to format_version 3.0.0

### DIFF
--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.11.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8215
 - version: "0.10.1"
   changes:
     - description: Add 'Request timeout' configuration.

--- a/packages/salesforce/data_stream/apex/_dev/test/pipeline/test-apex.log-expected.json
+++ b/packages/salesforce/data_stream/apex/_dev/test/pipeline/test-apex.log-expected.json
@@ -260,7 +260,9 @@
             ],
             "user": {
                 "id": "0052wpq000ACf2Q",
-                "roles": "Standard"
+                "roles": [
+                    "Standard"
+                ]
             }
         },
         {
@@ -328,7 +330,9 @@
             ],
             "user": {
                 "id": "0055j000000utlP",
-                "roles": "Standard"
+                "roles": [
+                    "Standard"
+                ]
             }
         },
         {
@@ -412,7 +416,9 @@
             ],
             "user": {
                 "id": "0055j000000utlP",
-                "roles": "Standard"
+                "roles": [
+                    "Standard"
+                ]
             }
         }
     ]

--- a/packages/salesforce/data_stream/apex/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/apex/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
@@ -394,17 +394,15 @@ processors:
     target_field: user.id
     ignore_missing: true
     ignore_failure: true
-- script:
+- set:
+    value: ["{{{json.USER_TYPE}}}"]
+    field: user.roles
     ignore_failure: true
-    lang: painless
-    source: |
-      def userType = ctx.json?.USER_TYPE;
-      if (userType != null) {
-        if (ctx.user == null) {
-          ctx.user = new HashMap();
-        }
-        ctx.user.roles = [userType];
-      }
+    ignore_empty_value: true
+- remove:
+    field: json.USER_TYPE
+    ignore_failure: true
+    ignore_missing: true
 # A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as “Salesforce.com IP”
 - rename:
     field: json.CLIENT_IP

--- a/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
@@ -394,11 +394,17 @@ processors:
     target_field: user.id
     ignore_missing: true
     ignore_failure: true
-- rename:
-    field: json.USER_TYPE
-    target_field: user.roles
-    ignore_missing: true
+- script:
     ignore_failure: true
+    lang: painless
+    source: |
+      def userType = ctx.json?.USER_TYPE;
+      if (userType != null) {
+        if (ctx.user == null) {
+          ctx.user = new HashMap();
+        }
+        ctx.user.roles = [userType];
+      }
 # A Salesforce internal IP (such as a login from Salesforce Workbench or AppExchange) is shown as “Salesforce.com IP”
 - rename:
     field: json.CLIENT_IP

--- a/packages/salesforce/data_stream/login_rest/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/login_rest/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/data_stream/login_rest/_dev/test/pipeline/test-login-rest.log-expected.json
+++ b/packages/salesforce/data_stream/login_rest/_dev/test/pipeline/test-login-rest.log-expected.json
@@ -74,7 +74,9 @@
             "user": {
                 "email": "user@elastic.co",
                 "id": "0055j000000utlPAAQ",
-                "roles": "Standard"
+                "roles": [
+                    "Standard"
+                ]
             },
             "user_agent": {
                 "name": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/IP_ADDRESS_REMOVED Safari/537.36"

--- a/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
@@ -214,17 +214,15 @@ processors:
     target_field: user.id
     ignore_missing: true
     ignore_failure: true
-- script:
+- set:
+    value: ["{{{json.USER_TYPE}}}"]
+    field: user.roles
     ignore_failure: true
-    lang: painless
-    source: |
-      def userType = ctx.json?.USER_TYPE;
-      if (userType != null) {
-        if (ctx.user == null) {
-          ctx.user = new HashMap();
-        }
-        ctx.user.roles = [userType];
-      }
+    ignore_empty_value: true
+- remove:
+      field: json.USER_TYPE
+      ignore_failure: true
+      ignore_missing: true    
 - rename:
     field: json.SOURCE_IP
     target_field: source.ip

--- a/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
@@ -214,11 +214,17 @@ processors:
     target_field: user.id
     ignore_missing: true
     ignore_failure: true
-- rename:
-    field: json.USER_TYPE
-    target_field: user.roles
-    ignore_missing: true
+- script:
     ignore_failure: true
+    lang: painless
+    source: |
+      def userType = ctx.json?.USER_TYPE;
+      if (userType != null) {
+        if (ctx.user == null) {
+          ctx.user = new HashMap();
+        }
+        ctx.user.roles = [userType];
+      }
 - rename:
     field: json.SOURCE_IP
     target_field: source.ip

--- a/packages/salesforce/data_stream/login_rest/sample_event.json
+++ b/packages/salesforce/data_stream/login_rest/sample_event.json
@@ -98,7 +98,9 @@
     "user": {
         "email": "user@elastic.co",
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     },
     "user_agent": {
         "name": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36"

--- a/packages/salesforce/data_stream/login_stream/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/login_stream/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/data_stream/login_stream/_dev/test/pipeline/test-login-stream.log-expected.json
+++ b/packages/salesforce/data_stream/login_stream/_dev/test/pipeline/test-login-stream.log-expected.json
@@ -87,7 +87,9 @@
             "user": {
                 "email": "user@elastic.co",
                 "id": "0055j000000utlPAAQ",
-                "roles": "Standard"
+                "roles": [
+                    "Standard"
+                ]
             },
             "user_agent": {
                 "name": "Unknown",

--- a/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
@@ -180,11 +180,17 @@ processors:
     target_field: user.id
     ignore_failure: true
     ignore_missing: true
-- rename:
-    field: json.UserType
-    target_field: user.roles
+- script:
     ignore_failure: true
-    ignore_missing: true
+    lang: painless
+    source: |
+      def userType = ctx.json?.UserType;
+      if (userType != null) {
+        if (ctx.user == null) {
+          ctx.user = new HashMap();
+        }
+        ctx.user.roles = [userType];
+      }
 - convert:
     field: json.SourceIp
     type: ip

--- a/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
@@ -180,17 +180,15 @@ processors:
     target_field: user.id
     ignore_failure: true
     ignore_missing: true
-- script:
+- set:
+    value: ["{{{json.UserType}}}"]
+    field: user.roles
     ignore_failure: true
-    lang: painless
-    source: |
-      def userType = ctx.json?.UserType;
-      if (userType != null) {
-        if (ctx.user == null) {
-          ctx.user = new HashMap();
-        }
-        ctx.user.roles = [userType];
-      }
+    ignore_empty_value: true
+- remove:
+      field: json.UserType
+      ignore_failure: true
+      ignore_missing: true
 - convert:
     field: json.SourceIp
     type: ip

--- a/packages/salesforce/data_stream/login_stream/sample_event.json
+++ b/packages/salesforce/data_stream/login_stream/sample_event.json
@@ -111,7 +111,9 @@
     "user": {
         "email": "user@elastic.co",
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     },
     "user_agent": {
         "name": "Unknown",

--- a/packages/salesforce/data_stream/logout_rest/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/logout_rest/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/data_stream/logout_rest/_dev/test/pipeline/test-logout-rest.log-expected.json
+++ b/packages/salesforce/data_stream/logout_rest/_dev/test/pipeline/test-logout-rest.log-expected.json
@@ -67,7 +67,9 @@
             ],
             "user": {
                 "id": "0055j000000utlPAAQ",
-                "roles": "Salesforce Administrator"
+                "roles": [
+                    "Salesforce Administrator"
+                ]
             }
         }
     ]

--- a/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
@@ -286,7 +286,7 @@ processors:
         map.put("X", "Salesforce Administrator");
         String temp = map.get(ctx.user?.roles);
         if (temp != null) {
-            ctx.user.roles = temp;
+            ctx.user.roles = [temp];
         }
 - remove:
     field: event.original

--- a/packages/salesforce/data_stream/logout_rest/sample_event.json
+++ b/packages/salesforce/data_stream/logout_rest/sample_event.json
@@ -91,6 +91,8 @@
     ],
     "user": {
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     }
 }

--- a/packages/salesforce/data_stream/logout_stream/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/logout_stream/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/data_stream/setupaudittrail/_dev/test/pipeline/test-common-config.yml
+++ b/packages/salesforce/data_stream/setupaudittrail/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,5 @@
 dynamic_fields:
-  event.ingested: ".*"
+  "event.ingested": ".*"
 fields:
   tags:
     - preserve_original_event

--- a/packages/salesforce/docs/README.md
+++ b/packages/salesforce/docs/README.md
@@ -580,7 +580,9 @@ An example event for `login_rest` looks as following:
     "user": {
         "email": "user@elastic.co",
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     },
     "user_agent": {
         "name": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36"
@@ -766,7 +768,9 @@ An example event for `login_stream` looks as following:
     "user": {
         "email": "user@elastic.co",
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     },
     "user_agent": {
         "name": "Unknown",
@@ -942,7 +946,9 @@ An example event for `logout_rest` looks as following:
     ],
     "user": {
         "id": "0055j000000utlPAAQ",
-        "roles": "Standard"
+        "roles": [
+            "Standard"
+        ]
     }
 }
 ```

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,14 +1,16 @@
-format_version: 1.0.0
+format_version: 3.0.0
 name: salesforce
 title: Salesforce
-version: "0.10.1"
-license: basic
+version: "0.11.0"
 description: Collect logs from Salesforce with Elastic Agent.
 type: integration
 categories:
   - observability
 conditions:
-  kibana.version: ^8.7.1
+  elastic:
+    subscription: basic
+  kibana:
+    version: ^8.7.1
 screenshots:
   - src: /img/salesforce-login.png
     title: Salesforce Login Dashboard
@@ -95,3 +97,4 @@ policy_templates:
         description: Collecting logs from Salesforce instances using Streaming API.
 owner:
   github: elastic/obs-infraobs-integrations
+  type: elastic

--- a/packages/salesforce/validation.yml
+++ b/packages/salesforce/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - SVR00002 # expected filter in dashboard: no filter found


### PR DESCRIPTION
The biggest change here is the modification of the simple `rename` processors to `script` in order to get the formatting of the list the way elastic-package wants it. I'm not sold on these changes, since it adds complexity for no change in behaviour. 

@jsoriano is there any way we could make changes in the validation for cases like this to avoid the added overhead in the ingest pipelines? 