### PR TITLE
[Cloudflare Logpush] Add non_aws_bucket_name option to AWS S3 input

### DIFF
--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -92,7 +92,7 @@ This module has been tested against **Cloudflare version v4**.
 
 
 **Note**:
-- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI, tipically in the form of `https(s)://<accountid>.r2.cloudflarestorage.com`, that will be used as the API endpoint of the service.
 - This setting can be also used to ingest data from other S3-compatible storage services.
 
 ### To collect data from AWS SQS, follow the below steps:

--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -90,6 +90,10 @@ This module has been tested against **Cloudflare version v4**.
   | Spectrum Event             | spectrum_event         |
   | Workers Trace Events       | workers_trace          |
 
+
+**Note**:
+- It is possible to ingest data from a third-party S3 compatible service by setting the parameter `Non AWS Bucket Name`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).

--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -92,7 +92,8 @@ This module has been tested against **Cloudflare version v4**.
 
 
 **Note**:
-- It is possible to ingest data from a third-party S3 compatible service by setting the parameter `Non AWS Bucket Name`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- This setting can be also used to ingest data from other S3-compatible storage services.
 
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Expose 'non_aws_bucket_name' option for the AWS S3 input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8278
 - version: "1.15.0"
   changes:
     - description: Improve 'event.original' check to avoid errors if set.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.16.0"
   changes:
-    - description: Expose 'non_aws_bucket_name' option for the AWS S3 input.
+    - description: Expose 'non_aws_bucket_name' option for the AWS S3 input to ingest data from Cloudflare R2.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8278
 - version: "1.15.0"

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_access_request }}
+non_aws_bucket_name: {{non_aws_bucket_name_access_request}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_access_request}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/access_request/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_access_request }}
-non_aws_bucket_name: {{non_aws_bucket_name_access_request}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_access_request }}
+non_aws_bucket_name: {{cloudflare_r2_access_request}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: access_request
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_access_request
+        type: text
+        title: "[Access Request][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: access_request
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_access_request
+      - name: cloudflare_r2_access_request
         type: text
-        title: "[Access Request][S3] Non AWS Bucket Name"
+        title: "[Access Request][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_audit }}
-non_aws_bucket_name: {{non_aws_bucket_name_audit}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_audit }}
+non_aws_bucket_name: {{cloudflare_r2_audit}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/audit/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_audit }}
+non_aws_bucket_name: {{non_aws_bucket_name_audit}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_audit}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: audit_logs
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_audit
+        type: text
+        title: "[Audit][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: audit_logs
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_audit
+      - name: cloudflare_r2_audit
         type: text
-        title: "[Audit][S3] Non AWS Bucket Name"
+        title: "[Audit][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_casb }}
-non_aws_bucket_name: {{non_aws_bucket_name_casb}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_casb }}
+non_aws_bucket_name: {{cloudflare_r2_casb}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/casb/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_casb }}
+non_aws_bucket_name: {{non_aws_bucket_name_casb}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_casb}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: casb
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_casb
+      - name: cloudflare_r2_casb
         type: text
