### PR TITLE
[O11y][K8] Migrate `Jobs`  dashboard visualizations to lens

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Migrate `Jobs` dashboard visualizations to lens.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #Fixme
+      link: https://github.com/elastic/integrations/pull/8262
 - version: 1.46.0
   changes:
     - description: Adapt fields for changes in file system info

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.47.0
+  changes:
+    - description: Migrate `Jobs` dashboard visualizations to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #Fixme
 - version: 1.46.0
   changes:
     - description: Adapt fields for changes in file system info

--- a/packages/kubernetes/kibana/dashboard/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -19,6 +19,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -57,96 +59,142 @@
                 "panelIndex": "ce57bb14-ee8a-43ba-bb57-a6f815838500",
                 "title": "Kubernetes Dashboards [Metrics Kubernetes]",
                 "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.10.2"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-9b261d2c-645a-4dca-9229-9d8c52e79b9f",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "e4408339-1fa7-47b3-bac9-d2e7945d989f",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9b261d2c-645a-4dca-9229-9d8c52e79b9f": {
+                                            "columnOrder": [
+                                                "d65fee9a-8196-4bcf-b80f-af8eae9974ea",
+                                                "3bd09ac0-4718-47e1-abb4-54cbcf502e63"
+                                            ],
+                                            "columns": {
+                                                "3bd09ac0-4718-47e1-abb4-54cbcf502e63": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"kubernetes.job.pods.active\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Active",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.job.pods.active"
+                                                },
+                                                "d65fee9a-8196-4bcf-b80f-af8eae9974ea": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.job.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.job.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "e4408339-1fa7-47b3-bac9-d2e7945d989f",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_job"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.state_job"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "breakdownByAccessor": "d65fee9a-8196-4bcf-b80f-af8eae9974ea",
+                                "collapseFn": "sum",
+                                "layerId": "9b261d2c-645a-4dca-9229-9d8c52e79b9f",
+                                "layerType": "data",
+                                "metricAccessor": "3bd09ac0-4718-47e1-abb4-54cbcf502e63"
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
-                                {
-                                    "id": "b4a76050-ba54-11ec-a38a-8738426ac550"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset :\"kubernetes.state_job\" "
-                            },
-                            "id": "401e6673-444f-4cd8-8d5e-b428cb1a0026",
-                            "index_pattern_ref_name": "metrics_65805e20-7bb7-43ef-99de-fc56c3de6af2_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "id": "261249a0-f757-40f1-93f2-fe8f59f99b8c",
-                                    "label": "Active",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "agg_with": "avg",
-                                            "field": "kubernetes.job.pods.active",
-                                            "id": "7575ba08-100d-4c17-9b30-546a1b44ba13",
-                                            "order": "desc",
-                                            "order_by": "@timestamp",
-                                            "size": 1,
-                                            "type": "top_hit"
-                                        },
-                                        {
-                                            "function": "sum",
-                                            "id": "8d1a4ba0-ba55-11ec-a38a-8738426ac550",
-                                            "type": "series_agg"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "kubernetes.job.name",
-                                    "terms_size": "100000",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "metric",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "Active Job Pods [Metrics Kubernetes]",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 12,
@@ -157,97 +205,143 @@
                 },
                 "panelIndex": "65805e20-7bb7-43ef-99de-fc56c3de6af2",
                 "title": "Active Job Pods [Metrics Kubernetes]",
