### PR TITLE
[UDP/TCP] Add reroute processor support

### DIFF
--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update ES permissions to support reroute processors
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7920
+      link: https://github.com/elastic/integrations/pull/8294
 - version: 1.15.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.16.0
+  changes:
+    - description: Update ES permissions to support reroute processors
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7920
 - version: 1.15.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/tcp/data_stream/generic/manifest.yml
+++ b/packages/tcp/data_stream/generic/manifest.yml
@@ -129,5 +129,6 @@ streams:
         type: yaml
         default: ""
 # Ensures integrations works with reroute processors and have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true
+elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/packages/tcp/data_stream/generic/manifest.yml
+++ b/packages/tcp/data_stream/generic/manifest.yml
@@ -128,3 +128,6 @@ streams:
 
         type: yaml
         default: ""
+# Ensures integrations works with reroute processors and have permissions to write data to `logs-*-*`
+elasticsearch.dynamic_dataset: true
+elasticsearch.dynamic_namespace: true

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,7 +3,7 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: integration
-version: "1.15.0"
+version: "1.16.0"
 conditions:
   kibana:
     version: "^8.2.1"

--- a/packages/tcp/validation.yml
+++ b/packages/tcp/validation.yml
@@ -1,3 +1,3 @@
 errors:
   exclude_checks:
-    - SVR00005  # Kibana version for saved tags.
+    - SVR00005 # Kibana version for saved tags.

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update ES permissions to support reroute processors
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/7920
+      link: https://github.com/elastic/integrations/pull/8294
 - version: 1.15.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.16.0
+  changes:
+    - description: Update ES permissions to support reroute processors
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/7920
 - version: 1.15.0
   changes:
     - description: ECS version updated to 8.10.0.

--- a/packages/udp/data_stream/generic/manifest.yml
+++ b/packages/udp/data_stream/generic/manifest.yml
@@ -103,3 +103,6 @@ streams:
 
         type: yaml
         default: ""
+# Ensures integrations works with reroute processors and have permissions to write data to `logs-*-*`
+elasticsearch.dynamic_dataset: true
+elasticsearch.dynamic_namespace: true

--- a/packages/udp/data_stream/generic/manifest.yml
+++ b/packages/udp/data_stream/generic/manifest.yml
@@ -104,5 +104,6 @@ streams:
         type: yaml
         default: ""
 # Ensures integrations works with reroute processors and have permissions to write data to `logs-*-*`
-elasticsearch.dynamic_dataset: true
-elasticsearch.dynamic_namespace: true
+elasticsearch:
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,7 +3,7 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: integration
-version: "1.15.0"
+version: "1.16.0"
 conditions:
   kibana:
     version: "^8.2.1"

--- a/packages/udp/validation.yml
+++ b/packages/udp/validation.yml
@@ -1,3 +1,3 @@
 errors:
   exclude_checks:
-    - SVR00005  # Kibana version for saved tags.
+    - SVR00005 # Kibana version for saved tags.


### PR DESCRIPTION
## Proposed commit message

This PR adds two flags to the datastream manifest for the TCP and UDP input packages, which allows the use of reroute processors, this is similar to for example https://github.com/elastic/integrations/pull/6340/.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #6340 

