### PR TITLE
[Atlassian Confluence] Adding new pagination conditions

### DIFF
--- a/packages/atlassian_confluence/_dev/deploy/docker/files/config.yml
+++ b/packages/atlassian_confluence/_dev/deploy/docker/files/config.yml
@@ -34,6 +34,19 @@ rules:
     query_params:
       startDate: "{startDate:[0-9]+}"
       endDate: "{endDate:[0-9]+}"
+      start: "4"
+      limit: "2"
+    responses:
+      - status_code: 200
+        body: |-
+          {"results":[],"start":2,"limit":2,"size":37,"_links":{"base":"https://test.atlassian.net/wiki","context":"/wiki","self":"https://test.atlassian.net/wiki/rest/api/audit"}}
+  - path: /wiki/rest/api/audit
+    methods: ["GET"]
+    request_headers:
+      authorization: Basic dGVzdC51c2VyOmFiYzEyMw==
+    query_params:
+      startDate: "{startDate:[0-9]+}"
+      endDate: "{endDate:[0-9]+}"
       start: "2"
       limit: "2"
     responses:

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Resolve possible infinite pagination for Confluence Cloud.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/8269
+      link: https://github.com/elastic/integrations/pull/8406
 - version: "1.21.0"
   changes:
     - description: Improve 'event.original' check to avoid errors if set.

--- a/packages/atlassian_confluence/changelog.yml
+++ b/packages/atlassian_confluence/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.1"
+  changes:
+    - description: Resolve possible infinite pagination for Confluence Cloud.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8269
 - version: "1.21.0"
   changes:
     - description: Improve 'event.original' check to avoid errors if set.

--- a/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -50,6 +50,10 @@ response.split:
 
 response.pagination:
   - set:
+      target: url.pagination_finished
+      value: '[[if (eq (len .last_response.body.results) 0)]][[.last_response.pagination_finished]][[end]]'
+      fail_on_template_error: true
+  - set:
       target: url.params.endDate
       value: '[[.last_response.url.params.Get "endDate"]]'
   - set:

--- a/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_confluence/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -50,10 +50,6 @@ response.split:
 
 response.pagination:
   - set:
-      target: url.pagination_finished
-      value: '[[if (eq (len .last_response.body.results) 0)]][[.last_response.pagination_finished]][[end]]'
-      fail_on_template_error: true
-  - set:
       target: url.params.endDate
       value: '[[.last_response.url.params.Get "endDate"]]'
   - set:
@@ -61,7 +57,8 @@ response.pagination:
       value: '[[.last_response.url.params.Get "startDate"]]'
   - set:
       target: url.params.start
-      value: '[[add (toInt .last_response.body.start) (toInt .last_response.body.limit)]]'
+      value: '[[if (ne (len .last_response.body.results) 0)]][[add (toInt .last_response.body.start) (toInt .last_response.body.limit)]][[end]]'
+      fail_on_template_error: true
   - set:
       target: url.params.limit
       value: '{{limit}}'

