### PR TITLE
[Buildkite] Update buildkite daily job as in Jenkins

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -15,7 +15,7 @@ steps:
       cpu: "8"
       memory: "4G"
 
-  - label: "Check integrations local stacks - Stack Version 7.17"
+  - label: "Check integrations local stacks - Stack Version v7.17"
     trigger: "integrations"
     build:
       env:
@@ -27,14 +27,14 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version 8.11"
+  - label: "Check integrations local stacks - Stack Version v8.12.0"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 8.11-SNAPSHOT
+        STACK_VERSION: 8.12.0-SNAPSHOT
     depends_on:
       - step: "check"
         allow_failure: false


### PR DESCRIPTION

## Proposed commit message

8.11.0 has been released. Move daily testing toward 8.12-SNAPSHOT.
https://buildkite.com/elastic/integrations-schedule-daily/builds?branch=main


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/pull/8471