-        title: "[CASB Findings][S3] Non AWS Bucket Name"
+        title: "[CASB Findings][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: casb
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_casb
+        type: text
+        title: "[CASB Findings][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_device_posture }}
+non_aws_bucket_name: {{non_aws_bucket_name_device_posture}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_device_posture}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/device_posture/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_device_posture }}
-non_aws_bucket_name: {{non_aws_bucket_name_device_posture}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_device_posture }}
+non_aws_bucket_name: {{cloudflare_r2_device_posture}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: device_posture
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_device_posture
+        type: text
+        title: "[Device Posture Results][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: device_posture
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_device_posture
+      - name: cloudflare_r2_device_posture
         type: text
-        title: "[Device Posture Results][S3] Non AWS Bucket Name"
+        title: "[Device Posture Results][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_dns }}
+non_aws_bucket_name: {{non_aws_bucket_name_dns}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_dns}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_dns }}
-non_aws_bucket_name: {{non_aws_bucket_name_dns}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_dns }}
+non_aws_bucket_name: {{cloudflare_r2_dns}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: dns
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_dns
+      - name: cloudflare_r2_dns
         type: text
-        title: "[DNS][S3] Non AWS Bucket Name"
+        title: "[DNS][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: dns
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_dns
+        type: text
+        title: "[DNS][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_dns_firewall }}
+non_aws_bucket_name: {{non_aws_bucket_name_dns_firewall}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_dns_firewall}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_dns_firewall }}
-non_aws_bucket_name: {{non_aws_bucket_name_dns_firewall}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_dns_firewall }}
+non_aws_bucket_name: {{cloudflare_r2_dns_firewall}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: dns_firewall
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_dns_firewall
+        type: text
+        title: "[DNS Firewall][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: dns_firewall
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_dns_firewall
+      - name: cloudflare_r2_dns_firewall
         type: text
-        title: "[DNS Firewall][S3] Non AWS Bucket Name"
+        title: "[DNS Firewall][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_firewall_event }}
+non_aws_bucket_name: {{non_aws_bucket_name_firewall_event}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_firewall_event}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_firewall_event }}
-non_aws_bucket_name: {{non_aws_bucket_name_firewall_event}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_firewall_event }}
+non_aws_bucket_name: {{cloudflare_r2_firewall_event}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: firewall_event
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_firewall_event
+      - name: cloudflare_r2_firewall_event
         type: text
-        title: "[Firewall Event][S3] Non AWS Bucket Name"
+        title: "[Firewall Event][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: firewall_event
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_firewall_event
+        type: text
+        title: "[Firewall Event][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_gateway_dns }}
-non_aws_bucket_name: {{non_aws_bucket_name_gateway_dns}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_gateway_dns }}
+non_aws_bucket_name: {{cloudflare_r2_gateway_dns}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_gateway_dns }}
+non_aws_bucket_name: {{non_aws_bucket_name_gateway_dns}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_gateway_dns}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: gateway_dns
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_gateway_dns
+        type: text
+        title: "[Gateway DNS][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: gateway_dns
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_gateway_dns
+      - name: cloudflare_r2_gateway_dns
         type: text
-        title: "[Gateway DNS][S3] Non AWS Bucket Name"
+        title: "[Gateway DNS][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_gateway_http }}
+non_aws_bucket_name: {{non_aws_bucket_name_gateway_http}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_gateway_http}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_gateway_http }}
-non_aws_bucket_name: {{non_aws_bucket_name_gateway_http}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_gateway_http }}
+non_aws_bucket_name: {{cloudflare_r2_gateway_http}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: gateway_http
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_gateway_http
+        type: text
+        title: "[Gateway HTTP][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: gateway_http
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_gateway_http
+      - name: cloudflare_r2_gateway_http
         type: text
-        title: "[Gateway HTTP][S3] Non AWS Bucket Name"
+        title: "[Gateway HTTP][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_gateway_network }}
-non_aws_bucket_name: {{non_aws_bucket_name_gateway_network}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_gateway_network }}
+non_aws_bucket_name: {{cloudflare_r2_gateway_network}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_gateway_network }}
+non_aws_bucket_name: {{non_aws_bucket_name_gateway_network}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_gateway_network}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: gateway_network
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_gateway_network
+        type: text
+        title: "[Gateway Network][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: gateway_network
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_gateway_network
+      - name: cloudflare_r2_gateway_network
         type: text
