### PR TITLE
[Cloud Security] Add Elastic-specific tags in CloudFormation

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,6 +6,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.6.3"
+  changes:
+    - description: Update URL for AWS
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8226
 - version: "1.6.2"
   changes:
     - description: Change the format_version in the package manifest to 3.0.0. Remove dotted YAML keys from package manifest. Add owner.type elastic to package manifest. Add missing object_type fields. Add security capability.

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.6.2"
+version: "1.6.3"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -116,7 +116,7 @@ policy_templates:
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.11.0-2023-09-10-08-35-18.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.11.0-2023-10-16-17-10-02.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations


### PR DESCRIPTION
## Proposed commit message
CloudFormation: Fix missing tags in cloud-security account

This is a temporary fix that tags required resources for the build to succeed. We can revert it after the QA cycle to find a more elegant solution.

See https://github.com/elastic/cloudbeat/pull/1415