### PR TITLE
[Kubernetes] Remove extra base fields for state datastreams

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.52.1
+  changes:
+    - description: Remove extra base fields from state data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8329
 - version: 1.52.0
   changes:
     - description: Add new data stream state_namespace.

--- a/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/base-fields.yml
@@ -13,36 +13,10 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      dimension: true
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
-
     - name: namespace
       type: keyword
       description: >
         Kubernetes namespace
-
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
 
     - name: labels.*
       type: object
@@ -58,25 +32,6 @@
       description: >
         Kubernetes annotations map
 
-    - name: node.labels.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes node labels map
-
-    - name: node.annotations.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes node annotations map
-
-    - name: node.uid
-      type: keyword
-      description: >
-        Kubernetes node UID
-
     - name: namespace_uid
       type: keyword
       description: >
@@ -89,56 +44,7 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: namespace_annotations.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes namespace annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: daemonset.name
-      type: keyword
-      description: >
-        Kubernetes daemonset name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: job.name
-      type: keyword
-      description: >
-        Name of the Job to which the Pod belongs
-
     - name: cronjob.name
       type: keyword
       description: >
         Name of the CronJob to which the Pod belongs
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -69,35 +45,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -69,35 +45,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_deployment/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_deployment/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -70,35 +46,8 @@
       description: >
         Kubernetes annotations map
 
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
     - name: deployment.name
       dimension: true
       type: keyword
       description: >
         Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_job/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -70,28 +46,6 @@
       description: >
         Kubernetes annotations map
 
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
     - name: job.name
       dimension: true
       type: keyword
@@ -102,13 +56,3 @@
       type: keyword
       description: >
         Name of the CronJob to which the Pod belongs
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_node/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_node/fields/base-fields.yml
@@ -13,36 +13,12 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
-
-    - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
 
     - name: node.name
       dimension: true
       type: keyword
       description: >
         Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
 
     - name: labels.*
       type: object
@@ -57,35 +33,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_persistentvolume/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/fields/base-fields.yml
@@ -13,35 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
-
-    - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
-
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
 
     - name: labels.*
       type: object
@@ -56,35 +27,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -69,35 +45,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_pod/fields/base-fields.yml
@@ -65,13 +65,6 @@
       description: >
         Kubernetes node labels map
 
-    - name: node.annotations.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes node annotations map
-
     - name: node.uid
       type: keyword
       description: >
@@ -88,20 +81,6 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes namespace labels map
-
-    - name: namespace_annotations.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes namespace annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
 
     - name: replicaset.name
       type: keyword
@@ -133,12 +112,3 @@
       description: >
         Name of the CronJob to which the Pod belongs
 
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,16 +32,6 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
-
     - name: labels.*
       type: object
       object_type: keyword
@@ -70,13 +46,6 @@
       description: >
         Kubernetes annotations map
 
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
     - name: replicaset.name
       dimension: true
       type: keyword
@@ -87,18 +56,3 @@
       type: keyword
       description: >
         Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/fields/base-fields.yml
@@ -13,36 +13,12 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       dimension: true
       type: keyword
       description: >
         Kubernetes namespace
-
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
 
     - name: labels.*
       type: object
@@ -57,35 +33,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_service/fields/base-fields.yml
@@ -13,39 +13,11 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
       description: >
         Kubernetes namespace
-
-    - name: labels.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes labels map
-
-    - name: annotations.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes annotations map
 
     - name: namespace_uid
       dimension: true
@@ -60,12 +32,20 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: namespace_annotations.*
+    - name: labels.*
       type: object
       object_type: keyword
       object_type_mapping_type: "*"
       description: >
-        Kubernetes namespace annotations map
+        Kubernetes labels map
+
+
+    - name: annotations.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes annotations map
 
     - name: selectors.*
       type: object
@@ -73,28 +53,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/fields/base-fields.yml
@@ -13,20 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
 
     - name: namespace
       type: keyword
