### PR TITLE
[ci] Fix Jenkinsfile to use the json files for pipeline benchmarks reporting

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -194,14 +194,14 @@ def gitHubCommentWithBenchmarkReport() {
     }
     dir("${BASE_DIR}") {
       // download artifacts for this PR
-      def bucketUri = getBenchmarkBucketURI() + "*.xml"
+      def bucketUri = getBenchmarkBucketURI() + "*.json"
       log(level: 'INFO', text: "googleStorageDownload(bucketUri: ${bucketUri}, localDirectory: ${currentBenchmarkResults}, pathPrefix: ${getBenchmarkPathPrefix()})")
       googleStorageDownload(bucketUri: bucketUri, credentialsId: "${JOB_GCS_CREDENTIALS}", localDirectory: currentBenchmarkResults, pathPrefix: getBenchmarkPathPrefix())
 
       // download artifacts from the target branch if any
       if (env.CHANGE_TARGET) {
         try {
-          copyArtifacts(filter: "${currentBenchmarkResults}/*.xml", flatten: true, optional: true, projectName: getBaselineJobName(), selector: lastWithArtifacts(), target: baseline)
+          copyArtifacts(filter: "${currentBenchmarkResults}/*.json", flatten: true, optional: true, projectName: getBaselineJobName(), selector: lastWithArtifacts(), target: baseline)
         } catch(e) {
           log(level: 'INFO', text: 'gitHubCommentWithBenchmarkReport: it was not possible to copy the previous build.')
           return

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -398,7 +398,7 @@ def prepareStack() {
 }
 
 def stashBenchmarkResults() {
-  def wildcard = 'build/benchmark-results/*.xml'
+  def wildcard = 'build/benchmark-results/*.json'
   r = sh(label: "isBenchmarkResultsPresent", script: "ls ${wildcard}", returnStatus: true)
   if (r != 0) {
     echo "isBenchmarkResultsPresent: benchmark files not found, report won't be stashed"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Now benchmarks results are generated as JSON files, this changes Jenkinsfile to use these instead of the old XML ones.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
~- [ ] I have verified that all data streams collect metrics or logs.~
~- [ ] I have added an entry to my package's `changelog.yml` file.~
~- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