-                "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens",
+                "version": "8.10.2"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-8da4f091-8450-456a-8496-aab42ef0871a",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "25697353-2613-4360-89cc-900c9e265a10",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "8da4f091-8450-456a-8496-aab42ef0871a": {
+                                            "columnOrder": [
+                                                "a7a7d706-d487-4ea4-ac4e-a52de432b629",
+                                                "8747afd9-3e1d-4da8-8f85-e3f526af747e"
+                                            ],
+                                            "columns": {
+                                                "8747afd9-3e1d-4da8-8f85-e3f526af747e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"kubernetes.job.pods.succeeded\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Succeeded",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.job.pods.succeeded"
+                                                },
+                                                "a7a7d706-d487-4ea4-ac4e-a52de432b629": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.job.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.job.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "25697353-2613-4360-89cc-900c9e265a10",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_job"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.state_job"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "breakdownByAccessor": "a7a7d706-d487-4ea4-ac4e-a52de432b629",
+                                "collapseFn": "sum",
+                                "layerId": "8da4f091-8450-456a-8496-aab42ef0871a",
+                                "layerType": "data",
+                                "metricAccessor": "8747afd9-3e1d-4da8-8f85-e3f526af747e"
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
-                                {
-                                    "id": "b4a76050-ba54-11ec-a38a-8738426ac550"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset :\"kubernetes.state_job\" "
-                            },
-                            "id": "401e6673-444f-4cd8-8d5e-b428cb1a0026",
-                            "index_pattern_ref_name": "metrics_9ecfd540-d36f-4869-836d-3dd704a6561f_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "id": "261249a0-f757-40f1-93f2-fe8f59f99b8c",
-                                    "label": "Succeeded",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "agg_with": "avg",
-                                            "field": "kubernetes.job.pods.succeeded",
-                                            "id": "7575ba08-100d-4c17-9b30-546a1b44ba13",
-                                            "order": "desc",
-                                            "order_by": "@timestamp",
-                                            "size": 1,
-                                            "type": "top_hit"
-                                        },
-                                        {
-                                            "function": "sum",
-                                            "id": "8d1a4ba0-ba55-11ec-a38a-8738426ac550",
-                                            "type": "series_agg"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "kubernetes.job.name",
-                                    "terms_size": "100000",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "metric",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "Succeeded Job Pods [Metrics Kubernetes]",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 12,
@@ -258,97 +352,143 @@
                 },
                 "panelIndex": "9ecfd540-d36f-4869-836d-3dd704a6561f",
                 "title": "Succeeded Job Pods [Metrics Kubernetes]",
-                "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens",
+                "version": "8.10.2"
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-81a3cd5d-50e5-4e31-b736-000de1673372",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "f5e0f998-307f-48b5-8a3d-a8ce10058dbd",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "81a3cd5d-50e5-4e31-b736-000de1673372": {
+                                            "columnOrder": [
+                                                "d373cc02-b4ba-4cb3-a0b1-da41564d4a96",
+                                                "9fd1fc3c-2013-4d03-9107-b03512a8f7dd"
+                                            ],
+                                            "columns": {
+                                                "9fd1fc3c-2013-4d03-9107-b03512a8f7dd": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"kubernetes.job.pods.failed\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Failed",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.job.pods.failed"
+                                                },
+                                                "d373cc02-b4ba-4cb3-a0b1-da41564d4a96": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.job.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.job.name"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "f5e0f998-307f-48b5-8a3d-a8ce10058dbd",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_job"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.state_job"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "breakdownByAccessor": "d373cc02-b4ba-4cb3-a0b1-da41564d4a96",
+                                "collapseFn": "sum",
+                                "layerId": "81a3cd5d-50e5-4e31-b736-000de1673372",
+                                "layerType": "data",
+                                "metricAccessor": "9fd1fc3c-2013-4d03-9107-b03512a8f7dd"
                             }
                         },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
-                                {
-                                    "id": "b4a76050-ba54-11ec-a38a-8738426ac550"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "filter": {
-                                "language": "kuery",
-                                "query": "data_stream.dataset :\"kubernetes.state_job\" "
-                            },
-                            "id": "401e6673-444f-4cd8-8d5e-b428cb1a0026",
-                            "index_pattern_ref_name": "metrics_c73b7420-ce63-4d11-b25e-387c7c76b9f1_0_index_pattern",
-                            "interval": "",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "formatter": "default",
-                                    "id": "261249a0-f757-40f1-93f2-fe8f59f99b8c",
-                                    "label": "Failed",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "agg_with": "avg",
-                                            "field": "kubernetes.job.pods.failed",
-                                            "id": "7575ba08-100d-4c17-9b30-546a1b44ba13",
-                                            "order": "desc",
-                                            "order_by": "@timestamp",
-                                            "size": 1,
-                                            "type": "top_hit"
-                                        },
-                                        {
-                                            "function": "sum",
-                                            "id": "8d1a4ba0-ba55-11ec-a38a-8738426ac550",
-                                            "type": "series_agg"
-                                        }
-                                    ],
-                                    "override_index_pattern": 0,
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_drop_last_bucket": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "kubernetes.job.name",
-                                    "terms_size": "10000",
-                                    "time_range_mode": "entire_time_range"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "metric",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
+                        "title": "Failed Job Pods [Metrics Kubernetes]",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 12,
@@ -359,8 +499,8 @@
                 },
                 "panelIndex": "c73b7420-ce63-4d11-b25e-387c7c76b9f1",
                 "title": "Failed Job Pods [Metrics Kubernetes]",
