### PR TITLE
[TI_MISP] Add support for EnforceWarningList filter parameter

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.26.0
+  changes:
+    - description: Adds support to filter on EnforceWarningList
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8436
 - version: 1.25.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adds support to filter on EnforceWarningList
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8436
+      link: https://github.com/elastic/integrations/pull/8475
 - version: 1.25.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,11 @@ request.transforms:
 - set:
     target: body.limit
     value: 10
+{{#if enforce_warning_list}}
+- set:
+    target: body.enforceWarninglist
+    value: true
+{{/if}}
 - set:
     target: body.returnFormat
     value: json

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -35,7 +35,7 @@ request.transforms:
 {{#if enforce_warning_list}}
 - set:
     target: body.enforceWarninglist
-    value: true
+    value: 1
 {{/if}}
 - set:
     target: body.returnFormat

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -64,6 +64,14 @@ streams:
         required: true
         show_user: true
         default: 10m
+      - name: enforce_warning_list
+        type: bool
+        title: Enforce Warning List
+        description: Allows filtering on events with [MISP Warning lists](https://www.circl.lu/doc/misp/warninglists/#misp-warning-lists-introduction-the-dilemma-of-false-positive). Commonly used to filter out possible false positives.
+        multi: false
+        required: false
+        show_user: true
+        default: false
       - name: ssl
         type: yaml
         title: SSL

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.25.0"
+version: "1.26.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

EnforceWarningList is a request body parameter that is used in the MISP API to filter out values that are believed to be false positives, as documented here: https://www.circl.lu/doc/misp/warninglists/#misp-warning-lists-introduction-the-dilemma-of-false-positive

SPEC: https://raw.githubusercontent.com/MISP/MISP/develop/app/webroot/doc/openapi.yaml

I decided to instead of setting this to true or false in the .yml.hbs file, I only actually set it once its true, in case older versions of MISP do not support this parameter. The default value is also false, to not change any behavior by default when upgrading.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