@@ -46,15 +32,11 @@
       description: >
         Kubernetes namespace labels map
 
-    - name: node.name
+    - name: statefulset.name
+      dimension: true
       type: keyword
       description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
+        Kubernetes statefulset name
 
     - name: labels.*
       type: object
@@ -69,36 +51,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      dimension: true
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/data_stream/state_storageclass/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/fields/base-fields.yml
@@ -13,35 +13,6 @@
 - name: kubernetes
   type: group
   fields:
-    - name: pod.name
-      type: keyword
-      description: >
-        Kubernetes pod name
-
-    - name: pod.uid
-      type: keyword
-      description: >
-        Kubernetes pod UID
-
-    - name: pod.ip
-      type: ip
-      description: >
-        Kubernetes pod IP
-
-    - name: namespace
-      type: keyword
-      description: >
-        Kubernetes namespace
-
-    - name: node.name
-      type: keyword
-      description: >
-        Kubernetes node name
-
-    - name: node.hostname
-      type: keyword
-      description: >
-        Kubernetes hostname as reported by the node’s kernel
 
     - name: labels.*
       type: object
@@ -56,35 +27,3 @@
       object_type_mapping_type: "*"
       description: >
         Kubernetes annotations map
-
-    - name: selectors.*
-      type: object
-      object_type: keyword
-      object_type_mapping_type: "*"
-      description: >
-        Kubernetes Service selectors map
-
-    - name: replicaset.name
-      type: keyword
-      description: >
-        Kubernetes replicaset name
-
-    - name: deployment.name
-      type: keyword
-      description: >
-        Kubernetes deployment name
-
-    - name: statefulset.name
-      type: keyword
-      description: >
-        Kubernetes statefulset name
-
-    - name: container.name
-      type: keyword
-      description: >
-        Kubernetes container name
-
-    - name: container.image
-      type: keyword
-      description: >-
-        Kubernetes container image

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -196,34 +196,17 @@ An example event for `state_container` looks as following:
 | kubernetes.container.cpu.request.cores | Container CPU requested cores | float |  | gauge |
 | kubernetes.container.cpu.request.nanocores | Container CPU requested nanocores | long |  | gauge |
 | kubernetes.container.id | Container id | keyword |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
 | kubernetes.container.memory.limit.bytes | Container memory limit in bytes | long | byte | gauge |
 | kubernetes.container.memory.request.bytes | Container requested memory in bytes | long | byte | gauge |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.container.status.phase | Container phase (running, waiting, terminated) | keyword |  |  |
 | kubernetes.container.status.ready | Container ready status | boolean |  |  |
 | kubernetes.container.status.reason | Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason. | keyword |  |  |
 | kubernetes.container.status.restarts | Container restarts count | integer |  | counter |
 | kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |  |
-| kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
-| kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
-| kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |  |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |  |
-| kubernetes.node.annotations.\* | Kubernetes node annotations map | object |  |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
-| kubernetes.node.labels.\* | Kubernetes node labels map | object |  |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |  |
-| kubernetes.node.uid | Kubernetes node UID | keyword |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -409,8 +392,6 @@ An example event for `state_cronjob` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.cronjob.active.count | Number of active pods for the cronjob | long |  | gauge |
 | kubernetes.cronjob.concurrency | Concurrency policy | keyword |  |  |
 | kubernetes.cronjob.created.sec | Epoch seconds since the cronjob was created | double | s | gauge |
@@ -420,19 +401,10 @@ An example event for `state_cronjob` looks as following:
 | kubernetes.cronjob.name | Cronjob name | keyword |  |  |
 | kubernetes.cronjob.next_schedule.sec | Epoch seconds for next cronjob run | double | s | gauge |
 | kubernetes.cronjob.schedule | Cronjob schedule | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -602,26 +574,15 @@ An example event for `state_daemonset` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.daemonset.name |  | keyword |  |
 | kubernetes.daemonset.replicas.available | The number of available replicas per DaemonSet | long | gauge |
 | kubernetes.daemonset.replicas.desired | The desired number of replicas per DaemonSet | long | gauge |
 | kubernetes.daemonset.replicas.ready | The number of ready replicas per DaemonSet | long | gauge |
 | kubernetes.daemonset.replicas.unavailable | The number of unavailable replicas per DaemonSet | long | gauge |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
