### PR TITLE
Migrate Synthetics to package spec v3

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adopt package spec v3
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/123456789
+      link: https://github.com/elastic/integrations/pull/8546
 - version: "1.1.1"
   changes:
     - description: Fix meta container mapping

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Adopt package spec v3
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/123456789
 - version: "1.1.1"
   changes:
     - description: Fix meta container mapping

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.2.0"
+- version: "1.2.0-rc1"
   changes:
     - description: Adopt package spec v3
       type: enhancement

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/browser/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser/fields/ecs.yml
@@ -168,6 +168,7 @@
     - name: answers
       level: extended
       type: object
+      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1155,13 +1158,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1179,7 +1184,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1188,7 +1194,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1158,15 +1155,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1184,8 +1179,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1194,8 +1188,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser/fields/http.yml
+++ b/packages/synthetics/data_stream/browser/fields/http.yml
@@ -22,6 +22,7 @@
 
         - name: headers.*
           type: object
+          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/browser/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser/fields/summary.yml
@@ -11,24 +11,27 @@
       type: integer
       description: >
         The number of endpoints that failed
+
     - name: status
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
-        A unique token used to group checks across attempts.        
-
+      description: "A unique token used to group checks across attempts.        \n"

--- a/packages/synthetics/data_stream/browser/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser/fields/synthetics.yml
@@ -14,7 +14,7 @@
         Indexed used for creating total order of all events in this invocation.
 
     - name: payload
-      object_type: text
+      object_type: keyword
       type: object
       enabled: false
     - name: blob

--- a/packages/synthetics/data_stream/browser/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser/fields/synthetics.yml
@@ -14,6 +14,7 @@
         Indexed used for creating total order of all events in this invocation.
 
     - name: payload
+      object_type: text
       type: object
       enabled: false
     - name: blob

--- a/packages/synthetics/data_stream/browser/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/synthetics/data_stream/browser/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "30d"
+data_retention: "365d"

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -9,10 +9,12 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "url.full.keyword"
-          - "monitor.id"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "url.full.keyword"
+            - "monitor.id"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check
@@ -52,7 +54,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "\"@every 3m\""
+        default: '"@every 3m"'
       - name: service.name
         type: text
         title: APM Service Name

--- a/packages/synthetics/data_stream/browser_network/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >
@@ -76,3 +77,4 @@
       type: boolean
       description: >
         True if monitor is created with the Fleet integration UI
+

--- a/packages/synthetics/data_stream/browser_network/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/common.yml
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.
@@ -77,4 +76,3 @@
       type: boolean
       description: >
         True if monitor is created with the Fleet integration UI
-

--- a/packages/synthetics/data_stream/browser_network/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/ecs.yml
@@ -168,6 +168,7 @@
     - name: answers
       level: extended
       type: object
+      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1155,13 +1158,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1179,7 +1184,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1188,7 +1194,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser_network/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1158,15 +1155,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1184,8 +1179,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1194,8 +1188,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser_network/fields/http.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/http.yml
@@ -38,6 +38,7 @@
 
         - name: headers.*
           type: object
+          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/browser_network/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/summary.yml
@@ -11,23 +11,27 @@
       type: integer
       description: >
         The number of endpoints that failed
+
     - name: status
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
-        A unique token used to group checks across attempts.  
+      description: "A unique token used to group checks across attempts.  \n"

--- a/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
@@ -15,6 +15,7 @@
 
     - name: payload
       type: object
+      object_type: text
       enabled: false
     - name: blob
       type: binary

--- a/packages/synthetics/data_stream/browser_network/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_network/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/synthetics/data_stream/browser_network/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_network/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "30d"
+data_retention: "14d"

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -9,12 +9,14 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "url.full.keyword"
-          - "http.request.url.keyword"
-          - "http.response.headers.etag"
-          - "monitor.id"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "url.full.keyword"
+            - "http.request.url.keyword"
+            - "http.response.headers.etag"
+            - "monitor.id"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >
@@ -76,3 +77,4 @@
       type: boolean
       description: >
         True if monitor is created with the Fleet integration UI
+

--- a/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.
@@ -77,4 +76,3 @@
       type: boolean
       description: >
         True if monitor is created with the Fleet integration UI
