### PR TITLE
elastic/obs-infraobs-integrations: Address skipped validation SVR00002

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.14.2
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 0.14.1
   changes:
     - description: Add null and ignore_missing check to handle event.original field.

--- a/packages/activemq/kibana/dashboard/activemq-8a0cbc90-f916-11ec-9736-016ee09668f5.json
+++ b/packages/activemq/kibana/dashboard/activemq-8a0cbc90-f916-11ec-9736-016ee09668f5.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "activemq.broker"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "activemq.broker"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -188,29 +210,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "e97d1cb0-3237-4d6a-9bc7-8b7ab8c699d8",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -403,29 +403,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "ad66c61f-b23d-4d78-bd08-635474184598",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -574,29 +552,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "815a9769-bfaf-450b-a311-0207b9e77365",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -741,29 +697,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5d935ffb-7266-42d2-865f-1ac53d948841",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -905,29 +839,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "3e5315d2-5eee-4820-9888-47559e66e7da",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1069,29 +981,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "02acd0aa-8adb-4014-9db9-9558c7f7d209",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.broker"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.broker"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1165,6 +1055,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "0bb4a077-65fc-4d3a-a6e6-39a7ec01e01f:indexpattern-datasource-current-indexpattern",

--- a/packages/activemq/kibana/dashboard/activemq-bbc52920-f916-11ec-9736-016ee09668f5.json
+++ b/packages/activemq/kibana/dashboard/activemq-bbc52920-f916-11ec-9736-016ee09668f5.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "activemq.queue"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "activemq.queue"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -114,29 +136,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "c8604f14-b353-4db8-bf8c-98701a4c0946",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -300,29 +300,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1cf3f5a6-bf8a-46db-8f9d-d65622ff22dc",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -486,29 +464,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1db31480-1773-4a7d-b9a9-ba15e0f71294",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -672,29 +628,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a0b760e3-966a-4026-9d4c-4706b63407c2",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -858,29 +792,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a439e754-dc49-4c20-a75e-810bea2d0fa6",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1047,29 +959,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "96903449-d137-4061-8f2e-6537780d0165",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1228,29 +1118,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a148322d-089b-4075-aefb-2660b3b3aaa7",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1403,29 +1271,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5df6b602-4411-412a-9d97-ced633d98049",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.queue"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.queue"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1503,6 +1349,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "3157f297-1d10-4340-8286-c94da70d2d5b:indexpattern-datasource-current-indexpattern",

--- a/packages/activemq/kibana/dashboard/activemq-d3639bc0-f916-11ec-9736-016ee09668f5.json
+++ b/packages/activemq/kibana/dashboard/activemq-d3639bc0-f916-11ec-9736-016ee09668f5.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "activemq.topic"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "activemq.topic"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -112,29 +134,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a0f2c1c4-e554-4a3c-a060-25ca7f4c69db",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -297,29 +297,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5822cc9e-7a5e-4a4f-bbc5-e64330b2f59b",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -482,29 +460,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "71a6295f-638d-4f94-a819-52adbfcb15fc",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -666,29 +622,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "af7973f5-ab9c-4474-8081-65ac126aa3c2",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -850,29 +784,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "90bf8a4a-75c8-4f64-b7d3-dd810191bb48",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1038,29 +950,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "4805e448-794f-43a9-b532-0e0a8afac07e",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1217,29 +1107,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "b1d623e0-1409-481b-9bf4-25de926265e4",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1391,29 +1259,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "d67e0346-14d1-4bc9-aee4-9bb6ecc912a0",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.topic"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.topic"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1491,6 +1337,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "1e5e96e7-dd15-437b-831f-4801b211cdfe:indexpattern-datasource-current-indexpattern",

--- a/packages/activemq/kibana/dashboard/activemq-eac72840-f916-11ec-9736-016ee09668f5.json
+++ b/packages/activemq/kibana/dashboard/activemq-eac72840-f916-11ec-9736-016ee09668f5.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "activemq.audit"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "activemq.audit"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -100,29 +122,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "e5d9ec26-7d86-4df9-8ecd-47862f1f9932",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.audit"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.audit"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -273,29 +273,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "310394e7-ccf5-4fb3-82c9-268d5b38b5e2",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.audit"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.audit"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -380,6 +358,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "25ee5210-609e-4bad-b145-f3c1cd7d981c:indexpattern-datasource-current-indexpattern",

--- a/packages/activemq/kibana/dashboard/activemq-f98d0c50-f916-11ec-9736-016ee09668f5.json
+++ b/packages/activemq/kibana/dashboard/activemq-f98d0c50-f916-11ec-9736-016ee09668f5.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "activemq.log"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "activemq.log"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -100,29 +122,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "2dd569bf-38d9-40b7-85c6-3b86d0984c8a",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.log"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.log"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -299,27 +299,6 @@
                                             "log.level": "ERROR"
                                         }
                                     }
