### PR TITLE
[AWS] Change SQS metrics statistic method

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.9.1"
   changes:
-    - description: Change SQS metrics statistic method
+    - description: Change SQS metrics statistic method, which includes changing ApproximateAgeOfOldestMessage from average to max, changing NumberOfMessagesDeleted, NumberOfEmptyReceives, NumberOfMessagesReceived and NumberOfMessagesSent from average to sum.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/8521
 - version: "2.9.0"

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.8.7"
+  changes:
+    - description: Change SQS metrics statistic method
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8521
 - version: "2.8.6"
   changes:
     - description: Add missing fields from beats input

--- a/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
@@ -47,13 +47,17 @@ metrics:
   - ApproximateAgeOfOldestMessage
 - namespace: AWS/SQS
   resource_type: sqs
-  statistic: ["Sum"]
+  statistic: ["Average"]
   name:
   - ApproximateNumberOfMessagesDelayed
   - ApproximateNumberOfMessagesNotVisible
   - ApproximateNumberOfMessagesVisible
+  - SentMessageSize
+- namespace: AWS/SQS
+  resource_type: sqs
+  statistic: ["Sum"]
+  name:
   - NumberOfMessagesDeleted
+  - NumberOfEmptyReceives
   - NumberOfMessagesReceived
   - NumberOfMessagesSent
-  - NumberOfEmptyReceives
-  - SentMessageSize

--- a/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/sqs/agent/stream/stream.yml.hbs
@@ -42,9 +42,13 @@ proxy_url: {{proxy_url}}
 metrics:
 - namespace: AWS/SQS
   resource_type: sqs
-  statistic: ["Average"]
+  statistic: ["Maximum"]
   name:
   - ApproximateAgeOfOldestMessage
+- namespace: AWS/SQS
+  resource_type: sqs
+  statistic: ["Sum"]
+  name:
   - ApproximateNumberOfMessagesDelayed
   - ApproximateNumberOfMessagesNotVisible
   - ApproximateNumberOfMessagesVisible

--- a/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
@@ -3,39 +3,39 @@ description: "Pipeline for SQS metrics"
 
 processors:
   - rename:
-      field: aws.sqs.metrics.ApproximateAgeOfOldestMessage.avg
+      field: aws.sqs.metrics.ApproximateAgeOfOldestMessage.max
       target_field: aws.sqs.oldest_message_age.sec
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesDelayed.avg
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesDelayed.sum
       target_field: aws.sqs.messages.delayed
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesNotVisible.avg
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesNotVisible.sum
       target_field: aws.sqs.messages.not_visible
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesVisible.avg
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesVisible.sum
       target_field: aws.sqs.messages.visible
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.NumberOfMessagesDeleted.avg
+      field: aws.sqs.metrics.NumberOfMessagesDeleted.sum
       target_field: aws.sqs.messages.deleted
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.NumberOfMessagesReceived.avg
+      field: aws.sqs.metrics.NumberOfMessagesReceived.sum
       target_field: aws.sqs.messages.received
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.NumberOfMessagesSent.avg
+      field: aws.sqs.metrics.NumberOfMessagesSent.sum
       target_field: aws.sqs.messages.sent
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.NumberOfEmptyReceives.avg
+      field: aws.sqs.metrics.NumberOfEmptyReceives.sum
       target_field: aws.sqs.empty_receives
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.SentMessageSize.avg
+      field: aws.sqs.metrics.SentMessageSize.sum
       target_field: aws.sqs.sent_message_size.bytes
       ignore_missing: true
   - remove:

--- a/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws/data_stream/sqs/elasticsearch/ingest_pipeline/default.yml
@@ -7,15 +7,15 @@ processors:
       target_field: aws.sqs.oldest_message_age.sec
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesDelayed.sum
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesDelayed.avg
       target_field: aws.sqs.messages.delayed
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesNotVisible.sum
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesNotVisible.avg
       target_field: aws.sqs.messages.not_visible
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.ApproximateNumberOfMessagesVisible.sum
+      field: aws.sqs.metrics.ApproximateNumberOfMessagesVisible.avg
       target_field: aws.sqs.messages.visible
       ignore_missing: true
   - rename:
