### PR TITLE
[Kubernetes] Add namespace visualization to Overview dashboard

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.52.1
+  changes:
+    - description: Add namespace visualization to Overview dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8329
 - version: 1.52.0
   changes:
     - description: Add new data stream state_namespace.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add namespace visualization to Overview dashboard.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8329
+      link: https://github.com/elastic/integrations/pull/8377
 - version: 1.52.0
   changes:
     - description: Add new data stream state_namespace.

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"748291db-2826-4242-9107-9a5226733a06\":{\"order\":0,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"748291db-2826-4242-9107-9a5226733a06\",\"enhancements\":{},\"selectedOptions\":[]}},\"2da8af79-7928-4741-8d03-866642f3c2a0\":{\"order\":1,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace\",\"id\":\"2da8af79-7928-4741-8d03-866642f3c2a0\",\"selectedOptions\":[],\"enhancements\":{}}}}"
+            "panelsJSON": "{\"ab7e24eb-5eda-4ac4-aee5-a3394e367e48\":{\"order\":0,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster Name\",\"id\":\"ab7e24eb-5eda-4ac4-aee5-a3394e367e48\",\"enhancements\":{},\"selectedOptions\":[]}},\"f9b39846-449c-430c-b83d-bb49afcd1691\":{\"order\":1,\"width\":\"large\",\"grow\":false,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"kubernetes.namespace\",\"title\":\"Namespace\",\"id\":\"f9b39846-449c-430c-b83d-bb49afcd1691\",\"selectedOptions\":[],\"enhancements\":{}}}}"
         },
         "description": "Overview of Kubernetes cluster metrics",
         "kibanaSavedObjectMeta": {
@@ -19,6 +19,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -49,15 +51,14 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "f1541205-b6eb-45a6-bdc5-9aaefa62af66",
+                    "i": "d8d7768b-7899-4c98-8bd6-7af8c2afa013",
                     "w": 33,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "f1541205-b6eb-45a6-bdc5-9aaefa62af66",
+                "panelIndex": "d8d7768b-7899-4c98-8bd6-7af8c2afa013",
                 "title": "Kubernetes Dashboards [Metrics Kubernetes]",
-                "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -88,19 +89,19 @@
                 },
                 "gridData": {
                     "h": 4,
-                    "i": "ace0daf9-5db7-44e5-9fc3-a1b1976b01c2",
+                    "i": "f25ce7ae-d731-48f2-bf09-6a7a6b0d1c19",
                     "w": 15,
                     "x": 33,
                     "y": 0
                 },
-                "panelIndex": "ace0daf9-5db7-44e5-9fc3-a1b1976b01c2",
+                "panelIndex": "f25ce7ae-d731-48f2-bf09-6a7a6b0d1c19",
                 "title": "Information",
