### PR TITLE
Added `beat.stats.libbeat.pipeline.queue.max_events` to elastic agent

### DIFF
--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -67,3 +67,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -66,3 +66,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -138,6 +138,8 @@
               type: long
             - name: queue.acked
               type: long
+            - name: queue.max_events
+              type: long
             - name: events
               type: group
               fields:

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -67,3 +67,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -70,3 +70,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -67,3 +67,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -67,3 +67,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -67,3 +67,7 @@
       type: long
       metric_type: counter
       description: Number of events successfully acknowledged by the output
+    - name: queue.max_events
+      type: long
+      metric_type: counter
+      description: Maximum number of events in a queue


### PR DESCRIPTION
Added `beat.stats.libbeat.pipeline.queue.max_events` to elastic agent mappings as introduced/exposed in https://github.com/elastic/beats/pull/37189