-                                },
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "f909fc3b-ab49-4307-896c-410d5042bd83",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "activemq.log"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "activemq.log"
-                                        }
-                                    }
                                 }
                             ],
                             "query": {
@@ -372,6 +351,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "b6bdc4b4-745a-4fa2-9928-9f7cb783f5b9:indexpattern-datasource-current-indexpattern",

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "0.14.1"
+version: "0.14.2"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:

--- a/packages/activemq/validation.yml
+++ b/packages/activemq/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Address SVR00002 validation skipped during package-spec v3 migration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "0.6.0"
   changes:
     - description: Update to Kibana 8.11 to support enhanced statsd implementation, and add system test cases.

--- a/packages/airflow/changelog.yml
+++ b/packages/airflow/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.6.1"
   changes:
-    - description: Address SVR00002 validation skipped during package-spec v3 migration
+    - description: Add global filter on data_stream.dataset to improve performance
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8348
 - version: "0.6.0"

--- a/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
+++ b/packages/airflow/kibana/dashboard/airflow-a3aa42d0-a465-11ed-9ff0-ab4dd59e4c75.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "airflow.statsd"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "airflow.statsd"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -914,6 +936,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "fd9c4a3c-6cf7-4d06-a859-cd1ac597b72b:indexpattern-datasource-layer-1f437331-dce0-4ea7-83b1-25f5af716cbb",

--- a/packages/airflow/manifest.yml
+++ b/packages/airflow/manifest.yml
@@ -1,6 +1,6 @@
 name: airflow
 title: Airflow
-version: "0.6.0"
+version: "0.6.1"
 description: Airflow Integration.
 type: integration
 format_version: "3.0.0"

--- a/packages/airflow/validation.yml
+++ b/packages/airflow/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Address SVR00002 validation skipped during package-spec v3 migration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 0.2.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "0.2.1"
   changes:
-    - description: Address SVR00002 validation skipped during package-spec v3 migration
+    - description: Add global filter on data_stream.dataset to improve performance
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8348
 - version: 0.2.0

--- a/packages/azure_functions/kibana/dashboard/azure_functions-5b40c9c0-33d4-11ee-8d85-2d7adebebd1b.json
+++ b/packages/azure_functions/kibana/dashboard/azure_functions-5b40c9c0-33d4-11ee-8d85-2d7adebebd1b.json
@@ -9,7 +9,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "azure.function"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "azure.function"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -2222,6 +2244,11 @@
         "dashboard": "8.7.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "58a522e8-acf6-4ad1-a5cc-a699ce9c26c0:indexpattern-datasource-layer-f6c3c469-2e64-4120-b144-997fb70575e2",

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: azure_functions
 title: "Azure Functions"
-version: "0.2.0"
+version: "0.2.1"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"

--- a/packages/azure_functions/validation.yml
+++ b/packages/azure_functions/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.10.1"
   changes:
-    - description: Address SVR00002 validation skipped during package-spec v3 migration
+    - description: Add global filter on data_stream.dataset to improve performance
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8348
 - version: 1.10.0

--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Address SVR00002 validation skipped during package-spec v3 migration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.10.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cassandra.metrics"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cassandra.metrics"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -176,32 +198,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "886877c1-b611-47a6-a744-15a02941b018",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "columns": [
@@ -554,29 +554,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "6d23911e-0983-4909-9678-ed97013196fd",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -714,32 +692,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1215e1ff-5606-4484-bf2c-bf1a24d0ebf4",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -898,32 +854,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "301014c4-00d1-4685-9cb8-20d370c691e6",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1083,32 +1017,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1797fb28-ed26-407f-9ba3-98e6d512b369",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1282,32 +1194,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "3740462a-7cfc-4ec7-9a22-d8325b93fa03",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1468,32 +1358,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1c8c960a-c931-4f35-ba88-4f3c9bad5181",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1653,32 +1521,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a32f2a0c-fd9f-4545-a362-5ef0da423138",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1955,32 +1801,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "4304fcdd-8834-43bc-a2c3-1e2359b69e88",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2185,32 +2009,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "b6f5adf6-7edc-4975-9274-f40614627d61",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2357,32 +2159,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1cf800da-1764-41e6-8bf3-e79d3b066a78",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2538,32 +2318,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "6f053a69-ca62-4cb0-89a1-a3652c434eae",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2705,32 +2463,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "4777a91a-3fee-44ee-8576-a9f92d31bbcc",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -2872,32 +2608,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "ef797281-7cfd-4afd-96b2-0ffe1ba6d72f",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3052,32 +2766,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "bea1c62b-4f2b-46f4-a6cc-4f8e44608515",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3237,32 +2929,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "f3ff6850-780d-4e21-a5f0-1ea72ebeefbd",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -3338,6 +3008,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "ea99aa96-c9cb-49a7-ac8e-9ed3461e3aef:indexpattern-datasource-layer-84e70f16-0200-46ec-b2d0-31534103e49f",

--- a/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-25b7d6d0-1c71-11ec-84f1-e1733c643874.json
@@ -351,32 +351,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "d4b251d7-e04c-4315-9be9-3355828498e3",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.metrics"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.metrics"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:cassandra.metrics)"
+                                "query": ""
                             },
                             "visualization": {
                                 "columns": [

--- a/packages/cassandra/kibana/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da.json
+++ b/packages/cassandra/kibana/dashboard/cassandra-49e4e6e0-cc54-11ec-8c59-ed6efced90da.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cassandra.log"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cassandra.log"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -125,32 +147,10 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "32a63ece-b6ce-4bc9-a426-a7d45555c74d",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "cassandra.log"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "cassandra.log"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "event.dataset : \"cassandra.log\" "
+                                "query": ""
                             },
                             "visualization": {
                                 "layers": [
@@ -218,6 +218,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "c70b222f-e779-42ed-bb48-ed7531aa00c0:indexpattern-datasource-layer-9e4b4d41-a619-4535-8e75-b7cfcf0a6fcb",

--- a/packages/cassandra/manifest.yml
+++ b/packages/cassandra/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cassandra
 title: Cassandra
-version: "1.10.0"
+version: "1.10.1"
 description: This Elastic integration collects logs and metrics from cassandra.
 type: integration
 categories:

--- a/packages/cassandra/validation.yml
+++ b/packages/cassandra/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.7.2"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "1.7.1"
   changes:
     - description: Add dimension field for container.id which was previously missed during package-spec v3 migration

--- a/packages/cockroachdb/kibana/dashboard/cockroachdb-e3ba0c30-9766-11e9-9eea-6f554992ec1f.json
+++ b/packages/cockroachdb/kibana/dashboard/cockroachdb-e3ba0c30-9766-11e9-9eea-6f554992ec1f.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "cockroachdb.status"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "cockroachdb.status"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1815,6 +1837,11 @@
         "dashboard": "8.4.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "2f4d0af4-077d-4012-9b3d-91e5ad9d0b78:indexpattern-datasource-layer-4e7c2d11-f5be-4c30-be93-9b0e061d2d75",

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: "1.7.1"
+version: "1.7.2"
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/cockroachdb/validation.yml
+++ b/packages/cockroachdb/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/coredns/changelog.yml
+++ b/packages/coredns/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.6.2
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 0.6.1
   changes:
     - description: Add null and ignore_missing check to handle event.original field.

--- a/packages/coredns/kibana/dashboard/coredns-8a1ad3ad-2439-452f-ae43-9e10fc076b7c.json
+++ b/packages/coredns/kibana/dashboard/coredns-8a1ad3ad-2439-452f-ae43-9e10fc076b7c.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "coredns.log"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "coredns.log"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -602,6 +624,11 @@
         "dashboard": "8.0.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "ea29d25a-43e9-4c64-b693-03e4c4ee2745:indexpattern-datasource-current-indexpattern",

--- a/packages/coredns/kibana/dashboard/coredns-8a1ad3ad-2439-452f-ae43-9e10fc076b7c.json
+++ b/packages/coredns/kibana/dashboard/coredns-8a1ad3ad-2439-452f-ae43-9e10fc076b7c.json
@@ -82,36 +82,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "coredns.log"
-                                        ],
-                                        "type": "phrases"
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "coredns.log"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -185,36 +156,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "coredns.log"
-                                        ],
-                                        "type": "phrases"
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "coredns.log"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -316,36 +258,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "coredns.log"
-                                        ],
-                                        "type": "phrases"
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "coredns.log"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -516,36 +429,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "indexRefName": "filter-index-pattern-0",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "coredns.log"
-                                        ],
-                                        "type": "phrases"
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "coredns.log"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""