@@ -35,7 +35,7 @@ processors:
       target_field: aws.sqs.empty_receives
       ignore_missing: true
   - rename:
-      field: aws.sqs.metrics.SentMessageSize.sum
+      field: aws.sqs.metrics.SentMessageSize.avg
       target_field: aws.sqs.sent_message_size.bytes
       ignore_missing: true
   - remove:

--- a/packages/aws/data_stream/sqs/fields/fields.yml
+++ b/packages/aws/data_stream/sqs/fields/fields.yml
@@ -21,17 +21,17 @@
           type: long
           metric_type: gauge
           description: |
-            The total number of messages in the queue that are delayed and not available for reading immediately.
+            The average number of messages in the queue that are delayed and not available for reading immediately.
         - name: messages.not_visible
           type: long
           metric_type: gauge
           description: |
-            The total number of messages that are in flight.
+            The average number of messages that are in flight.
         - name: messages.visible
           type: long
           metric_type: gauge
           description: |
-            The total number of messages available for retrieval from the queue.
+            The average number of messages available for retrieval from the queue.
         - name: messages.deleted
           type: long
           metric_type: gauge
@@ -57,7 +57,7 @@
           metric_type: gauge
           format: bytes
           description: |
-            The total size of messages added to a queue.
+            The average size of messages added to a queue.
         - name: queue.name
           type: keyword
           description: |

--- a/packages/aws/data_stream/sqs/fields/fields.yml
+++ b/packages/aws/data_stream/sqs/fields/fields.yml
@@ -16,48 +16,48 @@
           metric_type: gauge
           format: duration
           description: |
-            The approximate age of the oldest non-deleted message in the queue.
+            The maximum approximate age of the oldest non-deleted message in the queue.
         - name: messages.delayed
           type: long
           metric_type: gauge
           description: |
-            TThe number of messages in the queue that are delayed and not available for reading immediately.
+            The total number of messages in the queue that are delayed and not available for reading immediately.
         - name: messages.not_visible
           type: long
           metric_type: gauge
           description: |
-            The number of messages that are in flight.
+            The total number of messages that are in flight.
         - name: messages.visible
           type: long
           metric_type: gauge
           description: |
-            The number of messages available for retrieval from the queue.
+            The total number of messages available for retrieval from the queue.
         - name: messages.deleted
           type: long
           metric_type: gauge
           description: |
-            The number of messages deleted from the queue.
+            The total number of messages deleted from the queue.
         - name: messages.received
           type: long
           metric_type: gauge
           description: |
-            The number of messages returned by calls to the ReceiveMessage action.
+            The total number of messages returned by calls to the ReceiveMessage action.
         - name: messages.sent
           type: long
           metric_type: gauge
           description: |
-            The number of messages added to a queue.
+            The total number of messages added to a queue.
         - name: empty_receives
           type: long
           metric_type: gauge
           description: |
-            The number of ReceiveMessage API calls that did not return a message.
+            The total number of ReceiveMessage API calls that did not return a message.
         - name: sent_message_size.bytes
           type: long
           metric_type: gauge
           format: bytes
           description: |
-            The size of messages added to a queue.
+            The total size of messages added to a queue.
         - name: queue.name
           type: keyword
           description: |

--- a/packages/aws/docs/sqs.md
+++ b/packages/aws/docs/sqs.md
@@ -129,15 +129,15 @@ An example event for `sqs` looks as following:
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
 | aws.dimensions.QueueName | SQS queue name | keyword |  |
 | aws.sqs.empty_receives | The total number of ReceiveMessage API calls that did not return a message. | long | gauge |
