### PR TITLE
[Cisco Meraki] Simplify ipflows pipeline to cover ICMP events

### DIFF
--- a/packages/cisco_meraki/changelog.yml
+++ b/packages/cisco_meraki/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Simplify IPflows pipeline to cover ICMP events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8354
 - version: "1.17.1"
   changes:
     - description: Add missing `client.as.*` field definitions.

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-airmarshal-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-airmarshal-events.log-expected.json
@@ -22,7 +22,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479604.334549372 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='6A:3A:3E:85:D9:F6' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='23' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479604.334549372 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='6A:3A:3E:85:D9:F6' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='23' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -69,7 +69,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479580.487048774 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='35' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479580.487048774 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='35' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -116,7 +116,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479552.047395997 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='14' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479552.047395997 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='14' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -164,7 +164,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479537.315779167 MX84_1 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='E2:CB:9C:B5:DD:BE' channel='1' rssi='15' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479537.315779167 MX84_1 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='E2:CB:9C:B5:DD:BE' channel='1' rssi='15' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -206,7 +206,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479528.067423267 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='15' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479528.067423267 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='15' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -253,7 +253,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479493.484285651 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='15' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479493.484285651 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='15' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -301,7 +301,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479489.882680227 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='18' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479489.882680227 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='18' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -348,7 +348,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479484.972992227 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='39' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479484.972992227 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='39' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -395,7 +395,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479466.965046920 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='24' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479466.965046920 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='24' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -443,7 +443,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479461.791503607 MX84_6 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='AE:17:E8:C7:DF:FD' channel='11' rssi='10' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479461.791503607 MX84_6 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='AE:17:E8:C7:DF:FD' channel='11' rssi='10' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -485,7 +485,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479459.181348678 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='14' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479459.181348678 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='14' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -532,7 +532,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479456.670048547 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='16' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479456.670048547 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='16' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -579,7 +579,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479445.786718001 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='6A:3A:3E:85:D9:F6' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='11' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479445.786718001 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='6A:3A:3E:85:D9:F6' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='11' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -627,7 +627,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479442.047436097 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='20' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479442.047436097 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='20' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -674,7 +674,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479399.287689295 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='22' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479399.287689295 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='22' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -721,7 +721,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479376.407283267 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479376.407283267 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -768,7 +768,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479375.390251687 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='24' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479375.390251687 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='24' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -815,7 +815,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479371.594697827 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479371.594697827 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -862,7 +862,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479356.473299205 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='78:55:CD:18:8F:76' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479356.473299205 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='78:55:CD:18:8F:76' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -911,7 +911,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479354.489175845 MX84_6 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='78:28:CA:AA:6A:4A' channel='11' rssi='12' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479354.489175845 MX84_6 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='78:28:CA:AA:6A:4A' channel='11' rssi='12' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -953,7 +953,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479353.446408965 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='9' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479353.446408965 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='9' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1000,7 +1000,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479352.553639439 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='33' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479352.553639439 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='33' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1048,7 +1048,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479350.428006877 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='15' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479350.428006877 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='15' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1096,7 +1096,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479350.457045605 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479350.457045605 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1144,7 +1144,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479346.794313756 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='AE:17:E8:C7:D8:51' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='18' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479346.794313756 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='AE:17:E8:C7:D8:51' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='18' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1191,7 +1191,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479345.577452767 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='E2:CB:9C:B5:D4:1E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='30' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479345.577452767 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='E2:CB:9C:B5:D4:1E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='30' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1239,7 +1239,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479341.816936841 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='33' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479341.816936841 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='33' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1286,7 +1286,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479318.128184987 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='5C:AA:FD:5D:76:0E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='22' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479318.128184987 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='5C:AA:FD:5D:76:0E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='22' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1334,7 +1334,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479313.473165785 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='25' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479313.473165785 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='25' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1382,7 +1382,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479299.143407174 MX84_2 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='78:28:CA:AA:6A:0A' channel='1' rssi='21' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479299.143407174 MX84_2 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='78:28:CA:AA:6A:0A' channel='1' rssi='21' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1424,7 +1424,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479299.115949027 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='32' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479299.115949027 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='32' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1471,7 +1471,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479294.302067007 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='27' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479294.302067007 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='27' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1518,7 +1518,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479288.469042416 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='0E:8D:FB:70:0F:A8' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='7' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479288.469042416 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='0E:8D:FB:70:0F:A8' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='7' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1565,7 +1565,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479281.848397134 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:DF:FD' src='AA:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479281.848397134 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:DF:FD' src='AA:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1613,7 +1613,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479278.839671334 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='31' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479278.839671334 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='31' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1661,7 +1661,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479231.942342036 MX84_4 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' channel='36' rssi='9' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479231.942342036 MX84_4 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' channel='36' rssi='9' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1703,7 +1703,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479227.438567311 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='54' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479227.438567311 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='54' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1750,7 +1750,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479222.927379747 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479222.927379747 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1797,7 +1797,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479222.927802947 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='30' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479222.927802947 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='30' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1844,7 +1844,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479222.728876109 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='55' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479222.728876109 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='55' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1891,7 +1891,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479218.076400635 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='6' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479218.076400635 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='6' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -1938,7 +1938,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479203.375371107 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='49' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479203.375371107 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='49' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -1985,7 +1985,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479199.622640025 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='22' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479199.622640025 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='22' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2033,7 +2033,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479162.641725608 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:DF:FD' src='BE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479162.641725608 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:DF:FD' src='BE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2080,7 +2080,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479162.670104087 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='18' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479162.670104087 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='18' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2128,7 +2128,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479161.182241827 MX84_8 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' channel='149' rssi='9' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479161.182241827 MX84_8 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' channel='149' rssi='9' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2171,7 +2171,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479158.314592227 MX84_8 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' channel='149' rssi='8' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479158.314592227 MX84_8 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' channel='149' rssi='8' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2213,7 +2213,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479151.958073405 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479151.958073405 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2260,7 +2260,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479133.020606043 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='7' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479133.020606043 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='7' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2307,7 +2307,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479127.384572447 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='28' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479127.384572447 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='28' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2354,7 +2354,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479122.570882475 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='26' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479122.570882475 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='26' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2401,7 +2401,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479122.592807847 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='36' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479122.592807847 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='36' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2448,7 +2448,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479122.578597672 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='52' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479122.578597672 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='52' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2496,7 +2496,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479120.544286631 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='90:AC:3F:02:31:59' channel='6' rssi='50' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479120.544286631 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='90:AC:3F:02:31:59' channel='6' rssi='50' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2538,7 +2538,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479091.258858944 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='44' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479091.258858944 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='44' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2585,7 +2585,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479060.425068327 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:6A:4A' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='34' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647479060.425068327 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:6A:4A' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='34' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2633,7 +2633,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479037.677902643 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479037.677902643 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2680,7 +2680,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479036.783442760 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='28' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479036.783442760 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='28' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2727,7 +2727,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647479020.949227955 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='37' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647479020.949227955 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='37' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2775,7 +2775,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478974.912056258 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='08:A7:C0:3B:5A:95' channel='11' rssi='27' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478974.912056258 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='08:A7:C0:3B:5A:95' channel='11' rssi='27' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2817,7 +2817,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478966.089203455 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E1:41' src='AE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='8' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478966.089203455 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E1:41' src='AE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='8' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -2865,7 +2865,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478950.860971410 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:69:96' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='22' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478950.860971410 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:69:96' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='22' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2913,7 +2913,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478940.142724327 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='AE:17:E8:C7:E2:9D' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='29' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478940.142724327 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='AE:17:E8:C7:E2:9D' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='29' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -2961,7 +2961,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478936.678862087 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='7' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478936.678862087 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='7' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3008,7 +3008,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478907.739529447 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478907.739529447 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3055,7 +3055,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478855.303776534 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='39' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478855.303776534 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='39' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3102,7 +3102,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478849.532951889 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478849.532951889 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3150,7 +3150,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478845.877942207 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='26' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478845.877942207 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='26' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3197,7 +3197,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478822.111692485 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='13' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478822.111692485 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='13' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3244,7 +3244,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478818.039157925 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='4' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478818.039157925 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='4' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3292,7 +3292,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478800.349145072 MX84_5 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='6E:DA:36:A2:39:71' channel='11' rssi='7' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478800.349145072 MX84_5 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='6E:DA:36:A2:39:71' channel='11' rssi='7' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3334,7 +3334,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478799.177625347 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='14' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478799.177625347 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='14' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3381,7 +3381,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478788.838283552 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='17' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478788.838283552 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='17' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3428,7 +3428,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478782.939898885 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='4' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478782.939898885 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='4' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3476,7 +3476,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478782.932299301 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478782.932299301 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3524,7 +3524,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478782.930289746 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478782.930289746 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='13' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3573,7 +3573,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478695.528431433 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='78:28:CA:AA:6A:4A' channel='6' rssi='52' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478695.528431433 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='78:28:CA:AA:6A:4A' channel='6' rssi='52' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3615,7 +3615,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478693.465185593 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478693.465185593 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:DF:FD' src='92:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3662,7 +3662,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478669.549413486 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478669.549413486 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3709,7 +3709,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478626.517046787 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='49' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478626.517046787 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='49' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3756,7 +3756,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478591.602996834 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='27' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478591.602996834 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='27' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3803,7 +3803,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478569.035635205 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='14' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478569.035635205 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='14' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3850,7 +3850,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478567.751044590 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='27' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478567.751044590 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='27' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -3897,7 +3897,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478559.571303907 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='5C:AA:FD:5D:76:0E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='49' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478559.571303907 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='5C:AA:FD:5D:76:0E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='49' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3945,7 +3945,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478558.540066660 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='24' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478558.540066660 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='24' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -3992,7 +3992,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478554.934781027 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='50' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478554.934781027 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='50' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4039,7 +4039,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478541.587558726 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E1:41' src='AA:17:D8:C7:E1:41' dst='E2:CB:9C:B5:DA:7A' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478541.587558726 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E1:41' src='AA:17:D8:C7:E1:41' dst='E2:CB:9C:B5:DA:7A' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4087,7 +4087,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478534.671579931 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DA:7A' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='28' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478534.671579931 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DA:7A' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='28' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4135,7 +4135,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478508.007504325 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='5' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478508.007504325 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='5' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4183,7 +4183,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478487.013169927 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='30' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478487.013169927 MX84_2 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='30' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4231,7 +4231,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478483.410677512 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='33' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478483.410677512 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='33' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4278,7 +4278,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478478.614722093 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='32' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478478.614722093 MX84_1 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='32' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4325,7 +4325,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478440.565782942 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='14' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478440.565782942 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='14' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4372,7 +4372,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478408.128821330 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='21' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478408.128821330 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='21' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4420,7 +4420,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478403.005811325 MX84_5 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='AE:17:E8:C7:DF:FD' channel='11' rssi='8' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478403.005811325 MX84_5 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='AE:17:E8:C7:DF:FD' channel='11' rssi='8' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4462,7 +4462,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478383.070405853 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='44' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478383.070405853 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='44' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4509,7 +4509,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478373.816434235 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478373.816434235 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4557,7 +4557,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478339.127895652 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='78:28:CA:AA:6A:0A' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478339.127895652 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='1' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='78:28:CA:AA:6A:0A' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4599,7 +4599,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478298.296851316 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478298.296851316 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4646,7 +4646,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478293.380396754 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478293.380396754 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4694,7 +4694,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478268.953109023 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='10' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478268.953109023 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:DF:FD' src='BE:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='10' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4742,7 +4742,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478257.084985274 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='EE:CE:D5:6A:B6:22' channel='11' rssi='16' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478257.084985274 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='13' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='EE:CE:D5:6A:B6:22' channel='11' rssi='16' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4784,7 +4784,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478256.341194724 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:DF:FD' src='BE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='19' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478256.341194724 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:DF:FD' src='BE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='19' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4831,7 +4831,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478221.255609741 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478221.255609741 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -4878,7 +4878,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478145.758483684 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='5' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478145.758483684 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='6A:3A:3E:85:D7:D4' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='5' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4927,7 +4927,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478121.589518727 MX84_2 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:E1:41' src='AC:17:C8:C7:E1:41' dst='AE:17:E8:C7:E1:41' channel='1' rssi='22' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478121.589518727 MX84_2 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:E1:41' src='AC:17:C8:C7:E1:41' dst='AE:17:E8:C7:E1:41' channel='1' rssi='22' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -4969,7 +4969,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478119.868477795 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='7' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478119.868477795 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='7' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5017,7 +5017,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478114.277373007 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:69:96' channel='6' rssi='48' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478114.277373007 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi' vap='1' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='78:28:CA:AA:69:96' channel='6' rssi='48' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -5059,7 +5059,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478105.395836204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='53' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478105.395836204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='53' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5106,7 +5106,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478102.536782923 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='E2:CB:9C:B5:D7:80' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478102.536782923 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='E2:CB:9C:B5:D7:80' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -5153,7 +5153,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478092.108472035 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='27' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478092.108472035 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='27' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5200,7 +5200,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478087.649007204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='23' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478087.649007204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E2:9D' src='BE:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='23' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5247,7 +5247,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478063.434847715 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E1:41' src='AC:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='30' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478063.434847715 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E1:41' src='AC:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='30' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5294,7 +5294,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478054.846444450 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:DD:BE' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='3' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647478054.846444450 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:DD:BE' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='3' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -5341,7 +5341,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478039.876640835 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='11' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478039.876640835 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='11' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5388,7 +5388,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478035.923601924 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='23' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478035.923601924 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='23' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5436,7 +5436,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478034.762765475 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='27' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478034.762765475 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E1:41' src='AA:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='27' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5483,7 +5483,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478026.502834244 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='23' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478026.502834244 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='23' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5531,7 +5531,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478020.564810050 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478020.564810050 MX84_8 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5578,7 +5578,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478015.983013635 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='20' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478015.983013635 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='20' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5625,7 +5625,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478006.707247789 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='38' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478006.707247789 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:E1:41' src='BE:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='38' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5672,7 +5672,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647478001.603867573 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='34' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647478001.603867573 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='34' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5719,7 +5719,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477963.236026884 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='66' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477963.236026884 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='66' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5766,7 +5766,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477958.900449163 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477958.900449163 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5813,7 +5813,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477953.907583508 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='43' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477953.907583508 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='43' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -5860,7 +5860,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477953.724449475 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477953.724449475 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='E2:CB:9C:B5:C5:68' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='35' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -5907,7 +5907,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477945.336342244 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='24' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477945.336342244 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='24' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -5954,7 +5954,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477944.121686758 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='67' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477944.121686758 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='67' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -6002,7 +6002,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477940.363429956 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='34:8F:27:25:CC:48' channel='11' rssi='16' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477940.363429956 MX84 airmarshal_events type=ssid_spoofing_detected ssid='AwesomeWifi Guest' vap='13' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='34:8F:27:25:CC:48' channel='11' rssi='16' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -6044,7 +6044,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477930.038516204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='40' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477930.038516204 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='40' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6091,7 +6091,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477927.225784460 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477927.225784460 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:DF:FD' src='92:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6138,7 +6138,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477920.683178115 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='15' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477920.683178115 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='15' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6185,7 +6185,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477920.510699794 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='40' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477920.510699794 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='40' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6232,7 +6232,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477891.986568005 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='8' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477891.986568005 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:DF:FD' src='AA:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='8' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6279,7 +6279,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477881.304873506 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='12' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477881.304873506 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='12' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6326,7 +6326,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477873.769683395 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477873.769683395 MX84_7 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='11' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6374,7 +6374,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477872.782332783 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='52' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477872.782332783 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='52' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6421,7 +6421,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477871.675119845 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DD:BE' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='14' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477871.675119845 MX84_6 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='E2:CB:9C:B5:DD:BE' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='14' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -6468,7 +6468,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477864.088023180 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477864.088023180 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='9' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6515,7 +6515,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477834.810489249 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='26' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477834.810489249 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:E2:9D' src='AA:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='26' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6562,7 +6562,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477828.886032606 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='52' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477828.886032606 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='52' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6609,7 +6609,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477828.885258686 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='50' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477828.885258686 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='50' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6657,7 +6657,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477828.799864712 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='16' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477828.799864712 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='16' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6704,7 +6704,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477825.209110701 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='38' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477825.209110701 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='38' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6751,7 +6751,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477825.021409913 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='63' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477825.021409913 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='6A:3A:3E:85:CA:4E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='63' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -6798,7 +6798,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477825.024707684 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='59' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477825.024707684 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='59' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -6845,7 +6845,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477821.364087032 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='29' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477821.364087032 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='29' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6892,7 +6892,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477796.382660565 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='62' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477796.382660565 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:C8:C7:D8:51' src='BE:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='62' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6939,7 +6939,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477796.382227661 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='61' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477796.382227661 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AA:17:C8:C7:D8:51' src='AA:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='61' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -6986,7 +6986,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477796.381818586 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='61' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477796.381818586 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:D8:51' src='AC:17:C8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='61' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7033,7 +7033,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477795.407019364 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='46' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477795.407019364 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='46' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7080,7 +7080,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477795.385494917 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='58' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477795.385494917 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='58' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7128,7 +7128,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477795.385835866 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='58' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477795.385835866 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='58' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7176,7 +7176,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477793.576467473 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:DF:FD' src='AE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='33' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477793.576467473 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:DF:FD' src='AE:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='33' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7224,7 +7224,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477793.576769233 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:DF:FD' src='AA:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477793.576769233 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:DF:FD' src='AA:17:D8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='56' rssi='34' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7272,7 +7272,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477786.805604872 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='24' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477786.805604872 MX84_5 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E1:41' src='92:17:C8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='1' rssi='24' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7319,7 +7319,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477780.705460109 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='37' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477780.705460109 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:DF:FD' src='AC:17:C8:C7:DF:FD' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:DF:FD' vlan_id='0' channel='11' rssi='37' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7366,7 +7366,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477778.398160444 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='40' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477778.398160444 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E2:9D' src='BE:17:D8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='40' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7413,7 +7413,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477773.586461164 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='AE:17:E8:C7:D8:51' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='22' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477773.586461164 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='AE:17:E8:C7:D8:51' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='22' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7460,7 +7460,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477764.149946084 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='33' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477764.149946084 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:E1:41' src='BE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='33' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7507,7 +7507,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477764.145077176 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='31' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477764.145077176 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='31' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7554,7 +7554,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477764.143985243 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E1:41' src='AE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='30' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477764.143985243 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E1:41' src='AE:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='30' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7602,7 +7602,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477764.144283174 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E1:41' src='AA:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='30' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477764.144283174 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E1:41' src='AA:17:D8:C7:E1:41' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='30' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7650,7 +7650,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477763.225832662 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='E2:CB:9C:B5:D4:1E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477763.225832662 MX84_4 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:E2:9D' src='92:17:C8:C7:E2:9D' dst='E2:CB:9C:B5:D4:1E' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='9' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7697,7 +7697,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477744.039850991 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='50' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477744.039850991 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:C8:C7:D8:51' src='92:17:C8:C7:D8:51' dst='AE:17:E8:C7:DF:FD' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='6' rssi='50' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7744,7 +7744,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477733.453967364 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477733.453967364 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:D8:51' src='92:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7791,7 +7791,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477733.446493073 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='28' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477733.446493073 MX84_3 airmarshal_events type=rogue_ssid_detected ssid='' bssid='BE:17:D8:C7:D8:51' src='BE:17:D8:C7:D8:51' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='28' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -7838,7 +7838,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477733.420037284 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477733.420037284 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:D8:51' src='AA:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7886,7 +7886,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477733.419042244 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477733.419042244 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='48' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7934,7 +7934,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477733.411410011 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='51' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477733.411410011 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:D8:51' src='AE:17:D8:C7:D8:51' dst='38:BA:F8:CC:82:2E' wired_mac='AC:17:C8:C7:D8:51' vlan_id='0' channel='149' rssi='51' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -7982,7 +7982,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477716.431936901 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477716.431936901 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi Guest' bssid='AA:17:D8:C7:E2:9D' src='AA:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -8030,7 +8030,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477716.431151781 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477716.431151781 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E2:9D' src='92:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -8077,7 +8077,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477716.429168101 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477716.429168101 MX84 airmarshal_events type=rogue_ssid_detected ssid='AwesomeWifi' bssid='AE:17:D8:C7:E2:9D' src='AE:17:D8:C7:E2:9D' dst='E2:CB:9C:B5:D8:54' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='36' rssi='39' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"
@@ -8125,7 +8125,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477715.612600884 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='28' fc_type='0' fc_subtype='8'",
+                "original": "<134>1 1647477715.612600884 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='AC:17:C8:C7:E2:9D' src='AC:17:C8:C7:E2:9D' dst='FF:FF:FF:FF:FF:FF' wired_mac='AC:17:C8:C7:E2:9D' vlan_id='0' channel='11' rssi='28' fc_type='0' fc_subtype='8'",
                 "type": [
                     "info",
                     "indicator"
@@ -8172,7 +8172,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1647477702.046252324 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='5'",
+                "original": "<134>1 1647477702.046252324 MX84 airmarshal_events type=rogue_ssid_detected ssid='' bssid='92:17:D8:C7:E1:41' src='92:17:D8:C7:E1:41' dst='E2:CB:9C:B5:DC:6E' wired_mac='AC:17:C8:C7:E1:41' vlan_id='0' channel='36' rssi='35' fc_type='0' fc_subtype='5'",
                 "type": [
                     "info",
                     "indicator"

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-events.log-expected.json
@@ -19,7 +19,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479055.795119971 MR_device_2 events type=dfs_event channel='136' radio='2'",
+                "original": "<134>1 1647479055.795119971 MR_device_2 events type=dfs_event channel='136' radio='2'",
                 "type": [
                     "info"
                 ]
@@ -61,7 +61,7 @@
                     "network",
                     "authentication"
                 ],
-                "original": "\u003c134\u003e1 1647478401.421090826 MR_device_2 events type=wpa_deauth radio='1' vap='1' client_mac='E5:A4:98:71:9A:FE' aid='1034533358'",
+                "original": "<134>1 1647478401.421090826 MR_device_2 events type=wpa_deauth radio='1' vap='1' client_mac='E5:A4:98:71:9A:FE' aid='1034533358'",
                 "type": [
                     "info",
                     "end",
@@ -103,7 +103,7 @@
                     "network",
                     "authentication"
                 ],
-                "original": "\u003c134\u003e1 1647478402.126325721 MR_device_2 events type=wpa_auth radio='1' vap='1' client_mac='E4:F4:18:79:1F:E1' aid='910537108'",
+                "original": "<134>1 1647478402.126325721 MR_device_2 events type=wpa_auth radio='1' vap='1' client_mac='E4:F4:18:79:1F:E1' aid='910537108'",
                 "type": [
                     "info",
                     "start",
@@ -159,7 +159,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1647478709.602628785 MR_device_2 events type=disassociation radio='1' vap='1' client_mac='12:8D:1B:8A:D4:C8' channel='108' duration='309.163703632' auth_neg_dur='0.005547865' last_auth_ago='309.154547226' is_wpa='1' full_conn='0.121500990' ip_resp='0.121500990' ip_src='67.43.156.14' dns_req_rtt='0.018446771' dns_resp='0.190431042' dhcp_lease_completed='1.373967135' dhcp_server='8.8.8.8' dhcp_server_mac='18:3B:2E:5C:A7:F6' dhcp_resp='1.373967135' aid='1478558813'",
+                "original": "<134>1 1647478709.602628785 MR_device_2 events type=disassociation radio='1' vap='1' client_mac='12:8D:1B:8A:D4:C8' channel='108' duration='309.163703632' auth_neg_dur='0.005547865' last_auth_ago='309.154547226' is_wpa='1' full_conn='0.121500990' ip_resp='0.121500990' ip_src='67.43.156.14' dns_req_rtt='0.018446771' dns_resp='0.190431042' dhcp_lease_completed='1.373967135' dhcp_server='8.8.8.8' dhcp_server_mac='18:3B:2E:5C:A7:F6' dhcp_resp='1.373967135' aid='1478558813'",
                 "type": [
                     "info",
                     "access",
@@ -202,7 +202,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478402.117726086 MR_device_2 events type=association radio='1' vap='1' client_mac='12:8D:1B:8A:D4:C8' channel='140' rssi='20' aid='910537108'",
+                "original": "<134>1 1647478402.117726086 MR_device_2 events type=association radio='1' vap='1' client_mac='12:8D:1B:8A:D4:C8' channel='140' rssi='20' aid='910537108'",
                 "type": [
                     "info",
                     "access",
@@ -228,7 +228,7 @@
                 "event_subtype": "Site-to-Site VPN",
                 "event_type": "events",
                 "site_to_site_vpn": {
-                    "raw": " \u003cl2tp-over-ipsec-1|241\u003e CHILD_SA net-1{272} established with SPIs c6abe8d0(inbound) 4f04c590(outbound) and TS 89.160.20.112/32[udp/l2f] === 81.2.69.144/32[udp/l2f]"
+                    "raw": " <l2tp-over-ipsec-1|241> CHILD_SA net-1{272} established with SPIs c6abe8d0(inbound) 4f04c590(outbound) and TS 89.160.20.112/32[udp/l2f] === 81.2.69.144/32[udp/l2f]"
                 }
             },
             "ecs": {
@@ -239,7 +239,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478093.022430458 MX_device_1 events Site-to-Site VPN: \u003cl2tp-over-ipsec-1|241\u003e CHILD_SA net-1{272} established with SPIs c6abe8d0(inbound) 4f04c590(outbound) and TS 89.160.20.112/32[udp/l2f] === 81.2.69.144/32[udp/l2f]",
+                "original": "<134>1 1647478093.022430458 MX_device_1 events Site-to-Site VPN: <l2tp-over-ipsec-1|241> CHILD_SA net-1{272} established with SPIs c6abe8d0(inbound) 4f04c590(outbound) and TS 89.160.20.112/32[udp/l2f] === 81.2.69.144/32[udp/l2f]",
                 "type": [
                     "info",
                     "access"
@@ -264,7 +264,7 @@
                 "event_subtype": "Site-to-Site VPN",
                 "event_type": "events",
                 "site_to_site_vpn": {
-                    "raw": " \u003cl2tp-over-ipsec-1|241\u003e IKE_SA l2tp-over-ipsec-1[241] established between 89.160.20.112[89.160.20.112]...81.2.69.144[192.168.1.201]"
+                    "raw": " <l2tp-over-ipsec-1|241> IKE_SA l2tp-over-ipsec-1[241] established between 89.160.20.112[89.160.20.112]...81.2.69.144[192.168.1.201]"
                 }
             },
             "ecs": {
@@ -275,7 +275,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478092.029594666 MX_device_1 events Site-to-Site VPN: \u003cl2tp-over-ipsec-1|241\u003e IKE_SA l2tp-over-ipsec-1[241] established between 89.160.20.112[89.160.20.112]...81.2.69.144[192.168.1.201]",
+                "original": "<134>1 1647478092.029594666 MX_device_1 events Site-to-Site VPN: <l2tp-over-ipsec-1|241> IKE_SA l2tp-over-ipsec-1[241] established between 89.160.20.112[89.160.20.112]...81.2.69.144[192.168.1.201]",
                 "type": [
                     "info",
                     "access"
@@ -318,7 +318,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1647478222.583851938 MX84 events type=vpn_connectivity_change vpn_type='site-to-site' peer_contact='216.160.83.61:51856' peer_ident='2814ee002c075181bb1b7478ee073860' connectivity='false'",
+                "original": "<134>1 1647478222.583851938 MX84 events type=vpn_connectivity_change vpn_type='site-to-site' peer_contact='216.160.83.61:51856' peer_ident='2814ee002c075181bb1b7478ee073860' connectivity='false'",
                 "type": [
                     "info",
                     "connection"
@@ -355,7 +355,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479420.148681168 MX84 events dhcp lease of ip 10.0.2.213 from mx mac 68:3A:1E:42:60:59 for client mac E0:CB:BC:02:4F:80 from router 10.0.0.1 on subnet 255.255.252.0 with dns 10.0.0.1",
+                "original": "<134>1 1647479420.148681168 MX84 events dhcp lease of ip 10.0.2.213 from mx mac 68:3A:1E:42:60:59 for client mac E0:CB:BC:02:4F:80 from router 10.0.0.1 on subnet 255.255.252.0 with dns 10.0.0.1",
                 "type": [
                     "info",
                     "access",
@@ -394,7 +394,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479961.535491111 MX84 events dhcp no offers for mac A4:83:E7:02:A2:F1 host = 192.168.10.1",
+                "original": "<134>1 1647479961.535491111 MX84 events dhcp no offers for mac A4:83:E7:02:A2:F1 host = 192.168.10.1",
                 "type": [
                     "info",
                     "access",
@@ -443,7 +443,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1647478092.669153546 MX_device_4 events client_vpn_connect user id 'jwick@wwvpn.net' local ip 172.16.0.145 connected from 81.2.69.193",
+                "original": "<134>1 1647478092.669153546 MX_device_4 events client_vpn_connect user id 'jwick@wwvpn.net' local ip 172.16.0.145 connected from 81.2.69.193",
                 "type": [
                     "info",
                     "access",
@@ -508,7 +508,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1639132850.430422377 AP1 events type=disassociation radio='1' vap='1' client_mac='B0:A4:60:9B:3B:A6' channel='100' reason='1' instigator='2' duration='223.031691642' auth_neg_dur='0.005054229' last_auth_ago='223.020414600' is_wpa='1' full_conn='0.384002374' ip_resp='0.384002374' ip_src='10.197.39.50' http_resp='0.647356228' arp_resp='0.013562625' arp_src='10.197.39.50' dns_server='10.128.128.128' dns_req_rtt='0.023370084' dns_resp='0.263616104' dhcp_lease_completed='0.009196083' dhcp_server='10.128.128.128' dhcp_server_mac='E0:CB:BC:31:23:60' dhcp_resp='0.009196083' aid='977866432'",
+                "original": "<134>1 1639132850.430422377 AP1 events type=disassociation radio='1' vap='1' client_mac='B0:A4:60:9B:3B:A6' channel='100' reason='1' instigator='2' duration='223.031691642' auth_neg_dur='0.005054229' last_auth_ago='223.020414600' is_wpa='1' full_conn='0.384002374' ip_resp='0.384002374' ip_src='10.197.39.50' http_resp='0.647356228' arp_resp='0.013562625' arp_src='10.197.39.50' dns_server='10.128.128.128' dns_req_rtt='0.023370084' dns_resp='0.263616104' dhcp_lease_completed='0.009196083' dhcp_server='10.128.128.128' dhcp_server_mac='E0:CB:BC:31:23:60' dhcp_resp='0.009196083' aid='977866432'",
                 "type": [
                     "info",
                     "access",
@@ -549,7 +549,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132851.416656563 AP1 events type=aps_association_reject load='3' best_ap='192.168.128.38' best_ap_load='0' best_ap_rssi='37'",
+                "original": "<134>1 1639132851.416656563 AP1 events type=aps_association_reject load='3' best_ap='192.168.128.38' best_ap_load='0' best_ap_rssi='37'",
                 "type": [
                     "info"
                 ]
@@ -591,7 +591,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132851.608053271 AP1 events type=association radio='1' vap='0' client_mac='B0:A4:60:9B:3B:A6' last_known_client_ip='0.0.0.0' channel='100' rssi='40' aid='125455944'",
+                "original": "<134>1 1639132851.608053271 AP1 events type=association radio='1' vap='0' client_mac='B0:A4:60:9B:3B:A6' last_known_client_ip='0.0.0.0' channel='100' rssi='40' aid='125455944'",
                 "type": [
                     "info",
                     "access",
@@ -634,7 +634,7 @@
                     "network",
                     "authentication"
                 ],
-                "original": "\u003c134\u003e1 1639132851.615363021 AP1 events type=wpa_auth radio='1' vap='0' client_mac='B0:A4:60:9B:3B:A6' last_known_client_ip='0.0.0.0' aid='125455944'",
+                "original": "<134>1 1639132851.615363021 AP1 events type=wpa_auth radio='1' vap='0' client_mac='B0:A4:60:9B:3B:A6' last_known_client_ip='0.0.0.0' aid='125455944'",
                 "type": [
                     "info",
                     "start",
@@ -676,7 +676,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132852.193892187 AP1 events type=multiple_dhcp_servers_detected  vap='0' original_server_ip='192.168.130.2' original_server_mac='C8:E7:F0:C4:B0:B1' server_ip='192.168.130.3' server_mac='E8:B6:C2:57:C7:85'",
+                "original": "<134>1 1639132852.193892187 AP1 events type=multiple_dhcp_servers_detected  vap='0' original_server_ip='192.168.130.2' original_server_mac='C8:E7:F0:C4:B0:B1' server_ip='192.168.130.3' server_mac='E8:B6:C2:57:C7:85'",
                 "type": [
                     "info",
                     "protocol"
@@ -730,7 +730,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132852.718221083 AP1 events type=multiple_dhcp_servers_detected  vap='0' original_server_ip='192.168.130.3' original_server_mac='E8:B6:C2:57:C7:85' server_ip='192.168.130.2' server_mac='C8:E7:F0:C4:B0:B1'",
+                "original": "<134>1 1639132852.718221083 AP1 events type=multiple_dhcp_servers_detected  vap='0' original_server_ip='192.168.130.3' original_server_mac='E8:B6:C2:57:C7:85' server_ip='192.168.130.2' server_mac='C8:E7:F0:C4:B0:B1'",
                 "type": [
                     "info",
                     "protocol"
@@ -786,7 +786,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132860.489500682 1_2_AP_1 events type=association radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' last_known_client_ip='0.0.0.0' channel='104' rssi='29' aid='1187092323'",
+                "original": "<134>1 1639132860.489500682 1_2_AP_1 events type=association radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' last_known_client_ip='0.0.0.0' channel='104' rssi='29' aid='1187092323'",
                 "type": [
                     "info",
                     "access",
@@ -830,7 +830,7 @@
                     "network",
                     "authentication"
                 ],
-                "original": "\u003c134\u003e1 1639132861.230797660 1_2_AP_1 events type=8021x_eap_success radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' client_ip='0.0.0.0' identity='anonymous@gousto.co.uk' aid='1187092323'",
+                "original": "<134>1 1639132861.230797660 1_2_AP_1 events type=8021x_eap_success radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' client_ip='0.0.0.0' identity='anonymous@gousto.co.uk' aid='1187092323'",
                 "type": [
                     "info",
                     "start"
@@ -872,7 +872,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132861.280798139 1_2_AP_1 events type=8021x_auth radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' last_known_client_ip='0.0.0.0' identity='anonymous@gousto.co.uk' aid='1187092323'",
+                "original": "<134>1 1639132861.280798139 1_2_AP_1 events type=8021x_auth radio='1' vap='3' client_mac='54:8D:5A:EA:30:E9' last_known_client_ip='0.0.0.0' identity='anonymous@gousto.co.uk' aid='1187092323'",
                 "type": [
                     "info"
                 ]
@@ -933,7 +933,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1639132875.360638431 1_2_AP_4 events type=disassociation radio='1' vap='1' client_mac='36:E7:E9:AE:04:3D' channel='132' reason='8' apple_da_reason='7' instigator='2' duration='40.260521941' auth_neg_dur='0.024206187' last_auth_ago='40.229666962' is_wpa='1' full_conn='0.477861916' ip_resp='1.005954707' ip_src='10.68.128.113' http_resp='0.477861916' arp_resp='0.179876562' arp_src='10.68.128.113' dns_server='10.128.128.128' dns_req_rtt='0.095675854' dns_resp='0.416596437' dhcp_lease_completed='0.182086020' dhcp_server='10.128.128.128' dhcp_server_mac='E0:CB:BC:49:F7:26' dhcp_resp='0.182086020' aid='1750957891'",
+                "original": "<134>1 1639132875.360638431 1_2_AP_4 events type=disassociation radio='1' vap='1' client_mac='36:E7:E9:AE:04:3D' channel='132' reason='8' apple_da_reason='7' instigator='2' duration='40.260521941' auth_neg_dur='0.024206187' last_auth_ago='40.229666962' is_wpa='1' full_conn='0.477861916' ip_resp='1.005954707' ip_src='10.68.128.113' http_resp='0.477861916' arp_resp='0.179876562' arp_src='10.68.128.113' dns_server='10.128.128.128' dns_req_rtt='0.095675854' dns_resp='0.416596437' dhcp_lease_completed='0.182086020' dhcp_server='10.128.128.128' dhcp_server_mac='E0:CB:BC:49:F7:26' dhcp_resp='0.182086020' aid='1750957891'",
                 "type": [
                     "info",
                     "access",
@@ -996,7 +996,7 @@
                     "network",
                     "session"
                 ],
-                "original": "\u003c134\u003e1 1639132903.129587239 LG2_AP_01 events type=disassociation radio='1' vap='1' client_mac='8E:2F:69:33:FA:6A' channel='36' reason='8' apple_da_reason='7' instigator='2' duration='27.641499140' auth_neg_dur='0.008153688' last_auth_ago='27.627178619' is_wpa='1' full_conn='0.395120958' ip_resp='0.520431812' ip_src='10.72.66.49' http_resp='0.395120958' arp_resp='0.132684875' arp_src='10.72.66.49' dns_server='10.128.128.128' dns_req_rtt='0.121687' dns_resp='0.335365542' dhcp_lease_completed='0.133589958' dhcp_server='10.128.128.128' dhcp_server_mac='F8:9E:28:70:1A:7C' dhcp_resp='0.133589958' aid='1899362895'",
+                "original": "<134>1 1639132903.129587239 LG2_AP_01 events type=disassociation radio='1' vap='1' client_mac='8E:2F:69:33:FA:6A' channel='36' reason='8' apple_da_reason='7' instigator='2' duration='27.641499140' auth_neg_dur='0.008153688' last_auth_ago='27.627178619' is_wpa='1' full_conn='0.395120958' ip_resp='0.520431812' ip_src='10.72.66.49' http_resp='0.395120958' arp_resp='0.132684875' arp_src='10.72.66.49' dns_server='10.128.128.128' dns_req_rtt='0.121687' dns_resp='0.335365542' dhcp_lease_completed='0.133589958' dhcp_server='10.128.128.128' dhcp_server_mac='F8:9E:28:70:1A:7C' dhcp_resp='0.133589958' aid='1899362895'",
                 "type": [
                     "info",
                     "access",
@@ -1038,7 +1038,7 @@
                     "network",
                     "authentication"
                 ],
-                "original": "\u003c134\u003e1 1639132917.085087788 LG2_AP_01 events type=wpa_auth radio='1' vap='1' client_mac='8E:2F:69:33:FA:6A' aid='1546367691'",
+                "original": "<134>1 1639132917.085087788 LG2_AP_01 events type=wpa_auth radio='1' vap='1' client_mac='8E:2F:69:33:FA:6A' aid='1546367691'",
                 "type": [
                     "info",
                     "start",
@@ -1072,7 +1072,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1639132851.416656563 TCP9001 events Blocked ARP Packet from ab:01:02:03:04:05 with IP 81.2.69.144 on VLAN 123",
+                "original": "<134>1 1639132851.416656563 TCP9001 events Blocked ARP Packet from ab:01:02:03:04:05 with IP 81.2.69.144 on VLAN 123",
                 "type": [
                     "info"
                 ]
@@ -1126,7 +1126,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1694519069.914814259 TCP9001 events Port 4 changed STP role from designated to disabled",
+                "original": "<134>1 1694519069.914814259 TCP9001 events Port 4 changed STP role from designated to disabled",
                 "type": [
                     "info"
                 ]
@@ -1159,7 +1159,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1694519069.912939179 TCP9001 events port 4 status changed from 100fdx to down",
+                "original": "<134>1 1694519069.912939179 TCP9001 events port 4 status changed from 100fdx to down",
                 "type": [
                     "info"
                 ]
@@ -1192,7 +1192,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1694519040.863533579 TCP9001 events Port 1 changed STP role from disabled to designated",
+                "original": "<134>1 1694519040.863533579 TCP9001 events Port 1 changed STP role from disabled to designated",
                 "type": [
                     "info"
                 ]
@@ -1225,7 +1225,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1694519040.862946339 TCP9001 events port 1 status changed from down to 100fdx",
+                "original": "<134>1 1694519040.862946339 TCP9001 events port 1 status changed from down to 100fdx",
                 "type": [
                     "info"
                 ]
@@ -1258,7 +1258,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1694519007.104885873 TCP9001 events Auth failure resets to success",
+                "original": "<134>1 1694519007.104885873 TCP9001 events Auth failure resets to success",
                 "type": [
                     "info"
                 ]

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-flows.log-expected.json
@@ -21,7 +21,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478988.289402144 MX84_4 flows allow src=10.0.2.170 dst=10.0.0.34 mac=00:7C:2D:BD:76:F2 protocol=udp sport=54841 dport=15600",
+                "original": "<134>1 1647478988.289402144 MX84_4 flows allow src=10.0.2.170 dst=10.0.0.34 mac=00:7C:2D:BD:76:F2 protocol=udp sport=54841 dport=15600",
                 "type": [
                     "info",
                     "connection",
@@ -80,7 +80,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478988.476061795 MX84 flows src=216.160.83.57 dst=216.160.83.61 protocol=tcp sport=54445 dport=44210 pattern: 1 all",
+                "original": "<134>1 1647478988.476061795 MX84 flows src=216.160.83.57 dst=216.160.83.61 protocol=tcp sport=54445 dport=44210 pattern: 1 all",
                 "type": [
                     "info",
                     "access",
@@ -138,7 +138,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647478988.596151424 MX84_7 flows allow src=10.0.0.34 dst=10.0.0.234 mac=64:1C:B0:BA:F0:EC protocol=tcp sport=49761 dport=15500",
+                "original": "<134>1 1647478988.596151424 MX84_7 flows allow src=10.0.0.34 dst=10.0.0.234 mac=64:1C:B0:BA:F0:EC protocol=tcp sport=49761 dport=15500",
                 "type": [
                     "info",
                     "connection",
@@ -181,7 +181,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1664382879.496990921 AP_XXXX flows allow src=fe80::1021:83ca:b68:4cd8 dst=ff02::1:ffb6:a227 mac=28:FF:3C:AB:DB:AA protocol=icmp6 type=135",
+                "original": "<134>1 1664382879.496990921 AP_XXXX flows allow src=fe80::1021:83ca:b68:4cd8 dst=ff02::1:ffb6:a227 mac=28:FF:3C:AB:DB:AA protocol=icmp6 type=135",
                 "type": [
                     "info",
                     "connection",
@@ -223,7 +223,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1664385452.707589827 AP_XXXX flows allow src=172.16.12.23 dst=224.0.0.2 mac=4C:AB:4F:0D:3D:AA protocol=2",
+                "original": "<134>1 1664385452.707589827 AP_XXXX flows allow src=172.16.12.23 dst=224.0.0.2 mac=4C:AB:4F:0D:3D:AA protocol=2",
                 "type": [
                     "info",
                     "connection",
@@ -277,7 +277,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1664385453.129104346 AP_XXXX flows allow src=172.16.10.14 dst=81.2.69.144 mac=EC:63:D7:0F:6B:AA protocol=icmp type=8",
+                "original": "<134>1 1664385453.129104346 AP_XXXX flows allow src=172.16.10.14 dst=81.2.69.144 mac=EC:63:D7:0F:6B:AA protocol=icmp type=8",
                 "type": [
                     "info",
                     "connection",
@@ -306,7 +306,7 @@
                 "event_type": "flows",
                 "firewall": {
                     "action": "allow",
-                    "rule": "(dst 10.0.0.0/8) \u0026\u0026 (src 10.241.0.0/16)"
+                    "rule": "(dst 10.0.0.0/8) && (src 10.241.0.0/16)"
                 }
             },
             "destination": {
@@ -321,7 +321,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=10.241.77.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=138 dport=138 pattern: allow (dst 10.0.0.0/8) \u0026\u0026 (src 10.241.0.0/16)",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=10.241.77.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=138 dport=138 pattern: allow (dst 10.0.0.0/8) && (src 10.241.0.0/16)",
                 "type": [
                     "info",
                     "access",
@@ -380,7 +380,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=192.168.222.3 dst=216.160.83.57 mac=00:17:55:76:EC:12 protocol=tcp sport=61403 dport=9998 pattern: Group Policy Allow",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=192.168.222.3 dst=216.160.83.57 mac=00:17:55:76:EC:12 protocol=tcp sport=61403 dport=9998 pattern: Group Policy Allow",
                 "type": [
                     "info",
                     "access",
@@ -424,7 +424,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=10.8.6.10 dst=172.28.1.14 protocol=icmp type=8 pattern: allow all",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=10.8.6.10 dst=172.28.1.14 protocol=icmp type=8 pattern: allow all",
                 "type": [
                     "info",
                     "access",
@@ -482,7 +482,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=172.28.1.9 dst=216.160.83.61 mac=98:18:88:7C:45:BF protocol=udp sport=45713 dport=53 pattern: allow udp",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=172.28.1.9 dst=216.160.83.61 mac=98:18:88:7C:45:BF protocol=udp sport=45713 dport=53 pattern: allow udp",
                 "type": [
                     "info",
                     "access",
@@ -527,7 +527,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=10.10.10.11 dst=172.16.12.23 mac=9C:7B:EF:A9:6C:D8 protocol=udp sport=64138 dport=3289 pattern: deny (src 10.10.0.0/16)",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=10.10.10.11 dst=172.16.12.23 mac=9C:7B:EF:A9:6C:D8 protocol=udp sport=64138 dport=3289 pattern: deny (src 10.10.0.0/16)",
                 "type": [
                     "info",
                     "access",
@@ -572,7 +572,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=10.241.192.11 dst=10.8.2.6 mac=9C:7B:EF:A5:9C:9B protocol=tcp sport=54791 dport=80 pattern: deny all",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=10.241.192.11 dst=10.8.2.6 mac=9C:7B:EF:A5:9C:9B protocol=tcp sport=54791 dport=80 pattern: deny all",
                 "type": [
                     "info",
                     "access",
@@ -617,7 +617,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1674604848.429996761 MX84 flows src=192.168.201.81 dst=10.8.2.4 mac=B4:6B:FC:6A:E0:5A protocol=udp sport=60288 dport=53 pattern: allow all",
+                "original": "<134>1 1674604848.429996761 MX84 flows src=192.168.201.81 dst=10.8.2.4 mac=B4:6B:FC:6A:E0:5A protocol=udp sport=60288 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
@@ -662,7 +662,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "<134>1 948136486.721741837 MX60 firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
@@ -707,7 +707,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "<134>1 948136486.721741837 MX60 vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
@@ -752,7 +752,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "<134>1 948136486.721741837 MX60 cellular_firewall src=10.10.10.11 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",
@@ -797,7 +797,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
+                "original": "<134>1 948136486.721741837 MX60 bridge_anyconnect_client_vpn_firewall src=10.241.192.1 dst=10.241.77.255 mac=24:2F:FA:1E:B7:E6 protocol=udp sport=9562 dport=53 pattern: allow all",
                 "type": [
                     "info",
                     "access",

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-ip-flow.log
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-ip-flow.log
@@ -6,3 +6,5 @@
 <134>1 1647479325.842384731 MX84 ip_flow_end src=10.0.3.116 dst=67.43.156.14 protocol=udp sport=38422 dport=443 translated_src_ip=216.160.83.61 translated_port=38422
 <134>1 1647479325.842377481 MX84 ip_flow_end src=10.0.2.99 dst=10.0.0.1 protocol=udp sport=29534 dport=53 translated_dst_ip=89.160.20.112 translated_port=53
 <134>1 1647479325.755292025 MX100 ip_flow_end src=10.0.0.234 dst=81.2.69.144 protocol=tcp sport=36498 dport=80 translated_src_ip=1.128.3.4 translated_port=36498
+<134>1 1647479325.755292025 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.145 protocol=icmp translated_src_ip=1.128.3.4
+<134>1 1647479325.755292025 MX100 ip_flow_end src=10.0.2.99 dst=10.0.0.1 protocol=icmp translated_dst_ip=89.160.20.112

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-ip-flow.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-ip-flow.log-expected.json
@@ -28,7 +28,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479278.997155282 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.145 protocol=tcp sport=34294 dport=80 translated_src_ip=1.128.3.4 translated_port=34294",
+                "original": "<134>1 1647479278.997155282 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.145 protocol=tcp sport=34294 dport=80 translated_src_ip=1.128.3.4 translated_port=34294",
                 "type": [
                     "info"
                 ]
@@ -82,7 +82,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479278.995279215 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.143 protocol=udp sport=45061 dport=53 translated_src_ip=1.128.3.4 translated_port=45061",
+                "original": "<134>1 1647479278.995279215 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.143 protocol=udp sport=45061 dport=53 translated_src_ip=1.128.3.4 translated_port=45061",
                 "type": [
                     "info"
                 ]
@@ -136,7 +136,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479278.974067126 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.143 protocol=udp sport=37401 dport=53 translated_src_ip=1.128.3.4 translated_port=37401",
+                "original": "<134>1 1647479278.974067126 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.143 protocol=udp sport=37401 dport=53 translated_src_ip=1.128.3.4 translated_port=37401",
                 "type": [
                     "info"
                 ]
@@ -196,7 +196,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479278.911594876 MX84 ip_flow_start src=10.0.3.138 dst=89.160.20.156 protocol=tcp sport=61272 dport=443 translated_src_ip=216.160.83.61 translated_port=61272",
+                "original": "<134>1 1647479278.911594876 MX84 ip_flow_start src=10.0.3.138 dst=89.160.20.156 protocol=tcp sport=61272 dport=443 translated_src_ip=216.160.83.61 translated_port=61272",
                 "type": [
                     "info"
                 ]
@@ -265,7 +265,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479325.891451682 MX84 ip_flow_end src=10.0.2.249 dst=10.0.0.1 protocol=udp sport=7421 dport=53 translated_dst_ip=89.160.20.112 translated_port=53",
+                "original": "<134>1 1647479325.891451682 MX84 ip_flow_end src=10.0.2.249 dst=10.0.0.1 protocol=udp sport=7421 dport=53 translated_dst_ip=89.160.20.112 translated_port=53",
                 "type": [
                     "info"
                 ]
@@ -313,7 +313,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479325.842384731 MX84 ip_flow_end src=10.0.3.116 dst=67.43.156.14 protocol=udp sport=38422 dport=443 translated_src_ip=216.160.83.61 translated_port=38422",
+                "original": "<134>1 1647479325.842384731 MX84 ip_flow_end src=10.0.3.116 dst=67.43.156.14 protocol=udp sport=38422 dport=443 translated_src_ip=216.160.83.61 translated_port=38422",
                 "type": [
                     "info"
                 ]
@@ -382,7 +382,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479325.842377481 MX84 ip_flow_end src=10.0.2.99 dst=10.0.0.1 protocol=udp sport=29534 dport=53 translated_dst_ip=89.160.20.112 translated_port=53",
+                "original": "<134>1 1647479325.842377481 MX84 ip_flow_end src=10.0.2.99 dst=10.0.0.1 protocol=udp sport=29534 dport=53 translated_dst_ip=89.160.20.112 translated_port=53",
                 "type": [
                     "info"
                 ]
@@ -430,7 +430,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "\u003c134\u003e1 1647479325.755292025 MX100 ip_flow_end src=10.0.0.234 dst=81.2.69.144 protocol=tcp sport=36498 dport=80 translated_src_ip=1.128.3.4 translated_port=36498",
+                "original": "<134>1 1647479325.755292025 MX100 ip_flow_end src=10.0.0.234 dst=81.2.69.144 protocol=tcp sport=36498 dport=80 translated_src_ip=1.128.3.4 translated_port=36498",
                 "type": [
                     "info"
                 ]
@@ -450,6 +450,110 @@
                 },
                 "ip": "1.128.3.4",
                 "port": 36498
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-03-17T01:08:45.755Z",
+            "cisco_meraki": {
+                "event_type": "ip_flow_start"
+            },
+            "destination": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.145"
+            },
+            "ecs": {
+                "version": "8.10.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "<134>1 1647479325.755292025 MX100 ip_flow_start src=10.0.0.234 dst=81.2.69.145 protocol=icmp translated_src_ip=1.128.3.4",
+                "type": [
+                    "info"
+                ]
+            },
+            "network": {
+                "protocol": "icmp"
+            },
+            "observer": {
+                "hostname": "MX100"
+            },
+            "source": {
+                "as": {
+                    "number": 1221,
+                    "organization": {
+                        "name": "Telstra Pty Ltd"
+                    }
+                },
+                "ip": "1.128.3.4"
+            },
+            "tags": [
+                "forwarded",
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2022-03-17T01:08:45.755Z",
+            "cisco_meraki": {
+                "event_type": "ip_flow_end"
+            },
+            "destination": {
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.112"
+            },
+            "ecs": {
+                "version": "8.10.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "<134>1 1647479325.755292025 MX100 ip_flow_end src=10.0.2.99 dst=10.0.0.1 protocol=icmp translated_dst_ip=89.160.20.112",
+                "type": [
+                    "info"
+                ]
+            },
+            "network": {
+                "protocol": "icmp"
+            },
+            "observer": {
+                "hostname": "MX100"
+            },
+            "source": {
+                "ip": "10.0.2.99"
             },
             "tags": [
                 "forwarded",

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-security-events.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-security-events.log-expected.json
@@ -25,7 +25,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1637691198.348361125 MX84 security_event ids_alerted signature=1:29708:4 priority=1 timestamp=1637691198.330873 dhost=D0:AB:D5:7B:43:73 direction=ingress protocol=tcp/ip src=67.43.156.12:80 dst=10.0.3.162:56391 decision=allowed message: BROWSER-IE Microsoft Internet Explorer CSS uninitialized object access attempt detected",
+                "original": "<134>1 1637691198.348361125 MX84 security_event ids_alerted signature=1:29708:4 priority=1 timestamp=1637691198.330873 dhost=D0:AB:D5:7B:43:73 direction=ingress protocol=tcp/ip src=67.43.156.12:80 dst=10.0.3.162:56391 decision=allowed message: BROWSER-IE Microsoft Internet Explorer CSS uninitialized object access attempt detected",
                 "type": [
                     "info",
                     "indicator"
@@ -102,7 +102,7 @@
                     "threat",
                     "malware"
                 ],
-                "original": "\u003c134\u003e1 1637691298.984398273 MX84 security_event security_filtering_file_scanned url=http://www.eicar.org/download/eicar.com.txt src=192.168.128.2:53150 dst=67.43.156.15:80 mac=98:5A:EB:E1:81:2F name='EICAR:EICAR_Test_file_not_a_virus-tpd' sha256=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f disposition=malicious action=block",
+                "original": "<134>1 1637691298.984398273 MX84 security_event security_filtering_file_scanned url=http://www.eicar.org/download/eicar.com.txt src=192.168.128.2:53150 dst=67.43.156.15:80 mac=98:5A:EB:E1:81:2F name='EICAR:EICAR_Test_file_not_a_virus-tpd' sha256=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f disposition=malicious action=block",
                 "type": [
                     "info",
                     "indicator",
@@ -152,7 +152,7 @@
                     "threat",
                     "malware"
                 ],
-                "original": "\u003c134\u003e1 1637783435.239819833 MX84 security_event security_filtering_disposition_change name=EICAR:EICAR_Test_file_not_a_virus-tpd sha256=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f disposition=malicious action=allow",
+                "original": "<134>1 1637783435.239819833 MX84 security_event security_filtering_disposition_change name=EICAR:EICAR_Test_file_not_a_virus-tpd sha256=275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f disposition=malicious action=allow",
                 "type": [
                     "info",
                     "indicator",
@@ -196,7 +196,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1637783891.345984502 MX84 ids-alerts signature=129:4:1 priority=3 timestamp=1637783891.512569 direction=ingress protocol=tcp/ip src=67.43.156.15:80",
+                "original": "<134>1 1637783891.345984502 MX84 ids-alerts signature=129:4:1 priority=3 timestamp=1637783891.512569 direction=ingress protocol=tcp/ip src=67.43.156.15:80",
                 "type": [
                     "info",
                     "indicator"
@@ -254,7 +254,7 @@
                     "network",
                     "threat"
                 ],
-                "original": "\u003c134\u003e1 1637790201.246576346 MX84 ids-alerts signature=119:15:1 priority=2 timestamp=1637790201.238064 direction=egress protocol=tcp/ip src=192.168.111.254:56240",
+                "original": "<134>1 1637790201.246576346 MX84 ids-alerts signature=119:15:1 priority=2 timestamp=1637790201.238064 direction=egress protocol=tcp/ip src=192.168.111.254:56240",
                 "type": [
                     "info",
                     "indicator"

--- a/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-urls.log-expected.json
+++ b/packages/cisco_meraki/data_stream/log/_dev/test/pipeline/test-urls.log-expected.json
@@ -40,7 +40,7 @@
                     "network",
                     "web"
                 ],
-                "original": "\u003c134\u003e1 1647479503.348215340 MX84 urls src=10.0.1.29:60336 dst=89.160.20.156:80 mac=78:7B:8A:CC:05:18 request: UNKNOWN https://bitbucket.org/...",
+                "original": "<134>1 1647479503.348215340 MX84 urls src=10.0.1.29:60336 dst=89.160.20.156:80 mac=78:7B:8A:CC:05:18 request: UNKNOWN https://bitbucket.org/...",
                 "type": [
                     "info",
                     "error"
@@ -106,7 +106,7 @@
                     "network",
                     "web"
                 ],
-                "original": "\u003c134\u003e1 1647479503.676404537 MX84 urls src=10.0.0.234:56424 dst=89.160.20.112:443 mac=64:1C:AE:68:2A:01 request: GET https://lh3.googleusercontent.com/p/AFVnnY=w2048-h1024",
+                "original": "<134>1 1647479503.676404537 MX84 urls src=10.0.0.234:56424 dst=89.160.20.112:443 mac=64:1C:AE:68:2A:01 request: GET https://lh3.googleusercontent.com/p/AFVnnY=w2048-h1024",
                 "type": [
                     "info",
                     "access"
@@ -172,7 +172,7 @@
                     "network",
                     "web"
                 ],
-                "original": "\u003c134\u003e1 1647479503.676404537 MX84 urls src=10.0.0.234:56424 dst=89.160.20.112:443 mac=64:1C:AE:68:2A:01 agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:108.0) Gecko/20100101 Firefox/108.0' request: GET https://lh3.googleusercontent.com/p/AFVnnY=w2048-h1024",
+                "original": "<134>1 1647479503.676404537 MX84 urls src=10.0.0.234:56424 dst=89.160.20.112:443 mac=64:1C:AE:68:2A:01 agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:108.0) Gecko/20100101 Firefox/108.0' request: GET https://lh3.googleusercontent.com/p/AFVnnY=w2048-h1024",
                 "type": [
                     "info",
                     "access"

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/ipflows.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/ipflows.yml
@@ -9,7 +9,7 @@ processors:
     field: _temp.event
     field_split: ' '
     value_split: '='
-    if: ctx?._temp?.event != null
+    if: ctx._temp?.event != null
     tag: kv_ip_flow_fields
 # source field IP:port handling
 - convert:

--- a/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/ipflows.yml
+++ b/packages/cisco_meraki/data_stream/log/elasticsearch/ingest_pipeline/ipflows.yml
@@ -4,17 +4,13 @@ processors:
 - dissect:
     description: Determine if the token is src= or operation
     field: event.original
-    pattern: "%{} %{} %{} %{_temp.event_type} %{_temp.token} %{}"
-- dissect:
-    description: Case for src= follows ip_flow_start
-    field: event.original
-    pattern: "%{} ip_flow_start %{*src}=%{&src} %{*dst}=%{&dst} %{*prot}=%{&prot} %{*sport}=%{&sport} %{*dport}=%{&dport} %{*tsi}=%{&tsi} %{*tp}=%{&tp}"
-    if: ctx._temp.event_type == 'ip_flow_start' && ctx._temp.token.startsWith("src=") == true
-- dissect:
-    description: Case for src= follows ip_flow_end
-    field: event.original
-    pattern: "%{} ip_flow_end %{*src}=%{&src} %{*dst}=%{&dst} %{*prot}=%{&prot} %{*sport}=%{&sport} %{*dport}=%{&dport} %{*tsi_or_tdi}=%{&tsi_or_tdi} %{*tp}=%{&tp}"
-    if: ctx._temp.event_type == 'ip_flow_end' && ctx._temp.token.startsWith("src=") == true
+    pattern: "%{} %{} %{} %{_temp.event_type} %{_temp.event}"
+- kv:
+    field: _temp.event
+    field_split: ' '
+    value_split: '='
+    if: ctx?._temp?.event != null
+    tag: kv_ip_flow_fields
 # source field IP:port handling
 - convert:
     type: ip

--- a/packages/cisco_meraki/manifest.yml
+++ b/packages/cisco_meraki/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_meraki
 title: Cisco Meraki
-version: "1.17.1"
+version: "1.18.0"
 description: Collect logs from Cisco Meraki with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Several dissect processors have been replaced by a `kv` processor that makes the processing of `ip_flow` events less restrictive, so now ICMP events are also processed as well as TCP/UDP ones.

The changes related to this fix are applied in the `ipflows` ingest pipeline and the test file test-ip-flow.log. Further changes in the pull request are a consequence of unrelated changes that fixed the format of some special characters when running pipeline tests.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Added pipeline test case to verify the processors handle ICMP events properly.
