### PR TITLE
[Cloudflare Logpush] Add content-type header to HTTP endpoint setup docs

### DIFF
--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -137,6 +137,9 @@ curl --location --request POST 'https://api.cloudflare.com/client/v4/zones/<ZONE
     "logpull_options": "fields=RayID,EdgeStartTimestamp&timestamps=rfc3339"
 }'
 ```
+
+**Note**:
+- The destination_conf parameter inside the request data should set the Content-Type header to `application/json`. This is the content type that the HTTP endpoint expects for incoming events.
 - Default port for the HTTP Endpoint is _9560_.
 - When using the same port for more than one dataset, be sure to specify different dataset paths.
 

--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -132,7 +132,7 @@ curl --location --request POST 'https://api.cloudflare.com/client/v4/zones/<ZONE
 --header 'Content-Type: application/json' \
 --data-raw '{
     "name":"<public domain>",
-    "destination_conf": "https://<public domain>:<public port>/<dataset path>?header_<secret_header>=<secret_value>",
+    "destination_conf": "https://<public domain>:<public port>/<dataset path>?header_Content-Type=application/json&header_<secret_header>=<secret_value>",
     "dataset": "audit",
     "logpull_options": "fields=RayID,EdgeStartTimestamp&timestamps=rfc3339"
 }'

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.1"
+  changes:
+    - description: Add content-type header to request in HTTP endpoint documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8446
 - version: 1.17.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -137,6 +137,9 @@ curl --location --request POST 'https://api.cloudflare.com/client/v4/zones/<ZONE
     "logpull_options": "fields=RayID,EdgeStartTimestamp&timestamps=rfc3339"
 }'
 ```
+
+**Note**:
+- The destination_conf parameter inside the request data should set the Content-Type header to `application/json`. This is the content type that the HTTP endpoint expects for incoming events.
 - Default port for the HTTP Endpoint is _9560_.
 - When using the same port for more than one dataset, be sure to specify different dataset paths.
 

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -132,7 +132,7 @@ curl --location --request POST 'https://api.cloudflare.com/client/v4/zones/<ZONE
 --header 'Content-Type: application/json' \
 --data-raw '{
     "name":"<public domain>",
-    "destination_conf": "https://<public domain>:<public port>/<dataset path>?header_<secret_header>=<secret_value>",
+    "destination_conf": "https://<public domain>:<public port>/<dataset path>?header_Content-Type=application/json&header_<secret_header>=<secret_value>",
     "dataset": "audit",
     "logpull_options": "fields=RayID,EdgeStartTimestamp&timestamps=rfc3339"
 }'

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.17.0"
+version: "1.17.1"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

We have recently received feedback reporting that when configuring the HTTP endpoint for Cloudflare Logpush, incoming HTTP messages may contain an invalid `Content-Type` header while the HTTP endpoint input expects `application/json`. It leads to this error:
```
"error_message": "error 415: error pushing: error uploading to https: 415 {\"message\":\"wrong Content-Type header, expecting application/json\"}",
```

This pull request defines the `Content-Type` header when configuring the destination for the HTTP endpoint in the setup guide.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/8342