--- a/packages/coredns/manifest.yml
+++ b/packages/coredns/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: coredns
 title: "CoreDNS"
-version: "0.6.1"
+version: "0.6.2"
 description: "Collect logs from CoreDNS instances with Elastic Agent."
 type: integration
 categories:

--- a/packages/coredns/validation.yml
+++ b/packages/coredns/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/couchdb/changelog.yml
+++ b/packages/couchdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.1.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/couchdb/kibana/dashboard/couchdb-53dd9860-f87b-11ec-ba64-15286f858e89.json
+++ b/packages/couchdb/kibana/dashboard/couchdb-53dd9860-f87b-11ec-ba64-15286f858e89.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "couchdb.server"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "couchdb.server"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -84,29 +106,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "61e5dff2-b44b-4d06-819f-47756ad02be7",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -429,29 +429,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "79a91bd3-9eb6-47ba-a017-cd72422f5ade",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -794,29 +772,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "74faf8fa-97b2-4756-8c31-407cd9e54684",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1595,29 +1551,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "7c887bde-083b-4f70-ae33-9e489b93bf55",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -2046,29 +1980,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "79749aaf-a0bf-42f2-8d26-fb15eae5cc59",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -2410,29 +2322,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "fd88c3b5-f12d-44a9-8f72-10870f8dc6c5",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -3646,29 +3536,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "a61348b9-ac2c-4137-812a-469522d87a4f",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "couchdb.server"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "couchdb.server"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -3947,6 +3815,11 @@
         "dashboard": "8.4.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "1d74aeb0-0420-4f3c-9eab-39af0c4a3c69:indexpattern-datasource-layer-cb22559d-6889-4103-b78f-64d0e9230d7a",