@@ -792,8 +753,6 @@ An example event for `state_deployment` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.deployment.paused | Kubernetes deployment paused status | boolean |  |
 | kubernetes.deployment.replicas.available | Deployment available replicas | integer | gauge |
@@ -806,14 +765,6 @@ An example event for `state_deployment` looks as following:
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
@@ -1010,10 +961,7 @@ An example event for `state_job` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.job.completions.desired | The configured completion count for the job (Spec) | long | gauge |
 | kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |  |
 | kubernetes.job.owner.is_controller | Owner is controller ("true", "false", or `"\<none\>"`) | keyword |  |
@@ -1031,14 +979,6 @@ An example event for `state_job` looks as following:
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
@@ -1309,14 +1249,9 @@ An example event for `state_node` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |  | gauge |
 | kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |  | gauge |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
 | kubernetes.node.memory.allocatable.bytes | Node allocatable memory in bytes | long | byte | gauge |
 | kubernetes.node.memory.capacity.bytes | Node memory capacity in bytes | long | byte | gauge |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |
@@ -1329,12 +1264,6 @@ An example event for `state_node` looks as following:
 | kubernetes.node.status.pid_pressure | Node PIDPressure status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.ready | Node ready status (true, false or unknown) | keyword |  |  |
 | kubernetes.node.status.unschedulable | Node unschedulable status | boolean |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -1451,23 +1380,11 @@ An example event for `state_persistentvolume` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
-| kubernetes.namespace | Kubernetes namespace | keyword |  |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.persistentvolume.capacity.bytes | Volume capacity | long | byte | gauge |
 | kubernetes.persistentvolume.name | Volume name. | keyword |  |  |
 | kubernetes.persistentvolume.phase | Volume phase according to kubernetes | keyword |  |  |
 | kubernetes.persistentvolume.storage_class | Storage class for the volume | keyword |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -1643,27 +1560,16 @@ An example event for `state_persistentvolumeclaim` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |  |
 | kubernetes.persistentvolumeclaim.access_mode | Access mode. | keyword |  |  |
 | kubernetes.persistentvolumeclaim.name | PVC name. | keyword |  |  |
 | kubernetes.persistentvolumeclaim.phase | PVC phase. | keyword |  |  |
 | kubernetes.persistentvolumeclaim.request_storage.bytes | Requested capacity. | long | byte | gauge |
 | kubernetes.persistentvolumeclaim.storage_class | Storage class for the PVC. | keyword |  |  |
 | kubernetes.persistentvolumeclaim.volume_name | Binded volume name. | keyword |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -1828,18 +1734,14 @@ An example event for `state_pod` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
 | kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.job.name | Name of the Job to which the Pod belongs | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |
-| kubernetes.node.annotations.\* | Kubernetes node annotations map | object |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
 | kubernetes.node.labels.\* | Kubernetes node labels map | object |
 | kubernetes.node.name | Kubernetes node name | keyword |
@@ -1852,7 +1754,6 @@ An example event for `state_pod` looks as following:
 | kubernetes.pod.status.scheduled | Kubernetes pod scheduled status (true, false, unknown) | keyword |
 | kubernetes.pod.uid | Kubernetes pod UID | keyword |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |
 | kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
 | orchestrator.cluster.name | Name of the cluster. | keyword |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |
