### PR TITLE
Create a system test for cloud_defend to write basic data stream

### DIFF
--- a/packages/cloud_defend/data_stream/heartbeat/_dev/deploy/agent/custom-agent.yml
+++ b/packages/cloud_defend/data_stream/heartbeat/_dev/deploy/agent/custom-agent.yml
@@ -1,0 +1,8 @@
+version: "2.3"
+volumes:
+  blank:
+services:
+  docker-custom-agent:
+    user: root
+    volumes:
+      - blank:/cloud-defend-heartbeat

--- a/packages/cloud_defend/data_stream/heartbeat/_dev/test/system/test-heartbeat-config.yml
+++ b/packages/cloud_defend/data_stream/heartbeat/_dev/test/system/test-heartbeat-config.yml
@@ -1,0 +1,5 @@
+vars: ~
+input: cloud_defend/control
+data_stream:
+  vars:
+    period: 1m


### PR DESCRIPTION
This creates a custom-agent deploy strategy that allows cloud_defend to run in the system test environment by running with a root agent and leaving an empty volume at `/cloud-defend-heartbeat` so cloud_defend doesn't try to deploy it's ebpf or kubernetes sensors.

## Add: cloud_defend System test

This adds a system test for the heartbeat data stream in the cloud_defend package.
It includes a custom agent deploy method that triggers an inert state in cloud_defend
where none of the sensors are deployed, since the full functionality of cloud_defend 
is not supported in the kind k8s testing environment at the time of writing.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [-] I have added an entry to my package's `changelog.yml` file.
- [-] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Wait till the latest version of cloud-defend is released with the detection for the sentinel directory to enable heartbeat mode

## How to test this PR locally

Go to the `./packages/cloud_defend` directory within this repository and run `elastic-package test`

## Screenshots

```
--- Test results for package: cloud_defend - START ---
╭──────────────┬─────────────┬───────────┬───────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME                                                 │ RESULT │ TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────────────────────────────────────────────────────┼────────┼──────────────┤
│ cloud_defend │ alerts      │ asset     │ index_template logs-cloud_defend.alerts is loaded         │ PASS   │        931ns │
│ cloud_defend │ alerts      │ asset     │ ingest_pipeline logs-cloud_defend.alerts-1.2.2 is loaded  │ PASS   │        209ns │
│ cloud_defend │ file        │ asset     │ index_template logs-cloud_defend.file is loaded           │ PASS   │        146ns │
│ cloud_defend │ file        │ asset     │ ingest_pipeline logs-cloud_defend.file-1.2.2 is loaded    │ PASS   │        161ns │
│ cloud_defend │ heartbeat   │ asset     │ index_template metrics-cloud_defend.heartbeat is loaded   │ PASS   │        210ns │
│ cloud_defend │ metrics     │ asset     │ index_template metrics-cloud_defend.metrics is loaded     │ PASS   │        185ns │
│ cloud_defend │ process     │ asset     │ index_template logs-cloud_defend.process is loaded        │ PASS   │        154ns │
│ cloud_defend │ process     │ asset     │ ingest_pipeline logs-cloud_defend.process-1.2.2 is loaded │ PASS   │        189ns │
╰──────────────┴─────────────┴───────────┴───────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: cloud_defend - END   ---
--- Test results for package: cloud_defend - START ---
╭──────────────┬─────────────┬───────────┬───────────┬────────┬────────────────╮
│ PACKAGE      │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │   TIME ELAPSED │
├──────────────┼─────────────┼───────────┼───────────┼────────┼────────────────┤
│ cloud_defend │ heartbeat   │ system    │ heartbeat │ PASS   │ 1m9.912468141s │
╰──────────────┴─────────────┴───────────┴───────────┴────────┴────────────────╯
--- Test results for package: cloud_defend - END   ---
```