-

--- a/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
@@ -168,6 +168,7 @@
     - name: answers
       level: extended
       type: object
+      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1153,13 +1156,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1177,7 +1182,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1186,7 +1192,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1156,15 +1153,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1182,8 +1177,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1192,8 +1186,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/browser_screenshot/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/summary.yml
@@ -16,19 +16,23 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
+      description: >-
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
@@ -15,6 +15,7 @@
 
     - name: payload
       type: object
+      object_type: text
       enabled: false
     - name: blob
       type: binary

--- a/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "7d"

--- a/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "7d"
+data_retention: "14d"

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -9,9 +9,11 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "monitor.id"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "monitor.id"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -18,7 +18,7 @@
 - name: monitor
   type: group
   description: >
-    Common monitor fields.   
+    Common monitor fields.
 
   fields:
     - name: type
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/http/fields/ecs.yml
+++ b/packages/synthetics/data_stream/http/fields/ecs.yml
@@ -168,6 +168,7 @@
     - name: answers
       level: extended
       type: object
+      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1155,13 +1158,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1179,7 +1184,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1188,7 +1194,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/http/fields/ecs.yml
+++ b/packages/synthetics/data_stream/http/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1158,15 +1155,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1184,8 +1179,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1194,8 +1188,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/http/fields/http.yml
+++ b/packages/synthetics/data_stream/http/fields/http.yml
@@ -22,6 +22,7 @@
 
         - name: headers.*
           type: object
+          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/http/fields/summary.yml
+++ b/packages/synthetics/data_stream/http/fields/summary.yml
@@ -16,19 +16,23 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
+      description: >-
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/http/fields/tls.yml
+++ b/packages/synthetics/data_stream/http/fields/tls.yml
@@ -6,10 +6,8 @@
   fields:
     - name: certificate_not_valid_before
       type: date
-      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
-      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/http/lifecycle.yml
+++ b/packages/synthetics/data_stream/http/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/synthetics/data_stream/http/lifecycle.yml
+++ b/packages/synthetics/data_stream/http/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "30d"
+data_retention: "365d"

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -9,10 +9,12 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "monitor.id"
-          - "url.full.keyword"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "monitor.id"
+            - "url.full.keyword"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/http
     title: Synthetic monitor check
@@ -52,7 +54,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "\"@every 3m\""
+        default: '"@every 3m"'
       - name: urls
         type: text
         title: URL
@@ -241,7 +243,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true   
+        show_user: true
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/icmp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/icmp/fields/ecs.yml
@@ -169,6 +169,7 @@
       level: extended
       type: object
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
+      object_type: keyword
     - name: answers.class
       level: extended
       type: keyword
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1155,13 +1158,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1179,7 +1184,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1188,7 +1194,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/icmp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/icmp/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1158,15 +1155,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1184,8 +1179,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1194,8 +1188,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/icmp/fields/summary.yml
+++ b/packages/synthetics/data_stream/icmp/fields/summary.yml
@@ -16,19 +16,23 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
+      description: >-
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/icmp/fields/tls.yml
+++ b/packages/synthetics/data_stream/icmp/fields/tls.yml
@@ -6,10 +6,8 @@
   fields:
     - name: certificate_not_valid_before
       type: date
-      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
-      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/icmp/lifecycle.yml
+++ b/packages/synthetics/data_stream/icmp/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/synthetics/data_stream/icmp/lifecycle.yml
+++ b/packages/synthetics/data_stream/icmp/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "30d"
+data_retention: "365d"

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -9,10 +9,12 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "monitor.id"
-          - "url.full.keyword"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "monitor.id"
+            - "url.full.keyword"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check
@@ -52,7 +54,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "\"@every 3m\""
+        default: '"@every 3m"'
       - name: wait
         type: text
         title: Wait
@@ -116,7 +118,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true   
+        show_user: true
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -15,6 +15,7 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
+
 - name: monitor
   type: group
   description: >

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -58,7 +58,6 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
-      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/tcp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/tcp/fields/ecs.yml
@@ -169,6 +169,7 @@
       level: extended
       type: object
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
+      object_type: keyword
     - name: answers.class
       level: extended
       type: keyword
