### PR TITLE
Adopt Secrets in Cloud Posture Management

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,8 +10,7 @@
   changes:
     - description: Adopt Secrets
       type: enhancement
-      # TODO Fix PR
-      link: https://github.com/elastic/integrations/pull/8540
+      link: https://github.com/elastic/integrations/pull/8604
     - description: Bump Azure template branch
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8619

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,8 +6,12 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.7.0-preview06"
+- version: "1.7.0-preview07"
   changes:
+    - description: Adopt Secrets
+      type: enhancement
+      # TODO Fix PR
+      link: https://github.com/elastic/integrations/pull/8540
     - description: Bump Azure template branch
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8619

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -31,6 +31,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
       - name: session_token
         type: text
         title: Session Token
@@ -80,6 +81,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
       - name: session_token
         type: text
         title: Session Token
@@ -195,6 +197,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
       - name: azure.credentials.client_username
         type: text
         title: Client Username
@@ -207,6 +210,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
       - name: azure.credentials.client_certificate_path
         type: text
         title: Client Certificate Path
@@ -219,3 +223,4 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.7.0-preview06"
+version: "1.7.0-preview07"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## What

Adopt Secrets in Cloud Posture Management

Based on https://github.com/elastic/package-spec/pull/665 definition of what is possibly a secret the following the keys were labeled as secrets:

- cloudbeat/cis_eks
  - session_token
- cloudbeat/cis_aws
  - secret_access_key
- cloudbeat/cis_azure
  - azure.credentials.client_secret
  - azure.credentials.client_password
  - azure.credentials.client_certificate_password

Based on the criteria used of what potentially is a secret, more fields would have been classified as secret. Below you can find why they were not:

- cloudbeat/cis_eks
  -  session_token 
      - Not flagged as secret because it's a temporary token
- cloudbeat/cis_aws
  -  session_token 
      - Not flagged as secret because it's a temporary token

## Why

Adoption of secrets is a [kibana wide effort ](https://github.com/elastic/kibana/issues/154715) to remove the possibility of secrets leaks in kibana (via system logs/audit or humans)


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Test all integrations with secrets and validate that Posture Management still properly works 

## Related issues

- Closes https://github.com/elastic/security-team/issues/7380

## Screenshots

Example of stored secret:

![ezgif com-video-to-gif](https://github.com/elastic/integrations/assets/5350001/eaa6d82c-8d2f-457a-aaf8-4092b768c20a)
