### PR TITLE
[ti_rapid7_threat_command] Fix required stack capabilities

### DIFF
--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: 'Fix required stack capabilities'
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: 1.11.0
   changes:
     - description: Set 'partner' owner type.

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: 'Fix required stack capabilities'
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8268
 - version: 1.11.0
   changes:
     - description: Set 'partner' owner type.

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -2,13 +2,16 @@ format_version: 3.0.0
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
 # The version must be updated manually in the transform.yml files and transform APIs mentioned in README.
-version: "1.11.0"
+version: "1.11.1"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]
 conditions:
   kibana:
     version: ^8.7.1
+  elastic:
+    capabilities:
+      - security
 screenshots:
   - src: /img/ti_rapid7_threat_command-ioc_overview_1.png
     title: IOC Overview-1


### PR DESCRIPTION
## Proposed commit message

This package fails to start in stacks without the security plugin, as it requires
the security rule object type.

When trying to install with `elastic-package install`:
```
Error: can't install the package: could not zip-install package; API status code = 500; response body = {"statusCode":500,"error":"Internal Server Error","message":"Encountered 2 errors creating saved objects: [{\"type\":\"security-rule\",\"id\":\"af814670-3279-11ed-93fa-d354b323cd1b\",\"error\":{\"type\":\"unsupported_type\"}},{\"type\":\"security-rule\",\"id\":\"eaecc8f0-6704-11ed-80b2-9bbc46f73b72\",\"error\":{\"type\":\"unsupported_type\"}}]"}
```

Add the required capabilities to the manifest.

As a follow up we will need to remove the 1.10.0 and 1.11.0 versions of the package from the registry. cc @mrodm

## Checklist

- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Found in https://github.com/elastic/integrations/pull/8072

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