-                "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens",
+                "version": "8.10.2"
             },
             {
                 "embeddableConfig": {
@@ -540,7 +680,7 @@
                 "panelIndex": "574d76e2-ca20-4c75-9dac-31265a772ba5",
                 "title": "Informations per Job [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.10.2"
             },
             {
                 "embeddableConfig": {
@@ -691,33 +831,46 @@
                 "panelIndex": "2bb97a71-28ce-428d-99d1-01b1918aebf5",
                 "title": "Job Owner Informations [Metrics Kubernetes]",
                 "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "version": "8.10.2"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Jobs",
         "version": 1
     },
-    "coreMigrationVersion": "8.6.0",
-    "created_at": "2023-01-11T14:18:26.601Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-10-20T08:28:44.740Z",
     "id": "kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013",
-    "migrationVersion": {
-        "dashboard": "8.6.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "65805e20-7bb7-43ef-99de-fc56c3de6af2:metrics_65805e20-7bb7-43ef-99de-fc56c3de6af2_0_index_pattern",
+            "name": "65805e20-7bb7-43ef-99de-fc56c3de6af2:indexpattern-datasource-layer-9b261d2c-645a-4dca-9229-9d8c52e79b9f",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "9ecfd540-d36f-4869-836d-3dd704a6561f:metrics_9ecfd540-d36f-4869-836d-3dd704a6561f_0_index_pattern",
+            "name": "65805e20-7bb7-43ef-99de-fc56c3de6af2:e4408339-1fa7-47b3-bac9-d2e7945d989f",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "c73b7420-ce63-4d11-b25e-387c7c76b9f1:metrics_c73b7420-ce63-4d11-b25e-387c7c76b9f1_0_index_pattern",
+            "name": "9ecfd540-d36f-4869-836d-3dd704a6561f:indexpattern-datasource-layer-8da4f091-8450-456a-8496-aab42ef0871a",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "9ecfd540-d36f-4869-836d-3dd704a6561f:25697353-2613-4360-89cc-900c9e265a10",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c73b7420-ce63-4d11-b25e-387c7c76b9f1:indexpattern-datasource-layer-81a3cd5d-50e5-4e31-b736-000de1673372",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c73b7420-ce63-4d11-b25e-387c7c76b9f1:f5e0f998-307f-48b5-8a3d-a8ce10058dbd",
             "type": "index-pattern"
         },
         {
@@ -756,5 +909,6 @@
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.46.0
+version: 1.47.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - containers
   - kubernetes
 conditions:
-  kibana.version: "^8.10.1"
+  kibana.version: "^8.10.2"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

### Urgency
- High

### Activity Type
- Enhancement

## What does this PR do?
- Manually migrate `K8s Jobs` visualizations to the lens in the current Kibana version `8.10.2` itself. 

- Statistics for `K8s Jobs` Lens migration:
## Migration stats
  | Before Migration |   | After Migration |  
-- | -- | -- | -- | --
  | Lens | Vizualization | Lens | Vizualization
[Metrics Kubernetes] Jobs | 2 | 3 | 5 | 0

## Checklist

- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that panels are populated with data.
- [X] I have verified that panels are not distorted after being migrated to the lens.
- [x] I have updated screenshots of the dashboard.
- [X] I have verified that the data counts are matching and panel aggregations are the same as before.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [X] Migrated panels should be removed from visualization folder.
- [X] Migrated visualizations are populating in current Kibana version 8.10.2 itself.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7774

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

Before Migration:
![image](https://github.com/elastic/integrations/assets/124889398/6ca034eb-c6b7-4ccb-a7bb-2f42c89d3c7c)
After Migration:
![image](https://github.com/elastic/integrations/assets/124889398/9056056d-1c32-488a-a1a7-3670c9bbc211)