### PR TITLE
Added field `winlog.event_data.EnabledPrivilegeList` to windows and system integration

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.0"
+  changes:
+    - description: Added field `winlog.event_data.EnabledPrivilegeList` as type keyword to security data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8230	
 - version: "1.45.0"
   changes:
     - description: Upgrade to package spec 3.0.0.

--- a/packages/system/data_stream/security/fields/winlog.yml
+++ b/packages/system/data_stream/security/fields/winlog.yml
@@ -161,6 +161,8 @@
           type: keyword
         - name: DwordVal
           type: keyword
+        - name: EnabledPrivilegeList
+          type: keyword
         - name: EntryCount
           type: keyword
         - name: EventSourceId

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -755,6 +755,7 @@ An example event for `security` looks as following:
 | winlog.event_data.DriverNameLength |  | keyword |
 | winlog.event_data.Dummy |  | keyword |
 | winlog.event_data.DwordVal |  | keyword |
+| winlog.event_data.EnabledPrivilegeList |  | keyword |
 | winlog.event_data.EntryCount |  | keyword |
 | winlog.event_data.EventSourceId |  | keyword |
 | winlog.event_data.ExtraInfo |  | keyword |

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: system
 title: System
-version: 1.45.0
+version: 1.46.0
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.0"
+  changes:
+    - description: Added field `winlog.event_data.EnabledPrivilegeList` as type keyword to forwarded data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8230
 - version: "1.38.0"
   changes:
     - description: Modified the field definitions to reference ECS where possible and remove invalid field attributes.

--- a/packages/windows/data_stream/forwarded/fields/winlog.yml
+++ b/packages/windows/data_stream/forwarded/fields/winlog.yml
@@ -161,6 +161,8 @@
           type: keyword
         - name: DwordVal
           type: keyword
+        - name: EnabledPrivilegeList
+          type: keyword
         - name: EntryCount
           type: keyword
         - name: EventSourceId

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.38.0
+version: 1.39.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Added `winlog.event_data.EnabledPrivilegeList` field as type "keyword" in the following integrations:

- windows integration, forward data stream
- system integration, security data stream

This is needed for rule verification in the "security_detection_engine" integration and the "SeDebugPrivilege Enabled by a Suspicious Process" rule.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes elastic/kibana#169077

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