-        title: "[Gateway Network][S3] Non AWS Bucket Name"
+        title: "[Gateway Network][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_http_request }}
+non_aws_bucket_name: {{non_aws_bucket_name_http_request}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_http_request}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/http_request/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_http_request }}
-non_aws_bucket_name: {{non_aws_bucket_name_http_request}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_http_request }}
+non_aws_bucket_name: {{cloudflare_r2_http_request}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: http_request
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_http_request
+        type: text
+        title: "[HTTP Request][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: http_request
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_http_request
+      - name: cloudflare_r2_http_request
         type: text
-        title: "[HTTP Request][S3] Non AWS Bucket Name"
+        title: "[HTTP Request][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_magic_ids }}
+non_aws_bucket_name: {{non_aws_bucket_name_magic_ids}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_magic_ids}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_magic_ids }}
-non_aws_bucket_name: {{non_aws_bucket_name_magic_ids}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_magic_ids }}
+non_aws_bucket_name: {{cloudflare_r2_magic_ids}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: magic_ids
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_magic_ids
+        type: text
+        title: "[Magic IDS][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: magic_ids
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_magic_ids
+      - name: cloudflare_r2_magic_ids
         type: text
-        title: "[Magic IDS][S3] Non AWS Bucket Name"
+        title: "[Magic IDS][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_nel_report }}
+non_aws_bucket_name: {{non_aws_bucket_name_nel_report}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_nel_report}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/nel_report/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_nel_report }}
-non_aws_bucket_name: {{non_aws_bucket_name_nel_report}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_nel_report }}
+non_aws_bucket_name: {{cloudflare_r2_nel_report}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: nel_report
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_nel_report
+        type: text
+        title: "[NEL Report][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: nel_report
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_nel_report
+      - name: cloudflare_r2_nel_report
         type: text
-        title: "[NEL Report][S3] Non AWS Bucket Name"
+        title: "[NEL Report][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_network_analytics }}
+non_aws_bucket_name: {{non_aws_bucket_name_network_analytics}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_network_analytics}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_network_analytics }}
-non_aws_bucket_name: {{non_aws_bucket_name_network_analytics}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_network_analytics }}
+non_aws_bucket_name: {{cloudflare_r2_network_analytics}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: network_analytics_logs
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_network_analytics
+        type: text
+        title: "[Network Analytics][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: network_analytics_logs
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_network_analytics
+      - name: cloudflare_r2_network_analytics
         type: text
-        title: "[Network Analytics][S3] Non AWS Bucket Name"
+        title: "[Network Analytics][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_network_session }}
+non_aws_bucket_name: {{non_aws_bucket_name_network_session}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_network_session}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/network_session/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_network_session }}
-non_aws_bucket_name: {{non_aws_bucket_name_network_session}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_network_session }}
+non_aws_bucket_name: {{cloudflare_r2_network_session}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: network_session
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_network_session
+        type: text
+        title: "[Zero Trust Network Session][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: network_session
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_network_session
+      - name: cloudflare_r2_network_session
         type: text
-        title: "[Zero Trust Network Session][S3] Non AWS Bucket Name"
+        title: "[Zero Trust Network Session][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_sinkhole_http }}
-non_aws_bucket_name: {{non_aws_bucket_name_sinkhole_http}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_sinkhole_http }}
+non_aws_bucket_name: {{cloudflare_r2_sinkhole_http}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_sinkhole_http }}
+non_aws_bucket_name: {{non_aws_bucket_name_sinkhole_http}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_sinkhole_http}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: sinkhole_http
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_sinkhole_http
+      - name: cloudflare_r2_sinkhole_http
         type: text
