### PR TITLE
[Buildkite] Output raw strings instead of JSON strings in commits from API

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -418,7 +418,7 @@ get_commit_from_build() {
     local state_query_param="$3"
 
     local api_url="${API_BUILDKITE_PIPELINES_URL}/${pipeline}/builds?branch=${branch}&${state_query_param}&per_page=1"
-    local previous_commit=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "${api_url}" | jq '.[0] |.commit')
+    local previous_commit=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "${api_url}" | jq -r '.[0] |.commit')
     echoerr ">>> Commit from ${pipeline} - branch ${branch} - status: ${status} -> ${previous_commit}"
 
     echo ${previous_commit}

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -443,9 +443,6 @@ get_previous_successful_commit() {
 
 get_from_changeset() {
     local from=""
-    local previous_commit=$(get_previous_commit ${BUILDKITE_PIPELINE_SLUG} ${BUILDKITE_BRANCH})
-    echo ${previous_commit}
-    return
     if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then
         echo "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         return

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -443,6 +443,9 @@ get_previous_successful_commit() {
 
 get_from_changeset() {
     local from=""
+    local previous_commit=$(get_previous_commit ${BUILDKITE_PIPELINE_SLUG} ${BUILDKITE_BRANCH})
+    echo ${previous_commit}
+    return
     if [ "${BUILDKITE_PULL_REQUEST}" != "false" ]; then
         echo "origin/${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         return


### PR DESCRIPTION
## Proposed commit message

Fixes the value of the commit got from the Buldkite API to use raw strings.

Previously, the strings of those variables contained double quotes and it caused that git commands failed.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test values retrieved from Buildkite API (from jq command)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/8463


