### PR TITLE
Add 24h period configuration to all CSPM providers

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,8 +6,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.7.0-preview02"
+- version: "1.7.0-preview03"
   changes:
+    - description: Update all CSPM providers to run every 24h
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8516
     - description: Azure credentials configuration
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8376

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/azure.yml.hbs
@@ -1,3 +1,4 @@
+period: 24h
 fetchers:
 config:
   v1:

--- a/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_security_posture/data_stream/findings/agent/stream/gcp.yml.hbs
@@ -1,3 +1,4 @@
+period: 24h
 config:
   v1:
     type: cspm

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.7.0-preview02"
+version: "1.7.0-preview03"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Why
As mentioned on https://github.com/elastic/cloudbeat/issues/1478 currently only CSPM AWS runs on a 24h cycle, GCP and Azure run on a 4h cycle (default value), while all CSPM should run on a 24h period.

## What
Add 24h period configuration to all CSPMs. AWS already had, added to GCP and Azure.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] All CSPM have 24h period configured

## Related issues
- Closes https://github.com/elastic/cloudbeat/issues/1478