### PR TITLE
[Logstash] Logstash Integration Plugin drilldowns

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.6"
+  changes:
+    - description: Add Plugin drilldown
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8166
 - version: "2.3.5"
   changes:
     - description: Update manifest format version to 3.0.0 for logstash integration package

--- a/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
@@ -110,7 +110,7 @@ program: |
         "plugin":{
           "type":"filter",
           "filter":{
-            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == filter.id), tuple.source).flatten()[0],
+            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == filter.id), tuple.source)[0],
             "id":filter.id,
             "name":filter.name,
             "elasticsearch.cluster.id":event.es_cluster_id_map.map(tuple, (tuple.plugin_id == filter.id), tuple.cluster_id),
@@ -139,7 +139,7 @@ program: |
           "output":{
             "id":output.id,
             "name":output.name,
-            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == output.id), tuple.source).flatten()[0],
+            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == output.id), tuple.source)[0],
             "elasticsearch.cluster.id":event.es_cluster_id_map.map(tuple, (tuple.plugin_id == output.id), tuple.cluster_id),
             "flow": has(output.flow) ? output.flow : {},
             "events":{

--- a/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
@@ -1,6 +1,6 @@
 config_version: "2"
 interval: {{period}}
-resource.url: "{{url}}/_node/stats?graph=true&vertices=true"
+resource.url: "{{url}}/_node"
 {{#if resource_ssl}}
 resource.ssl:
   {{resource_ssl}}
@@ -17,11 +17,21 @@ redact:
   fields: ~
 
 program: |
-  get(state.url)
+  get(state.url + "/stats?graph=true&vertices=true")
   .as(resp, bytes(resp.Body)
   .decode_json().as(body,
     body.pipelines.map(pipeline_name, pipeline_name != ".monitoring-logstash", {"name":pipeline_name}.with(body.pipelines[pipeline_name])
       .with({
+        "pipeline_source_map":
+          get(state.url + "/pipelines/" + pipeline_name + "?graph=true&vertices=true")
+            .as(resp, bytes(resp.Body).decode_json()
+              .as(body, body.pipelines.map(pipeline_name, ((body.pipelines[pipeline_name].graph.graph.vertices)
+                .as(vertices, vertices.map(each, each.type == "plugin", {"plugin_id":each.id, "source":each.meta.source})
+                )
+              )
+            ).drop("graph").flatten()
+          )
+        ),
         "es_cluster_id":((body.pipelines[pipeline_name].vertices).as(vertices, vertices.map(each, has(each.cluster_uuid), each.cluster_uuid))),
         "es_cluster_id_map":((body.pipelines[pipeline_name].vertices).as(vertices, vertices.map(each, has(each.cluster_uuid), {"plugin_id":each.id, "cluster_id":each.cluster_uuid}))),
         "outputs":body.pipelines[pipeline_name].plugins.outputs,
@@ -45,6 +55,7 @@ program: |
         "plugin":{
           "type":"input",
           "input":{
+            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == input.id), tuple.source)[0],
             "elasticsearch.cluster.id":event.es_cluster_id_map.map(tuple, (tuple.plugin_id == input.id), tuple.cluster_id),
             "name":input.name,
             "id":input.id,
@@ -99,6 +110,7 @@ program: |
         "plugin":{
           "type":"filter",
           "filter":{
+            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == filter.id), tuple.source).flatten()[0],
             "id":filter.id,
             "name":filter.name,
             "elasticsearch.cluster.id":event.es_cluster_id_map.map(tuple, (tuple.plugin_id == filter.id), tuple.cluster_id),
@@ -127,6 +139,7 @@ program: |
           "output":{
             "id":output.id,
             "name":output.name,
+            "source":event.pipeline_source_map.map(tuple, (tuple.plugin_id == output.id), tuple.source).flatten()[0],
             "elasticsearch.cluster.id":event.es_cluster_id_map.map(tuple, (tuple.plugin_id == output.id), tuple.cluster_id),
             "flow": has(output.flow) ? output.flow : {},
             "events":{

--- a/packages/logstash/data_stream/plugins/fields/fields.yml
+++ b/packages/logstash/data_stream/plugins/fields/fields.yml
@@ -1,5 +1,6 @@
 - name: logstash.pipeline
   type: group
+  description: Logstash pipeline metrics
   fields:
     - name: name
       type: keyword
@@ -84,6 +85,18 @@
               type: long
               metric_type: counter
               description: number of events emitted by the input
+            - name: source
+              type: group
+              description: Pipeline Source location
+              fields:
+                - name: column
+                  type: keyword
+                - name: id
+                  type: keyword
+                - name: line
+                  type: long
+                - name: protocol
+                  type: keyword
             - name: flow
               type: group
               description: flow metrics
@@ -123,6 +136,18 @@
               type: long
               description: number of events emitted by the filter
               metric_type: counter
+            - name: source
+              type: group
+              description: Pipeline Source location
+              fields:
+                - name: column
+                  type: keyword
+                - name: id
+                  type: keyword
+                - name: line
+                  type: long
+                - name: protocol
+                  type: keyword
             - name: flow
               type: group
               description: flow metrics
@@ -170,6 +195,18 @@
               type: long
               metric_type: counter
               description: number of events emitted by the output
+            - name: source
+              type: group
+              description: Pipeline Source location
+              fields:
+                - name: column
+                  type: keyword
+                - name: id
+                  type: keyword
+                - name: line
+                  type: long
+                - name: protocol
+                  type: keyword
             - name: flow
               type: group
               description: flow metrics

--- a/packages/logstash/data_stream/plugins/sample_event.json
+++ b/packages/logstash/data_stream/plugins/sample_event.json
@@ -1,5 +1,5 @@
 {
-    "@timestamp": "2023-10-04T18:51:48.661Z",
+    "@timestamp": "2023-10-20T18:44:48.720Z",
     "data_stream": {
         "dataset": "logstash.plugins",
         "namespace": "default",
@@ -11,26 +11,26 @@
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.plugins",
-        "ingested": "2023-10-04T18:51:49Z"
+        "ingested": "2023-10-20T18:44:49Z"
     },
     "host": {
         "architecture": "x86_64",
         "hostname": "macbook-pro.local",
         "id": "AA4215F6-994F-5CCE-B6F2-B6AED75AE125",
         "ip": [
-            "192.168.1.184"
+            "192.168.4.26"
         ],
         "mac": [
             "AC-DE-48-00-11-22"
         ],
         "name": "macbook-pro.local",
         "os": {
-            "build": "22F82",
+            "build": "22G120",
             "family": "darwin",
-            "kernel": "22.5.0",
+            "kernel": "22.6.0",
             "name": "macOS",
             "platform": "darwin",
-            "version": "13.4.1"
+            "version": "13.6"
         }
     },
     "input": {
@@ -38,37 +38,40 @@
     },
     "logstash": {
         "pipeline": {
-            "elasticsearch": {
-                "cluster": {
-                    "id": "2IcePuo6RCi_511abdJxLQ"
-                }
-            },
             "host": {
-                "address": "0.0.0.0:9600",
-                "name": "21d61ee7529e"
+                "address": "127.0.0.1:9602",
+                "name": "logstash9602"
             },
-            "id": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
-            "name": "pipeline-with-memory-queue",
+            "id": "1bccb98d65bdccf4215bc31f59ba1d47df59141b348899509f633fba4c093318",
+            "name": "slow",
             "plugin": {
-                "codec": {
-                    "decode": {
-                        "duration": {
-                            "ms": 0
-                        },
-                        "in": 0,
-                        "out": 0
+                "input": {
+                    "events": {
+                        "out": 17228
                     },
-                    "encode": {
-                        "duration": {
-                            "ms": 0
-                        },
-                        "in": 0
+                    "flow": {
+                        "throughput": {
+                            "current": 1.097,
+                            "last_1_minute": 1.037
+                        }
                     },
-                    "id": "plain_f62ef0fc-3db5-44fb-a464-0458e6181aa0",
-                    "name": "plain"
+                    "id": "slow_destination",
+                    "name": "pipeline",
+                    "source": {
+                        "column": "3",
+                        "id": "/Users/blah/ingestdemo/logstash-8.8.2/slow.conf",
+                        "line": 2,
+                        "protocol": "file"
+                    },
+                    "time": {
+                        "queue_push_duration": {
+                            "ms": 154
+                        }
+                    }
                 },
-                "type": "codec"
+                "type": "input"
             }
         }
     }
 }
+

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -1095,6 +1095,10 @@ pipeline collection period, and setting it to an appropriate value.
 | logstash.pipeline.plugin.filter.flow.worker_utilization.last_1_minute | worker utilization for this plugin | scaled_float |  | gauge |
 | logstash.pipeline.plugin.filter.id | Id of filter plugin | keyword |  |  |
 | logstash.pipeline.plugin.filter.name | Name of filter plugin | keyword |  |  |
+| logstash.pipeline.plugin.filter.source.column |  | keyword |  |  |
+| logstash.pipeline.plugin.filter.source.id |  | keyword |  |  |
+| logstash.pipeline.plugin.filter.source.line |  | long |  |  |
+| logstash.pipeline.plugin.filter.source.protocol |  | keyword |  |  |
 | logstash.pipeline.plugin.filter.time.duration.ms | amount of time working on events in this plugin | long | ms | counter |
 | logstash.pipeline.plugin.input.elasticsearch.cluster.id | Elasticsearch clusters this Logstash plugin is attached to | keyword |  |  |
 | logstash.pipeline.plugin.input.events.out | number of events emitted by the input | long |  | counter |
@@ -1102,6 +1106,10 @@ pipeline collection period, and setting it to an appropriate value.
 | logstash.pipeline.plugin.input.flow.throughput.last_1_minute | throughput of this input plugin | scaled_float |  | gauge |
 | logstash.pipeline.plugin.input.id | Id of input plugin | keyword |  |  |
 | logstash.pipeline.plugin.input.name | Name of input plugin | keyword |  |  |
+| logstash.pipeline.plugin.input.source.column |  | keyword |  |  |
+| logstash.pipeline.plugin.input.source.id |  | keyword |  |  |
+| logstash.pipeline.plugin.input.source.line |  | long |  |  |
+| logstash.pipeline.plugin.input.source.protocol |  | keyword |  |  |
 | logstash.pipeline.plugin.input.time.queue_push_duration.ms | amount of time spend pushing events to the queue | long | ms | counter |
 | logstash.pipeline.plugin.output.elasticsearch.cluster.id | Elasticsearch clusters this Logstash plugin is attached to | keyword |  |  |
 | logstash.pipeline.plugin.output.events.in | number of events received by the output | long |  | counter |
@@ -1112,6 +1120,10 @@ pipeline collection period, and setting it to an appropriate value.
 | logstash.pipeline.plugin.output.flow.worker_utilization.last_1_minute | worker utilization for this plugin | scaled_float |  | gauge |
 | logstash.pipeline.plugin.output.id | Id of output plugin | keyword |  |  |
 | logstash.pipeline.plugin.output.name | Name of output plugin | keyword |  |  |
+| logstash.pipeline.plugin.output.source.column |  | keyword |  |  |
+| logstash.pipeline.plugin.output.source.id |  | keyword |  |  |
+| logstash.pipeline.plugin.output.source.line |  | long |  |  |
+| logstash.pipeline.plugin.output.source.protocol |  | keyword |  |  |
 | logstash.pipeline.plugin.output.time.duration.ms | amount of time working on events in this plugin | long | ms | counter |
 | logstash.pipeline.plugin.type | Type of the plugin | keyword |  |  |
 | process.pid | Process id. | long |  |  |

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -1139,7 +1139,7 @@ An example event for `plugins` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-10-04T18:51:48.661Z",
+    "@timestamp": "2023-10-20T18:44:48.720Z",
     "data_stream": {
         "dataset": "logstash.plugins",
         "namespace": "default",
@@ -1151,26 +1151,26 @@ An example event for `plugins` looks as following:
     "event": {
         "agent_id_status": "verified",
         "dataset": "logstash.plugins",
-        "ingested": "2023-10-04T18:51:49Z"
+        "ingested": "2023-10-20T18:44:49Z"
     },
     "host": {
         "architecture": "x86_64",
         "hostname": "macbook-pro.local",
         "id": "AA4215F6-994F-5CCE-B6F2-B6AED75AE125",
         "ip": [
-            "192.168.1.184"
+            "192.168.4.26"
         ],
         "mac": [
             "AC-DE-48-00-11-22"
         ],
         "name": "macbook-pro.local",
         "os": {
-            "build": "22F82",
+            "build": "22G120",
             "family": "darwin",
-            "kernel": "22.5.0",
+            "kernel": "22.6.0",
             "name": "macOS",
             "platform": "darwin",
-            "version": "13.4.1"
+            "version": "13.6"
         }
     },
     "input": {
@@ -1178,38 +1178,42 @@ An example event for `plugins` looks as following:
     },
     "logstash": {
         "pipeline": {
-            "elasticsearch": {
-                "cluster": {
-                    "id": "2IcePuo6RCi_511abdJxLQ"
-                }
-            },
             "host": {
-                "address": "0.0.0.0:9600",
-                "name": "21d61ee7529e"
+                "address": "127.0.0.1:9602",
+                "name": "logstash9602"
             },
-            "id": "0542fa70daa36dc3e858ea099f125cc8c9e451ebbfe8ea8867e52f9764da0a35",
-            "name": "pipeline-with-memory-queue",
+            "id": "1bccb98d65bdccf4215bc31f59ba1d47df59141b348899509f633fba4c093318",
+            "name": "slow",
             "plugin": {
-                "codec": {
-                    "decode": {
-                        "duration": {
-                            "ms": 0
-                        },
-                        "in": 0,
-                        "out": 0
+                "input": {
+                    "events": {
+                        "out": 17228
                     },
-                    "encode": {
-                        "duration": {
-                            "ms": 0
-                        },
-                        "in": 0
+                    "flow": {
+                        "throughput": {
+                            "current": 1.097,
+                            "last_1_minute": 1.037
+                        }
                     },
-                    "id": "plain_f62ef0fc-3db5-44fb-a464-0458e6181aa0",
-                    "name": "plain"
+                    "id": "slow_destination",
+                    "name": "pipeline",
+                    "source": {
+                        "column": "3",
+                        "id": "/Users/blah/ingestdemo/logstash-8.8.2/slow.conf",
+                        "line": 2,
+                        "protocol": "file"
+                    },
+                    "time": {
+                        "queue_push_duration": {
+                            "ms": 154
+                        }
+                    }
                 },
-                "type": "codec"
+                "type": "input"
             }
         }
     }
 }
+
+
 ```

--- a/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
@@ -1,0 +1,924 @@
+{
+    "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": true,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "4aff7033-df04-407e-a5e7-204e525cc7f4": {
+                                            "columnOrder": [
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                                "38429427-9766-4356-b23d-324e21ee862e",
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55"
+                                            ],
+                                            "columns": {
+                                                "38429427-9766-4356-b23d-324e21ee862e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.filter.source.line\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Line",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.source.line"
+                                                },
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.filter.source.protocol\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config type",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.source.protocol"
+                                                },
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.name"
+                                                },
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Host",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 6
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.filter.source.column\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Column",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.source.column"
+                                                },
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.filter.source.id\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config location",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.source.id"
+                                                },
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.id"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                        "isTransposed": false,
+                                        "width": 156.2
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                        "isTransposed": false,
+                                        "width": 284.96
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                        "isTransposed": false,
+                                        "width": 83.71000000000001
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "cbe301a7-0aa1-4d20-839b-7e1762287f55",
+                                        "isTransposed": false,
+                                        "width": 113.37666666666667
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Input Plugin Table",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "725cfaec-6b12-4cca-a48a-a2cb52e030f2",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "725cfaec-6b12-4cca-a48a-a2cb52e030f2",
+                "title": "Filter plugin info",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.filter.name",
+                                                            "logstash.pipeline.plugin.filter.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events received per scecond",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.filter.events.in))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.events.in"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Input Plugin Events Received per second",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "f73489b6-c1cd-4819-9f93-6637372e3c42",
+                    "w": 24,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "f73489b6-c1cd-4819-9f93-6637372e3c42",
+                "title": "Filter plugin events received/s",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.filter.name",
+                                                            "logstash.pipeline.plugin.filter.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events emitted per scecond",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.filter.events.out))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events received per scecond",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.events.out"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events received per scecond",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Input Plugin Events Received per second",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "0691466c-c84b-4dff-94e0-d041b264a28c",
+                    "w": 24,
+                    "x": 24,
+                    "y": 8
+                },
+                "panelIndex": "0691466c-c84b-4dff-94e0-d041b264a28c",
+                "title": "Filter plugin events emitted/s",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.filter.name",
+                                                            "logstash.pipeline.plugin.filter.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Time spent in filter",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.filter.time.duration.ms))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of counter_rate(max(logstash.pipeline.plugin.filter.time.duration.ms))",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.filter.time.duration.ms"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of counter_rate(max(logstash.pipeline.plugin.filter.time.duration.ms))",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Input Plugin Events Received per second",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "a58c0555-a83f-4d60-b0ee-7f3ed340a15f",
+                    "w": 24,
+                    "x": 0,
+                    "y": 19
+                },
+                "panelIndex": "a58c0555-a83f-4d60-b0ee-7f3ed340a15f",
+                "title": "Time spent in filter",
+                "type": "lens",
+                "version": "8.10.1"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics Logstash] Filter plugin info",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-19T20:55:05.397Z",
+    "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
+    "managed": false,
+    "references": [
+        {
+            "id": "logstash-sm-metrics",
+            "name": "725cfaec-6b12-4cca-a48a-a2cb52e030f2:indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "f73489b6-c1cd-4819-9f93-6637372e3c42:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "0691466c-c84b-4dff-94e0-d041b264a28c:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "a58c0555-a83f-4d60-b0ee-7f3ed340a15f:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
+}

--- a/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
@@ -1,0 +1,722 @@
+{
+    "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": true,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "fleet-managed-default",
+                                "name": "tag-ref-fleet-managed-default",
+                                "type": "tag"
+                            },
+                            {
+                                "id": "fleet-pkg-logstash-default",
+                                "name": "tag-ref-fleet-pkg-logstash-default",
+                                "type": "tag"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "4aff7033-df04-407e-a5e7-204e525cc7f4": {
+                                            "columnOrder": [
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                                "38429427-9766-4356-b23d-324e21ee862e",
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55"
+                                            ],
+                                            "columns": {
+                                                "38429427-9766-4356-b23d-324e21ee862e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.input.source.line\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Line",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.input.source.line"
+                                                },
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.input.source.protocol\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config type",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.input.source.protocol"
+                                                },
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.input.name"
+                                                },
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Host",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 6
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.input.source.column\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Column",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.input.source.column"
+                                                },
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.input.source.id\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config location",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.input.source.id"
+                                                },
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 3
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.input.id"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                        "isTransposed": false,
+                                        "width": 156.2
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                        "isTransposed": false,
+                                        "width": 284.96
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                        "isTransposed": false,
+                                        "width": 83.71000000000001
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "cbe301a7-0aa1-4d20-839b-7e1762287f55",
+                                        "isTransposed": false,
+                                        "width": 113.37666666666667
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "layerType": "data"
+                            }
+                        },
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "0dae91c8-a8b4-42e3-aa09-975d3f16838c",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "0dae91c8-a8b4-42e3-aa09-975d3f16838c",
+                "title": "Input plugin info",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-d8c819f8-8804-46a3-91b3-fcce155d6688",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "fleet-managed-default",
+                                "name": "tag-ref-fleet-managed-default",
+                                "type": "tag"
+                            },
+                            {
+                                "id": "fleet-pkg-logstash-default",
+                                "name": "tag-ref-fleet-pkg-logstash-default",
+                                "type": "tag"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "d8c819f8-8804-46a3-91b3-fcce155d6688": {
+                                            "columnOrder": [
+                                                "7a48ee41-a9c0-4aab-967f-dc87363cd3c0",
+                                                "c544042e-4cda-4208-861c-72eb6ea9374b",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X0",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X1"
+                                            ],
+                                            "columns": {
+                                                "7a48ee41-a9c0-4aab-967f-dc87363cd3c0": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c544042e-4cda-4208-861c-72eb6ea9374b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.input.name",
+                                                            "logstash.pipeline.plugin.input.id"
+                                                        ],
+                                                        "size": 3
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Queue push duration",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms"
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.input.time.queue_push_duration.ms))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Queue push duration",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.input.time.queue_push_duration.ms"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Queue push duration",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_MONOTONE_X",
+                                "emphasizeFitting": true,
+                                "endValue": "None",
+                                "fittingFunction": "Linear",
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": -90,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "dacc1460-c122-4ac9-a69c-e9da996daba4"
+                                        ],
+                                        "layerId": "d8c819f8-8804-46a3-91b3-fcce155d6688",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c544042e-4cda-4208-861c-72eb6ea9374b",
+                                        "xAccessor": "7a48ee41-a9c0-4aab-967f-dc87363cd3c0"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "dataBounds"
+                                }
+                            }
+                        },
+                        "title": "Input plugin time spent pushing to queue",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "6db65c65-f84c-444d-92a5-4da4fa5d42e5",
+                    "w": 24,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "6db65c65-f84c-444d-92a5-4da4fa5d42e5",
+                "title": "Input plugin time spent pushing to queue",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "fleet-managed-default",
+                                "name": "tag-ref-fleet-managed-default",
+                                "type": "tag"
+                            },
+                            {
+                                "id": "fleet-pkg-logstash-default",
+                                "name": "tag-ref-fleet-pkg-logstash-default",
+                                "type": "tag"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.input.name",
+                                                            "logstash.pipeline.plugin.input.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events Emitted per second",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.input.events.out))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of counter_rate(max(logstash.pipeline.plugin.input.events.out))",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.input.events.out"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of counter_rate(max(logstash.pipeline.plugin.input.events.out))",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "fd726c15-3c7d-4ec0-b75e-a133923fbbdb",
+                    "w": 24,
+                    "x": 24,
+                    "y": 8
+                },
+                "panelIndex": "fd726c15-3c7d-4ec0-b75e-a133923fbbdb",
+                "title": "Input plugin events received/s",
+                "type": "lens",
+                "version": "8.10.1"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics Logstash] Input plugin Info",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-19T20:52:16.694Z",
+    "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
+    "managed": false,
+    "references": [
+        {
+            "id": "logstash-sm-metrics",
+            "name": "0dae91c8-a8b4-42e3-aa09-975d3f16838c:indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "6db65c65-f84c-444d-92a5-4da4fa5d42e5:indexpattern-datasource-layer-d8c819f8-8804-46a3-91b3-fcce155d6688",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "fd726c15-3c7d-4ec0-b75e-a133923fbbdb:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
+}

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -2190,7 +2190,27 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
-                    "enhancements": {},
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": true,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": true
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "Go to Dashboard"
+                                    },
+                                    "eventId": "00282d6c-b89c-4128-bb67-2edb07bd75ec",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
                     "hidePanelTitles": true
                 },
                 "gridData": {
@@ -3604,7 +3624,27 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
-                    "enhancements": {},
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": true,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": true
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "Go to Dashboard"
+                                    },
+                                    "eventId": "39d990b9-e5e4-4be5-b3d3-f46708f767ed",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
                     "hidePanelTitles": true
                 },
                 "gridData": {
@@ -5269,7 +5309,27 @@
                         "type": "lens",
                         "visualizationType": "lnsDatatable"
                     },
-                    "enhancements": {},
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": true,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": true
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "Go to Dashboard"
+                                    },
+                                    "eventId": "0343ae17-9524-48b6-86e2-450b3813b462",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
                     "hidePanelTitles": true
                 },
                 "gridData": {
@@ -7030,7 +7090,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-09T13:26:37.526Z",
+    "created_at": "2023-10-19T20:58:56.792Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "managed": true,
     "references": [
@@ -7090,6 +7150,11 @@
             "type": "index-pattern"
         },
         {
+            "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
+            "name": "9a34af7e-5f12-49b4-86e0-5577203711eb:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:00282d6c-b89c-4128-bb67-2edb07bd75ec:dashboardId",
+            "type": "dashboard"
+        },
+        {
             "id": "logstash-sm-metrics",
             "name": "f94ee279-63d8-45de-bfa0-9c93416b9752:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
             "type": "index-pattern"
@@ -7108,6 +7173,11 @@
             "id": "logstash-sm-metrics",
             "name": "97bcb728-f0e5-4047-aade-2ef56bd33c22:indexpattern-datasource-layer-df79554f-08e3-4f7f-b438-80bc81e14637",
             "type": "index-pattern"
+        },
+        {
+            "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
+            "name": "97bcb728-f0e5-4047-aade-2ef56bd33c22:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:39d990b9-e5e4-4be5-b3d3-f46708f767ed:dashboardId",
+            "type": "dashboard"
         },
         {
             "id": "logstash-sm-metrics",
@@ -7133,6 +7203,11 @@
             "id": "logstash-sm-metrics",
             "name": "5ea51e10-bede-40f6-9842-f840617bcc8b:indexpattern-datasource-layer-df79554f-08e3-4f7f-b438-80bc81e14637",
             "type": "index-pattern"
+        },
+        {
+            "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
+            "name": "5ea51e10-bede-40f6-9842-f840617bcc8b:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:0343ae17-9524-48b6-86e2-450b3813b462:dashboardId",
+            "type": "dashboard"
         },
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
@@ -1,0 +1,964 @@
+{
+    "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "optionsJSON": {
+            "hidePanelTitles": false,
+            "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": true,
+            "useMargins": true
+        },
+        "panelsJSON": [
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "4aff7033-df04-407e-a5e7-204e525cc7f4": {
+                                            "columnOrder": [
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                                "38429427-9766-4356-b23d-324e21ee862e",
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55"
+                                            ],
+                                            "columns": {
+                                                "38429427-9766-4356-b23d-324e21ee862e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.output.source.line\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Line",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.output.source.line"
+                                                },
+                                                "62f457aa-b19d-470b-831a-a4e8abdacaff": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.output.source.protocol\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config type",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.output.source.protocol"
+                                                },
+                                                "7272b9e2-f9ba-41f8-b13a-239ebce42ebf": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.output.name"
+                                                },
+                                                "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Host",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "cbe301a7-0aa1-4d20-839b-7e1762287f55": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.output.source.column\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Column",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.output.source.column"
+                                                },
+                                                "d1381da1-8513-4351-8943-5eb6a5438ec3": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.plugin.output.source.id\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Config location",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.output.source.id"
+                                                },
+                                                "f4c6a93a-b321-4c7a-9a44-e347c2b9f415": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Plugin Id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.plugin.output.id"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "7272b9e2-f9ba-41f8-b13a-239ebce42ebf",
+                                        "isTransposed": false,
+                                        "width": 156.2
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "d1381da1-8513-4351-8943-5eb6a5438ec3",
+                                        "isTransposed": false,
+                                        "width": 284.96
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "62f457aa-b19d-470b-831a-a4e8abdacaff",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "38429427-9766-4356-b23d-324e21ee862e",
+                                        "isTransposed": false,
+                                        "width": 83.71000000000001
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "cbe301a7-0aa1-4d20-839b-7e1762287f55",
+                                        "isTransposed": false,
+                                        "width": 113.37666666666667
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "f4c6a93a-b321-4c7a-9a44-e347c2b9f415",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "ca464fe6-7ced-4cda-86b0-1f3f973fa7b1",
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "4aff7033-df04-407e-a5e7-204e525cc7f4",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "Input Plugin Table",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "bf0c010c-5d4e-4431-bf4a-984857796346",
+                    "w": 48,
+                    "x": 0,
+                    "y": 0
+                },
+                "panelIndex": "bf0c010c-5d4e-4431-bf4a-984857796346",
+                "title": "Output plugin info",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-d8c819f8-8804-46a3-91b3-fcce155d6688",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "d8c819f8-8804-46a3-91b3-fcce155d6688": {
+                                            "columnOrder": [
+                                                "7a48ee41-a9c0-4aab-967f-dc87363cd3c0",
+                                                "c544042e-4cda-4208-861c-72eb6ea9374b",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X0",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X1",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X2",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X3",
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X4"
+                                            ],
+                                            "columns": {
+                                                "7a48ee41-a9c0-4aab-967f-dc87363cd3c0": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c544042e-4cda-4208-861c-72eb6ea9374b": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.output.name",
+                                                            "logstash.pipeline.plugin.output.id"
+                                                        ],
+                                                        "size": 3
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Time spent in plugin",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "ms/event"
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.output.time.duration.ms))/counter_rate(max(logstash.pipeline.plugin.output.events.out))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X4"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Time spent in plugin",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.output.time.duration.ms"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Time spent in plugin",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Time spent in plugin",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.output.events.out"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Time spent in plugin",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X2"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Time spent in plugin",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X1",
+                                                                "dacc1460-c122-4ac9-a69c-e9da996daba4X3"
+                                                            ],
+                                                            "location": {
+                                                                "max": 129,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "counter_rate(max(logstash.pipeline.plugin.output.time.duration.ms))/counter_rate(max(logstash.pipeline.plugin.output.events.out))",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X1",
+                                                        "dacc1460-c122-4ac9-a69c-e9da996daba4X3"
+                                                    ],
+                                                    "scale": "ratio"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_MONOTONE_X",
+                                "emphasizeFitting": true,
+                                "endValue": "None",
+                                "fittingFunction": "Linear",
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": -90,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "dacc1460-c122-4ac9-a69c-e9da996daba4"
+                                        ],
+                                        "layerId": "d8c819f8-8804-46a3-91b3-fcce155d6688",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c544042e-4cda-4208-861c-72eb6ea9374b",
+                                        "xAccessor": "7a48ee41-a9c0-4aab-967f-dc87363cd3c0"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "dataBounds"
+                                }
+                            }
+                        },
+                        "title": "Input Plugin Time spent pushing to queue",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "1d8e04da-e2c7-45f9-a48b-5e72b707a177",
+                    "w": 48,
+                    "x": 0,
+                    "y": 8
+                },
+                "panelIndex": "1d8e04da-e2c7-45f9-a48b-5e72b707a177",
+                "title": "Time spent in output plugin ms/event",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.output.name",
+                                                            "logstash.pipeline.plugin.output.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events Emitted per second",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.output.events.in))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.output.events.in"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Output plugin events received/s",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "9c3b9cbf-e8b3-4634-93cc-73eb68a3b7d1",
+                    "w": 24,
+                    "x": 0,
+                    "y": 19
+                },
+                "panelIndex": "9c3b9cbf-e8b3-4634-93cc-73eb68a3b7d1",
+                "title": "Output plugin events received/s",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "03132fcd-13a1-4f64-88ad-31cbf8b4e043": {
+                                            "columnOrder": [
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde",
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0",
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                            ],
+                                            "columns": {
+                                                "2c04dbf8-9f1b-4d3b-a598-1503b9d97010": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of logstash.host.name + 2 others",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of logstash.pipeline.total.events.out",
+                                                            "operationType": "count",
+                                                            "params": {
+                                                                "emptyAsNull": true
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.events.out"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "logstash.pipeline.plugin.output.name",
+                                                            "logstash.pipeline.plugin.output.id"
+                                                        ],
+                                                        "size": 20
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dc": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Events Emitted per second",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "counter_rate(max(logstash.pipeline.plugin.output.events.in))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.plugin.output.events.in"
+                                                },
+                                                "b02fb0ac-3ead-4546-ac07-2d21f54628dcX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Events Emitted per second",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "b02fb0ac-3ead-4546-ac07-2d21f54628dcX0"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "d531162d-3ee2-4de1-8427-c57e8d679cde": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "b02fb0ac-3ead-4546-ac07-2d21f54628dc"
+                                        ],
+                                        "layerId": "03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "2c04dbf8-9f1b-4d3b-a598-1503b9d97010",
+                                        "xAccessor": "d531162d-3ee2-4de1-8427-c57e8d679cde"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Output plugin events received/s",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "064304b4-4d2d-4ec1-ada3-f18e2abc792b",
+                    "w": 24,
+                    "x": 24,
+                    "y": 19
+                },
+                "panelIndex": "064304b4-4d2d-4ec1-ada3-f18e2abc792b",
+                "title": "Output plugin events emitted/s",
+                "type": "lens",
+                "version": "8.10.1"
+            }
+        ],
+        "timeRestore": false,
+        "title": "[Metrics Logstash] Output plugin info",
+        "version": 1
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-19T20:49:48.847Z",
+    "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
+    "managed": false,
+    "references": [
+        {
+            "id": "logstash-sm-metrics",
+            "name": "bf0c010c-5d4e-4431-bf4a-984857796346:indexpattern-datasource-layer-4aff7033-df04-407e-a5e7-204e525cc7f4",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "1d8e04da-e2c7-45f9-a48b-5e72b707a177:indexpattern-datasource-layer-d8c819f8-8804-46a3-91b3-fcce155d6688",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "9c3b9cbf-e8b3-4634-93cc-73eb68a3b7d1:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "064304b4-4d2d-4ec1-ada3-f18e2abc792b:indexpattern-datasource-layer-03132fcd-13a1-4f64-88ad-31cbf8b4e043",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
+}

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.3.5
+version: 2.3.6
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

## Proposed commit message

This PR adds additional drilldown dashboards on input, filter and output plugin in order to to add contextual information about where a plugin was defined. This is important, as it allows users to quickly find out which of many plugins
of the same type are being referenced in the dashboards, without needing to rewrite long and complex pipeline configurations to add identifiers to each of their plugin definitions.

To do this, the CEL code is augmented to retrieve pipeline information from the `/pipelines/#{pipeline_name}` endpoint, which provides information about each of the pipeline graphs.

This commit also updates the field definitions to add source objects for each
of the main plugin types.

## Screenshots

Drilldown dashboards are created for `input`, `filter`, and `output` plugin types, with links added from the plugin tables from the `Single Pipeline View` dashboard.

<img width="1718" alt="Screenshot 2023-10-20 at 2 42 25 PM" src="https://github.com/elastic/integrations/assets/4061337/c8bea10a-b758-451a-9a1b-899ff0d8258b">


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


