### PR TITLE
[prisma_cloud] Update the Cursor in the Data Collection of Alert and Audit Data Stream and HTTP Timeout Default Values

### DIFF
--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Update the cursor in data collection of the alert data stream and the default value of HTTP Client Timeout.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.5.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update the cursor in data collection of the alert data stream and the default value of HTTP Client Timeout.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8580
 - version: "0.5.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -27,8 +27,7 @@ redact:
     - password
 program: |
   (
-    state.with(has(state.want_more) && !(state.want_more)
-    ?
+    state.with(has(state.want_more) && !(state.want_more) ?
       post_request(
         state.url + "/login",
         "application/json",
@@ -41,75 +40,86 @@ program: |
     ).as(state, state.with(
       request("GET", state.url + "/v2/alert?timeType=relative&detailed=true&limit=" + string(state.batch_size) + "&timeAmount=" +
         (
-          has(state.want_more) && !(state.want_more)
-         ?
+          has(state.want_more) && !(state.want_more) ?
           (
-           has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null
-           ?
-             string((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
-           :
+            has(state.cursor) && has(state.cursor.last_time_amount) &&
+            state.cursor.last_time_amount != null ?
+             string((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
+          :
              string(state.time_amount) + "&timeUnit=" + state.time_unit
           )
-         :
+        :
           (
-            has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null
-            ?
-            string((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.first_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
+            has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null ?
+              string((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.first_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
             :
-            "null"
+              "null"
           ) + (has(state.page_token) ? "&pageToken=" + state.page_token : "")
-         )
-        ).with({
-          "Header":{
-            "x-redlock-auth": [state.access_token],
-          }
-        }).do_request().as(resp, bytes(resp.Body).decode_json().as(inner_body, {
-            "events": inner_body.items.map(e, {
-              "message": e.encode_json(),
-            }),
-            "url": state.url,
-            "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
-            "cursor": {
-              "last_time_amount": (
-                has(inner_body.items) && inner_body.items.size() > 0
-                ?
-                 (
-                  has(state.cursor) && has(state.cursor.last_time_amount) && inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount
-                  ?
+        )
+      ).with({
+         "Header":{
+           "x-redlock-auth": [state.access_token],
+         }
+      }).do_request().as(resp,
+        bytes(resp.Body).decode_json().as(inner_body, {
+          "events": inner_body.items.map(e, {
+            "message": e.encode_json(),
+          }),
+          "url": state.url,
+          "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
+          "cursor": {
+            "last_time_amount": (
+              has(inner_body.items) && inner_body.items.size() > 0 ?
+                (
+                  has(state.cursor) && has(state.cursor.last_time_amount) &&
+                  inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount ?
                     state.cursor.last_time_amount
                   :
                     inner_body.items.map(e, e.lastUpdated).max()
-                 )
-                :
-                  (
-                    has(state.cursor) && has(state.cursor.last_time_amount)
-                    ?
-                      state.cursor.last_time_amount
-                    :
-                      null
-                  )
+                )
+              :
+                (
+                  has(state.cursor) && has(state.cursor.last_time_amount) ?
+                    state.cursor.last_time_amount
+                  :
+                    null
+                )
               ),
               "first_time_amount": (
-                 has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null && has(inner_body.items)
-                 ?
-                  ( ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ? state.cursor.first_time_amount : state.cursor.last_time_amount)
+                 has(state.cursor) && has(state.cursor.first_time_amount) &&
+                 state.cursor.first_time_amount != null && has(inner_body.items) ?
+                   (
+                     ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ?
+                       state.cursor.first_time_amount
+                     :
+                       state.cursor.last_time_amount
+                   )
                  :
-                  int(timestamp(now())-duration(string
-                  (state.time_unit == "year" ? int(state.time_amount)*365*24*60 :
-                    state.time_unit == "month" ? int(state.time_amount)*30*24*60 :
-                      state.time_unit == "week" ? int(state.time_amount)*7*24*60 :
-                        state.time_unit == "day" ? int(state.time_amount)*24*60 :
-                        state.time_unit == "hour" ? int(state.time_amount)*60 : int(state.time_amount)
-                          )+"m"))*1000
+                   int(timestamp(now)-duration(string(
+                     state.time_unit == "year" ?
+                       int(state.time_amount)*365*24*60
+                     : state.time_unit == "month" ?
+                       int(state.time_amount)*30*24*60
+                     : state.time_unit == "week" ?
+                       int(state.time_amount)*7*24*60
+                     : state.time_unit == "day" ?
+                       int(state.time_amount)*24*60
+                     : state.time_unit == "hour" ?
+                       int(state.time_amount)*60
+                     : int(state.time_amount)
+                   )+"m"))*1000
               ),
             },
-            "want_more": ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows),
+            "want_more": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows,
             "user": state.user,
             "password": state.password,
             "batch_size": string(state.batch_size),
             "time_amount": string(state.time_amount),
             "time_unit": state.time_unit,
-            "total_rows": ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) ? (int(state.total_rows) + size(inner_body.items)) : 0,
+            "total_rows": (int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows ?
+              int(state.total_rows) + size(inner_body.items)
+            :
+              0,
           }))
       )
     )

--- a/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/alert/agent/stream/input.yml.hbs
@@ -34,49 +34,32 @@ program: |
         "application/json",
         {"username":state.user,"password":state.password}.encode_json()
       ).do_request().as(resp, bytes(resp.Body).decode_json().as(body, {
-          "access_token": body.token
+          "access_token": body.token,
       }))
     :
       {}
     ).as(state, state.with(
-      request("GET",
-        (has(state.want_more) && !(state.want_more)
-        ?
-          (state.url + "/v2/alert?" + "timeType=relative&timeAmount=" +
-          (has(state.cursor) && has(state.cursor.time_amount_in_hours) && state.cursor.time_amount_in_hours != null
-            ?
-              string(state.cursor.time_amount_in_hours)
-            :
-              string(state.time_amount)) +
-              "&timeUnit=" +
-              (has(state.cursor) && has(state.cursor.time_amount_in_hours) && state.cursor.time_amount_in_hours != null
-              ?
-                "hour"
-              :
-                state.time_unit) +
-                "&detailed=true" +
-                "&limit=" + string(state.batch_size))
-        :
-          (state.url + "/v2/alert?" + "timeType=relative&timeAmount=" +
-          (has(state.cursor) && has(state.cursor.time_amount_in_hours) && state.cursor.time_amount_in_hours != null
-          ?
-            string(state.cursor.time_amount_in_hours)
-          :
-            string(state.time_amount)) + "&timeUnit=" +
-            (has(state.cursor) && has(state.cursor.time_amount_in_hours) && state.cursor.time_amount_in_hours != null
-            ?
-              "hour"
-            :
-              state.time_unit) + "&detailed=true" +
-              "&limit=" + string(state.batch_size) +
-              (
-                has(state.page_token)
-                ?
-                  "&pageToken=" + state.page_token
-                :
-                  "")
+      request("GET", state.url + "/v2/alert?timeType=relative&detailed=true&limit=" + string(state.batch_size) + "&timeAmount=" +
+        (
+          has(state.want_more) && !(state.want_more)
+         ?
+          (
+           has(state.cursor) && has(state.cursor.last_time_amount) && state.cursor.last_time_amount != null
+           ?
+             string((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
+           :
+             string(state.time_amount) + "&timeUnit=" + state.time_unit
           )
-        )).with({
+         :
+          (
+            has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null
+            ?
+            string((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.first_time_amount))+"ms")))).getMinutes() + 1) + "&timeUnit=minute"
+            :
+            "null"
+          ) + (has(state.page_token) ? "&pageToken=" + state.page_token : "")
+         )
+        ).with({
           "Header":{
             "x-redlock-auth": [state.access_token],
           }
@@ -87,27 +70,46 @@ program: |
             "url": state.url,
             "page_token": has(inner_body.nextPageToken) ? inner_body.nextPageToken : "",
             "cursor": {
-              "time_amount_in_hours": (
+              "last_time_amount": (
                 has(inner_body.items) && inner_body.items.size() > 0
                 ?
-                  (now() - timestamp(int(timestamp(0)+duration(string(int(inner_body.items.map(e, e.lastUpdated).max()))+"ms")))).getHours()
+                 (
+                  has(state.cursor) && has(state.cursor.last_time_amount) && inner_body.items.map(e, e.lastUpdated).max() < state.cursor.last_time_amount
+                  ?
+                    state.cursor.last_time_amount
+                  :
+                    inner_body.items.map(e, e.lastUpdated).max()
+                 )
                 :
                   (
-                    has(state.cursor) && has(state.cursor.time_amount_in_hours)
+                    has(state.cursor) && has(state.cursor.last_time_amount)
                     ?
-                      state.cursor.time_amount_in_hours
+                      state.cursor.last_time_amount
                     :
                       null
                   )
-              )
+              ),
+              "first_time_amount": (
+                 has(state.cursor) && has(state.cursor.first_time_amount) && state.cursor.first_time_amount != null && has(inner_body.items)
+                 ?
+                  ( ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) && state.want_more ? state.cursor.first_time_amount : state.cursor.last_time_amount)
+                 :
+                  int(timestamp(now())-duration(string
+                  (state.time_unit == "year" ? int(state.time_amount)*365*24*60 :
+                    state.time_unit == "month" ? int(state.time_amount)*30*24*60 :
+                      state.time_unit == "week" ? int(state.time_amount)*7*24*60 :
+                        state.time_unit == "day" ? int(state.time_amount)*24*60 :
+                        state.time_unit == "hour" ? int(state.time_amount)*60 : int(state.time_amount)
+                          )+"m"))*1000
+              ),
             },
-            "total_rows": (int(state.total_rows) + size(inner_body.items)),
-            "want_more": ((int(state.total_rows)) < inner_body.totalRows),
+            "want_more": ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows),
             "user": state.user,
             "password": state.password,
             "batch_size": string(state.batch_size),
             "time_amount": string(state.time_amount),
-            "time_unit": state.time_unit
+            "time_unit": state.time_unit,
+            "total_rows": ((int(state.total_rows) + size(inner_body.items)) < inner_body.totalRows) ? (int(state.total_rows) + size(inner_body.items)) : 0,
           }))
       )
     )

--- a/packages/prisma_cloud/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/prisma_cloud/data_stream/alert/elasticsearch/ingest_pipeline/default.yml
@@ -34,7 +34,7 @@ processors:
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - fingerprint:
       fields:
-        - json._id
+        - json.id
         - json.lastUpdated
       target_field: _id
       ignore_missing: true

--- a/packages/prisma_cloud/data_stream/alert/manifest.yml
+++ b/packages/prisma_cloud/data_stream/alert/manifest.yml
@@ -52,7 +52,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        default: 30s
+        default: 60s
       - name: enable_request_tracer
         type: bool
         title: Enable request tracing

--- a/packages/prisma_cloud/data_stream/alert/sample_event.json
+++ b/packages/prisma_cloud/data_stream/alert/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2023-09-06T12:30:41.966Z",
     "agent": {
-        "ephemeral_id": "7a1c5441-4384-4ef1-a6d3-079ed7052a4c",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "ephemeral_id": "748799a0-a545-468b-9b86-764414774225",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -25,7 +25,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -37,7 +37,7 @@
         "dataset": "prisma_cloud.alert",
         "end": "2023-09-06T12:30:41.966Z",
         "id": "N-3910",
-        "ingested": "2023-11-03T06:29:20Z",
+        "ingested": "2023-11-27T09:08:39Z",
         "kind": "alert",
         "original": "{\"alertAdditionalInfo\":{\"scannerVersion\":\"CS_2.0\"},\"alertAttribution\":{\"attributionEventList\":[{\"event\":\"first_event\",\"event_ts\":1694003441966,\"username\":\"alex123\"}],\"resourceCreatedBy\":\"string\",\"resourceCreatedOn\":0},\"alertRules\":[],\"alertTime\":1694003441966,\"firstSeen\":1694003441966,\"history\":[{\"modifiedBy\":\"alex123\",\"modifiedOn\":\"1694003441966\",\"reason\":\"Reason1\",\"status\":\"OPEN\"}],\"id\":\"N-3910\",\"investigateOptions\":{\"alertId\":\"N-3910\"},\"lastSeen\":1694003441966,\"lastUpdated\":1694003441966,\"metadata\":null,\"policy\":{\"complianceMetadata\":[{\"complianceId\":\"qwer345bv\",\"customAssigned\":true,\"policyId\":\"werf435tr\",\"requirementDescription\":\"Description of policy compliance.\",\"requirementId\":\"req-123-xyz\",\"requirementName\":\"rigidity\",\"sectionDescription\":\"Description of section.\",\"sectionId\":\"sect-453-abc\",\"sectionLabel\":\"label-1\",\"standardDescription\":\"Description of standard.\",\"standardId\":\"stand-543-pqr\",\"standardName\":\"Class 1\"}],\"deleted\":false,\"description\":\"This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0/0). EC2 instances with unrestricted access to the internet may enable bad actors to use brute force on a system to gain unauthorised access to the entire network. As a best practice, restrict traffic from unknown IP addresses and limit the access to known hosts, services, or specific entities.\",\"findingTypes\":[],\"labels\":[\"Prisma_Cloud\",\"Attack Path Rule\"],\"lastModifiedBy\":\"template@redlock.io\",\"lastModifiedOn\":1687474999057,\"name\":\"AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0/0)\",\"policyId\":\"ad23603d-754e-4499-8988-b8017xxxx98\",\"policyType\":\"network\",\"recommendation\":\"The following steps are recommended to restrict unrestricted access from the Internet:\\n1. Visit the Network path Analysis from Source to Destination and review the network path components that allow internet access.\\n2. Identify the network component on which restrictive rules can be implemented.\\n3. Implement the required changes and make sure no other resources have been impacted due to these changes:\\n a) The overly permissive Security Group rules can be made more restrictive.\\n b) Move the instance inside a restrictive subnet if the instance does not need to be publicly accessible.\\n c) Define a NAT rule to restrict traffic coming from the Internet to the respective instance.\",\"remediable\":false,\"remediation\":{\"actions\":[{\"operation\":\"buy\",\"payload\":\"erefwsdf\"}],\"cliScriptTemplate\":\"temp1\",\"description\":\"Description of CLI Script Template.\"},\"severity\":\"high\",\"systemDefault\":true},\"policyId\":\"ad23603d-754e-4499-8988-b801xxx85898\",\"reason\":\"NEW_ALERT\",\"resource\":{\"account\":\"AWS Cloud Account\",\"accountId\":\"710002259376\",\"additionalInfo\":null,\"cloudAccountGroups\":[\"Default Account Group\"],\"cloudServiceName\":\"Amazon EC2\",\"cloudType\":\"aws\",\"data\":null,\"id\":\"i-04578exxxx8100947\",\"name\":\"IS-37133\",\"region\":\"AWS Virginia\",\"regionId\":\"us-east-1\",\"resourceApiName\":\"aws-ec2-describe-instances\",\"resourceConfigJsonAvailable\":false,\"resourceDetailsAvailable\":true,\"resourceTs\":1694003441915,\"resourceType\":\"INSTANCE\",\"rrn\":\"rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947\",\"unifiedAssetId\":\"66c543b6261c4d9edxxxxxb42e15f4\",\"url\":\"https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947\"},\"status\":\"open\"}",
         "start": "2023-09-06T12:30:41.966Z",

--- a/packages/prisma_cloud/data_stream/audit/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/audit/agent/stream/input.yml.hbs
@@ -19,7 +19,6 @@ state:
   password: {{password}}
   time_amount: {{time_amount}}
   time_unit: {{time_unit}}
-  state_interval: {{interval}}
 redact:
   fields:
     - password
@@ -37,17 +36,11 @@ program: |
       request("GET",
         state.url +
         "/audit/redlock?timeType=relative&timeAmount=" +
-        (has(state.cursor) && has(state.cursor.time_amount_in_minute) && state.cursor.time_amount_in_minute != null
+        (has(state.cursor) && has(state.cursor.last_updated_timestamp) && state.cursor.last_updated_timestamp != null
           ?
-            string(state.cursor.time_amount_in_minute)
+            string(int((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_updated_timestamp))+"ms")))).getMinutes()) + 1) + "&timeUnit=minute"
           :
-            string(state.time_amount)) +
-            "&timeUnit=" +
-            (has(state.cursor) && has(state.cursor.time_amount_in_minute) && state.cursor.time_amount_in_minute != null
-            ?
-              "minute"
-            :
-              state.time_unit)
+            string(state.time_amount) +"&timeUnit=" + state.time_unit)
       ).with({
         "Header":{
           "x-redlock-auth": [state.access_token],
@@ -57,15 +50,15 @@ program: |
             "message": e.encode_json(),
           }),
           "cursor": {
-              "time_amount_in_minute": (
+              "last_updated_timestamp": (
                 inner_body.size() > 0
                 ?
-                  (int((now() - timestamp(int(timestamp(0)+duration(string(int(inner_body.map(e, e.timestamp).max()))+"ms")))).getSeconds()) + int((duration(state.state_interval)).getSeconds()))/60
+                  inner_body.map(e, e.timestamp).max()
                 :
                   (
-                    has(state.cursor) && has(state.cursor.time_amount_in_minute)
+                    has(state.cursor) && has(state.cursor.last_updated_timestamp)
                     ?
-                      state.cursor.time_amount_in_minute
+                      state.cursor.last_updated_timestamp
                     :
                       null
                   )

--- a/packages/prisma_cloud/data_stream/audit/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/audit/agent/stream/input.yml.hbs
@@ -38,7 +38,7 @@ program: |
         "/audit/redlock?timeType=relative&timeAmount=" +
         (has(state.cursor) && has(state.cursor.last_updated_timestamp) && state.cursor.last_updated_timestamp != null
           ?
-            string(int((now() - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_updated_timestamp))+"ms")))).getMinutes()) + 1) + "&timeUnit=minute"
+            string(int((now - timestamp(int(timestamp(0)+duration(string(int(state.cursor.last_updated_timestamp))+"ms")))).getMinutes()) + 1) + "&timeUnit=minute"
           :
             string(state.time_amount) +"&timeUnit=" + state.time_unit)
       ).with({

--- a/packages/prisma_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/prisma_cloud/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -28,6 +28,12 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - fingerprint:
+      fields:
+        - json.action
+        - json.timestamp
+      target_field: _id
+      ignore_missing: true
   - convert:
       field: json.ipAddress
       tag: convert_ip_address_to_ip

--- a/packages/prisma_cloud/data_stream/audit/manifest.yml
+++ b/packages/prisma_cloud/data_stream/audit/manifest.yml
@@ -44,7 +44,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        default: 30s
+        default: 60s
       - name: enable_request_tracer
         type: bool
         title: Enable request tracing

--- a/packages/prisma_cloud/data_stream/audit/sample_event.json
+++ b/packages/prisma_cloud/data_stream/audit/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2023-09-13T08:40:39.068Z",
     "agent": {
-        "ephemeral_id": "15be3105-9474-4419-9495-3ba7d5eddf5b",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "ephemeral_id": "748799a0-a545-468b-9b86-764414774225",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -16,7 +16,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -27,7 +27,7 @@
             "authentication"
         ],
         "dataset": "prisma_cloud.audit",
-        "ingested": "2023-11-03T06:30:33Z",
+        "ingested": "2023-11-27T09:09:44Z",
         "kind": "event",
         "original": "{\"action\":\"'john.user@google.com'(with role 'System Admin':'System Admin') logged in via access key.\",\"actionType\":\"LOGIN\",\"ipAddress\":\"81.2.69.192\",\"resourceName\":\"john.user@google.com\",\"resourceType\":\"Login\",\"result\":\"Successful\",\"timestamp\":1694594439068,\"user\":\"john.user@google.com\"}",
         "outcome": "success",

--- a/packages/prisma_cloud/data_stream/host/manifest.yml
+++ b/packages/prisma_cloud/data_stream/host/manifest.yml
@@ -44,7 +44,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        default: 30s
+        default: 60s
       - name: enable_request_tracer
         type: bool
         title: Enable request tracing

--- a/packages/prisma_cloud/data_stream/host_profile/manifest.yml
+++ b/packages/prisma_cloud/data_stream/host_profile/manifest.yml
@@ -44,7 +44,7 @@ streams:
         multi: false
         required: true
         show_user: false
-        default: 30s
+        default: 60s
       - name: enable_request_tracer
         type: bool
         title: Enable request tracing

--- a/packages/prisma_cloud/docs/README.md
+++ b/packages/prisma_cloud/docs/README.md
@@ -125,8 +125,8 @@ An example event for `alert` looks as following:
 {
     "@timestamp": "2023-09-06T12:30:41.966Z",
     "agent": {
-        "ephemeral_id": "7a1c5441-4384-4ef1-a6d3-079ed7052a4c",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "ephemeral_id": "748799a0-a545-468b-9b86-764414774225",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -149,7 +149,7 @@ An example event for `alert` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -161,7 +161,7 @@ An example event for `alert` looks as following:
         "dataset": "prisma_cloud.alert",
         "end": "2023-09-06T12:30:41.966Z",
         "id": "N-3910",
-        "ingested": "2023-11-03T06:29:20Z",
+        "ingested": "2023-11-27T09:08:39Z",
         "kind": "alert",
         "original": "{\"alertAdditionalInfo\":{\"scannerVersion\":\"CS_2.0\"},\"alertAttribution\":{\"attributionEventList\":[{\"event\":\"first_event\",\"event_ts\":1694003441966,\"username\":\"alex123\"}],\"resourceCreatedBy\":\"string\",\"resourceCreatedOn\":0},\"alertRules\":[],\"alertTime\":1694003441966,\"firstSeen\":1694003441966,\"history\":[{\"modifiedBy\":\"alex123\",\"modifiedOn\":\"1694003441966\",\"reason\":\"Reason1\",\"status\":\"OPEN\"}],\"id\":\"N-3910\",\"investigateOptions\":{\"alertId\":\"N-3910\"},\"lastSeen\":1694003441966,\"lastUpdated\":1694003441966,\"metadata\":null,\"policy\":{\"complianceMetadata\":[{\"complianceId\":\"qwer345bv\",\"customAssigned\":true,\"policyId\":\"werf435tr\",\"requirementDescription\":\"Description of policy compliance.\",\"requirementId\":\"req-123-xyz\",\"requirementName\":\"rigidity\",\"sectionDescription\":\"Description of section.\",\"sectionId\":\"sect-453-abc\",\"sectionLabel\":\"label-1\",\"standardDescription\":\"Description of standard.\",\"standardId\":\"stand-543-pqr\",\"standardName\":\"Class 1\"}],\"deleted\":false,\"description\":\"This policy identifies AWS EC2 instances that are internet reachable with unrestricted access (0.0.0.0/0). EC2 instances with unrestricted access to the internet may enable bad actors to use brute force on a system to gain unauthorised access to the entire network. As a best practice, restrict traffic from unknown IP addresses and limit the access to known hosts, services, or specific entities.\",\"findingTypes\":[],\"labels\":[\"Prisma_Cloud\",\"Attack Path Rule\"],\"lastModifiedBy\":\"template@redlock.io\",\"lastModifiedOn\":1687474999057,\"name\":\"AWS EC2 instance that is internet reachable with unrestricted access (0.0.0.0/0)\",\"policyId\":\"ad23603d-754e-4499-8988-b8017xxxx98\",\"policyType\":\"network\",\"recommendation\":\"The following steps are recommended to restrict unrestricted access from the Internet:\\n1. Visit the Network path Analysis from Source to Destination and review the network path components that allow internet access.\\n2. Identify the network component on which restrictive rules can be implemented.\\n3. Implement the required changes and make sure no other resources have been impacted due to these changes:\\n a) The overly permissive Security Group rules can be made more restrictive.\\n b) Move the instance inside a restrictive subnet if the instance does not need to be publicly accessible.\\n c) Define a NAT rule to restrict traffic coming from the Internet to the respective instance.\",\"remediable\":false,\"remediation\":{\"actions\":[{\"operation\":\"buy\",\"payload\":\"erefwsdf\"}],\"cliScriptTemplate\":\"temp1\",\"description\":\"Description of CLI Script Template.\"},\"severity\":\"high\",\"systemDefault\":true},\"policyId\":\"ad23603d-754e-4499-8988-b801xxx85898\",\"reason\":\"NEW_ALERT\",\"resource\":{\"account\":\"AWS Cloud Account\",\"accountId\":\"710002259376\",\"additionalInfo\":null,\"cloudAccountGroups\":[\"Default Account Group\"],\"cloudServiceName\":\"Amazon EC2\",\"cloudType\":\"aws\",\"data\":null,\"id\":\"i-04578exxxx8100947\",\"name\":\"IS-37133\",\"region\":\"AWS Virginia\",\"regionId\":\"us-east-1\",\"resourceApiName\":\"aws-ec2-describe-instances\",\"resourceConfigJsonAvailable\":false,\"resourceDetailsAvailable\":true,\"resourceTs\":1694003441915,\"resourceType\":\"INSTANCE\",\"rrn\":\"rrn:aws:instance:us-east-1:710000059376:e7ddce5a1ffcb47bxxxxxerf2635a3b4d9da3:i-04578e0008100947\",\"unifiedAssetId\":\"66c543b6261c4d9edxxxxxb42e15f4\",\"url\":\"https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0457xxxxx00947\"},\"status\":\"open\"}",
         "start": "2023-09-06T12:30:41.966Z",
@@ -494,8 +494,8 @@ An example event for `audit` looks as following:
 {
     "@timestamp": "2023-09-13T08:40:39.068Z",
     "agent": {
-        "ephemeral_id": "15be3105-9474-4419-9495-3ba7d5eddf5b",
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "ephemeral_id": "748799a0-a545-468b-9b86-764414774225",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -509,7 +509,7 @@ An example event for `audit` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f2974986-16b8-49d0-803d-316e0e9f4e94",
+        "id": "47449736-bd61-40ad-89a6-41d7f7acc093",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -520,7 +520,7 @@ An example event for `audit` looks as following:
             "authentication"
         ],
         "dataset": "prisma_cloud.audit",
-        "ingested": "2023-11-03T06:30:33Z",
+        "ingested": "2023-11-27T09:09:44Z",
         "kind": "event",
         "original": "{\"action\":\"'john.user@google.com'(with role 'System Admin':'System Admin') logged in via access key.\",\"actionType\":\"LOGIN\",\"ipAddress\":\"81.2.69.192\",\"resourceName\":\"john.user@google.com\",\"resourceType\":\"Login\",\"result\":\"Successful\",\"timestamp\":1694594439068,\"user\":\"john.user@google.com\"}",
         "outcome": "success",

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.8.0
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "0.5.0"
+version: "0.6.0"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- BugFix

## What does this PR do?
**1. Change the default value of HTTP Client Timeout from 30s to 60s**
For the larger dataset, Prisma API is taking a longer wait time to send the response that is greater than `30s` hence update the default value of timeout to `60s` for all the data streams.

**2. Update the Cursor Logic of the Alert and Audit Data Stream**
There was a bug in the cursor implementation, earlier it was storing the value  `(now - lastUpdated.max)` which resulted in the wrong subsequent requests call. Hence updated the cursor implementation to `now() - cursor` at the time of request call.
Also, use `getMinutes()` instead of `getHours()` to get a more precise time as the Prisma API filter supports the minimum time unit as a minute.

**3. Add fingerprint to the Audit Data Stream.**
As the `getMinutes()` returns the floor value results in some data dropping hence added `+1` explicity to the requests and added fingerprint to remove the duplicated values due to adding the extra minutes.
The fields added in the fingerprint suggested [here](https://github.com/elastic/integrations/issues/8372#issuecomment-1825734637)

**4. Minor Bugfix in Alert Pipeline**
Due to a typing mistake, the wrong field was used in the alert pipeline fingerprint processors hence corrected that. Changed it from `json._id` to `json.id`.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

### All changes
- [x] Change follows the [contributing guidelines](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md)
- [x] Supported versions of the monitoring target are documented
- [x] Supported operating systems are documented (if applicable)
- [x] Integration or [System tests](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md) exist
- [x] Documentation exists
- [x] Fields follow [ECS](https://github.com/elastic/ecs) and [naming conventions](https://www.elastic.co/guide/en/beats/devguide/master/event-conventions.html)
- [x] At least a manual test with ES / Kibana / Agent has been performed.
- [x] Required Kibana version set to: ^8.10.1

## How to test this PR locally
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/prisma_cloud directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/8372
- Closes https://github.com/elastic/sdh-beats/issues/4049

## Automated Test

[prisma_test_file.txt](https://github.com/elastic/integrations/files/13473260/prisma_test_file.txt)