--- a/packages/atlassian_confluence/data_stream/audit/sample_event.json
+++ b/packages/atlassian_confluence/data_stream/audit/sample_event.json
@@ -1,43 +1,18 @@
 {
-    "@timestamp": "2021-11-22T23:44:13.873Z",
+    "@timestamp": "2021-11-16T09:25:56.666Z",
     "agent": {
-        "ephemeral_id": "3bcd4f83-81b7-45d2-b083-b19a7da7ad6f",
-        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
+        "ephemeral_id": "eff59388-5443-486b-92f3-eb3f0bc07a73",
+        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.0"
+        "version": "8.10.2"
     },
     "confluence": {
         "audit": {
-            "extra_attributes": [
-                {
-                    "name": "Query",
-                    "nameI18nKey": "atlassian.audit.event.attribute.query"
-                },
-                {
-                    "name": "Results returned",
-                    "nameI18nKey": "atlassian.audit.event.attribute.results",
-                    "value": "57"
-                },
-                {
-                    "name": "ID Range",
-                    "nameI18nKey": "atlassian.audit.event.attribute.id",
-                    "value": "1 - 57"
-                },
-                {
-                    "name": "Timestamp Range",
-                    "nameI18nKey": "atlassian.audit.event.attribute.timestamp",
-                    "value": "2021-11-22T23:42:45.791Z - 2021-11-22T23:43:22.615Z"
-                }
-            ],
-            "method": "Browser",
+            "external_collaborator": false,
             "type": {
-                "action": "Audit Log search performed",
-                "actionI18nKey": "atlassian.audit.event.action.audit.search",
-                "area": "AUDIT_LOG",
-                "category": "Auditing",
-                "categoryI18nKey": "atlassian.audit.event.category.audit",
-                "level": "BASE"
+                "action": "User deactivated",
+                "category": "Users and groups"
             }
         }
     },
@@ -50,62 +25,29 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
-        "snapshot": true,
-        "version": "8.8.0"
+        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
+        "snapshot": false,
+        "version": "8.10.2"
     },
     "event": {
-        "action": "atlassian.audit.event.action.audit.search",
+        "action": "User deactivated",
         "agent_id_status": "verified",
+        "created": "2023-11-06T13:09:50.385Z",
         "dataset": "atlassian_confluence.audit",
-        "ingested": "2023-05-09T21:17:32Z",
+        "ingested": "2023-11-06T13:09:51Z",
         "kind": "event",
-        "original": "{\"affectedObjects\":[],\"auditType\":{\"action\":\"Audit Log search performed\",\"actionI18nKey\":\"atlassian.audit.event.action.audit.search\",\"area\":\"AUDIT_LOG\",\"category\":\"Auditing\",\"categoryI18nKey\":\"atlassian.audit.event.category.audit\",\"level\":\"BASE\"},\"author\":{\"id\":\"2c9580827d4a06e8017d4a07c3e10000\",\"name\":\"test.user\",\"type\":\"user\"},\"changedValues\":[],\"extraAttributes\":[{\"name\":\"Query\",\"nameI18nKey\":\"atlassian.audit.event.attribute.query\",\"value\":\"\"},{\"name\":\"Results returned\",\"nameI18nKey\":\"atlassian.audit.event.attribute.results\",\"value\":\"57\"},{\"name\":\"ID Range\",\"nameI18nKey\":\"atlassian.audit.event.attribute.id\",\"value\":\"1 - 57\"},{\"name\":\"Timestamp Range\",\"nameI18nKey\":\"atlassian.audit.event.attribute.timestamp\",\"value\":\"2021-11-22T23:42:45.791Z - 2021-11-22T23:43:22.615Z\"}],\"method\":\"Browser\",\"source\":\"81.2.69.143\",\"system\":\"http://confluence.internal:8090\",\"timestamp\":{\"epochSecond\":1637624653,\"nano\":873000000},\"version\":\"1.0\"}",
+        "original": "{\"affectedObject\":{\"name\":\"\",\"objectType\":\"\"},\"associatedObjects\":[],\"author\":{\"accountType\":\"\",\"displayName\":\"System\",\"externalCollaborator\":false,\"isExternalCollaborator\":false,\"operations\":null,\"publicName\":\"Unknown user\",\"type\":\"user\"},\"category\":\"Users and groups\",\"changedValues\":[],\"creationDate\":1637054756666,\"description\":\"\",\"remoteAddress\":\"81.2.69.143\",\"summary\":\"User deactivated\",\"superAdmin\":false,\"sysAdmin\":false}",
         "type": [
             "info"
         ]
     },
-    "host": {
-        "architecture": "x86_64",
-        "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "cff3d165179d4aef9596ddbb263e3adb",
-        "ip": [
-            "172.23.0.7"
-        ],
-        "mac": [
-            "02-42-AC-17-00-07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "focal",
-            "family": "debian",
-            "kernel": "5.10.47-linuxkit",
-            "name": "Ubuntu",
-            "platform": "ubuntu",
-            "type": "linux",
-            "version": "20.04.5 LTS (Focal Fossa)"
-        }
-    },
     "input": {
-        "type": "log"
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/test-audit.log"
-        },
-        "offset": 0
+        "type": "httpjson"
     },
     "related": {
-        "hosts": [
-            "confluence.internal"
-        ],
         "ip": [
             "81.2.69.143"
         ]
-    },
-    "service": {
-        "address": "http://confluence.internal:8090"
     },
     "source": {
         "address": "81.2.69.143",
@@ -125,10 +67,10 @@
     },
     "tags": [
         "preserve_original_event",
+        "forwarded",
         "confluence-audit"
     ],
     "user": {
-        "full_name": "test.user",
-        "id": "2c9580827d4a06e8017d4a07c3e10000"
+        "full_name": "System"
     }
 }