@@ -242,7 +243,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain is all of the labels under the registered_domain.
+      description:
+        'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -250,7 +252,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -285,7 +288,6 @@
   fields:
     - name: version
       level: core
-      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."
@@ -1099,7 +1101,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The field contains the file extension from the original request url, excluding the leading dot.
+      description:
+        'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1155,13 +1158,15 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
+      description:
+        'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description: 'The highest registered url domain, stripped of the subdomain.
+      description:
+        'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1179,7 +1184,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description:
+        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1188,7 +1194,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description:
+        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/tcp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/tcp/fields/ecs.yml
@@ -243,8 +243,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain is all of the labels under the registered_domain.
+      description: 'The subdomain is all of the labels under the registered_domain.
 
         If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: www
@@ -252,8 +251,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk
@@ -1101,8 +1099,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The field contains the file extension from the original request url, excluding the leading dot.
+      description: 'The field contains the file extension from the original request url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
@@ -1158,15 +1155,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The query field describes the query string of the request, such as "q=elasticsearch".
+      description: 'The query field describes the query string of the request, such as "q=elasticsearch".
 
         The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.'
     - name: registered_domain
       level: extended
       type: wildcard
-      description:
-        'The highest registered url domain, stripped of the subdomain.
+      description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
 
@@ -1184,8 +1179,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
+      description: 'The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
 
         For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period.'
       example: east
@@ -1194,8 +1188,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description:
-        'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
+      description: 'The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".'
       example: co.uk

--- a/packages/synthetics/data_stream/tcp/fields/summary.yml
+++ b/packages/synthetics/data_stream/tcp/fields/summary.yml
@@ -16,19 +16,23 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
+
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
+
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
+
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
+
     - name: retry_group
       type: keyword
-      description: >
+      description: >-
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/tcp/fields/tls.yml
+++ b/packages/synthetics/data_stream/tcp/fields/tls.yml
@@ -6,10 +6,8 @@
   fields:
     - name: certificate_not_valid_before
       type: date
-      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
-      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/tcp/lifecycle.yml
+++ b/packages/synthetics/data_stream/tcp/lifecycle.yml
@@ -1,0 +1,1 @@
+data_retention: "30d"

--- a/packages/synthetics/data_stream/tcp/lifecycle.yml
+++ b/packages/synthetics/data_stream/tcp/lifecycle.yml
@@ -1,1 +1,1 @@
-data_retention: "30d"
+data_retention: "365d"

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -9,10 +9,12 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort.field:
-          - "monitor.id"
-          - "url.full.keyword"
-  privileges.indices: [auto_configure, create_doc, read]
+        sort:
+          field:
+            - "monitor.id"
+            - "url.full.keyword"
+  privileges:
+    indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check
@@ -52,7 +54,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: "\"@every 3m\""
+        default: '"@every 3m"'
       - name: hosts
         type: text
         title: Host
@@ -170,7 +172,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true   
+        show_user: true
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -1,12 +1,12 @@
-format_version: 1.0.0
+format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.1.1
+version: 1.2.0
 categories: ["observability"]
-release: ga
 type: integration
-license: basic
+source:
+  license: Elastic-2.0
 policy_templates:
   - name: synthetics
     title: Elastic Synthetics
@@ -25,7 +25,8 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana.version: "^8.11.0"
+  kibana:
+    version: "^8.11.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.0.1
+format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
@@ -33,3 +33,4 @@ icons:
     type: image/svg+xml
 owner:
   github: elastic/obs-ux-infra_services-team
+  type: elastic

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.2.0
+version: 1.2.0-rc1
 categories: ["observability"]
 type: integration
 source:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.0.0
+format_version: 3.0.1
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.


### PR DESCRIPTION
## Proposed commit message

Resolves #8572.

Related to https://github.com/elastic/integrations/issues/5681.

Migrated the Synthetics package to package-spec v3.

Notably
- removed disallowed usages of `required` keyword
- specified `object_type` where required
- remove `keyword.dot` syntax as disallowed
- remove `deprecated` field
- update `license` to nest under `source` field
- switch `license` specification from `basic` to `Elastic-2.0`
- bump to new minor version

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- https://github.com/elastic/synthetics-dev/issues/185

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
