### PR TITLE
[Kubernetes] Update K8s version for 1.28 compatibility

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     HOME = "${env.WORKSPACE}"
     DOCKER_COMPOSE_VERSION = "v2.17.2"
     KIND_VERSION = "v0.20.0"
-    K8S_VERSION = "v1.27.3"
+    K8S_VERSION = "v1.28.0"
     JOB_GCS_BUCKET = 'fleet-ci-temp'
     JOB_GCS_BUCKET_INTERNAL = 'fleet-ci-temp-internal'
     JOB_GCS_CREDENTIALS = 'fleet-ci-gcs-plugin'

--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -99,7 +99,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.25.x - 1.27.x] versions
+The Kubernetes package is tested with Kubernetes [1.26.x - 1.28.x] versions
 
 ## Dashboard
 

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -99,7 +99,7 @@ This defaults to `/var/log/kubernetes/kube-apiserver-audit.log`.
 
 ## Compatibility
 
-The Kubernetes package is tested with Kubernetes [1.25.x - 1.27.x] versions
+The Kubernetes package is tested with Kubernetes [1.26.x - 1.28.x] versions
 
 ## Dashboard
 


### PR DESCRIPTION
## What does this PR do?

Add support for Kubernetes latest version 1.28.

## Related issues

https://github.com/elastic/observability-dev/issues/2802