--- a/packages/couchdb/manifest.yml
+++ b/packages/couchdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: couchdb
 title: CouchDB
-version: "1.1.0"
+version: "1.1.1"
 description: Collect metrics from CouchDB with Elastic Agent.
 type: integration
 categories:

--- a/packages/couchdb/validation.yml
+++ b/packages/couchdb/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/golang/changelog.yml
+++ b/packages/golang/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "1.2.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/golang/kibana/dashboard/golang-a121edd0-8767-11ed-8520-df2d9ce4ab4e.json
+++ b/packages/golang/kibana/dashboard/golang-a121edd0-8767-11ed-8520-df2d9ce4ab4e.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "golang.heap"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "golang.heap"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -164,29 +186,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1bd73572-7c27-496c-b12c-412766a59c0c",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -324,29 +324,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "2aa48336-d8a4-4736-995a-4d75ddca56fc",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -636,29 +614,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "1e2f5876-5b62-4ee8-8c5b-35b98945e96c",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -849,29 +805,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "5f857e4b-360c-44f2-9247-db5b560b9045",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -1045,29 +979,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "d12512bd-9f47-40c3-83ed-30891eee9bd0",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -1233,29 +1145,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "03d1b546-3968-438a-8f79-95c5f6cbd6e6",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.heap"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.heap"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -1332,6 +1222,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "daf3ca73-64c5-4b66-9ac7-4def199244b8:indexpattern-datasource-layer-d7b05855-d158-4730-af2f-a13d024b8323",

--- a/packages/golang/kibana/dashboard/golang-c7732730-8b84-11ed-96d7-d70fe6fd6ac1.json
+++ b/packages/golang/kibana/dashboard/golang-c7732730-8b84-11ed-96d7-d70fe6fd6ac1.json
@@ -10,37 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "kibanaSavedObjectMeta": {
-                    "searchSourceJSON": {
-                        "filter": [
-                            {
-                                "$state": {
-                                    "store": "appState"
-                                },
-                                "meta": {
-                                    "alias": null,
-                                    "disabled": false,
-                                    "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                    "key": "data_stream.dataset",
-                                    "negate": false,
-                                    "params": {
-                                        "query": "golang.expvar"
-                                    },
-                                    "type": "phrase"
-                                },
-                                "query": {
-                                    "match_phrase": {
-                                        "data_stream.dataset": "golang.expvar"
-                                    }
-                                }
-                            }
-                        ],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "golang.expvar"
+                            },
+                            "type": "phrase"
+                        },
                         "query": {
-                            "language": "kuery",
-                            "query": ""
+                            "match_phrase": {
+                                "data_stream.dataset": "golang.expvar"
+                            }
                         }
                     }
-                },
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""

--- a/packages/golang/kibana/dashboard/golang-c7732730-8b84-11ed-96d7-d70fe6fd6ac1.json
+++ b/packages/golang/kibana/dashboard/golang-c7732730-8b84-11ed-96d7-d70fe6fd6ac1.json
@@ -10,7 +10,37 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "kibanaSavedObjectMeta": {
+                    "searchSourceJSON": {
+                        "filter": [
+                            {
+                                "$state": {
+                                    "store": "appState"
+                                },
+                                "meta": {
+                                    "alias": null,
+                                    "disabled": false,
+                                    "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                                    "key": "data_stream.dataset",
+                                    "negate": false,
+                                    "params": {
+                                        "query": "golang.expvar"
+                                    },
+                                    "type": "phrase"
+                                },
+                                "query": {
+                                    "match_phrase": {
+                                        "data_stream.dataset": "golang.expvar"
+                                    }
+                                }
+                            }
+                        ],
+                        "query": {
+                            "language": "kuery",
+                            "query": ""
+                        }
+                    }
+                },
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -91,29 +121,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "30bd0d62-712f-48c5-9cf1-55f9f58b8d16",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.expvar"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.expvar"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -222,29 +230,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "f658f2a0-350f-4da8-8d8e-f065cb0d4af0",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.expvar"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.expvar"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -373,29 +359,7 @@
                                     }
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "532b7f7f-25c7-4a69-828d-85c0d7fce53c",
-                                        "key": "event.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "golang.expvar"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "event.dataset": "golang.expvar"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -474,6 +438,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "25efbed7-f886-4d46-8e72-3faac6725e82:indexpattern-datasource-layer-8e423e62-b6b5-4916-9885-0da5e571c331",

