### PR TITLE
Disable jenkins daily job in favor of Buildkite pipeline

### DIFF
--- a/.ci/jobs/integrations-daily.yml
+++ b/.ci/jobs/integrations-daily.yml
@@ -18,5 +18,3 @@
             reference-repo: /var/lib/jenkins/.git-references/integrations.git
             branches:
               - main
-    triggers:
-      - timed: 'H H(2-5) * * *'

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -18,9 +18,6 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
     quietPeriod(10)
   }
-  triggers {
-    cron('H H(2-5) * * *')
-  }
   stages {
     stage('Daily integration builds') {
       parallel {

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -107,8 +107,7 @@ spec:
       skip_intermediate_builds_branch_filter: '!main'
       env:
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-        # SLACK_NOTIFICATIONS_CHANNEL: '#beats-build' as the current jenkins schedule-daily?
-        SLACK_NOTIFICATIONS_CHANNEL: '#ingest-test-notifications'   #TODO: will be changed before GO-PROD
+        SLACK_NOTIFICATIONS_CHANNEL: '#beats-build'
         SLACK_NOTIFICATIONS_ALL_BRANCHES: 'true'
         SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:


### PR DESCRIPTION
## Proposed commit message

This PR disables Jenkins daily job in favor of the Buildkite pipeline:
- https://fleet-ci.elastic.co/job/Ingest-manager/job/integrations-daily/
- https://buildkite.com/elastic/integrations-schedule-daily/

## Checklist

- ~[ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm slack channel to use

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

