### PR TITLE
Add `dimension` field previously missed during package-spec v3 migration

### DIFF
--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
-- version: 0.5.0
+- version: "0.5.1"
+  changes:
+    - description: Add dimension field for container.id which was previously missed during package-spec v3 migration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8259
+- version: "0.5.0"
   changes:
     - description: Update the package format_version to 3.0.0.
       type: enhancement

--- a/packages/airflow/data_stream/statsd/fields/ecs.yml
+++ b/packages/airflow/data_stream/statsd/fields/ecs.yml
@@ -8,6 +8,7 @@
   external: ecs
 - name: container.id
   external: ecs
+  dimension: true
 - name: container.name
   external: ecs
 - name: container.runtime

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.5.0"
+version: "0.5.1"
 description: Airflow Integration.
 type: integration
 format_version: "3.0.0"

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,4 +1,9 @@
-- version: 1.7.0
+- version: "1.7.1"
+  changes:
+    - description: Add dimension field for container.id which was previously missed during package-spec v3 migration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8259
+- version: "1.7.0"
   changes:
     - description: Update the package format_version to 3.0.0.
       type: enhancement

--- a/packages/cockroachdb/data_stream/status/fields/ecs.yml
+++ b/packages/cockroachdb/data_stream/status/fields/ecs.yml
@@ -8,6 +8,7 @@
   external: ecs
 - name: container.id
   external: ecs
+  dimension: true
 - name: container.name
   external: ecs
 - name: container.runtime

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: "1.7.0"
+version: "1.7.1"
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Add `dimension: true` for a couple of packages (airflow and cockroachdb) which was previously missed in https://github.com/elastic/integrations/pull/8170 during package-spec v3 migration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