--- a/packages/atlassian_confluence/data_stream/audit/sample_event.json
+++ b/packages/atlassian_confluence/data_stream/audit/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2021-11-16T09:25:56.666Z",
     "agent": {
-        "ephemeral_id": "eff59388-5443-486b-92f3-eb3f0bc07a73",
-        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
+        "ephemeral_id": "5e7e2606-c5b7-4cca-bcf6-5a9959484395",
+        "id": "1f67a92c-38d3-40a8-9093-c4495a7411a3",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.2"
@@ -25,16 +25,16 @@
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
+        "id": "1f67a92c-38d3-40a8-9093-c4495a7411a3",
         "snapshot": false,
         "version": "8.10.2"
     },
     "event": {
         "action": "User deactivated",
         "agent_id_status": "verified",
-        "created": "2023-11-06T13:09:50.385Z",
+        "created": "2023-11-06T13:17:04.339Z",
         "dataset": "atlassian_confluence.audit",
-        "ingested": "2023-11-06T13:09:51Z",
+        "ingested": "2023-11-06T13:17:05Z",
         "kind": "event",
         "original": "{\"affectedObject\":{\"name\":\"\",\"objectType\":\"\"},\"associatedObjects\":[],\"author\":{\"accountType\":\"\",\"displayName\":\"System\",\"externalCollaborator\":false,\"isExternalCollaborator\":false,\"operations\":null,\"publicName\":\"Unknown user\",\"type\":\"user\"},\"category\":\"Users and groups\",\"changedValues\":[],\"creationDate\":1637054756666,\"description\":\"\",\"remoteAddress\":\"81.2.69.143\",\"summary\":\"User deactivated\",\"superAdmin\":false,\"sysAdmin\":false}",
         "type": [

--- a/packages/atlassian_confluence/docs/README.md
+++ b/packages/atlassian_confluence/docs/README.md
@@ -122,45 +122,20 @@ An example event for `audit` looks as following:
 
 ```json
 {
-    "@timestamp": "2021-11-22T23:44:13.873Z",
+    "@timestamp": "2021-11-16T09:25:56.666Z",
     "agent": {
-        "ephemeral_id": "3bcd4f83-81b7-45d2-b083-b19a7da7ad6f",
-        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
+        "ephemeral_id": "45ee6e3c-08cf-4549-ad89-e66308c2dc3f",
+        "id": "a9a47dbc-07fa-4133-96f0-b9608f7395eb",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.0"
+        "version": "8.10.2"
     },
     "confluence": {
         "audit": {
-            "extra_attributes": [
-                {
-                    "name": "Query",
-                    "nameI18nKey": "atlassian.audit.event.attribute.query"
-                },
-                {
-                    "name": "Results returned",
-                    "nameI18nKey": "atlassian.audit.event.attribute.results",
-                    "value": "57"
-                },
-                {
-                    "name": "ID Range",
-                    "nameI18nKey": "atlassian.audit.event.attribute.id",
-                    "value": "1 - 57"
-                },
-                {
-                    "name": "Timestamp Range",
-                    "nameI18nKey": "atlassian.audit.event.attribute.timestamp",
-                    "value": "2021-11-22T23:42:45.791Z - 2021-11-22T23:43:22.615Z"
-                }
-            ],
-            "method": "Browser",
+            "external_collaborator": false,
             "type": {
-                "action": "Audit Log search performed",
-                "actionI18nKey": "atlassian.audit.event.action.audit.search",
-                "area": "AUDIT_LOG",
-                "category": "Auditing",
-                "categoryI18nKey": "atlassian.audit.event.category.audit",
-                "level": "BASE"
+                "action": "User deactivated",
+                "category": "Users and groups"
             }
         }
     },
@@ -173,62 +148,29 @@ An example event for `audit` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "cdda426a-7e47-48c4-b2f5-b9f1ad5bf08a",
-        "snapshot": true,
-        "version": "8.8.0"
+        "id": "a9a47dbc-07fa-4133-96f0-b9608f7395eb",
+        "snapshot": false,
+        "version": "8.10.2"
     },
     "event": {
-        "action": "atlassian.audit.event.action.audit.search",
+        "action": "User deactivated",
         "agent_id_status": "verified",
+        "created": "2023-11-06T13:00:55.851Z",
         "dataset": "atlassian_confluence.audit",
-        "ingested": "2023-05-09T21:17:32Z",
+        "ingested": "2023-11-06T13:00:56Z",
         "kind": "event",
-        "original": "{\"affectedObjects\":[],\"auditType\":{\"action\":\"Audit Log search performed\",\"actionI18nKey\":\"atlassian.audit.event.action.audit.search\",\"area\":\"AUDIT_LOG\",\"category\":\"Auditing\",\"categoryI18nKey\":\"atlassian.audit.event.category.audit\",\"level\":\"BASE\"},\"author\":{\"id\":\"2c9580827d4a06e8017d4a07c3e10000\",\"name\":\"test.user\",\"type\":\"user\"},\"changedValues\":[],\"extraAttributes\":[{\"name\":\"Query\",\"nameI18nKey\":\"atlassian.audit.event.attribute.query\",\"value\":\"\"},{\"name\":\"Results returned\",\"nameI18nKey\":\"atlassian.audit.event.attribute.results\",\"value\":\"57\"},{\"name\":\"ID Range\",\"nameI18nKey\":\"atlassian.audit.event.attribute.id\",\"value\":\"1 - 57\"},{\"name\":\"Timestamp Range\",\"nameI18nKey\":\"atlassian.audit.event.attribute.timestamp\",\"value\":\"2021-11-22T23:42:45.791Z - 2021-11-22T23:43:22.615Z\"}],\"method\":\"Browser\",\"source\":\"81.2.69.143\",\"system\":\"http://confluence.internal:8090\",\"timestamp\":{\"epochSecond\":1637624653,\"nano\":873000000},\"version\":\"1.0\"}",
+        "original": "{\"affectedObject\":{\"name\":\"\",\"objectType\":\"\"},\"associatedObjects\":[],\"author\":{\"accountType\":\"\",\"displayName\":\"System\",\"externalCollaborator\":false,\"isExternalCollaborator\":false,\"operations\":null,\"publicName\":\"Unknown user\",\"type\":\"user\"},\"category\":\"Users and groups\",\"changedValues\":[],\"creationDate\":1637054756666,\"description\":\"\",\"remoteAddress\":\"81.2.69.143\",\"summary\":\"User deactivated\",\"superAdmin\":false,\"sysAdmin\":false}",
         "type": [
             "info"
         ]
     },
-    "host": {
-        "architecture": "x86_64",
-        "containerized": true,
-        "hostname": "docker-fleet-agent",
-        "id": "cff3d165179d4aef9596ddbb263e3adb",
-        "ip": [
-            "172.23.0.7"
-        ],
-        "mac": [
-            "02-42-AC-17-00-07"
-        ],
-        "name": "docker-fleet-agent",
-        "os": {
-            "codename": "focal",
-            "family": "debian",
-            "kernel": "5.10.47-linuxkit",
-            "name": "Ubuntu",
-            "platform": "ubuntu",
-            "type": "linux",
-            "version": "20.04.5 LTS (Focal Fossa)"
-        }
-    },
     "input": {
-        "type": "log"
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/test-audit.log"
-        },
-        "offset": 0
+        "type": "httpjson"
     },
     "related": {
-        "hosts": [
-            "confluence.internal"
-        ],
         "ip": [
             "81.2.69.143"
         ]
-    },
-    "service": {
-        "address": "http://confluence.internal:8090"
     },
     "source": {
         "address": "81.2.69.143",
@@ -248,11 +190,11 @@ An example event for `audit` looks as following:
     },
     "tags": [
         "preserve_original_event",
+        "forwarded",
         "confluence-audit"
     ],
     "user": {
-        "full_name": "test.user",
-        "id": "2c9580827d4a06e8017d4a07c3e10000"
+        "full_name": "System"
     }
 }
 ```

--- a/packages/atlassian_confluence/docs/README.md
+++ b/packages/atlassian_confluence/docs/README.md
@@ -124,8 +124,8 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2021-11-16T09:25:56.666Z",
     "agent": {
-        "ephemeral_id": "45ee6e3c-08cf-4549-ad89-e66308c2dc3f",
-        "id": "a9a47dbc-07fa-4133-96f0-b9608f7395eb",
+        "ephemeral_id": "eff59388-5443-486b-92f3-eb3f0bc07a73",
+        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.2"
@@ -148,16 +148,16 @@ An example event for `audit` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "a9a47dbc-07fa-4133-96f0-b9608f7395eb",
+        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
         "snapshot": false,
         "version": "8.10.2"
     },
     "event": {
         "action": "User deactivated",
         "agent_id_status": "verified",
-        "created": "2023-11-06T13:00:55.851Z",
+        "created": "2023-11-06T13:09:50.385Z",
         "dataset": "atlassian_confluence.audit",
-        "ingested": "2023-11-06T13:00:56Z",
+        "ingested": "2023-11-06T13:09:51Z",
         "kind": "event",
         "original": "{\"affectedObject\":{\"name\":\"\",\"objectType\":\"\"},\"associatedObjects\":[],\"author\":{\"accountType\":\"\",\"displayName\":\"System\",\"externalCollaborator\":false,\"isExternalCollaborator\":false,\"operations\":null,\"publicName\":\"Unknown user\",\"type\":\"user\"},\"category\":\"Users and groups\",\"changedValues\":[],\"creationDate\":1637054756666,\"description\":\"\",\"remoteAddress\":\"81.2.69.143\",\"summary\":\"User deactivated\",\"superAdmin\":false,\"sysAdmin\":false}",
         "type": [

--- a/packages/atlassian_confluence/docs/README.md
+++ b/packages/atlassian_confluence/docs/README.md
@@ -124,8 +124,8 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2021-11-16T09:25:56.666Z",
     "agent": {
-        "ephemeral_id": "eff59388-5443-486b-92f3-eb3f0bc07a73",
-        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
+        "ephemeral_id": "5e7e2606-c5b7-4cca-bcf6-5a9959484395",
+        "id": "1f67a92c-38d3-40a8-9093-c4495a7411a3",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.2"
@@ -148,16 +148,16 @@ An example event for `audit` looks as following:
         "version": "8.10.0"
     },
     "elastic_agent": {
-        "id": "e4953194-1a45-4268-b1d0-bed4299144b9",
+        "id": "1f67a92c-38d3-40a8-9093-c4495a7411a3",
         "snapshot": false,
         "version": "8.10.2"
     },
     "event": {
         "action": "User deactivated",
         "agent_id_status": "verified",
-        "created": "2023-11-06T13:09:50.385Z",
+        "created": "2023-11-06T13:17:04.339Z",
         "dataset": "atlassian_confluence.audit",
-        "ingested": "2023-11-06T13:09:51Z",
+        "ingested": "2023-11-06T13:17:05Z",
         "kind": "event",
         "original": "{\"affectedObject\":{\"name\":\"\",\"objectType\":\"\"},\"associatedObjects\":[],\"author\":{\"accountType\":\"\",\"displayName\":\"System\",\"externalCollaborator\":false,\"isExternalCollaborator\":false,\"operations\":null,\"publicName\":\"Unknown user\",\"type\":\"user\"},\"category\":\"Users and groups\",\"changedValues\":[],\"creationDate\":1637054756666,\"description\":\"\",\"remoteAddress\":\"81.2.69.143\",\"summary\":\"User deactivated\",\"superAdmin\":false,\"sysAdmin\":false}",
         "type": [

--- a/packages/atlassian_confluence/manifest.yml
+++ b/packages/atlassian_confluence/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: atlassian_confluence
 title: Atlassian Confluence
-version: "1.21.0"
+version: "1.21.1"
 description: Collect logs from Atlassian Confluence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Currently the pagination settings specifically for atlassian cloud do not have a failure condition on pagination, and therefore ends up paginating forever.

There is a few ways to resolve this, I think maybe the best approach would have been to simply utilize the "next" link that is included in each response, as the "next" value is missing once there is no more results. This is done for the on-prem version of confluence (and other atlassian products like jira).

However to keep the state working as it is, I have added the failure condition instead, which also works just fine.

There should be some investigation into making the pagination smarter on these niche scenarios.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