-                "type": "visualization",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "",
                         "references": [],
                         "state": {
                             "adHocDataViews": {
@@ -425,15 +426,349 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "33530265-ff62-49e7-9518-f430efb0dde0",
+                    "i": "c32061cb-e6a6-432d-95e6-cf8fd2f44444",
                     "w": 8,
                     "x": 0,
                     "y": 4
                 },
-                "panelIndex": "33530265-ff62-49e7-9518-f430efb0dde0",
+                "panelIndex": "c32061cb-e6a6-432d-95e6-cf8fd2f44444",
                 "title": "Nodes",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
+                                            "columnOrder": [
+                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                                                "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                            ],
+                                            "columns": {
+                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "30s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "62125b6d-3199-420b-9d3b-46f159e15d7f": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.node.status.ready:\"true\" and data_stream.dataset :\"kubernetes.state_node\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Total Memory",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
+                                                },
+                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100000 values of kubernetes.node.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "customLabel": false,
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 100000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.node.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        },
+                                        "dff09473-7596-48c7-bbf4-beccee70d845": {
+                                            "columnOrder": [
+                                                "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                                                "307be273-94a6-41ab-b93b-0debde733492"
+                                            ],
+                                            "columns": {
+                                                "307be273-94a6-41ab-b93b-0debde733492": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset :\"kubernetes.container\"    "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Memory Used",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "showArrayValues": false,
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.container.memory.usage.bytes"
+                                                },
+                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "30s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "6677e92c-5874-49c1-979e-c16c0d3838cd": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100000 values of kubernetes.container.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "customLabel": false,
+                                                            "dataType": "number",
+                                                            "isBucketed": false,
+                                                            "label": "Count of records",
+                                                            "operationType": "count",
+                                                            "params": {},
+                                                            "scale": "ratio",
+                                                            "sourceField": "___records___"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 100000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.container.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": [
+                                            "kubernetes.container",
+                                            "kubernetes.state_node"
+                                        ],
+                                        "type": "phrases",
+                                        "value": [
+                                            "kubernetes.container",
+                                            "kubernetes.state_node"
+                                        ]
+                                    },
+                                    "query": {
+                                        "bool": {
+                                            "minimum_should_match": 1,
+                                            "should": [
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "kubernetes.container"
+                                                    }
+                                                },
+                                                {
+                                                    "match_phrase": {
+                                                        "data_stream.dataset": "kubernetes.state_node"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "307be273-94a6-41ab-b93b-0debde733492"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
+                                        "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#00bfb3",
+                                                "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "accessors": [
+                                            "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "negative",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
+                                        "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#bd271e",
+                                                "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "top",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "xTitle": "",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "ff159cfe-ddb2-4844-9b72-e841b601426b",
+                    "w": 20,
+                    "x": 8,
+                    "y": 4
+                },
+                "panelIndex": "ff159cfe-ddb2-4844-9b72-e841b601426b",
+                "title": "Memory used vs total memory",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -798,923 +1133,14 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "d0fadeee-3c79-443b-bfcb-b70e78d168e9",
+                    "i": "59f800b7-15e6-4a49-a03d-39e1f842e11b",
                     "w": 20,
                     "x": 28,
                     "y": 4
                 },
-                "panelIndex": "d0fadeee-3c79-443b-bfcb-b70e78d168e9",
+                "panelIndex": "59f800b7-15e6-4a49-a03d-39e1f842e11b",
                 "title": "Cores used vs total cores",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "dfd1702f-213e-4fa2-98e3-5106657c62e7": {
-                                            "columnOrder": [
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            ],
-                                            "columns": {
-                                                "5c33dcdb-21de-4bdc-b564-ba82ed037d11": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "30s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "62125b6d-3199-420b-9d3b-46f159e15d7f": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.node.status.ready:\"true\" and data_stream.dataset :\"kubernetes.state_node\" "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Total Memory",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.node.memory.allocatable.bytes"
-                                                },
-                                                "f0953a4e-8498-4b22-a63a-d24e4a069ed3": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100000 values of kubernetes.node.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 100000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.node.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        },
-                                        "dff09473-7596-48c7-bbf4-beccee70d845": {
-                                            "columnOrder": [
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                                "307be273-94a6-41ab-b93b-0debde733492"
-                                            ],
-                                            "columns": {
-                                                "307be273-94a6-41ab-b93b-0debde733492": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "data_stream.dataset :\"kubernetes.container\"    "
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Memory Used",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "showArrayValues": false,
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.container.memory.usage.bytes"
-                                                },
-                                                "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "30s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "6677e92c-5874-49c1-979e-c16c0d3838cd": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100000 values of kubernetes.container.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "missingBucket": false,
-                                                        "orderAgg": {
-                                                            "customLabel": false,
-                                                            "dataType": "number",
-                                                            "isBucketed": false,
-                                                            "label": "Count of records",
-                                                            "operationType": "count",
-                                                            "params": {},
-                                                            "scale": "ratio",
-                                                            "sourceField": "___records___"
-                                                        },
-                                                        "orderBy": {
-                                                            "type": "custom"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 100000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.container.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "21cde57c-0e69-4e4c-b3e9-659de2778d06",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ],
-                                        "type": "phrases",
-                                        "value": [
-                                            "kubernetes.container",
-                                            "kubernetes.state_node"
-                                        ]
-                                    },
-                                    "query": {
-                                        "bool": {
-                                            "minimum_should_match": 1,
-                                            "should": [
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.container"
-                                                    }
-                                                },
-                                                {
-                                                    "match_phrase": {
-                                                        "data_stream.dataset": "kubernetes.state_node"
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "fillOpacity": 0.5,
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "307be273-94a6-41ab-b93b-0debde733492"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dff09473-7596-48c7-bbf4-beccee70d845",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "default",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "area",
-                                        "splitAccessor": "6677e92c-5874-49c1-979e-c16c0d3838cd",
-                                        "xAccessor": "46082fb5-9abc-42a0-8e4d-8a8d40a66ddf",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#00bfb3",
-                                                "forAccessor": "307be273-94a6-41ab-b93b-0debde733492"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "accessors": [
-                                            "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "dfd1702f-213e-4fa2-98e3-5106657c62e7",
-                                        "layerType": "data",
-                                        "palette": {
-                                            "name": "negative",
-                                            "type": "palette"
-                                        },
-                                        "seriesType": "line",
-                                        "splitAccessor": "f0953a4e-8498-4b22-a63a-d24e4a069ed3",
-                                        "xAccessor": "5c33dcdb-21de-4bdc-b564-ba82ed037d11",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "color": "#bd271e",
-                                                "forAccessor": "62125b6d-3199-420b-9d3b-46f159e15d7f"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "maxLines": 1,
-                                    "position": "top",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "xTitle": "",
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yLeftScale": "linear",
-                                "yRightExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightScale": "linear",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "a91d36c0-f405-4c04-8510-11134bd259f0",
-                    "w": 20,
-                    "x": 8,
-                    "y": 4
-                },
-                "panelIndex": "a91d36c0-f405-4c04-8510-11134bd259f0",
-                "title": "Memory used vs total memory",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "state_daemonset-ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "ready": {
-                                            "script": {
-                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            ],
-                                            "columns": {
-                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "ready"
-                                                },
-                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.daemonset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.daemonset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_daemonset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_daemonset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
-                                            "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
-                                        "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "bottom",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "valuesInLegend": true,
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
-                    "w": 10,
-                    "x": 28,
-                    "y": 13
-                },
-                "panelIndex": "a45792c9-1600-4632-bf8e-a0a0984d82d9",
-                "title": "DaemonSets",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [],
-                        "state": {
-                            "adHocDataViews": {
-                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
-                                    "name": "state-pods-adhoc",
-                                    "runtimeFieldMap": {
-                                        "failed": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "not_running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "pending": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "running": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        },
-                                        "succeeded": {
-                                            "script": {
-                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "state_replicaset_ad-hoc",
-                                    "runtimeFieldMap": {
-                                        "not_ready": {
-                                            "script": {
-                                                "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
-                                            },
-                                            "type": "long"
-                                        }
-                                    },
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                },
-                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
-                                    "name": "daemonsets-ad-hoc",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "metrics-*,*:metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "b7b25285-ced1-481d-999e-1886b3463594": {
-                                            "columnOrder": [
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            ],
-                                            "columns": {
-                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Filters",
-                                                    "operationType": "filters",
-                                                    "params": {
-                                                        "filters": [
-                                                            {
-                                                                "input": {
-                                                                    "language": "kuery",
-                                                                    "query": ""
-                                                                },
-                                                                "label": "Status"
-                                                            }
-                                                        ]
-                                                    },
-                                                    "scale": "ordinal"
-                                                },
-                                                "a51a9822-167b-4b8f-b7a6-3051da30164b": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.replicaset.replicas.ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "reducedTimeRange": "1m",
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.replicaset.replicas.ready"
-                                                },
-                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "not_ready: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Not Ready",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "not_ready"
-                                                },
-                                                "fcc76997-5b49-416b-81ba-37d65ea25296": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.replicaset.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "kubernetes.replicaset.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "kubernetes.state_replicaset"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "kubernetes.state_replicaset"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [
-                                {
-                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
-                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a51a9822-167b-4b8f-b7a6-3051da30164b",
-                                            "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                        ],
-                                        "collapseFn": "sum",
-                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "bar_horizontal",
-                                        "showGridlines": false,
-                                        "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
-                                        "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
-                                        "yConfig": [
-                                            {
-                                                "color": "#bd271e",
-                                                "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
-                                            },
-                                            {
-                                                "color": "#00bfb3",
-                                                "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": false,
-                                    "position": "right",
-                                    "showSingleSeries": false
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": true
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "show",
-                                "xTitle": "",
-                                "yTitle": ""
-                            }
-                        },
-                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 6,
-                    "i": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
-                    "w": 10,
-                    "x": 38,
-                    "y": 13
-                },
-                "panelIndex": "eb118cf7-b033-4bcf-acdf-dab0b5da73e7",
-                "title": "ReplicaSets",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1886,15 +1312,14 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "64dd7c4e-b503-4cc4-8c61-e17c52204b54",
+                    "i": "9c35c316-5f71-4e96-9b00-70f32f5cde18",
                     "w": 9,
                     "x": 0,
                     "y": 13
                 },
-                "panelIndex": "64dd7c4e-b503-4cc4-8c61-e17c52204b54",
+                "panelIndex": "9c35c316-5f71-4e96-9b00-70f32f5cde18",
                 "title": "Running pods per namespace",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2193,15 +1618,14 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "91e43cd8-5259-43a8-b9d7-a098875ae5b3",
+                    "i": "5c668c32-d7e2-4547-9dcf-e45cbb614f48",
                     "w": 9,
                     "x": 9,
                     "y": 13
                 },
-                "panelIndex": "91e43cd8-5259-43a8-b9d7-a098875ae5b3",
+                "panelIndex": "5c668c32-d7e2-4547-9dcf-e45cbb614f48",
                 "title": "Pods",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2506,15 +1930,584 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "9543898d-c036-4680-b122-45fe721c0226",
+                    "i": "1c962f35-c142-44b8-9527-746a1b1cd79c",
                     "w": 10,
                     "x": 18,
                     "y": 13
                 },
-                "panelIndex": "9543898d-c036-4680-b122-45fe721c0226",
+                "panelIndex": "1c962f35-c142-44b8-9527-746a1b1cd79c",
                 "title": "Deployments",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                                    "name": "state-pods-adhoc",
+                                    "runtimeFieldMap": {
+                                        "failed": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "not_running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "pending": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "succeeded": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                },
+                                "295ecdc5-f413-4f20-9f77-74927a10d33d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                    "name": "state_daemonset-ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "not_ready": {
+                                            "script": {
+                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value != 0) {emit(1)}"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "ready": {
+                                            "script": {
+                                                "source": "if (doc[\"kubernetes.daemonset.replicas.desired\"].value - doc[\"kubernetes.daemonset.replicas.ready\"].value == 0) {emit(1)}"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                },
+                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                                    "name": "daemonsets-ad-hoc",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b7b25285-ced1-481d-999e-1886b3463594": {
+                                            "columnOrder": [
+                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                            ],
+                                            "columns": {
+                                                "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "not_ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "not_ready"
+                                                },
+                                                "0e2a3f8d-cc26-453d-bed1-b184e48756b2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "ready"
+                                                },
+                                                "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Filters",
+                                                    "operationType": "filters",
+                                                    "params": {
+                                                        "filters": [
+                                                            {
+                                                                "input": {
+                                                                    "language": "kuery",
+                                                                    "query": ""
+                                                                },
+                                                                "label": "Status"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scale": "ordinal"
+                                                },
+                                                "e36fb66d-f9b0-46d3-aec4-52638d34d308": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.daemonset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.daemonset.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_daemonset"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.state_daemonset"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "295ecdc5-f413-4f20-9f77-74927a10d33d",
+                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0e2a3f8d-cc26-453d-bed1-b184e48756b2",
+                                            "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "splitAccessor": "e36fb66d-f9b0-46d3-aec4-52638d34d308",
+                                        "xAccessor": "5b89a3a0-f94e-49c2-bc43-fdd4c7671ea5",
+                                        "yConfig": [
+                                            {
+                                                "color": "#bd271e",
+                                                "forAccessor": "05b6d6a0-0ed8-4f14-a3e4-68071b01b03c"
+                                            },
+                                            {
+                                                "color": "#00bfb3",
+                                                "forAccessor": "0e2a3f8d-cc26-453d-bed1-b184e48756b2"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "bottom",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "valuesInLegend": true,
+                                "xTitle": "",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "d2ebf653-5565-4230-8f1a-3f93a6dd1dcf",
+                    "w": 10,
+                    "x": 28,
+                    "y": 13
+                },
+                "panelIndex": "d2ebf653-5565-4230-8f1a-3f93a6dd1dcf",
+                "title": "DaemonSets",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "0fa53a1e-0589-4380-b700-70dd489a33de": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "0fa53a1e-0589-4380-b700-70dd489a33de",
+                                    "name": "state-pods-adhoc",
+                                    "runtimeFieldMap": {
+                                        "failed": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "not_running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\" || doc['kubernetes.pod.status.phase'].value == \"failed\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "pending": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"pending\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "running": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"running\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        },
+                                        "succeeded": {
+                                            "script": {
+                                                "source": "if (doc['kubernetes.pod.status.phase'].value == \"succeeded\") { emit(1) }"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                },
+                                "dbfaeb6f-4fff-4043-8bf8-19d5345fd339": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                                    "name": "state_replicaset_ad-hoc",
+                                    "runtimeFieldMap": {
+                                        "not_ready": {
+                                            "script": {
+                                                "source": "def ready = doc['kubernetes.replicaset.replicas.ready'].value;\ndef des = doc['kubernetes.replicaset.replicas.desired'].value;\nemit(des-ready)"
+                                            },
+                                            "type": "long"
+                                        }
+                                    },
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                },
+                                "f8fa576a-6f91-4a11-a43d-7f3964869d7d": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "f8fa576a-6f91-4a11-a43d-7f3964869d7d",
+                                    "name": "daemonsets-ad-hoc",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*,*:metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b7b25285-ced1-481d-999e-1886b3463594": {
+                                            "columnOrder": [
+                                                "fcc76997-5b49-416b-81ba-37d65ea25296",
+                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                                                "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                            ],
+                                            "columns": {
+                                                "446fc0b3-a6c8-4f4d-914b-748d488083a1": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Filters",
+                                                    "operationType": "filters",
+                                                    "params": {
+                                                        "filters": [
+                                                            {
+                                                                "input": {
+                                                                    "language": "kuery",
+                                                                    "query": ""
+                                                                },
+                                                                "label": "Status"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "scale": "ordinal"
+                                                },
+                                                "a51a9822-167b-4b8f-b7a6-3051da30164b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "kubernetes.replicaset.replicas.ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "reducedTimeRange": "1m",
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.replicaset.replicas.ready"
+                                                },
+                                                "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "not_ready: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Not Ready",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "not_ready"
+                                                },
+                                                "fcc76997-5b49-416b-81ba-37d65ea25296": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10000 values of kubernetes.replicaset.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.replicaset.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "kubernetes.state_replicaset"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "kubernetes.state_replicaset"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [
+                                {
+                                    "id": "dbfaeb6f-4fff-4043-8bf8-19d5345fd339",
+                                    "name": "indexpattern-datasource-layer-b7b25285-ced1-481d-999e-1886b3463594",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "a51a9822-167b-4b8f-b7a6-3051da30164b",
+                                            "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                        ],
+                                        "collapseFn": "sum",
+                                        "layerId": "b7b25285-ced1-481d-999e-1886b3463594",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_horizontal",
+                                        "showGridlines": false,
+                                        "splitAccessor": "fcc76997-5b49-416b-81ba-37d65ea25296",
+                                        "xAccessor": "446fc0b3-a6c8-4f4d-914b-748d488083a1",
+                                        "yConfig": [
+                                            {
+                                                "color": "#bd271e",
+                                                "forAccessor": "e8f5e7ee-1dc9-46e8-b43a-18f7a358d920"
+                                            },
+                                            {
+                                                "color": "#00bfb3",
+                                                "forAccessor": "a51a9822-167b-4b8f-b7a6-3051da30164b"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "position": "right",
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_horizontal",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "show",
+                                "xTitle": "",
+                                "yTitle": ""
+                            }
+                        },
+                        "title": "Total Pods per Namespace [Metrics Kubernetes] (copy 1)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": []
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 6,
+                    "i": "4cee43da-da65-4c38-b723-5195a0356cce",
+                    "w": 10,
+                    "x": 38,
+                    "y": 13
+                },
+                "panelIndex": "4cee43da-da65-4c38-b723-5195a0356cce",
+                "title": "ReplicaSets",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2703,15 +2696,14 @@
                 },
                 "gridData": {
                     "h": 11,
-                    "i": "14ceb02d-63b6-448a-85fe-28a9e974e80c",
-                    "w": 24,
-                    "x": 0,
+                    "i": "67ca2ace-f83e-46ae-b9b9-ae12fd4216f4",
+                    "w": 17,
+                    "x": 13,
                     "y": 19
                 },
-                "panelIndex": "14ceb02d-63b6-448a-85fe-28a9e974e80c",
+                "panelIndex": "67ca2ace-f83e-46ae-b9b9-ae12fd4216f4",
                 "title": "Top CPU intensive pods",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2900,15 +2892,172 @@
                 },
                 "gridData": {
                     "h": 11,
-                    "i": "783789d4-8473-40f5-acf0-7ae5c850cd3e",
-                    "w": 24,
-                    "x": 24,
+                    "i": "d752a69e-1f27-4dfc-a5d8-ddcc6f6af7fe",
+                    "w": 18,
+                    "x": 30,
                     "y": 19
                 },
-                "panelIndex": "783789d4-8473-40f5-acf0-7ae5c850cd3e",
+                "panelIndex": "d752a69e-1f27-4dfc-a5d8-ddcc6f6af7fe",
                 "title": "Top memory intensive pods",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-646f5275-fa3f-4808-9b01-24b383d044bd",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "646f5275-fa3f-4808-9b01-24b383d044bd": {
+                                            "columnOrder": [
+                                                "ba9eab45-c75c-4d4b-a8b8-6a27af6b54e0",
+                                                "c3fddd49-fbb6-4c93-91f3-769a258dd8d4",
+                                                "8850eb95-f764-45d3-813b-d00f7341f3d8"
+                                            ],
+                                            "columns": {
+                                                "8850eb95-f764-45d3-813b-d00f7341f3d8": {
+                                                    "customLabel": true,
+                                                    "dataType": "boolean",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"kubernetes.state_namespace.status.terminating\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Terminating",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.state_namespace.status.terminating"
+                                                },
+                                                "ba9eab45-c75c-4d4b-a8b8-6a27af6b54e0": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 namespaces",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": false,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "kubernetes.namespace"
+                                                },
+                                                "c3fddd49-fbb6-4c93-91f3-769a258dd8d4": {
+                                                    "customLabel": true,
+                                                    "dataType": "boolean",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"kubernetes.state_namespace.status.active\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Active",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.state_namespace.status.active"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "c3fddd49-fbb6-4c93-91f3-769a258dd8d4",
+                                        "width": 111.66666666666669
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "8850eb95-f764-45d3-813b-d00f7341f3d8",
+                                        "width": 131.66666666666663
+                                    },
+                                    {
+                                        "columnId": "ba9eab45-c75c-4d4b-a8b8-6a27af6b54e0",
+                                        "isTransposed": false,
+                                        "width": 221.66666666666674
+                                    }
+                                ],
+                                "layerId": "646f5275-fa3f-4808-9b01-24b383d044bd",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "98d1ad5a-5637-4b25-9046-f7117cdcfdd1",
+                    "w": 13,
+                    "x": 0,
+                    "y": 19
+                },
+                "panelIndex": "98d1ad5a-5637-4b25-9046-f7117cdcfdd1",
+                "title": "Namespaces",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 11,
+                    "i": "765e6f47-9f10-4eb3-aebf-b6238089f46a",
+                    "w": 24,
+                    "x": 24,
+                    "y": 30
+                },
+                "panelIndex": "765e6f47-9f10-4eb3-aebf-b6238089f46a",
+                "panelRefName": "panel_765e6f47-9f10-4eb3-aebf-b6238089f46a",
+                "title": "Latest Kubernetes warnings",
+                "type": "search"
             },
             {
                 "embeddableConfig": {
@@ -3097,141 +3246,126 @@
                 },
                 "gridData": {
                     "h": 11,
-                    "i": "2525515f-80e7-455f-b88b-53e4abf31cd2",
+                    "i": "92f36119-6a25-4329-8df4-f10578748cb0",
                     "w": 24,
                     "x": 0,
                     "y": 30
                 },
-                "panelIndex": "2525515f-80e7-455f-b88b-53e4abf31cd2",
+                "panelIndex": "92f36119-6a25-4329-8df4-f10578748cb0",
                 "title": "Kubernetes warning events",
-                "type": "lens",
-                "version": "8.6.0-SNAPSHOT"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 11,
-                    "i": "a59fd3c5-5f33-425d-b14e-4713222cc729",
-                    "w": 24,
-                    "x": 24,
-                    "y": 30
-                },
-                "panelIndex": "a59fd3c5-5f33-425d-b14e-4713222cc729",
-                "panelRefName": "panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
-                "title": "Latest Kubernetes warnings",
-                "type": "search",
-                "version": "8.6.0-SNAPSHOT"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
         "title": "[Metrics Kubernetes] Cluster Overview",
         "version": 1
     },
-    "coreMigrationVersion": "8.6.0",
-    "created_at": "2023-01-12T14:44:58.161Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2023-11-02T08:34:41.761Z",
     "id": "kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c",
-    "migrationVersion": {
-        "dashboard": "8.6.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "d0fadeee-3c79-443b-bfcb-b70e78d168e9:indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
+            "name": "ff159cfe-ddb2-4844-9b72-e841b601426b:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d0fadeee-3c79-443b-bfcb-b70e78d168e9:indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
+            "name": "ff159cfe-ddb2-4844-9b72-e841b601426b:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d0fadeee-3c79-443b-bfcb-b70e78d168e9:fbaf3405-fab6-4f09-883d-45368cf97670",
+            "name": "ff159cfe-ddb2-4844-9b72-e841b601426b:21cde57c-0e69-4e4c-b3e9-659de2778d06",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dfd1702f-213e-4fa2-98e3-5106657c62e7",
+            "name": "59f800b7-15e6-4a49-a03d-39e1f842e11b:indexpattern-datasource-layer-c165f898-73a9-48b1-afa9-2b6e75f3cc1f",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:indexpattern-datasource-layer-dff09473-7596-48c7-bbf4-beccee70d845",
+            "name": "59f800b7-15e6-4a49-a03d-39e1f842e11b:indexpattern-datasource-layer-dde29dcf-00ae-4b80-8d9e-ab45c51efba0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "a91d36c0-f405-4c04-8510-11134bd259f0:21cde57c-0e69-4e4c-b3e9-659de2778d06",
+            "name": "59f800b7-15e6-4a49-a03d-39e1f842e11b:fbaf3405-fab6-4f09-883d-45368cf97670",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "64dd7c4e-b503-4cc4-8c61-e17c52204b54:indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
+            "name": "9c35c316-5f71-4e96-9b00-70f32f5cde18:indexpattern-datasource-layer-2ca9773d-0221-478b-b8bc-90bb8d439f33",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "64dd7c4e-b503-4cc4-8c61-e17c52204b54:5c81359c-376d-41bd-984d-60fb106f2e33",
+            "name": "9c35c316-5f71-4e96-9b00-70f32f5cde18:5c81359c-376d-41bd-984d-60fb106f2e33",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "14ceb02d-63b6-448a-85fe-28a9e974e80c:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+            "name": "67ca2ace-f83e-46ae-b9b9-ae12fd4216f4:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "14ceb02d-63b6-448a-85fe-28a9e974e80c:a06a30d5-05f1-46ea-9075-3e6051f5781a",
+            "name": "67ca2ace-f83e-46ae-b9b9-ae12fd4216f4:a06a30d5-05f1-46ea-9075-3e6051f5781a",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "14ceb02d-63b6-448a-85fe-28a9e974e80c:9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
+            "name": "67ca2ace-f83e-46ae-b9b9-ae12fd4216f4:9c0b0d2f-c443-4c41-b55c-c7ad0db60302",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "783789d4-8473-40f5-acf0-7ae5c850cd3e:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
+            "name": "d752a69e-1f27-4dfc-a5d8-ddcc6f6af7fe:indexpattern-datasource-layer-06a776d4-f25a-45c0-a54e-82d0cb913047",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "783789d4-8473-40f5-acf0-7ae5c850cd3e:8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
+            "name": "d752a69e-1f27-4dfc-a5d8-ddcc6f6af7fe:8769bfd6-a9c7-4bab-b048-0e2fcffe8114",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "783789d4-8473-40f5-acf0-7ae5c850cd3e:d79e5279-bd92-48b0-bd92-767cf6b8892d",
+            "name": "d752a69e-1f27-4dfc-a5d8-ddcc6f6af7fe:d79e5279-bd92-48b0-bd92-767cf6b8892d",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "2525515f-80e7-455f-b88b-53e4abf31cd2:indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "2525515f-80e7-455f-b88b-53e4abf31cd2:086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
+            "name": "98d1ad5a-5637-4b25-9046-f7117cdcfdd1:indexpattern-datasource-layer-646f5275-fa3f-4808-9b01-24b383d044bd",
             "type": "index-pattern"
         },
         {
             "id": "kubernetes-ee55101a-9f62-44da-b64c-ffa1eb5abad8",
-            "name": "a59fd3c5-5f33-425d-b14e-4713222cc729:panel_a59fd3c5-5f33-425d-b14e-4713222cc729",
+            "name": "765e6f47-9f10-4eb3-aebf-b6238089f46a:panel_765e6f47-9f10-4eb3-aebf-b6238089f46a",
             "type": "search"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_748291db-2826-4242-9107-9a5226733a06:optionsListDataView",
+            "name": "92f36119-6a25-4329-8df4-f10578748cb0:indexpattern-datasource-layer-a69d8e15-2ebf-401c-af12-4b6762f230db",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_2da8af79-7928-4741-8d03-866642f3c2a0:optionsListDataView",
+            "name": "92f36119-6a25-4329-8df4-f10578748cb0:086a73a8-ac9d-48eb-b5b7-3c697278cc9e",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_ab7e24eb-5eda-4ac4-aee5-a3394e367e48:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_f9b39846-449c-430c-b83d-bb49afcd1691:optionsListDataView",
             "type": "index-pattern"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.52.0
+version: 1.52.1
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## What

Add namespace visualization to Overview dashboard.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

1. Clone this branch.
2. Check Overview dashboard under assets in Kubernetes integration.

## Related issues

Relates to https://github.com/elastic/elastic-agent/issues/3100.


## Screenshots

Change is the table added for the top 10 namespaces:

![Metrics Kubernetes  Cluster Overview](https://github.com/elastic/integrations/assets/113898685/18ecc66a-5880-4cae-9361-9dae7f3bf3cc)
