### PR TITLE
Update the Kibana version for Microsoft Entra ID Entity Analytics integration

### DIFF
--- a/packages/entityanalytics_entra_id/_dev/build/docs/README.md
+++ b/packages/entityanalytics_entra_id/_dev/build/docs/README.md
@@ -36,7 +36,7 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.9.0**.
+The minimum **kibana.version** required is **8.11.0**.
 
 ## Setup
 

--- a/packages/entityanalytics_entra_id/changelog.yml
+++ b/packages/entityanalytics_entra_id/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.6.1
+  changes:
+    - description: Update Kibana version to 8.11.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8499
 - version: 0.6.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/entityanalytics_entra_id/docs/README.md
+++ b/packages/entityanalytics_entra_id/docs/README.md
@@ -36,7 +36,7 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.9.0**.
+The minimum **kibana.version** required is **8.11.0**.
 
 ## Setup
 

--- a/packages/entityanalytics_entra_id/manifest.yml
+++ b/packages/entityanalytics_entra_id/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: entityanalytics_entra_id
 title: "Microsoft Entra ID Entity Analytics"
-version: "0.6.0"
+version: "0.6.1"
 description: "Collect identities from Microsoft Entra ID (formerly Azure Active Directory) with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
This PR updates the minimum compatible Kibana version for Microsoft Entra ID Entity Analytics integration.

Closes https://github.com/elastic/integrations/issues/8422
