### PR TITLE
Fix issue 8309

### DIFF
--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.6.1"
+  changes:
+    - description: Fix azure signinlogs pipeline when using Azure ISV to ingest logs into Elastic
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.6.0"
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/azure/data_stream/signinlogs/elasticsearch/ingest_pipeline/default.yml
@@ -124,7 +124,7 @@ processors:
   - script:
       if: ctx?.event?.duration != null
       lang: painless
-      source: ctx.event.duration = ctx.event.duration * 1000000
+      source: ctx.event.duration = Long.parseLong(ctx.event.duration) * 1000000
   - rename:
       field: azure.signinlogs.location
       target_field: geo.country_iso_code


### PR DESCRIPTION
- Bug

Please explain:

- WHAT: fixes the pipeline issue with azure signinlogs
- WHY:  seemingly ctx.event.duration can come in as a string when using Azure ISV to ship logs to Elastic

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #8309