-| aws.sqs.messages.delayed | The total number of messages in the queue that are delayed and not available for reading immediately. | long | gauge |
+| aws.sqs.messages.delayed | The average number of messages in the queue that are delayed and not available for reading immediately. | long | gauge |
 | aws.sqs.messages.deleted | The total number of messages deleted from the queue. | long | gauge |
-| aws.sqs.messages.not_visible | The total number of messages that are in flight. | long | gauge |
+| aws.sqs.messages.not_visible | The average number of messages that are in flight. | long | gauge |
 | aws.sqs.messages.received | The total number of messages returned by calls to the ReceiveMessage action. | long | gauge |
 | aws.sqs.messages.sent | The total number of messages added to a queue. | long | gauge |
-| aws.sqs.messages.visible | The total number of messages available for retrieval from the queue. | long | gauge |
+| aws.sqs.messages.visible | The average number of messages available for retrieval from the queue. | long | gauge |
 | aws.sqs.oldest_message_age.sec | The maximum approximate age of the oldest non-deleted message in the queue. | long | gauge |
 | aws.sqs.queue.name | SQS queue name | keyword |  |
-| aws.sqs.sent_message_size.bytes | The total size of messages added to a queue. | long | gauge |
+| aws.sqs.sent_message_size.bytes | The average size of messages added to a queue. | long | gauge |
 | aws.tags | Tag key value pairs from aws resources. | flattened |  |
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |

--- a/packages/aws/docs/sqs.md
+++ b/packages/aws/docs/sqs.md
@@ -128,16 +128,16 @@ An example event for `sqs` looks as following:
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
 | aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
 | aws.dimensions.QueueName | SQS queue name | keyword |  |
-| aws.sqs.empty_receives | The number of ReceiveMessage API calls that did not return a message. | long | gauge |
-| aws.sqs.messages.delayed | TThe number of messages in the queue that are delayed and not available for reading immediately. | long | gauge |
-| aws.sqs.messages.deleted | The number of messages deleted from the queue. | long | gauge |
-| aws.sqs.messages.not_visible | The number of messages that are in flight. | long | gauge |
-| aws.sqs.messages.received | The number of messages returned by calls to the ReceiveMessage action. | long | gauge |
-| aws.sqs.messages.sent | The number of messages added to a queue. | long | gauge |
-| aws.sqs.messages.visible | The number of messages available for retrieval from the queue. | long | gauge |
-| aws.sqs.oldest_message_age.sec | The approximate age of the oldest non-deleted message in the queue. | long | gauge |
+| aws.sqs.empty_receives | The total number of ReceiveMessage API calls that did not return a message. | long | gauge |
+| aws.sqs.messages.delayed | The total number of messages in the queue that are delayed and not available for reading immediately. | long | gauge |
+| aws.sqs.messages.deleted | The total number of messages deleted from the queue. | long | gauge |
+| aws.sqs.messages.not_visible | The total number of messages that are in flight. | long | gauge |
+| aws.sqs.messages.received | The total number of messages returned by calls to the ReceiveMessage action. | long | gauge |
+| aws.sqs.messages.sent | The total number of messages added to a queue. | long | gauge |
+| aws.sqs.messages.visible | The total number of messages available for retrieval from the queue. | long | gauge |
+| aws.sqs.oldest_message_age.sec | The maximum approximate age of the oldest non-deleted message in the queue. | long | gauge |
 | aws.sqs.queue.name | SQS queue name | keyword |  |
-| aws.sqs.sent_message_size.bytes | The size of messages added to a queue. | long | gauge |
+| aws.sqs.sent_message_size.bytes | The total size of messages added to a queue. | long | gauge |
 | aws.tags | Tag key value pairs from aws resources. | flattened |  |
 | cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
 | cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.8.6
+version: 2.8.7
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

This PR changes the statistic method that we use to pull SQS cloudwatch metrics. 

ApproximateAgeOfOldestMessage: average -> max
NumberOfMessagesDeleted: average -> sum
NumberOfEmptyReceives: average -> sum
NumberOfMessagesReceived: average -> sum
NumberOfMessagesSent: average -> sum

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
