### PR TITLE
auditd_manager: make socket type selection a set of options and correct documentation

### DIFF
--- a/packages/auditd_manager/changelog.yml
+++ b/packages/auditd_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.16.1
+  changes:
+    - description: Fix socket type selection and documentation.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8558
 - version: 1.16.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
+++ b/packages/auditd_manager/data_stream/auditd/agent/stream/auditd.yml.hbs
@@ -3,12 +3,8 @@ condition: ${host.platform} == 'linux'
 
 type: audit/auditd
 include_raw_message: true
-{{#if multicast}}
-socket_type: multicast
-{{else}}
-socket_type: unicast
+socket_type: '{{socket_type}}'
 immutable: {{immutable}}
-{{/if}}
 resolve_ids: {{resolve_ids}}
 failure_mode: {{failure_mode}}
 {{#if audit_rules}}
@@ -16,7 +12,7 @@ audit_rules: {{escape_string audit_rules}}
 {{/if}}
 {{#if audit_rule_files.length}}
 audit_rule_files:
-{{#each audit_rule_files as |file i|}}
+{{#each audit_rule_files as |file|}}
   - {{file}}
 {{/each}}
 {{/if}}
@@ -28,7 +24,7 @@ tags:
 {{#if preserve_original_event}}
   - preserve_original_event
 {{/if}}
-{{#each tags as |tag i|}}
+{{#each tags as |tag|}}
   - {{tag}}
 {{/each}}
 {{#contains "forwarded" tags}}

--- a/packages/auditd_manager/data_stream/auditd/manifest.yml
+++ b/packages/auditd_manager/data_stream/auditd/manifest.yml
@@ -6,26 +6,33 @@ streams:
     template_path: auditd.yml.hbs
     description: Collect auditd events
     vars:
-      - name: multicast
-        type: bool
+      - name: socket_type
         title: Multicast socket type
         show_user: true
+        required: true
         multi: false
-        default: false
+        type: select
+        options:
+          - text: auto
+            value: ''
+          - text: unicast
+            value: unicast
+          - text: multicast
+            value: multicast
+        default: ''
         description: |
-          This setting controls if the socket type used to receive events is multicast.
-          This setting should be disabled when `elastic-agent` is the primary userspace
-          daemon for receiving audit events and managing the rules. Only a single process
-          can receive audit events if this is disabled, so any other daemons should be
-          stopped (e.g. stop `auditd`).
+          This setting controls the socket type used to receive events. This setting should
+          be set to `unicast` when `elastic-agent` is the primary userspace daemon for receiving
+          audit events and managing the rules. Only a single process can receive audit events
+          when using unicast sockets, so any other daemons should be stopped (e.g. stop `auditd`).
 
-          This setting can be enabled with kernel versions 3.16 and newer. By setting it
-          `elastic-agent` will receive an audit event broadcast that is not exclusive
+          Multicast can be enabled with kernel versions 3.16 and newer. By setting it to
+          `multicast` `elastic-agent` will receive an audit event broadcast that is not exclusive
           to a single process. This is ideal for situations where `auditd` is running and
           managing the rules.
 
-          If it is set to `true`, but the kernel version is less than 3.16 it will be
-          automatically disabled.
+          If `auto` is selected, `elastic-agent` will attempt to use multicast sockets, falling
+          back to unicast if multicast is not available.
       - name: immutable
         type: bool
         title: Immutable
@@ -34,7 +41,7 @@ streams:
         default: false
         description: |
           This boolean setting sets the audit config as immutable (`-e 2`).
-          This option can only be used if `multicast` is disabled since `elastic-agent`
+          This option can only be used if socket type is not `multicast` since `elastic-agent`
           needs to manage the rules to be able to set it.
 
           Please note that with this setting enabled, after Elastic Agent restarts or

--- a/packages/auditd_manager/manifest.yml
+++ b/packages/auditd_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: auditd_manager
 title: "Auditd Manager"
-version: "1.16.0"
+version: "1.16.1"
 description: "The Auditd Manager Integration receives audit events from the Linux Audit Framework that is a part of the Linux kernel."
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The valid options for socket_type in auditbeat are unicast, multicast and '', checked during config validation, so provide a selection which maps 'auto' to ''.

Unfortunately, we are not able to check that the combination of socket type and immutability are valid (this would require that we be able to compare a value in the template to 'multicast', but no comparison helpers exist in the handlbars instance used for integration config templates). The best we can do is tell users not to do this; it will show up in log failures.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #8557 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
