### PR TITLE
[Buildkite] Update cronline for schedule-daily job

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -90,7 +90,7 @@ spec:
       schedules:
         main_daily:
           branch: "main"
-          cronline: "@daily"
+          cronline: "30 1 * * *"
           message: "Run the daily jobs"
       provider_settings:
         trigger_mode: none # don't trigger jobs from github activity


### PR DESCRIPTION
## Proposed commit message

Updates the cron to trigger the schedule-daily Buildkite pipeline, so it runs similar to when Jenkins runs this same pipeline (tried to not use the same hours as in Jenkins to avoid creating so many VMs at the same time):  https://github.com/elastic/integrations/blob/c87d2f78f530d281fc9a2823de3c1b0a7e8a4605/.ci/schedule-daily.groovy#L22


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

