### PR TITLE
[etcd] Add metric_type mapping for leader dataset

### DIFF
--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.7.0
+  changes:
+    - description: Add metric_type mapping for leader datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add metric_type mapping for leader datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8330
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/data_stream/leader/fields/fields.yml
+++ b/packages/etcd/data_stream/leader/fields/fields.yml
@@ -15,10 +15,12 @@
                   fields:
                     - name: success
                       type: integer
+                      metric_type: counter
                       description: |
                         Successful Raft RPC requests
                     - name: fail
                       type: integer
+                      metric_type: counter
                       description: |
                         Failed Raft RPC requests
         - name: latency
@@ -32,14 +34,19 @@
                   fields:
                     - name: average
                       type: scaled_float
+                      metric_type: gauge
                     - name: current
                       type: scaled_float
+                      metric_type: gauge
                     - name: maximum
                       type: scaled_float
+                      metric_type: gauge
                     - name: minimum
                       type: integer
+                      metric_type: gauge
                     - name: standardDeviation
                       type: scaled_float
+                      metric_type: gauge
     - name: leader
       type: keyword
       description: |

--- a/packages/etcd/docs/README.md
+++ b/packages/etcd/docs/README.md
@@ -237,27 +237,27 @@ An example event for `leader` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| etcd.api_version | Etcd API version for metrics retrieval | keyword |
-| etcd.leader.followers.counts.followers.counts.fail | Failed Raft RPC requests | integer |
-| etcd.leader.followers.counts.followers.counts.success | Successful Raft RPC requests | integer |
-| etcd.leader.followers.latency.followers.latency.average |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.current |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.maximum |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.minimum |  | integer |
-| etcd.leader.followers.latency.followers.latency.standardDeviation |  | scaled_float |
-| etcd.leader.leader | ID of actual leader | keyword |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host.ip | Host ip addresses. | ip |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| etcd.api_version | Etcd API version for metrics retrieval | keyword |  |
+| etcd.leader.followers.counts.followers.counts.fail | Failed Raft RPC requests | integer | counter |
+| etcd.leader.followers.counts.followers.counts.success | Successful Raft RPC requests | integer | counter |
+| etcd.leader.followers.latency.followers.latency.average |  | scaled_float | gauge |
+| etcd.leader.followers.latency.followers.latency.current |  | scaled_float | gauge |
+| etcd.leader.followers.latency.followers.latency.maximum |  | scaled_float | gauge |
+| etcd.leader.followers.latency.followers.latency.minimum |  | integer | gauge |
+| etcd.leader.followers.latency.followers.latency.standardDeviation |  | scaled_float | gauge |
+| etcd.leader.leader | ID of actual leader | keyword |  |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 ### self

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: etcd
 title: etcd
-version: "0.6.0"
+version: "0.7.0"
 description: Collect metrics from etcd servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- Added metric_type mapping to leader datastream.
- To benefit from the TSDB enablement of the package.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry


## Related issues
- https://github.com/elastic/integrations/issues/8327 

## Screenshots


