### PR TITLE
o365: prevent API calls having a start time more than 168h in the past

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.2"
+  changes:
+    - description: Prevent initial API call failure when a delayed call would result in a start time before 168h in the past.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8402
 - version: "1.25.1"
   changes:
     - description: Add start time fallback for responses that do not include the `startTime` query.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -63,6 +63,7 @@ redact:
   fields: ~
 
 program: |
+  now().as(now, // Prevent now time skew. Remove this and the closing parenthesis when kibana.version is 8.10.1 or higher.
   "{{content_types}}".split(",").map(content_type_raw,
       content_type_raw.trim_space()
   ).map(content_type,
@@ -91,22 +92,24 @@ program: |
                               content_type_state[0].content_created_at.as(content_type_state_created_at,
                                   // if saved time inside state is more than 7 days old, then change it to 7 days.
                                   content_type_state_created_at.parse_time(time_layout.RFC3339).as(state_created_at,
-                                      state_created_at < (now() - duration("168h")) ?
-                                          now() - duration("168h")
+                                      // The 168h API age limit is expressed as 167h55m to
+                                      // prevent API call delay from causing a call to fail.
+                                      state_created_at < (now - duration("167h55m")) ?
+                                          now - duration("167h55m")
                                       :
                                           state_created_at
                                   ).as(state_created_at_calc, 
                                       state.base.list_contents_url + content_type + "&PublisherIdentifier={{azure_tenant_id}}" 
                                           + "&startTime=" + string(state_created_at_calc + duration("1s"))
-                                          + "&endTime=" + string((state_created_at_calc + duration("24h")).as(calc_end_time, calc_end_time <= now() ? calc_end_time : now()))
+                                          + "&endTime=" + string((state_created_at_calc + duration("24h")).as(calc_end_time, calc_end_time <= now ? calc_end_time : now))
                                   )
                               )
                           )
                       :
                           // initial run when no cursor state exists i.e., polling from initial_interval
                           state.base.list_contents_url + content_type + "&PublisherIdentifier={{azure_tenant_id}}"  
-                              + "&startTime=" + string(now() - duration(state.base.list_contents_start_time))
-                              + "&endTime=" + string((now() - duration(state.base.list_contents_start_time) + duration("24h")).as(calc_end_time, calc_end_time <= now() ? calc_end_time : now()))
+                              + "&startTime=" + string(now - duration(state.base.list_contents_start_time))
+                              + "&endTime=" + string((now - duration(state.base.list_contents_start_time) + duration("24h")).as(calc_end_time, calc_end_time <= now ? calc_end_time : now))
                   ).do_request().as(list_contents_resp,
                       bytes(list_contents_resp.Body).decode_json().as(list_contents_resp_body,
                           (
@@ -143,7 +146,7 @@ program: |
                                               )
                                           ) ||
                                           (
-                                              {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().split('T')[0] != now().format("2006-01-02")
+                                              {"temp": list_contents_resp_body}.collate("temp.contentCreated").max().split('T')[0] != now.format("2006-01-02")
                                           )
                                       )
                                   })
@@ -164,12 +167,12 @@ program: |
                                               e.content_type == content_type
                                           )[0].content_created_at
                                       :
-                                          string(now() - duration(state.base.list_contents_start_time))
+                                          string(now - duration(state.base.list_contents_start_time))
                                   ),
                                   "next_page": "",
                                   "want_more_content": (
                                       has(list_contents_resp.StatusCode) && list_contents_resp.StatusCode == 200 &&
-                                      (reqQuery.endTime[0].split('T')[0] != now().format("2006-01-02"))
+                                      (reqQuery.endTime[0].split('T')[0] != now.format("2006-01-02"))
                                   )
                               })
                       )
@@ -183,7 +186,7 @@ program: |
                           (has (state.cursor) && has(state.cursor.content_types_state_as_list)) ?
                               state.cursor.content_types_state_as_list.filter(e, e.content_type == content_type)[0].content_created_at
                           :
-                              string(now() - duration(state.base.list_contents_start_time))
+                              string(now - duration(state.base.list_contents_start_time))
                       ,
                       "next_page": "",
                       "want_more_content": false
@@ -201,6 +204,7 @@ program: |
           "content_types_state_as_list": events_list.drop(["events_per_content_type"]),
       }
   })
+  ) // Remove when kibana.version is 8.10.1+.
 
 {{#if tags}}
 tags:

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -57,10 +57,10 @@ streams:
       - name: initial_interval
         type: text
         title: Initial Interval
-        description: Initial interval for the first API call. Default starts fetching events from 168h, i.e., 7 days ago. This value should not be more than 7 days ago. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
+        description: Initial interval for the first API call. Default starts fetching events from 167h55m, i.e., 7 days ago. This value should not be more than this and will be cut to 167h55m if it is. Supports following suffixes - "h" (hour), "m" (minute), "s" (second), "ms" (millisecond), "us" (microsecond), and "ns" (nanosecond)
         show_user: true
         required: true
-        default: 168h
+        default: 167h55m
       - name: resource_ssl
         type: yaml
         title: Resource SSL Configuration

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.25.1"
+version: "1.25.2"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

If an API call takes some time to reach the server, the startTime parameter may have slipped into the time before 168h before now. So reduce our window from 168h to 167h55m to allow leeway for this.

Similarly, the allowable interval from start to end time is 24h, and it is possible that the end time now() call is some time after the start time now() call. CEL has no subexpression evaluation order guarantee, so we cannot ensure end is called first by re-ordering the lines. So work around the old behaviour of the now global until the kibana.version for the package is guaranteed to provide an eval-start now value, when we are depending on v8.10.1 (v8.9.1 is also valid, but limiting on that would allow v8.10.0 which does not have the fix).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
