### PR TITLE
[etcd] Add metric type mapping for metrics dataset

### DIFF
--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add metric_type mapping for metrics datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8351
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.7.1
+  changes:
+    - description: Add metric_type mapping for metrics datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/data_stream/metrics/fields/fields.yml
+++ b/packages/etcd/data_stream/metrics/fields/fields.yml
@@ -6,30 +6,37 @@
       fields:
         - name: mvcc_db_total_size.bytes
           type: long
+          metric_type: gauge
           description: |
             Size of stored data at MVCC
         - name: wal_fsync_duration.ns.bucket.*
           type: long
+          metric_type: counter
           description: |
             Latency for writing ahead logs to disk
         - name: wal_fsync_duration.ns.count
           type: long
+          metric_type: counter
           description: |
             Write ahead logs count
         - name: wal_fsync_duration.ns.sum
           type: long
+          metric_type: counter
           description: |
             Write ahead logs latency sum
         - name: backend_commit_duration.ns.bucket.*
           type: long
+          metric_type: counter
           description: |
             Latency for writing backend changes to disk
         - name: backend_commit_duration.ns.count
           type: long
+          metric_type: counter
           description: |
             Backend commits count
         - name: backend_commit_duration.ns.sum
           type: long
+          metric_type: counter
           description: |
             Backend commits latency sum
     - name: memory
@@ -40,6 +47,7 @@
           fields:
             - name: bytes
               type: long
+              metric_type: gauge
               description: |
                 Memory allocated bytes as of MemStats Go
     - name: network
@@ -50,6 +58,7 @@
           fields:
             - name: bytes
               type: long
+              metric_type: counter
               description: |
                 gRPC sent bytes total
         - name: client_grpc_received
@@ -57,6 +66,7 @@
           fields:
             - name: bytes
               type: long
+              metric_type: counter
               description: |
                 gRPC received bytes total
     - name: server
@@ -64,6 +74,7 @@
       fields:
         - name: has_leader
           type: byte
+          metric_type: gauge
           description: |
             Whether a leader exists in the cluster
         - name: leader_changes
@@ -71,6 +82,7 @@
           fields:
             - name: count
               type: long
+              metric_type: counter
               description: |
                 Number of leader changes seen at the cluster
         - name: proposals_committed
@@ -78,6 +90,7 @@
           fields:
             - name: count
               type: long
+              metric_type: gauge
               description: |
                 Number of consensus proposals commited
         - name: proposals_pending
@@ -85,6 +98,7 @@
           fields:
             - name: count
               type: long
+              metric_type: gauge
               description: |
                 Number of consensus proposals pending
         - name: proposals_failed
@@ -92,6 +106,7 @@
           fields:
             - name: count
               type: long
+              metric_type: counter
               description: |
                 Number of consensus proposals failed
         - name: grpc_started
@@ -99,6 +114,7 @@
           fields:
             - name: count
               type: long
+              metric_type: counter
               description: |
                 Number of sent gRPC requests
         - name: grpc_handled
@@ -106,5 +122,6 @@
           fields:
             - name: count
               type: long
+              metric_type: counter
               description: |
                 Number of received gRPC requests

