### PR TITLE
[memcached]: Address skipped validation SVR00003

### DIFF
--- a/packages/memcached/changelog.yml
+++ b/packages/memcached/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Address SVR00003 validation skipped during package-spec v3 migration
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8347
 - version: 1.3.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/memcached/changelog.yml
+++ b/packages/memcached/changelog.yml
@@ -1,8 +1,8 @@
 # newer versions go on top
 - version: "1.3.1"
   changes:
-    - description: Address SVR00003 validation skipped during package-spec v3 migration
-      type: bugfix
+    - description: Remove dangling references from the dashboard
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/8347
 - version: 1.3.0
   changes:

--- a/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
+++ b/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
@@ -1069,16 +1069,6 @@
             "id": "metrics-*",
             "name": "5061237a-3a71-485a-be3f-5d8e629e579e:indexpattern-datasource-layer-09bed68a-54a8-41fe-8e2f-6937efc350b4",
             "type": "index-pattern"
-        },
-        {
-            "id": "memcached-fleet-managed-default",
-            "name": "tag-fleet-managed-default",
-            "type": "tag"
-        },
-        {
-            "id": "memcached-fleet-pkg-memcached-default",
-            "name": "tag-fleet-pkg-memcached-default",
-            "type": "tag"
         }
     ],
     "type": "dashboard"

--- a/packages/memcached/manifest.yml
+++ b/packages/memcached/manifest.yml
@@ -1,6 +1,6 @@
 name: memcached
 title: Memcached
-version: "1.3.0"
+version: "1.3.1"
 description: Memcached Integration
 type: integration
 categories:

--- a/packages/memcached/validation.yml
+++ b/packages/memcached/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
-    - SVR00003
     - SVR00002


### PR DESCRIPTION
I have written a Go program that is based on `ValiadateKibanaNoDanglingObjectIDs` lint from `package-spec` repository. It uses the same logic to find the dangling references and sets the correct parameters for yq to do in-place changes:

Example:
```sh
$ yq -i -I4 'del(.references.[] | .. | select(.id == "memcached-fleet-managed-default" and .type == "tag"))' kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
```

I'll soon push that program so that other teams can also use the same to remove any dangling object ids. Very easy to use.

## Proposed commit message

Address SVR00003 for memcached package i.e., removal of dangling object ids.

This is to address the skipped validation part of the package-spec v3 migration.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

Installs successfully and no obvious breakages in viz.

## Related issues

- Relates https://github.com/elastic/integrations/issues/8028