-        title: "[Sinkhole HTTP][S3] Non AWS Bucket Name"
+        title: "[Sinkhole HTTP][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: sinkhole_http
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_sinkhole_http
+        type: text
+        title: "[Sinkhole HTTP][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_spectrum_event }}
-non_aws_bucket_name: {{non_aws_bucket_name_spectrum_event}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_spectrum_event }}
+non_aws_bucket_name: {{cloudflare_r2_spectrum_event}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_spectrum_event }}
+non_aws_bucket_name: {{non_aws_bucket_name_spectrum_event}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_spectrum_event}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 
@@ -68,18 +96,18 @@ proxy_url: {{proxy_url}}
 {{/if}}
 tags:
 {{#if collect_s3_logs}}
-  - collect_s3_logs
+- collect_s3_logs
 {{else}}
-  - collect_sqs_logs
+- collect_sqs_logs
 {{/if}}
 {{#if preserve_original_event}}
-  - preserve_original_event
+- preserve_original_event
 {{/if}}
 {{#if preserve_duplicate_custom_fields}}
-  - preserve_duplicate_custom_fields
+- preserve_duplicate_custom_fields
 {{/if}}
 {{#each tags as |tag|}}
-  - {{tag}}
+- {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}
 publisher_pipeline.disable_host: true

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: spectrum_event
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_spectrum_event
+        type: text
+        title: "[Spectrum Event][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: spectrum_event
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_spectrum_event
+      - name: cloudflare_r2_spectrum_event
         type: text
-        title: "[Spectrum Event][S3] Non AWS Bucket Name"
+        title: "[Spectrum Event][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
@@ -1,17 +1,40 @@
-{{#if collect_s3_logs}}
+{{! The aws-s3 input can be configured to read from an SQS queue or an S3 bucket. }}
 
-{{#if bucket_arn}}
-bucket_arn: {{bucket_arn}}
+{{!
+When using an S3 bucket, you can specify only one of the following options:
+- An AWS bucket ARN
+- A non-AWS bucket name
+}}
+
+{{#if collect_s3_logs}}
+{{! shared S3 bucket polling options }}
+{{#if number_of_workers }}
+number_of_workers: {{ number_of_workers }}
 {{/if}}
-{{#if number_of_workers}}
-number_of_workers: {{number_of_workers}}
+
+{{#if bucket_list_prefix }}
+bucket_list_prefix: {{ bucket_list_prefix }}
 {{/if}}
-{{#if interval}}
-bucket_list_interval: {{interval}}
+
+{{#if bucket_list_interval }}
+bucket_list_interval: {{ bucket_list_interval }}
 {{/if}}
-{{#if bucket_list_prefix}}
-bucket_list_prefix: {{bucket_list_prefix}}
+
+{{! AWS S3 bucket ARN options }}
+{{#unless non_aws_bucket_name}}
+{{#if bucket_arn }}
+bucket_arn: {{ bucket_arn }}
 {{/if}}
+{{/unless}}
+
+{{! non-AWS S3 bucket ARN options }}
+{{#unless bucket_arn}}
+{{#if non_aws_bucket_name_workers_trace }}
+non_aws_bucket_name: {{non_aws_bucket_name_workers_trace}}
+{{else if non_aws_bucket_name}}
+non_aws_bucket_name: {{non_aws_bucket_name}}
+{{/if}}
+{{/unless}}
 
 {{else}}
 
@@ -20,19 +43,24 @@ queue_url: {{queue_url_workers_trace}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}
+
 {{#if visibility_timeout}}
 visibility_timeout: {{visibility_timeout}}
 {{/if}}
+
 {{#if api_timeout}}
 api_timeout: {{api_timeout}}
 {{/if}}
+
 {{#if max_number_of_messages}}
 max_number_of_messages: {{max_number_of_messages}}
 {{/if}}
+
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
 {{/if}}
+{{! end SQS queue }}
 
 {{/if}}
 

--- a/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
@@ -29,10 +29,10 @@ bucket_arn: {{ bucket_arn }}
 
 {{! non-AWS S3 bucket ARN options }}
 {{#unless bucket_arn}}
-{{#if non_aws_bucket_name_workers_trace }}
-non_aws_bucket_name: {{non_aws_bucket_name_workers_trace}}
-{{else if non_aws_bucket_name}}
-non_aws_bucket_name: {{non_aws_bucket_name}}
+{{#if cloudflare_r2_workers_trace }}
+non_aws_bucket_name: {{cloudflare_r2_workers_trace}}
+{{else if cloudflare_r2}}
+non_aws_bucket_name: {{cloudflare_r2}}
 {{/if}}
 {{/unless}}
 

--- a/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/agent/stream/aws-s3.yml.hbs
@@ -116,3 +116,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -75,13 +75,13 @@ streams:
         show_user: true
         default: workers_trace
         description: Prefix to apply for the list request to the S3 bucket.
-      - name: non_aws_bucket_name_workers_trace
+      - name: cloudflare_r2_workers_trace
         type: text
-        title: "[Workers Trace Event][S3] Non AWS Bucket Name"
+        title: "[Workers Trace Event][S3] Cloudflare R2 Bucket Name"
         multi: false
         required: false
         show_user: true
-        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
+        description: "Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. It will override the global Cloudflare R2 Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -75,6 +75,13 @@ streams:
         show_user: true
         default: workers_trace
         description: Prefix to apply for the list request to the S3 bucket.
+      - name: non_aws_bucket_name_workers_trace
+        type: text
+        title: "[Workers Trace Event][S3] Non AWS Bucket Name"
+        multi: false
+        required: false
+        show_user: true
+        description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. It will override the global Non AWS Bucket Name if provided."
       - name: interval
         type: text
         title: '[S3] Interval'

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -92,7 +92,7 @@ This module has been tested against **Cloudflare version v4**.
 
 
 **Note**:
-- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI, tipically in the form of `https(s)://<accountid>.r2.cloudflarestorage.com`, that will be used as the API endpoint of the service.
 - This setting can be also used to ingest data from other S3-compatible storage services.
 
 ### To collect data from AWS SQS, follow the below steps:
@@ -4919,3 +4919,4 @@ An example event for `workers_trace` looks as following:
 | url.subdomain | The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain. For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
 | url.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | url.username | Username of the request. | keyword |
+

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -90,6 +90,10 @@ This module has been tested against **Cloudflare version v4**.
   | Spectrum Event             | spectrum_event         |
   | Workers Trace Events       | workers_trace          |
 
+
+**Note**:
+- It is possible to ingest data from a third-party S3 compatible service by setting the parameter `Non AWS Bucket Name`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -92,7 +92,8 @@ This module has been tested against **Cloudflare version v4**.
 
 
 **Note**:
-- It is possible to ingest data from a third-party S3 compatible service by setting the parameter `Non AWS Bucket Name`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- It is possible to ingest data from Cloudflare R2, an S3-compatible storage service, by setting the parameter `Cloudflare R2`. Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication, as well as the endpoint must be set to replace the default API endpoint. Endpoint should be a full URI in the form of `https(s)://<s3 endpoint>`, that will be used as the API endpoint of the service.
+- This setting can be also used to ingest data from other S3-compatible storage services.
 
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -96,8 +96,8 @@ policy_templates:
               #    sxSmbIUfc2SGJGCJD4I=
               #    -----END CERTIFICATE-----
       - type: aws-s3
-        title: Collect Cloudflare Logpush logs via AWS S3 or AWS SQS
-        description: Collecting Logpush logs from Cloudflare via AWS S3 or AWS SQS.
+        title: Collect Cloudflare Logpush logs via AWS S3, AWS SQS or Cloudflare R2
+        description: Collecting Logpush logs from Cloudflare via AWS S3, AWS SQS or Cloudflare R2.
         vars:
           - name: collect_s3_logs
             required: true
@@ -114,14 +114,14 @@ policy_templates:
             required: false
             show_user: true
             description: It is a required parameter for collecting logs via the AWS S3 Bucket.
-          - name: non_aws_bucket_name
+          - name: cloudflare_r2
             type: text
-            title: "[Global][S3] Non AWS Bucket Name"
+            title: "[Global][S3] Cloudflare R2 Bucket Name"
             multi: false
             required: false
             show_user: true
             description: |-
-              This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required.
+              Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required.
               Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the non-AWS S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint.
           - name: queue_url
             type: text

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -120,7 +120,9 @@ policy_templates:
             multi: false
             required: false
             show_user: true
-            description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required. \nUsing non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint."
+            description: |-
+              This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required.
+              Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the non-AWS S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint.
           - name: queue_url
             type: text
             title: "[Global][SQS] Queue URL"

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.15.0"
+version: "1.16.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:
@@ -114,6 +114,13 @@ policy_templates:
             required: false
             show_user: true
             description: It is a required parameter for collecting logs via the AWS S3 Bucket.
+          - name: non_aws_bucket_name
+            type: text
+            title: "[Global][S3] Non AWS Bucket Name"
+            multi: false
+            required: false
+            show_user: true
+            description: "This can replace Bucket ARN with a Bucket Name for collecting logs from a 3rd party S3 compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required. \nUsing non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint."
           - name: queue_url
             type: text
             title: "[Global][SQS] Queue URL"


### PR DESCRIPTION
## Proposed commit message

It exposes the `non_aws_bucket_name` of the AWS S3 input for the Cloudflare Logpush integration so users are able to collect logs from a 3rd party S3 bucket. Apart from the global setting, a local one for each data stream has been added so a different bucket can be set for each data stream.

See more about how to use the `non_aws_bucket_name` [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html).

The new parameter is called `Cloudflare R2 bucket name`, as Cloudflare R2 is the S3-compatible storage service that Cloudflare provides by default, so it is assumed to be the one used by its users. Nevertheless, it is also noted that the parameter can be used to specify any other S3-compliant service.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

<img width="757" alt="image" src="https://github.com/elastic/integrations/assets/29475387/052b9bb1-ee36-4a18-b4d4-8970cb144ff0">