--- a/packages/etcd/docs/README.md
+++ b/packages/etcd/docs/README.md
@@ -172,36 +172,36 @@ An example event for `metrics` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type |
-|---|---|---|
-| @timestamp | Event timestamp. | date |
-| data_stream.dataset | Data stream dataset. | constant_keyword |
-| data_stream.namespace | Data stream namespace. | constant_keyword |
-| data_stream.type | Data stream type. | constant_keyword |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
-| etcd.api_version | Etcd API version for metrics retrieval | keyword |
-| etcd.disk.backend_commit_duration.ns.bucket.\* | Latency for writing backend changes to disk | long |
-| etcd.disk.backend_commit_duration.ns.count | Backend commits count | long |
-| etcd.disk.backend_commit_duration.ns.sum | Backend commits latency sum | long |
-| etcd.disk.mvcc_db_total_size.bytes | Size of stored data at MVCC | long |
-| etcd.disk.wal_fsync_duration.ns.bucket.\* | Latency for writing ahead logs to disk | long |
-| etcd.disk.wal_fsync_duration.ns.count | Write ahead logs count | long |
-| etcd.disk.wal_fsync_duration.ns.sum | Write ahead logs latency sum | long |
-| etcd.memory.go_memstats_alloc.bytes | Memory allocated bytes as of MemStats Go | long |
-| etcd.network.client_grpc_received.bytes | gRPC received bytes total | long |
-| etcd.network.client_grpc_sent.bytes | gRPC sent bytes total | long |
-| etcd.server.grpc_handled.count | Number of received gRPC requests | long |
-| etcd.server.grpc_started.count | Number of sent gRPC requests | long |
-| etcd.server.has_leader | Whether a leader exists in the cluster | byte |
-| etcd.server.leader_changes.count | Number of leader changes seen at the cluster | long |
-| etcd.server.proposals_committed.count | Number of consensus proposals commited | long |
-| etcd.server.proposals_failed.count | Number of consensus proposals failed | long |
-| etcd.server.proposals_pending.count | Number of consensus proposals pending | long |
-| event.dataset | Event dataset | constant_keyword |
-| event.module | Event module | constant_keyword |
-| host.ip | Host ip addresses. | ip |
-| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |
+| Field | Description | Type | Metric Type |
+|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |
+| data_stream.type | Data stream type. | constant_keyword |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
+| etcd.api_version | Etcd API version for metrics retrieval | keyword |  |
+| etcd.disk.backend_commit_duration.ns.bucket.\* | Latency for writing backend changes to disk | long | counter |
+| etcd.disk.backend_commit_duration.ns.count | Backend commits count | long | counter |
+| etcd.disk.backend_commit_duration.ns.sum | Backend commits latency sum | long | counter |
+| etcd.disk.mvcc_db_total_size.bytes | Size of stored data at MVCC | long | gauge |
+| etcd.disk.wal_fsync_duration.ns.bucket.\* | Latency for writing ahead logs to disk | long | counter |
+| etcd.disk.wal_fsync_duration.ns.count | Write ahead logs count | long | counter |
+| etcd.disk.wal_fsync_duration.ns.sum | Write ahead logs latency sum | long | counter |
+| etcd.memory.go_memstats_alloc.bytes | Memory allocated bytes as of MemStats Go | long | gauge |
+| etcd.network.client_grpc_received.bytes | gRPC received bytes total | long | counter |
+| etcd.network.client_grpc_sent.bytes | gRPC sent bytes total | long | counter |
+| etcd.server.grpc_handled.count | Number of received gRPC requests | long | counter |
+| etcd.server.grpc_started.count | Number of sent gRPC requests | long | counter |
+| etcd.server.has_leader | Whether a leader exists in the cluster | byte | gauge |
+| etcd.server.leader_changes.count | Number of leader changes seen at the cluster | long | counter |
+| etcd.server.proposals_committed.count | Number of consensus proposals commited | long | gauge |
+| etcd.server.proposals_failed.count | Number of consensus proposals failed | long | counter |
+| etcd.server.proposals_pending.count | Number of consensus proposals pending | long | gauge |
+| event.dataset | Event dataset | constant_keyword |  |
+| event.module | Event module | constant_keyword |  |
+| host.ip | Host ip addresses. | ip |  |
+| service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
 
 
 ### leader

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: etcd
 title: etcd
-version: "0.6.0"
+version: "0.7.1"
 description: Collect metrics from etcd servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.3.0"
+    version: "^8.9.0"
   elastic:
     subscription: basic
 icons:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- Added metric_type mapping to leader datastream.
- To benefit from the TSDB enablement of the package.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry


## Related issues
- https://github.com/elastic/integrations/issues/8327 

## Screenshots