--- a/packages/golang/manifest.yml
+++ b/packages/golang/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: golang
 title: Golang
-version: "1.2.0"
+version: "1.2.1"
 description: This Elastic integration collects metrics from Golang applications.
 type: integration
 categories:

--- a/packages/golang/validation.yml
+++ b/packages/golang/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/hadoop/changelog.yml
+++ b/packages/hadoop/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "1.5.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/hadoop/kibana/dashboard/hadoop-3e16f2c0-cd28-11ec-be30-1d9331f0b107.json
+++ b/packages/hadoop/kibana/dashboard/hadoop-3e16f2c0-cd28-11ec-be30-1d9331f0b107.json
@@ -9,7 +9,29 @@
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "hadoop.application"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "hadoop.application"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -611,6 +633,11 @@
     "id": "hadoop-3e16f2c0-cd28-11ec-be30-1d9331f0b107",
     "managed": false,
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "21b49c8e-4de0-4e5f-bd72-89f3dc794af1:indexpattern-datasource-layer-dcf6a578-de72-4570-9fd8-f157f6494eb8",

--- a/packages/hadoop/kibana/dashboard/hadoop-70125ec0-cf78-11ec-bc3e-6faca2b11df2.json
+++ b/packages/hadoop/kibana/dashboard/hadoop-70125ec0-cf78-11ec-bc3e-6faca2b11df2.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "hadoop.node_manager"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "hadoop.node_manager"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -517,6 +539,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "de277d30-051b-4343-b67b-b6b243c140f2:indexpattern-datasource-layer-b8ee20df-453e-488f-806e-6f4079a76be6",

--- a/packages/hadoop/kibana/dashboard/hadoop-c06fb680-cf76-11ec-bc3e-6faca2b11df2.json
+++ b/packages/hadoop/kibana/dashboard/hadoop-c06fb680-cf76-11ec-bc3e-6faca2b11df2.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "hadoop.namenode"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "hadoop.namenode"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -430,6 +452,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "hadoop-c4e16fe0-cf73-11ec-bc3e-6faca2b11df2",
             "name": "1f52942c-5657-4bab-8e38-5cf69692f448:panel_1f52942c-5657-4bab-8e38-5cf69692f448",

--- a/packages/hadoop/kibana/dashboard/hadoop-c06fb680-cf76-11ec-bc3e-6faca2b11df2.json
+++ b/packages/hadoop/kibana/dashboard/hadoop-c06fb680-cf76-11ec-bc3e-6faca2b11df2.json
@@ -15,14 +15,27 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                             "key": "data_stream.dataset",
                             "negate": false,
-                            "params": {
-                                "query": "hadoop.namenode"
-                            },
-                            "type": "phrase"
+                            "params": [
+                                "hadoop.namenode",
+                                "hadoop.datanode"
+                            ],
+                            "type": "phrases"
                         },
                         "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "hadoop.namenode"
