### PR TITLE
[etcd] Fix incorrect field mapping in leader dataset

### DIFF
--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix incorrect field mappings in leader datastream
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8417
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.6.1
+  changes:
+    - description: Fix incorrect field mappings in leader datastream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/etcd/data_stream/leader/fields/fields.yml
+++ b/packages/etcd/data_stream/leader/fields/fields.yml
@@ -1,46 +1,27 @@
 - name: etcd.leader
   type: group
   fields:
-    - name: followers
-      type: group
-      fields:
-        - name: counts
-          type: group
-          fields:
-            - name: followers
-              type: group
-              fields:
-                - name: counts
-                  type: group
-                  fields:
-                    - name: success
-                      type: integer
-                      description: |
-                        Successful Raft RPC requests
-                    - name: fail
-                      type: integer
-                      description: |
-                        Failed Raft RPC requests
-        - name: latency
-          type: group
-          fields:
-            - name: followers
-              type: group
-              fields:
-                - name: latency
-                  type: group
-                  fields:
-                    - name: average
-                      type: scaled_float
-                    - name: current
-                      type: scaled_float
-                    - name: maximum
-                      type: scaled_float
-                    - name: minimum
-                      type: integer
-                    - name: standardDeviation
-                      type: scaled_float
-    - name: leader
-      type: keyword
-      description: |
-        ID of actual leader
+  - name: follower
+    type: group
+    description: >
+      Contains follower statistics.
+    fields:
+      - name: id
+        type: keyword
+        description: ID of follower
+      - name: latency
+        type: group
+        description: >
+          Latency to each peer in the cluster
+        fields:
+          - name: ms
+            type: scaled_float
+      - name: success_operations
+        type: long
+        description: successful Raft RPC requests
+      - name: failed_operations
+        type: long
+        description: failed Raft RPC requests
+      - name: leader
+        type: keyword
+        description: ID of actual leader

--- a/packages/etcd/data_stream/leader/sample_event.json
+++ b/packages/etcd/data_stream/leader/sample_event.json
@@ -1,11 +1,18 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "etcd": {
-        "api_version": "2",
         "leader": {
-            "followers": {},
-            "leader": "8e9e05c52164694d"
-        }
+          "follower": {
+            "leader": "91bc3c398fb3c146",
+            "latency": {
+              "ms": 0.001169
+            },
+            "failed_operations": 0,
+            "id": "8211f1d0f64f3269",
+            "success_operations": 5
+          }
+        },
+        "api_version": "2"
     },
     "event": {
         "dataset": "etcd.leader",

--- a/packages/etcd/docs/README.md
+++ b/packages/etcd/docs/README.md
@@ -214,11 +214,18 @@ An example event for `leader` looks as following:
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "etcd": {
-        "api_version": "2",
         "leader": {
-            "followers": {},
-            "leader": "8e9e05c52164694d"
-        }
+            "follower": {
+                "leader": "91bc3c398fb3c146",
+                "latency": {
+                    "ms": 0.001169
+                },
+                "failed_operations": 0,
+                "id": "8211f1d0f64f3269",
+                "success_operations": 5
+            }
+        },
+        "api_version": "2"
     },
     "event": {
         "dataset": "etcd.leader",

--- a/packages/etcd/docs/README.md
+++ b/packages/etcd/docs/README.md
@@ -245,14 +245,11 @@ An example event for `leader` looks as following:
 | data_stream.type | Data stream type. | constant_keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | etcd.api_version | Etcd API version for metrics retrieval | keyword |
-| etcd.leader.followers.counts.followers.counts.fail | Failed Raft RPC requests | integer |
-| etcd.leader.followers.counts.followers.counts.success | Successful Raft RPC requests | integer |
-| etcd.leader.followers.latency.followers.latency.average |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.current |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.maximum |  | scaled_float |
-| etcd.leader.followers.latency.followers.latency.minimum |  | integer |
-| etcd.leader.followers.latency.followers.latency.standardDeviation |  | scaled_float |
-| etcd.leader.leader | ID of actual leader | keyword |
+| etcd.leader.follower.failed_operations | failed Raft RPC requests | long |
+| etcd.leader.follower.id | ID of follower | keyword |
+| etcd.leader.follower.latency.ms |  | scaled_float |
+| etcd.leader.follower.leader | ID of actual leader | keyword |
+| etcd.leader.follower.success_operations | successful Raft RPC requests | long |
 | event.dataset | Event dataset | constant_keyword |
 | event.module | Event module | constant_keyword |
 | host.ip | Host ip addresses. | ip |

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: etcd
 title: etcd
-version: "0.6.0"
+version: "0.6.1"
 description: Collect metrics from etcd servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

- Bug

## Proposed commit message

Fix the field mappings under leader datastream

Please explain:

The field mapping of the leader datastream is incorrect. 
This change fixes the incorrect field mapping.



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- elastic-package build
- elastic-package stack up -v -d --services package-registry

## How to test this PR locally

- Verification of field mappings after the change

## Related issues


- Closes #8373


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