@@ -2030,26 +1931,17 @@ An example event for `state_replicaset` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |
 | kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
 | kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
 | kubernetes.replicaset.replicas.available | The number of replicas per ReplicaSet | long | gauge |
 | kubernetes.replicaset.replicas.desired | The number of replicas per ReplicaSet | long | gauge |
 | kubernetes.replicaset.replicas.labeled | The number of fully labeled replicas per ReplicaSet | long | gauge |
 | kubernetes.replicaset.replicas.observed | The generation observed by the ReplicaSet controller | long | gauge |
 | kubernetes.replicaset.replicas.ready | The number of ready replicas per ReplicaSet | long | gauge |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
@@ -2162,24 +2054,13 @@ An example event for `state_resourcequota` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |  |
 | kubernetes.resourcequota.created.sec | Epoch seconds since the ResourceQuota was created | double | s | gauge |
 | kubernetes.resourcequota.name | ResourceQuota name | keyword |  |  |
 | kubernetes.resourcequota.quota | Quota informed (hard or used) for the resource | double |  | gauge |
 | kubernetes.resourcequota.resource | Resource name the quota applies to | keyword |  |  |
 | kubernetes.resourcequota.type | Quota information type, `hard` or `used` | keyword |  |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |  |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |  |  |
 | orchestrator.cluster.name | Name of the cluster. | keyword |  |  |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |  |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |  |
@@ -2326,18 +2207,10 @@ An example event for `state_service` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
 | kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.namespace_annotations.\* | Kubernetes namespace annotations map | object |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
 | kubernetes.selectors.\* | Kubernetes Service selectors map | object |
 | kubernetes.service.cluster_ip | Internal IP for the service. | keyword |
 | kubernetes.service.created | Service creation date | date |
@@ -2348,7 +2221,6 @@ An example event for `state_service` looks as following:
 | kubernetes.service.load_balancer_ip | Load Balancer service IP | keyword |
 | kubernetes.service.name | Service name. | keyword |
 | kubernetes.service.type | Service type | keyword |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
 | orchestrator.cluster.name | Name of the cluster. | keyword |
 | orchestrator.cluster.url | URL of the API used to manage the cluster. | keyword |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |
@@ -2529,20 +2401,10 @@ An example event for `state_statefulset` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |
-| kubernetes.container.image | Kubernetes container image | keyword |  |
-| kubernetes.container.name | Kubernetes container name | keyword |  |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |  |
 | kubernetes.labels.\* | Kubernetes labels map | object |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |
 | kubernetes.namespace_labels.\* | Kubernetes namespace labels map | object |  |
 | kubernetes.namespace_uid | Kubernetes namespace UID | keyword |  |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |
-| kubernetes.node.name | Kubernetes node name | keyword |  |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |  |
-| kubernetes.pod.name | Kubernetes pod name | keyword |  |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |  |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |  |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |  |
 | kubernetes.statefulset.created | The creation timestamp (epoch) for StatefulSet | long | gauge |
 | kubernetes.statefulset.generation.desired | The desired generation per StatefulSet | long | gauge |
 | kubernetes.statefulset.generation.observed | The observed generation per StatefulSet | long | gauge |
@@ -2665,19 +2527,7 @@ An example event for `state_storageclass` looks as following:
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |
-| kubernetes.container.image | Kubernetes container image | keyword |
-| kubernetes.container.name | Kubernetes container name | keyword |
-| kubernetes.deployment.name | Kubernetes deployment name | keyword |
 | kubernetes.labels.\* | Kubernetes labels map | object |
-| kubernetes.namespace | Kubernetes namespace | keyword |
-| kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |
-| kubernetes.node.name | Kubernetes node name | keyword |
-| kubernetes.pod.ip | Kubernetes pod IP | ip |
-| kubernetes.pod.name | Kubernetes pod name | keyword |
-| kubernetes.pod.uid | Kubernetes pod UID | keyword |
-| kubernetes.replicaset.name | Kubernetes replicaset name | keyword |
-| kubernetes.selectors.\* | Kubernetes Service selectors map | object |
-| kubernetes.statefulset.name | Kubernetes statefulset name | keyword |
 | kubernetes.storageclass.created | Storage class creation date | date |
 | kubernetes.storageclass.name | Storage class name. | keyword |
 | kubernetes.storageclass.provisioner | Volume provisioner for the storage class. | keyword |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.52.0
