### PR TITLE
ci - bump daily job to use 8.12-SNAPSHOT

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -39,12 +39,12 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.11') {
+        stage('with stack v8.12') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
               parameters: [
-                stringParam(name: 'stackVersion', value: '8.11-SNAPSHOT'),
+                stringParam(name: 'stackVersion', value: '8.12-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true),
                 booleanParam(name: 'skip_publishing', value: true),
               ],

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -39,12 +39,12 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.12') {
+        stage('with stack v8.12.0') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
               parameters: [
-                stringParam(name: 'stackVersion', value: '8.12-SNAPSHOT'),
+                stringParam(name: 'stackVersion', value: '8.12.0-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true),
                 booleanParam(name: 'skip_publishing', value: true),
               ],


### PR DESCRIPTION
## Proposed commit message

8.11.0 has been released. Move daily testing toward 8.12-SNAPSHOT.

https://fleet-ci.elastic.co/job/Ingest-manager/job/integrations-daily/