### PR TITLE
[Cloud Security] Assign default GCP account type (#8228) Revert

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,11 +6,6 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.6.4-preview1"
-  changes:
-    - description: Assign default GCP account type
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/8228
 - version: "1.6.3"
   changes:
     - description: Update URL for AWS

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
@@ -10,11 +10,7 @@ config:
       {{#if gcp.organization_id}}
       organization_id: {{gcp.organization_id}}
       {{/if}}
-      {{#if gcp.account_type}}
       account_type: {{gcp.account_type}}
-      {{else}}
-      account_type: single-account
-      {{/if}}
       credentials:
         {{#if gcp.credentials.file}}
         credentials_file_path: {{gcp.credentials.file}}

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.6.4-preview1"
+version: "1.6.3"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Proposed commit message
This reverts commit 1c150f80885139eb51da39e1d95d99f763abe660.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