+version: 1.52.1
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- WHAT: remove extra base fields for all `state_*` datastreams.
- WHY:  we have many fields for the data streams that never hold any value or are not related to it.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How this was tested

1. Created a cluster with the configuration `kind-config.yaml` present in this repo.
2. Deployed all resources in `kubernetes/_dev/deploy/k8s` (these are also the resources being used in testing). Modified some to add annotations.
3. The Kubernetes integrations has all data streams enabled.



## Bugs and warnings

There are some things that don't seem to match expected behaviour.

The most significant one is this:

- `kubernetes.annotations.*` never holds value for any `state_*` datastream. I tried to add `metadata.annotations` to the objects, but none were reported:
  - Is this a bug or expected behavior?
  - I am leaving this group field in all of them, as I am unsure of the answer for the above.

Proof:

![Screenshot from 2023-11-03 11-09-12](https://github.com/elastic/integrations/assets/113898685/50044b1b-eaf2-485b-a7cb-52d265768496)



And if I check (for example) one PVC in the cluster, I can see annotations there:

![Screenshot from 2023-11-03 11-32-20](https://github.com/elastic/integrations/assets/113898685/ba8b0f3f-5687-41a3-878b-c10973835c6b)

Same for a job:

![Screenshot from 2023-11-03 11-40-16](https://github.com/elastic/integrations/assets/113898685/08ded0b9-ffb4-4f36-ad1d-accb2d6ffd15)

And so on.


Other unexpected behaviours:
- Resource quota does not seem to hold `kubernetes.labels.*` even when they were added to the manifest file.
- `state_pod` holds data for `node.labels.*` but not for `node.annotations.*` (same problem as `kubernetes.annotations.*`). This field was removed.
- The same is happening for `namespace_labels.*` and `namespace_annotations.*`. I added the warning separately for these data streams.


## Changes

**NOTE**: Take into account the group field `kubernetes.annotations.*` was not removed from any data stream even if no results were reported. This seems like a bug that needs to be fixed.


For each data stream, the following fields were removed:

<details>
<summary>
state_container
</summary>

  - `kubernetes.node.annotations.*`
  - `kubernetes.namespace_annotations.*`
  - `kubernetes.selectors.*`
  - `kubernetes.container.image`

</details>

- **Warning**: `kubernetes.deployment.name` had no values, even though there were deployments in the cluster... Maybe there is a bug in the code, as it does not seem to be expected. I did not remove this field. Same for `kubernetes.cronjob.name`.


<details>
<summary>
state_cronjob
</summary>

  - `kubernetes.pod.name`
  - `kubernetes.pod.uid`
  - `kubernetes.pod.ip`
  - `kubernetes.node.name`
  - `kubernetes.node.hostname`
  - `kubernetes.selectors.*`
  - `kubernetes.replicaset.name`
  - `kubernetes.deployment.name`
  - `kubernetes.statefulset.name`
  - `kubernetes.container.name`
  - `kubernetes.container.image`

</details>


<details>
<summary>
state_daemonset
</summary>

  - `kubernetes.pod.name`
  - `kubernetes.pod.uid`
  - `kubernetes.pod.ip`
  - `kubernetes.node.name`
  - `kubernetes.node.hostname`
  - `kubernetes.selectors.*`
  - `kubernetes.replicaset.name`
  - `kubernetes.deployment.name`
  - `kubernetes.statefulset.name`
  - `kubernetes.container.name`
  - `kubernetes.container.image`

</details>


<details>
<summary>
state_deployment
</summary>

  - `kubernetes.pod.name`
  - `kubernetes.pod.uid`
  - `kubernetes.pod.ip`
  - `kubernetes.node.name`
  - `kubernetes.node.hostname`
  - `kubernetes.selectors.*`
  - `kubernetes.replicaset.name`
  - `kubernetes.statefulset.name`
  - `kubernetes.container.name`
  - `kubernetes.container.image`

</details>


<details>
<summary>
state_job
</summary>

  - `kubernetes.pod.name`
  - `kubernetes.pod.uid`
  - `kubernetes.pod.ip`
  - `kubernetes.node.name`
  - `kubernetes.node.hostname`
  - `kubernetes.selectors.*`
  - `kubernetes.replicaset.name`
  - `kubernetes.deployment.name`
  - `kubernetes.statefulset.name`
  - `kubernetes.container.name`
  - `kubernetes.container.image`
</details>


<details>
<summary>
state_namespace
</summary>
Newly introduced, nothing to delete.
</details>

<details>
<summary>
state_node
</summary>

  - `kubernetes.pod.name`
  - `kubernetes.pod.uid`
  - `kubernetes.pod.ip`
  - `kubernetes.namespace`
  - `kubernetes.node.hostname`
  - `kubernetes.selectors.*`
  - `kubernetes.replicaset.name`
  - `kubernetes.deployment.name`
  - `kubernetes.statefulset.name`
  - `kubernetes.container.name`
  - `kubernetes.container.image`
</details>



<details>
<summary>
state_persistentvolume
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.namespace`
- `kubernetes.node.name`
- `kubernetes.node.hostname`
- `kubernetes.selectors.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>


<details>
<summary>
state_persistentvolumeclaim
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.namespace`
- `kubernetes.node.name`
- `kubernetes.selectors.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>


<details>
<summary>
state_pod
</summary>

- `kubernetes.node.annotations.*`
- `kubernetes.namespace_annotations.*`
- `kubernetes.selectors.*`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>

- **Warning**: `kubernetes.deployment.name` had no values, even though there were deployments in the cluster... Maybe there is a bug in the code, as it does not seem to be expected. I did not remove this field. Same for `kubernetes.cronjob.name`.
- **Warning**: there is data for `node.labels.*` but not for `node.annotations.*` (same problem as `kubernetes.annotations.*`). This field was removed. 
- **Warning**: same case for `namespace_labels.*` and `namespace_annotations.*`. This field was also removed.

<details>
<summary>
state_replicaset
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.node.name`
- `kubernetes.node.hostname`
- `kubernetes.selectors.*`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>



<details>
<summary>
state_resourcequota
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.node.name`
- `kubernetes.selectors.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>



<details>
<summary>
state_service
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.namespace_annotations.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>

- **Warning**: `namespace_labels.*` and `namespace_annotations.*`: one has value, the other has not. Expected?... This field was also removed.

<details>
<summary>
state_statefulset
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.node.name`
- `kubernetes.node.hostname`
- `kubernetes.seletectors.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.seletectors.*`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>


<details>
<summary>
state_storageclass
</summary>

- `kubernetes.pod.name`
- `kubernetes.pod.uid`
- `kubernetes.pod.ip`
- `kubernetes.node.name`
- `kubernetes.node.hostname`
- `kubernetes.namespace`
- `kubernetes.seletectors.*`
- `kubernetes.replicaset.name`
- `kubernetes.deployment.name`
- `kubernetes.statefulset.name`
- `kubernetes.container.name`
- `kubernetes.container.image`
</details>


## Results

Expected result is that nothing will be broken and everything will keep running as before.

I built the package and update the policy. It was updated as expected:
![Screenshot from 2023-11-03 11-59-43](https://github.com/elastic/integrations/assets/113898685/833f25ec-ed0c-45e9-8d8e-1aa2055b5292)


I also checked every dashboard and all were still working as before (not including screenshots to not overwhelm this description).