### PR TITLE
Improve and unify dimensions for Elastic-Agent and Beats metrics

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Improve and unify dimensions for Elastic-Agent and Beats metrics, this avoids duplicated TSDB entries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8238
 - version: "1.15.0"
   changes:
     - description: Add data stream for logs of Universal Profiling services.

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -418,3 +418,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -190,3 +190,4 @@
                   type: long
                   description: >
                     Number of read errors
+

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,3 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
+- name: agent.id
+  external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -8,7 +8,6 @@
     - name: process
       level: extended
       type: keyword
-      dimension: true
       description: Process run by the Elastic Agent.
       example: metricbeat
     - name: snapshot
@@ -423,3 +422,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/ecs.yml
@@ -15,3 +15,9 @@
 - name: agent.id
   external: ecs
   dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -47,3 +47,22 @@
     - name: system_packet_drops
       type: long
       description: Number of udp drops noted in /proc/net/udp
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,3 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
+- name: agent.id
+  external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
+  dimension: true

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/ecs.yml
@@ -4,9 +4,6 @@
   external: ecs
 - name: agent.ephemeral_id
   external: ecs
-- name: agent.id
-  external: ecs
-  dimension: true
 - name: agent.name
   external: ecs
 - name: agent.type
@@ -15,6 +12,12 @@
   external: ecs
 - name: log.level
   external: ecs
-- name: service.address
+- name: agent.id
   external: ecs
+  dimension: true
+- name: component.id
+  type: keyword
+  dimension: true
+- name: metricset.name
+  type: keyword
   dimension: true

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -423,3 +423,22 @@
               metric_type: counter
               description: |
                 Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: Metricset name
+      example: stats

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.15.0
+version: 1.16.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

The metrics from Elastic-Agent package define some time series but
not enough dimensions for the entries to be unique. This commit adds
new mappings and dimensions to make all metrics events unique as well
as unifies the dimensions from Elastic-Agent and Beats.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist
 - [x] Merge after https://github.com/elastic/elastic-agent/pull/3626

## Why do we need those new dimensions?
The combination of the dimension fields plus the timestamp field must be unique within the timeseries. In the case of the indexes used by the Elastic-Agent integration that will make Elasticsearch return 409 Conflict for the duplicated event.

This PR uses the following fields for metrics from Elastic-Agent and Beats:
 - `agent.id`: Each deployed Elastic-Agent has got a unique ID, this ID is present in each event generated by its components, hence different Beats process share the same ID.
 - `component.id`: Each component run by Elastic-Agent has got a unique ID and each component run in a independent process, this is enough to to ensure different process using the same Beats binary will have unique IDs
 - `metricset.name`: For each component we collect more than one set of metrics, so it is possible some of them are going to be have the same timestamp, which will lead to collisions. Having the metricset name as dimension ensures there will not be any collision. For some Beats we collect at least `stats` and `state` metricset (the input configuration can be seen [here](https://github.com/elastic/elastic-agent/blob/39ebf3d424b3da13d1cb9a6350d2746bfc7cf6c7/internal/pkg/agent/application/monitoring/v1_monitor.go#L625)). We also collect a [`json` metricset](https://github.com/elastic/elastic-agent/blob/39ebf3d424b3da13d1cb9a6350d2746bfc7cf6c7/internal/pkg/agent/application/monitoring/v1_monitor.go#L687).

**Why was `service.address` removed?**
`service.address` is frequently the same given the address can be a named pipe on Windows, e.g:
```json
  "agent": {
    "name": "agent",
    "type": "metricbeat",
    "version": "8.9.1"
  },
  "service": {
    "name": "beat",
    "type": "beat",
    "address": "http://npipe/stats"
  }
```

https://github.com/elastic/integrations/issues/7977 contains more details about some possible collisions and how to avoid them.

## How to test this PR locally

1. Build the Elastic-Agent package
```sh
cd packages/elastic_agent 
elastic-package -v build
```

2. Deploy the stack
```
elastic-package stack up --version=8.12.0-SNAPSHOT -v -d
```

3. Build a custom Elastic-Agent
Clone the code from the branch [`fix-tsdb-metrics`](https://github.com/belimawr/elastic-agent/tree/fix-tsdb-metrics) or the [Elastic-Agent PR](https://github.com/elastic/elastic-agent/pull/3626), the build
```
DEV=true EXTERNAL=false PACKAGES=tar.gz PLATFORMS=linux/amd64 mage -v package
```
Adjust the `PLATFORMS` according to your system.

4. Create a new policy with system metrics and monitoring enabled
5. Deploy your build of the Elastic-Agent. You can either install it or enroll and then execute as a normal user.
6. Go to Kibana -> Discover, select the `metrics-*` dataview. The entries from `data_stream.dataset: elastic_agent.*` sent by the Elastic-Agent you build (eg. you can also filter by `host.name`) should all contain a `component.id` field.

### Bonus: Testing with Logstash
Testing with Logstash has got the advantage that Logstash will log 409s from Elasticsearch, making it clear the fields are correctly ingested in Elasticsearch. However, this PR alone is not enough to prevent the 409s happening, you will need to also use the Elastic-Agent build mentioned above (see step 3).

First you need to configure Logstash to get receive data from Elastic-Agent and send it to Elasticsearch. For this test the easiest way to get a Stack running is to use [`elastic-package`](https://github.com/elastic/elastic-package), it will also enable you to deploy the custom `elastic-agent` integration from the PR mentioned above.

Here is a configuration for Logstash, it uses some self generated certificates and the default credentials from Elastic-Pakcage.

<details><summary>logstash-sample.conf</summary>
<p>

```
input {
  elastic_agent {
    port => 5044
    ssl => true
    ssl_certificate_authorities => ["/home/tiago/sandbox/tls/rootCA.crt"]
    ssl_certificate => "/home/tiago/sandbox/tls/server__server_cert.crt"
    ssl_key => "/home/tiago/sandbox/tls/server_cert.pkcs8.key"
    ssl_verify_mode => "force_peer"    
  }
}

output {
  elasticsearch {
    hosts => ["https://localhost:9200"]
    user => "elastic"
    password => "changeme"
    cacert => "/home/tiago/.elastic-package/profiles/default/certs/ca-cert.pem"
  }
}
```

</p>
</details> 

1. Once Logstash is up and running, in Kibana go to Fleet -> Settings and add a Logstash output.
2. Create a new policy with system metrics and monitoring enabled
3. Go to Fleet -> Agent policies -> <your policy> -> Settings and change the output for integrations and monitoring to use Logstash
4. Deploy the Elastic-Agent
5. Ensure the fields `component.id` and `component.binary` are set for events that match `data_stream.dataset: elastic_agent.*`
6. There should be no 409 error from Elasticsearch.

**Important:**
Make sure your Elastic-Agent can resolve the hostnames the elastic-package stack uses, on Linux add this to your `/etc/hosts`
```
 127.0.0.1 localhost elasticsearch fleet-server kibana
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/3626
- Closes https://github.com/elastic/integrations/issues/7977

~~## Screenshots~~

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
