### PR TITLE
Migrate obs-infraobs-integrations to package-spec v3 #6

### DIFF
--- a/packages/sql_input/_dev/build/build.yml
+++ b/packages/sql_input/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: git@v8.7.0
-

--- a/packages/sql_input/changelog.yml
+++ b/packages/sql_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.5.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8203
 - version: "0.4.0"
   changes:
     - description: Add `condition` and `processors` settings.

--- a/packages/sql_input/fields/input.yml
+++ b/packages/sql_input/fields/input.yml
@@ -23,3 +23,4 @@
     - name: metrics.*
       description: Default mapping for metric fields. You need to add your own custom mappings when storing other kinds of information.
       type: object
+      object_type: keyword

--- a/packages/sql_input/manifest.yml
+++ b/packages/sql_input/manifest.yml
@@ -1,14 +1,16 @@
-format_version: 2.0.0
+format_version: "3.0.0"
 name: sql
 title: "SQL Input"
-version: "0.4.0"
+version: "0.5.0"
 description: "Collects Metrics by Quering on SQL Databases"
 type: input
 categories:
   - custom
 conditions:
-  kibana.version: "^8.8.0"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.8.0"
+  elastic:
+    subscription: "basic"
 icons:
   - src: /img/sql-server-icon.svg
     title: SQL logo
@@ -73,3 +75,4 @@ policy_templates:
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 owner:
   github: elastic/obs-infraobs-integrations
+  type: elastic

--- a/packages/statsd_input/_dev/build/build.yml
+++ b/packages/statsd_input/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: git@v8.7.0
-

--- a/packages/statsd_input/_dev/test/system/test-default-config.yml
+++ b/packages/statsd_input/_dev/test/system/test-default-config.yml
@@ -2,6 +2,6 @@ service_notify_signal: SIGHUP
 vars:
   listen_address: 0.0.0.0
   listen_port: 8125
-  data_stream.dataset: statsd_input.statsd
+  "data_stream.dataset": statsd_input.statsd
 assert:
   hit_count: 3

--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.3.0
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8203
 - version: "0.2.3"
   changes:
     - description: Improve documentation for the package.

--- a/packages/statsd_input/fields/input.yml
+++ b/packages/statsd_input/fields/input.yml
@@ -8,3 +8,4 @@
 - name: statsd.*.*
   description: Default mapping for metric fields. You need to add your own custom mappings when storing other kinds of information.
   type: object
+  object_type: keyword

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -1,14 +1,16 @@
-format_version: 2.0.0
+format_version: "3.0.0"
 name: statsd_input
 title: StatsD Input
-version: "0.2.3"
+version: "0.3.0"
 description: StatsD Input Package
 type: input
 categories:
   - observability
 conditions:
-  kibana.version: "^8.8.0"
-  elastic.subscription: "basic"
+  kibana:
+    version: "^8.8.0"
+  elastic:
+    subscription: "basic"
 icons:
   - src: /img/statsd.svg
     title: statsd
@@ -40,3 +42,4 @@ policy_templates:
         default: 8125
 owner:
   github: elastic/obs-infraobs-integrations
+  type: elastic


### PR DESCRIPTION
Follow discussion (from the PR these packages are pulled from as they were blocking changes getting merged for other packages): 
- https://github.com/elastic/integrations/pull/8203#discussion_r1365073934
- https://github.com/elastic/integrations/pull/8203#discussion_r1365074249

## Proposed commit message

Pulled out the following packages from https://github.com/elastic/integrations/pull/8203 as it is blocking package-spec v3 migration for other packages in that PR. As these packages have some confusion in their mappings, pulled out the changes to this branch.

- [x] statsd_input
- [x] sql_input

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
