### PR TITLE
[Buildkite] Reuse from and to changesets in Buildkite scripts

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -479,6 +479,10 @@ get_to_changeset() {
 
 is_pr_affected() {
     local package="${1}"
+    local from=${2:-""}
+    local to=${3:-""}
+
+    echo "[${package}] Original commits: from '${from}' - to: '${to}'"
 
     if ! is_supported_stack ; then
         echo "[${package}] PR is not affected: unsupported stack (${STACK_VERSION})"
@@ -497,24 +501,21 @@ is_pr_affected() {
         return 0
     fi
 
-    # setting default values for a PR
-    # TODO: get previous built commit as in Jenkins (groovy)
-    # def from = env.CHANGE_TARGET?.trim() ? "origin/${env.CHANGE_TARGET}" : "${env.GIT_PREVIOUS_COMMIT?.trim() ? env.GIT_PREVIOUS_COMMIT : env.GIT_BASE_COMMIT}"
-    local from="$(get_from_changeset)"
-    local to="$(get_to_changeset)"
+    if [[ "${from}" == ""  || "${to}" == "" ]]; then
+        echo "[${package}] Calculating commits: from '${from}' - to: '${to}'"
+        # setting default values for a PR
+        from="$(get_from_changeset)"
+        to="$(get_to_changeset)"
 
-    # TODO: If running for an integration branch (main, backport-*) check with
-    # GIT_PREVIOUS_SUCCESSFUL_COMMIT to check if the branch is still healthy.
-    # If this value is not available, check with last commit.
-    if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
-        echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
-        # TODO: get previous successful commit as in Jenkins (groovy)
-        # from = env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim() ? env.GIT_PREVIOUS_SUCCESSFUL_COMMIT : "origin/${env.BRANCH_NAME}^"
-        from="origin/${BUILDKITE_BRANCH}^"
-        to="origin/${BUILDKITE_BRANCH}"
+        # If this value is not available, check with last commit.
+        if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
+            echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
+            from="origin/${BUILDKITE_BRANCH}^"
+            to="origin/${BUILDKITE_BRANCH}"
+        fi
     fi
 
-    echo "[${package}]: commits: from: ${from} - to: ${to}"
+    echo "[${package}]: commits: from: '${from}' - to: '${to}'"
 
     echo "[${package}] git-diff: check non-package files"
     if git diff --name-only $(git merge-base ${from} ${to}) ${to} | egrep -v '^(packages/|.github/CODEOWNERS)' ; then
@@ -724,6 +725,8 @@ upload_safe_logs_from_package() {
 # Helper to run all tests and checks for a package
 process_package() {
     local package="$1"
+    local from=${2:-""}
+    local to=${3:-""}
     local exit_code=0
 
     echo "--- Package ${package}: check"
@@ -746,7 +749,7 @@ process_package() {
         fi
     fi
 
-    if ! reason=$(is_pr_affected ${package}) ; then
+    if ! reason=$(is_pr_affected ${package} ${from} ${to}) ; then
         echo "${reason}"
         echo "- ${reason}" >> ${SKIPPED_PACKAGES_FILE_PATH}
         popd > /dev/null

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -469,6 +469,7 @@ get_from_changeset() {
 }
 
 get_to_changeset() {
+    # Changeset that triggered the build
     local to="${BUILDKITE_COMMIT}"
 
     if [[ "${BUILDKITE_BRANCH}" == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
@@ -503,16 +504,9 @@ is_pr_affected() {
 
     if [[ "${from}" == ""  || "${to}" == "" ]]; then
         echo "[${package}] Calculating commits: from '${from}' - to: '${to}'"
-        # setting default values for a PR
+        # setting range of changesets to check differences
         from="$(get_from_changeset)"
         to="$(get_to_changeset)"
-
-        # If this value is not available, check with last commit.
-        if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
-            echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
-            from="origin/${BUILDKITE_BRANCH}^"
-            to="origin/${BUILDKITE_BRANCH}"
-        fi
     fi
 
     echo "[${package}]: commits: from: '${from}' - to: '${to}'"

--- a/.buildkite/scripts/test_integrations_with_serverless.sh
+++ b/.buildkite/scripts/test_integrations_with_serverless.sh
@@ -50,11 +50,22 @@ echo "Waiting time to avoid getaddrinfo ENOTFOUND errors..."
 sleep 120
 echo "Done."
 
+# setting default values for a PR
+from="$(get_from_changeset)"
+to="$(get_to_changeset)"
+
+# If this value is not available, check with last commit.
+if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
+    echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
+    from="origin/${BUILDKITE_BRANCH}^"
+    to="origin/${BUILDKITE_BRANCH}"
+fi
+
 any_package_failing=0
 
 pushd packages > /dev/null
 for package in $(list_all_directories); do
-    if ! process_package ${package} ; then
+    if ! process_package ${package} ${from} ${to}; then
         any_package_failing=1
     fi
 done

--- a/.buildkite/scripts/test_integrations_with_serverless.sh
+++ b/.buildkite/scripts/test_integrations_with_serverless.sh
@@ -50,16 +50,9 @@ echo "Waiting time to avoid getaddrinfo ENOTFOUND errors..."
 sleep 120
 echo "Done."
 
-# setting default values for a PR
+# setting range of changesets to check differences
 from="$(get_from_changeset)"
 to="$(get_to_changeset)"
-
-# If this value is not available, check with last commit.
-if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
-    echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
-    from="origin/${BUILDKITE_BRANCH}^"
-    to="origin/${BUILDKITE_BRANCH}"
-fi
 
 any_package_failing=0
 

--- a/.buildkite/scripts/test_one_package.sh
+++ b/.buildkite/scripts/test_one_package.sh
@@ -11,7 +11,12 @@ BENCHMARK_THRESHOLD=${BENCHMARK_THRESHOLD:-'15'}
 SKIPPED_PACKAGES_FILE_PATH="${WORKSPACE}/skipped_packages.txt"
 FAILED_PACKAGES_FILE_PATH="${WORKSPACE}/failed_packages.txt"
 
+# package name
 package="$1"
+# changesets
+from=${2:-""}
+to=${3:-""}
+
 
 if [ ! -d packages ]; then
     echo "Missing packages folder"
@@ -31,7 +36,7 @@ with_kubernetes
 use_elastic_package
 
 pushd packages > /dev/null
-if ! process_package ${package}; then
+if ! process_package ${package} ${from} ${to}; then
     echo "[${package}] failed"
     exit 1
 fi

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -23,16 +23,11 @@ EOF
 
 # Get from and to changesets to avoid repeating the same queries for each package
 
-# setting default values for a PR
+# setting range of changesets to check differences
 from="$(get_from_changeset)"
 to="$(get_to_changeset)"
 
-# If this value is not available, check with last commit.
-if [[ ${BUILDKITE_BRANCH} == "main" || ${BUILDKITE_BRANCH} =~ ^backport- ]]; then
-    echo "[${package}] PR is affected: running on ${BUILDKITE_BRANCH} branch"
-    from="origin/${BUILDKITE_BRANCH}^"
-    to="origin/${BUILDKITE_BRANCH}"
-fi
+echo "[DEBUG] Checking with commits: from: '${from}' to: '${to}'"
 
 packages_to_test=0
 


### PR DESCRIPTION

## Proposed commit message

Fix the calculation of from and to changesets when the build is triggered from the `main` or `backport-*` branches.

Moreover, this calculation has been move at the beginning of the pipeline. This help us to avoid querying to Buildkite for the previous builds for each package tested.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Ensure buildkite API token is just queried once
- [x] Check that the same commits are used in all the steps of the build.

## Related issues

- Relates https://github.com/elastic/integrations/pull/8316
- Relates https://github.com/elastic/integrations/pull/8462