+                            "bool": {
+                                "minimum_should_match": 1,
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "hadoop.namenode"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "hadoop.datanode"
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/packages/hadoop/kibana/dashboard/hadoop-cb235590-cd24-11ec-be30-1d9331f0b107.json
+++ b/packages/hadoop/kibana/dashboard/hadoop-cb235590-cd24-11ec-be30-1d9331f0b107.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "hadoop.cluster"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "hadoop.cluster"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1169,6 +1191,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "08fde296-94c6-4dbd-bd1f-77c67e0125e6:indexpattern-datasource-layer-35726819-8a70-4f5e-b150-1626c191f380",

--- a/packages/hadoop/manifest.yml
+++ b/packages/hadoop/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: hadoop
 title: Hadoop
-version: "1.5.0"
+version: "1.5.1"
 description: Collect metrics from Apache Hadoop with Elastic Agent.
 type: integration
 categories:

--- a/packages/hadoop/validation.yml
+++ b/packages/hadoop/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.4"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "1.17.3"
   changes:
     - description: Update documentation for custom log format processing.

--- a/packages/iis/kibana/dashboard/iis-2c171500-858b-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-2c171500-858b-11ea-91bc-ab084c7ec0e7.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "iis.webserver"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iis.webserver"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1673,6 +1695,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "1f700551-5464-467f-99ec-3b329e355195:indexpattern-datasource-layer-182147bc-f15e-4d7e-80f0-f63350a5b838",

--- a/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
+++ b/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "iis.access"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iis.access"
+                            }
+                        }
+                    }
+                ],
                 "highlightAll": true,
                 "query": {
                     "language": "kuery",
@@ -805,6 +827,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "iis-0ac17980-e1d8-11ec-baf0-970634a1784d",
             "name": "ec72819b-6985-4761-94ae-5d5fcc9e682a:panel_ec72819b-6985-4761-94ae-5d5fcc9e682a",

--- a/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
+++ b/packages/iis/kibana/dashboard/iis-4278ad30-fe16-11e7-a3b0-d13028918f9f.json
@@ -15,14 +15,27 @@
                             "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
                             "key": "data_stream.dataset",
                             "negate": false,
-                            "params": {
-                                "query": "iis.access"
-                            },
-                            "type": "phrase"
+                            "params": [
+                                "iis.access",
+                                "iis.error"
+                            ],
+                            "type": "phrases"
                         },
                         "query": {
-                            "match_phrase": {
-                                "data_stream.dataset": "iis.access"
+                            "bool": {
+                                "minimum_should_match": 1,
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "iis.access"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "iis.error"
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-4b975820-85a1-11ea-91bc-ab084c7ec0e7.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "iis.website"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iis.website"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -2559,6 +2581,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "d366a32e-1ed5-4089-82b4-e9e34b674c43:indexpattern-datasource-layer-ed85fb90-3616-4a1a-91e7-4baa6c2f0e6d",

--- a/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-b4108810-861c-11ea-91bc-ab084c7ec0e7.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "iis.application_pool"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iis.application_pool"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1251,6 +1273,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "5cb9f7e0-eb7c-4a40-8746-bf7a38f005f5:indexpattern-datasource-layer-180189b1-7216-4cf8-a803-95b53c2f6e40",

--- a/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
+++ b/packages/iis/kibana/dashboard/iis-ebc23240-8572-11ea-91bc-ab084c7ec0e7.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "iis.webserver"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "iis.webserver"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1788,6 +1810,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "df67a70e-5ca5-4822-9abf-98f68987176b:indexpattern-datasource-layer-7d537da3-5163-404f-8219-5848d516628c",

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: "1.17.3"
+version: "1.17.4"
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/iis/validation.yml
+++ b/packages/iis/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
-    - SVR00002
     - SVR00004

--- a/packages/influxdb/changelog.yml
+++ b/packages/influxdb/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 0.7.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/influxdb/kibana/dashboard/influxdb-6382b060-1eb0-11ed-8cd7-b31b0e0c177f.json
+++ b/packages/influxdb/kibana/dashboard/influxdb-6382b060-1eb0-11ed-8cd7-b31b0e0c177f.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "influxdb.advstatus"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "influxdb.advstatus"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1650,6 +1672,11 @@
         "dashboard": "8.6.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "c2056724-c40b-48ca-958e-8dd52060ea71:indexpattern-datasource-layer-398b1ceb-409e-4bdf-b966-7393c1894cd3",

--- a/packages/influxdb/kibana/dashboard/influxdb-ccddb0c0-276e-11ed-8cd7-b31b0e0c177f.json
+++ b/packages/influxdb/kibana/dashboard/influxdb-ccddb0c0-276e-11ed-8cd7-b31b0e0c177f.json
@@ -3,7 +3,29 @@
         "description": "Influxdb database status metrics dashboard",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "influxdb.status"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "influxdb.status"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1804,6 +1826,11 @@
         "dashboard": "8.6.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "f3cb70cd-b289-4323-88a1-228a71eb2fa6:indexpattern-datasource-layer-b6955c61-f2a1-40ae-bfed-b399db73b8c3",

--- a/packages/influxdb/manifest.yml
+++ b/packages/influxdb/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: influxdb
 title: "InfluxDb"
-version: "0.7.0"
+version: "0.7.1"
 description: "Collect metrics from Influxdb database"
 type: integration
 categories:

--- a/packages/influxdb/validation.yml
+++ b/packages/influxdb/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: "1.11.0"
   changes:
     - description: Add missing SSL fields to agent config.

--- a/packages/kafka/kibana/dashboard/kafka-943caca0-87ee-11e7-ad9c-db80de0bf8d3.json
+++ b/packages/kafka/kibana/dashboard/kafka-943caca0-87ee-11e7-ad9c-db80de0bf8d3.json
@@ -3,7 +3,29 @@
         "description": "Logs Kafka integration dashboard",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "kafka.log"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "kafka.log"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -333,31 +355,7 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "0d3f3d8b-6a25-4de7-9fc3-2640ac541625",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kafka.log"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": {
-                                                "query": "kafka.log"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -462,6 +460,11 @@
         "dashboard": "8.7.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "logs-*",
             "name": "1:indexpattern-datasource-layer-d74d8027-0eee-45ec-941d-5e9e0b4e4ee9",

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: kafka
 title: Kafka
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/kafka/validation.yml
+++ b/packages/kafka/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
-    - SVR00002
     - SVR00004

--- a/packages/kafka/validation.yml
+++ b/packages/kafka/validation.yml
@@ -1,3 +1,4 @@
 errors:
   exclude_checks:
+    - SVR00002
     - SVR00004

--- a/packages/memcached/changelog.yml
+++ b/packages/memcached/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.3.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
+++ b/packages/memcached/kibana/dashboard/memcached-a36fa0b0-eccf-11ec-b66b-6bfdc9ecc703.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "memcached.stats"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "memcached.stats"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -1030,6 +1052,11 @@
         "dashboard": "8.5.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "555d1c56-312e-4267-8eea-95ccb985af39:indexpattern-datasource-layer-0b4a67e5-9927-450e-b80a-d8e4d960ec81",

--- a/packages/memcached/manifest.yml
+++ b/packages/memcached/manifest.yml
@@ -1,6 +1,6 @@
 name: memcached
 title: Memcached
-version: "1.3.0"
+version: "1.3.1"
 description: Memcached Integration
 type: integration
 categories:

--- a/packages/traefik/changelog.yml
+++ b/packages/traefik/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.11.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.11.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/traefik/kibana/dashboard/traefik-Logs-Traefik-Dashboard.json
+++ b/packages/traefik/kibana/dashboard/traefik-Logs-Traefik-Dashboard.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "traefik.access"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "traefik.access"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -119,7 +141,7 @@
                             "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(data_stream.dataset:traefik.access)"
+                                "query": ""
                             },
                             "visualization": {
                                 "gridlinesVisibilitySettings": {
@@ -647,7 +669,7 @@
                             "filters": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset:traefik.access"
+                                "query": ""
                             },
                             "visualization": {
                                 "fittingFunction": "Linear",
@@ -724,6 +746,11 @@
         "dashboard": "8.0.0"
     },
     "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "traefik-71eaad00-e257-11ec-baf0-970634a1784d",
             "name": "121accaa-e45e-414b-b9a3-f73fba06cf83:panel_121accaa-e45e-414b-b9a3-f73fba06cf83",

--- a/packages/traefik/manifest.yml
+++ b/packages/traefik/manifest.yml
@@ -1,6 +1,6 @@
 name: traefik
 title: Traefik
-version: "1.11.0"
+version: "1.11.1"
 description: Collect logs and metrics from Traefik servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/traefik/validation.yml
+++ b/packages/traefik/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.1.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/websphere_application_server/kibana/dashboard/websphere_application_server-381af9f0-bae2-11ec-b244-51e5cddeab04.json
+++ b/packages/websphere_application_server/kibana/dashboard/websphere_application_server-381af9f0-bae2-11ec-b244-51e5cddeab04.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "websphere_application_server.threadpool"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "websphere_application_server.threadpool"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -277,6 +299,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "websphere_application_server-43d23d70-baed-11ec-b244-51e5cddeab04",
             "name": "b007e627-23d4-4328-b064-3877c40ca3c3:panel_b007e627-23d4-4328-b064-3877c40ca3c3",

--- a/packages/websphere_application_server/kibana/dashboard/websphere_application_server-5d9b0860-b582-11ec-89b4-c91c947c1fb3.json
+++ b/packages/websphere_application_server/kibana/dashboard/websphere_application_server-5d9b0860-b582-11ec-89b4-c91c947c1fb3.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "websphere_application_server.jdbc"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "websphere_application_server.jdbc"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -106,6 +128,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "websphere_application_server-37972440-b49d-11ec-9a7c-ef3101c300f1",
             "name": "afecf39d-0a9d-4d47-9ad4-c85a8e0efc99:panel_afecf39d-0a9d-4d47-9ad4-c85a8e0efc99",

--- a/packages/websphere_application_server/kibana/dashboard/websphere_application_server-b8da46b0-b595-11ec-888d-b1230de080fd.json
+++ b/packages/websphere_application_server/kibana/dashboard/websphere_application_server-b8da46b0-b595-11ec-888d-b1230de080fd.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "websphere_application_server.servlet"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "websphere_application_server.servlet"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -76,6 +98,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "websphere_application_server-39c70fd0-b59e-11ec-888d-b1230de080fd",
             "name": "310de529-9ca0-46bd-b1cc-223c1a51cb38:panel_310de529-9ca0-46bd-b1cc-223c1a51cb38",

--- a/packages/websphere_application_server/kibana/dashboard/websphere_application_server-db548380-c06d-11ec-8552-f3dc1a6b95f9.json
+++ b/packages/websphere_application_server/kibana/dashboard/websphere_application_server-db548380-c06d-11ec-8552-f3dc1a6b95f9.json
@@ -10,7 +10,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "websphere_application_server.session_manager"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "websphere_application_server.session_manager"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -103,6 +125,11 @@
         "dashboard": "8.3.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "websphere_application_server-f28f6670-c07a-11ec-8552-f3dc1a6b95f9",
             "name": "19872277-f696-4e82-a0d0-3a84dbc246e6:panel_19872277-f696-4e82-a0d0-3a84dbc246e6",

--- a/packages/websphere_application_server/manifest.yml
+++ b/packages/websphere_application_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: websphere_application_server
 title: WebSphere Application Server
-version: "1.1.0"
+version: "1.1.1"
 description: Collects metrics from IBM WebSphere Application Server with Elastic Agent.
 type: integration
 categories:

--- a/packages/websphere_application_server/validation.yml
+++ b/packages/websphere_application_server/validation.yml
@@ -1,4 +1,3 @@
 errors:
   exclude_checks:
     - SVR00004
-    - SVR00002

--- a/packages/zookeeper/changelog.yml
+++ b/packages/zookeeper/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Add global filter on data_stream.dataset to improve performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8348
 - version: 1.10.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/zookeeper/kibana/dashboard/zookeeper-467207a0-231e-11e9-bb66-8baac426dfd4.json
+++ b/packages/zookeeper/kibana/dashboard/zookeeper-467207a0-231e-11e9-bb66-8baac426dfd4.json
@@ -4,7 +4,29 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "zookeeper.mntr"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "zookeeper.mntr"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -959,6 +981,11 @@
         "dashboard": "8.2.0"
     },
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "1:indexpattern-datasource-current-indexpattern",

--- a/packages/zookeeper/manifest.yml
+++ b/packages/zookeeper/manifest.yml
@@ -1,6 +1,6 @@
 name: zookeeper
 title: ZooKeeper Metrics
-version: "1.10.0"
+version: "1.10.1"
 description: Collect metrics from ZooKeeper service with Elastic Agent.
 type: integration
 icons:

--- a/packages/zookeeper/validation.yml
+++ b/packages/zookeeper/validation.yml
@@ -1,3 +1,0 @@
-errors:
-  exclude_checks:
-    - SVR00002


### PR DESCRIPTION
I'll break down the relevant parts of the filter added in the dashboards (a filter looks like this when exported):

```json
"filter": [
    {
        "$state": {
            "store": "appState"
        },
        "meta": {
            "alias": null,
            "disabled": false,
            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
            "key": "data_stream.dataset",
            "negate": false,
            "params": {
                "query": "airflow.statsd"
            },
            "type": "phrase"
        },
        "query": {
            "match_phrase": {
                "data_stream.dataset": "airflow.statsd"
            }
        }
    }
],
```

- "filter": An array containing filter configurations used to narrow down data in visualizations or dashboards.

    - "meta": Metadata about the filter.
        - "indexRefName": A reference to an index pattern. It's set to "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index" and points to the index pattern associated with the filter. If there are already a few filters, depends on the position [0] can change. But as SVR00002 means there's no filter there in the filter configuration, it would always be [0] in our case.
        - "key": The field on which the filter operates, specified as "data_stream.dataset".
        - "params": Contains filter-specific parameters. It includes a "query" parameter with a value of "airflow.statsd", indicating that the filter matches data where the "data_stream.dataset" field equals "airflow.statsd".
        - "type": Specifies the filter type, set to "phrase", indicating it's a phrase filter. ([ref](https://www.elastic.co/guide/en/beats/packetbeat/current/kibana-queries-filters.html#_string_queries))

    - "query": Defines the filter's query, which is a "match_phrase" query matching the "data_stream.dataset" field with the value "airflow.statsd".

This filter is used to filter data within a Kibana dashboard based on the "data_stream.dataset" field and the phrase "airflow.statsd". The "indexRefName" references the index pattern associated with the filter, allowing you to specify the index-pattern within the dashboard where the filter applies.


Reference added for `kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index`
```json
{
            "id": "metrics-*",
            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
            "type": "index-pattern"
},
```

- "id": This specifies the ID of the reference. Contains the index-pattern.

- "name": This specifies the name of the reference. This name is a reference to the index pattern associated with the filter in the dashboard's search source configuration defined earlier.

- "type": This indicates the type of the reference. Reference is associated with an index pattern i.e., metric-*


You can associate an index pattern with the filter in the dashboard and enable the dashboard to use data from that specific index pattern when rendering visualizations.

How each filter is added per dashboard:

- Check the dataset types (logs or metrics) and based on that decide the index-pattern (also other references in the dashboard gives a clue)
- Check the fields used in the dashboard (they belong to which dataset)
- If per dashboard, only a single dataset is used then add a global filter for that dataset and add the reference.

Note: All filters were added manually. I also checked with older stack versions 8.0.0, 8.3.0, etc. to see how the filters are being added. Didn't use elastic-package's export dashboards as it changes a lot more things which would make it very hard to review. Out of all packages that have SVR00002, the lowest kibana.version in the manifest is 8.0.0 and that's why patterns of the filters are checked only until 8.0.0.

Please also see https://github.com/elastic/integrations/pull/8348#issuecomment-1790196842  before reviewing as I have written some rough notes which might be helpful.

## Proposed commit message

Add a global filter to the dashboard and remove the subfilters on the dataset and a global filter on the dataset is introduced. Filters on data_stream.dataset are applied with a phrase type filter on the dataset that is being used in that particular dashboard.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Do a sampling and pick packages. Test them by adding some data to see if all viz are working as expected. Need help from reviewers on this to distribute work.

## Related issues

Relates https://github.com/elastic/integrations/issues/8028