### PR TITLE
[elastic_agent] add data_streams for Universal Profiling services

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Add data stream for logs of Universal Profiling services.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8276
 - version: "1.14.0"
   changes:
     - description: Modify field mappings to reference ECS fields where possible and remove duplicate field declarations.

--- a/packages/elastic_agent/data_stream/pf_elastic_collector/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_collector/fields/base-fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.type
+  external: ecs
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_elastic_collector/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_collector/fields/ecs.yml
@@ -1,0 +1,16 @@
+- external: ecs
+  name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_elastic_collector/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_collector/fields/fields.yml
@@ -1,0 +1,25 @@
+- name: message
+  external: ecs
+- name: elastic_agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Elastic Agent id.
+    - name: process
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Process run by the Elastic Agent.
+      example: metricbeat
+    - name: snapshot
+      level: extended
+      type: boolean
+      description: Is the agent running from a snapshot build
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Elastic agent version.
+      example: 7.11.0

--- a/packages/elastic_agent/data_stream/pf_elastic_collector/manifest.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_collector/manifest.yml
@@ -1,0 +1,7 @@
+title: Elastic Agent
+dataset: elastic_agent.pf_elastic_collector
+type: logs
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false

--- a/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/base-fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.type
+  external: ecs
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/ecs.yml
@@ -1,0 +1,16 @@
+- external: ecs
+  name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_symbolizer/fields/fields.yml
@@ -1,0 +1,25 @@
+- name: message
+  external: ecs
+- name: elastic_agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Elastic Agent id.
+    - name: process
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Process run by the Elastic Agent.
+      example: metricbeat
+    - name: snapshot
+      level: extended
+      type: boolean
+      description: Is the agent running from a snapshot build
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Elastic agent version.
+      example: 7.11.0

--- a/packages/elastic_agent/data_stream/pf_elastic_symbolizer/manifest.yml
+++ b/packages/elastic_agent/data_stream/pf_elastic_symbolizer/manifest.yml
@@ -1,0 +1,7 @@
+title: Elastic Agent
+dataset: elastic_agent.pf_elastic_symbolizer
+type: logs
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/base-fields.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/base-fields.yml
@@ -1,0 +1,8 @@
+- name: data_stream.type
+  external: ecs
+- name: data_stream.dataset
+  external: ecs
+- name: data_stream.namespace
+  external: ecs
+- name: "@timestamp"
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/ecs.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/ecs.yml
@@ -1,0 +1,16 @@
+- external: ecs
+  name: ecs.version
+- name: agent.build.original
+  external: ecs
+- name: agent.ephemeral_id
+  external: ecs
+- name: agent.id
+  external: ecs
+- name: agent.name
+  external: ecs
+- name: agent.type
+  external: ecs
+- name: agent.version
+  external: ecs
+- name: log.level
+  external: ecs

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/fields/fields.yml
@@ -1,0 +1,25 @@
+- name: message
+  external: ecs
+- name: elastic_agent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Elastic Agent id.
+    - name: process
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Process run by the Elastic Agent.
+      example: metricbeat
+    - name: snapshot
+      level: extended
+      type: boolean
+      description: Is the agent running from a snapshot build
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Elastic agent version.
+      example: 7.11.0

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/manifest.yml
@@ -1,0 +1,7 @@
+title: Elastic Agent
+dataset: elastic_agent.pf_host_agent
+type: logs
+elasticsearch:
+  index_template:
+    mappings:
+      dynamic: false

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.14.0
+version: 1.15.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

So far logs of Universal Profiling services were not picked and indexed to make them available via Kibana. Add a dedicated `data_stream` for each Universal Profiling service.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Screenshots
![20231024-145257](https://github.com/elastic/integrations/assets/1132494/77106453-3e7c-430f-9148-812d80c27a86)

