### PR TITLE
[EDR Workflows] Adjust Sentinel One Cloud Funnel mappings to support Analyzer - entity_id

### DIFF
--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.9.1
+  changes:
+    - description: Added different mappings to some process fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8561
 - version: 0.9.0
   changes:
     - description: Added support for GCS input.

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
-- version: 0.9.1
+- version: 0.10.0
   changes:
-    - description: Map process tgt fields to use src and src to use parent
+    - description: Adjust `process.*` fields to support Analyzer.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8608
 - version: 0.9.0

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.9.1
   changes:
-    - description: Added different mappings to some process fields
+    - description: Map process fields to entity_id
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8561
 - version: 0.9.0

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Map process fields to entity_id
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8561
+      link: https://github.com/elastic/integrations/pull/8608
 - version: 0.9.0
   changes:
     - description: Added support for GCS input.

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.9.1
   changes:
-    - description: Map process fields to entity_id
+    - description: Map process tgt fields to use src and src to use parent
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8608
 - version: 0.9.0

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-command-script.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-command-script.log-expected.json
@@ -29,6 +29,7 @@
             },
             "process": {
                 "command_line": "powershell.exe-ExecutionPolicyRestricted-CommandWrite-Host'Finalresult:1';",
+                "entity_id": "230B188E26085676",
                 "hash": {
                     "md5": "7353f60b1739074eb17c5f4dddefe239",
                     "sha1": "6cbce4a295c163791b60fc23d285e6d84f28ee4c",
@@ -37,6 +38,7 @@
                 "name": "powershell.exe",
                 "parent": {
                     "command_line": "C:\\Windows\\system32\\CompatTelRunner.exe-m:appraiser.dll-f:DoScheduledTelemetryRun-cv:1DRRwZous0W15sCL.2",
+                    "entity_id": "8608188E26085676",
                     "hash": {
                         "sha1": "134fd2ad04cf59b0c10596230da5daf6fc711bd1",
                         "sha256": "046f009960f70981597cd7b3a1e44cbb4ba5893cc1407734366aa55fbeda5d66"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-cross-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-cross-process.log-expected.json
@@ -29,6 +29,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "F27AB6F105F6C47A",
                 "hash": {
                     "md5": "6693974b22d16712c9a164e154c17556",
                     "sha1": "ebec2705217692afae8e9cc5e82d58d78e7d6d89",
@@ -37,6 +38,7 @@
                 "name": "chrome.exe",
                 "parent": {
                     "command_line": "\"C:\\ProgramFiles\\Google\\Chrome\\Application\\chrome.exe\"--single-argumenthttps://nam04.safelinks.protection.outlook.com/?url=https%3A%2F%2Fwww.asdf.com%2FCopy%2520A%3Fdl%3D0%26subfolder_nav_tracking%3D1&data=05%7C01%7CCeliaVerPloeg%7C122a5275b9e3%7C0%7C0%7C638000749817681064%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=Oe8GdP%2Fty%2FFwi58b87FF5qp1VjewxNXjXfEBWVf5urI%3D&reserved=0",
+                    "entity_id": "F17AB6F105F6C47A",
                     "hash": {
                         "sha1": "ebec2705217692afae8e9cc5e82d58d78e7d6d89",
                         "sha256": "a462f776c0935c7359e941d9a23b62243e3eabbd1694065fe2e1dc521e685698"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-dns.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-dns.log-expected.json
@@ -29,6 +29,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "AFD43004051AA366",
                 "hash": {
                     "md5": "421f6d5ec86f6b930646321fc6ed2c46",
                     "sha1": "d8b12c9072fdcf68ec152befb004add14b5c25b8",
@@ -37,6 +38,7 @@
                 "name": "CC.Falcon.OrderModule.exe",
                 "parent": {
                     "command_line": "C:\\Users\\asdf\\AppData\\Local\\LANInternational\\VIERO\\Application\\7.22.1.105\\VIERO.exe",
+                    "entity_id": "8CD23004051AA366",
                     "hash": {
                         "sha1": "f9bc4c756eab5121ace7ec1cf6a394be0439dec0",
                         "sha256": "d2213413a6a558981670676ff0575e31542067ef69ee7e061c0308c4f0c0888d"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-file.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-file.log-expected.json
@@ -36,6 +36,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "BA34D0202623D4E6",
                 "hash": {
                     "md5": "32f678531906e17dd7e9508d289c8d0a",
                     "sha1": "2797538e84a534cc5aa2d2700c0d1ca297aaa507",
@@ -44,6 +45,7 @@
                 "name": "chrome.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles\\MediaMonitors\\MediaMonitors.WebCrawler.Desktop.exe",
+                    "entity_id": "3F41C4202623D4E6",
                     "hash": {
                         "sha1": "cb3d662017fc8f5ca5fd8f843781dc979bc39f3a",
                         "sha256": "bea718b473f35cfc401a8e529ec6461427ed6a2cf7dd819cb1a7895b57e3e5a7"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-indicator.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-indicator.log-expected.json
@@ -23,6 +23,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "9544B91D29223D1A",
                 "hash": {
                     "md5": "72260ce9438a7a9a8a5ba101eda4d6bd",
                     "sha1": "090436b0679559cb2d5e863ad9c9135613f38d77",
@@ -31,6 +32,7 @@
                 "name": "WmiApSrv.exe",
                 "parent": {
                     "command_line": "C:\\WINDOWS\\system32\\services.exe",
+                    "entity_id": "B4C1F07EC98B907A",
                     "hash": {
                         "sha1": "86662690d627002d7cab3285f7be3e6d87b35cfb",
                         "sha256": "9090e0e44e14709fb09b23b98572e0e61c810189e2de8f7156021bc81c3b1bb6"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-login.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-login.log-expected.json
@@ -25,6 +25,7 @@
                 "type": "server"
             },
             "process": {
+                "entity_id": "61D19661DB864A92",
                 "pid": 776,
                 "start": "2022-09-25T05:39:44.297Z",
                 "user": {

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-module.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-module.log-expected.json
@@ -23,6 +23,7 @@
             },
             "process": {
                 "command_line": "\\??\\C:\\WINDOWS\\system32\\conhost.exe0xffffffff-ForceV1",
+                "entity_id": "08693A26E6783D52",
                 "hash": {
                     "md5": "0d698af330fd17bee3bf90011d49251d",
                     "sha1": "52a7274a0b4f9493632060fe25993a2ef24fe827",
@@ -31,6 +32,7 @@
                 "name": "conhost.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles\\SentinelOne\\SentinelAgent22.1.4.10010\\ranger\\SentinelRanger.exe\"\"{\\\"agentVersion\\\":\\\"22.1.4.10010\\\",\\\"authToken\\\":\\\"jhdskdhkdgdgdahdksaHDKJsdhkNjUifQ.+dVxpFE/Hqs5RGjPczU8DC9i1tw\\\",\\\"dataFolder\\\":\\\"C:\\\\\\\\ProgramData\\\\\\\\Sentinel\\\\\\\\ranger\\\",\\\"logsFolder\\\":\\\"C:\\\\\\\\ProgramData\\\\\\\\Sentinel\\\\\\\\logs\\\",\\\"maxIdleTime\\\":300,\\\"sendUnsuccessful\\\":false,\\\"url\\\":\\\"wss://asdf-123.sentinelone.org\\\",\\\"uuid\\\":\\\"asdf1234\\\"}",
+                    "entity_id": "07693A26E6783D52",
                     "hash": {
                         "sha1": "a5032d5e80fc742245cb58546c4476e18747f4a0",
                         "sha256": "3b509cfd164bdfe4e330c039745051b8057cc05b8974b1c87e7db7e1fc3eb659"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-network-action.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-network-action.log-expected.json
@@ -38,6 +38,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "778A830FDFF04CF5",
                 "hash": {
                     "md5": "b0bd1ff76f58006d879fee68a1241528",
                     "sha1": "9037711d20353f0adec0c4558a77f6277dab778b",
@@ -46,6 +47,7 @@
                 "name": "chrome.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles(x86)\\Google\\Chrome\\Application\\chrome.exe",
+                    "entity_id": "728A830FDFF04CF5",
                     "hash": {
                         "sha1": "9037711d20353f0adec0c4558a77f6277dab778b",
                         "sha256": "03155d327c65a8768c571018132e17336fa38349eb0c96e9cbbf5ea905ed750e"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -233,7 +233,7 @@
                             "is_redirect_cmd_processor": false,
                             "is_storyline_root": false,
                             "name": "nr-winpkg.exe",
-                            "pid": 4720,
+                            "pid": "4720",
                             "publisher": "NEWRELIC,INC.",
                             "session_id": "0",
                             "signed_status": "signed",

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -28,32 +28,32 @@
                 "type": "server"
             },
             "process": {
-                "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
-                "entity_id": "F59445BAF5BC03DA",
+                "command_line": "./nr-winpkg",
+                "entity_id": "D0046CBAF5BC03DA",
                 "hash": {
-                    "md5": "7c99f420f8985a4ccf428f9fe2b090f0",
-                    "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
-                    "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
+                    "md5": "65f9131df4b7c909ae41add0fcd172fa",
+                    "sha1": "a1d7ac9e15c26535a7dec40bba21cda4de078504",
+                    "sha256": "b00b5e5d4e268b8dbd0af0749edb6626e686403c71f1c81ae08d18242046f29e"
                 },
-                "name": "newrelic-infra.exe",
+                "name": "nr-winpkg.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles\\NewRelic\\newrelic-infra\\newrelic-infra-service.exe",
-                    "entity_id": "C19445BAF5BC03DA",
+                    "entity_id": "F59445BAF5BC03DA",
                     "hash": {
-                        "sha1": "9ef7039dadb490762d4446892b1c0323f06bd1c2",
-                        "sha256": "f62c2d5c9e7605c75a0c8fcb9c2b506267ca0e6706766e033495d81dac4e302c"
+                        "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
+                        "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
                     },
-                    "name": "newrelic-infra-service.exe",
-                    "pid": 3132,
-                    "start": "2022-09-10T04:36:45.701Z",
-                    "title": "Test123",
+                    "name": "newrelic-infra.exe",
+                    "pid": 3596,
+                    "start": "2022-09-10T04:36:46.181Z",
+                    "title": "newrelic-infra.exe",
                     "user": {
-                        "name": "asdf\\SYSTEM"
+                        "name": "NTAUTHORITY\\SYSTEM"
                     }
                 },
-                "pid": 3596,
-                "start": "2022-09-10T04:36:46.181Z",
-                "title": "newrelic-infra.exe",
+                "pid": "4720",
+                "start": "2022-10-03T15:32:29.464Z",
+                "title": "nr-winpkg.exe",
                 "user": {
                     "name": "NTAUTHORITY\\SYSTEM"
                 }

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -29,16 +29,16 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
-                "entity_id": "D0046CBAF5BC03DA",
+                "entity_id": "F59445BAF5BC03DA",
                 "hash": {
                     "md5": "7c99f420f8985a4ccf428f9fe2b090f0",
                     "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
                     "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
                 },
-                "name": "nr-winpkg.exe",
+                "name": "newrelic-infra.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles\\NewRelic\\newrelic-infra\\newrelic-infra-service.exe",
-                    "entity_id": "F59445BAF5BC03DA",
+                    "entity_id": "C19445BAF5BC03DA",
                     "hash": {
                         "sha1": "9ef7039dadb490762d4446892b1c0323f06bd1c2",
                         "sha256": "f62c2d5c9e7605c75a0c8fcb9c2b506267ca0e6706766e033495d81dac4e302c"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -51,6 +51,7 @@
                         "name": "NTAUTHORITY\\SYSTEM"
                     }
                 },
+                "pid": 4720,
                 "start": "2022-10-03T15:32:29.464Z",
                 "title": "nr-winpkg.exe",
                 "user": {
@@ -232,7 +233,7 @@
                             "is_redirect_cmd_processor": false,
                             "is_storyline_root": false,
                             "name": "nr-winpkg.exe",
-                            "pid": "4720",
+                            "pid": 4720,
                             "publisher": "NEWRELIC,INC.",
                             "session_id": "0",
                             "signed_status": "signed",

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -35,15 +35,15 @@
                     "sha1": "a1d7ac9e15c26535a7dec40bba21cda4de078504",
                     "sha256": "b00b5e5d4e268b8dbd0af0749edb6626e686403c71f1c81ae08d18242046f29e"
                 },
-                "name": "nr-winpkg.exe",
                 "parent": {
-                    "command_line": "C:\\ProgramFiles\\NewRelic\\newrelic-infra\\newrelic-infra-service.exe",
+                    "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
                     "entity_id": "F59445BAF5BC03DA",
                     "hash": {
+                        "md5": "7c99f420f8985a4ccf428f9fe2b090f0",
                         "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
                         "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
                     },
-                    "name": "newrelic-infra.exe",
+                    "name": "nr-winpkg.exe",
                     "pid": 3596,
                     "start": "2022-09-10T04:36:46.181Z",
                     "title": "newrelic-infra.exe",
@@ -51,7 +51,6 @@
                         "name": "NTAUTHORITY\\SYSTEM"
                     }
                 },
-                "pid": "4720",
                 "start": "2022-10-03T15:32:29.464Z",
                 "title": "nr-winpkg.exe",
                 "user": {

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -35,6 +35,7 @@
                     "sha1": "a1d7ac9e15c26535a7dec40bba21cda4de078504",
                     "sha256": "b00b5e5d4e268b8dbd0af0749edb6626e686403c71f1c81ae08d18242046f29e"
                 },
+                "name": "nr-winpkg.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
                     "entity_id": "F59445BAF5BC03DA",
@@ -43,7 +44,7 @@
                         "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
                         "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
                     },
-                    "name": "nr-winpkg.exe",
+                    "name": "newrelic-infra.exe",
                     "pid": 3596,
                     "start": "2022-09-10T04:36:46.181Z",
                     "title": "newrelic-infra.exe",

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-process.log-expected.json
@@ -29,14 +29,16 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "D0046CBAF5BC03DA",
                 "hash": {
                     "md5": "7c99f420f8985a4ccf428f9fe2b090f0",
                     "sha1": "7f3981d9bf5d134065541387a77b9f651471fa0f",
                     "sha256": "058043b4d2b74a31dda6966a7a0c292a04e898bd4dabaefdc6b0eabf518c40d1"
                 },
-                "name": "newrelic-infra.exe",
+                "name": "nr-winpkg.exe",
                 "parent": {
                     "command_line": "C:\\ProgramFiles\\NewRelic\\newrelic-infra\\newrelic-infra-service.exe",
+                    "entity_id": "F59445BAF5BC03DA",
                     "hash": {
                         "sha1": "9ef7039dadb490762d4446892b1c0323f06bd1c2",
                         "sha256": "f62c2d5c9e7605c75a0c8fcb9c2b506267ca0e6706766e033495d81dac4e302c"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-registry.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-registry.log-expected.json
@@ -29,6 +29,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "7A5B258D66B11991",
                 "hash": {
                     "md5": "c78655bc80301d76ed4fef1c1ea40a7d",
                     "sha1": "619652b42afe5fb0e3719d7aeda7a5494ab193e8",
@@ -37,6 +38,7 @@
                 "name": "svchost.exe",
                 "parent": {
                     "command_line": "C:\\Windows\\system32\\services.exe",
+                    "entity_id": "55A75E7FE942CE7D",
                     "hash": {
                         "sha1": "ff658a36899e43fec3966d608b4aa4472de7a378",
                         "sha256": "a86d6a6d1f5a0efcd649792a06f3ae9b37158d48493d2eca7f52dcc1cb9b6536"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-scheduled-task.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-scheduled-task.log-expected.json
@@ -23,6 +23,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "0AF3AD1313577E13",
                 "hash": {
                     "md5": "9b86c2a9ff7b8e697a9bbe015d4c9d0e",
                     "sha1": "c364f32c9df2fb147131618b9793346ae5d8f745",
@@ -31,6 +32,7 @@
                 "name": "Lenovo.Modern.ImController.exe",
                 "parent": {
                     "command_line": "C:\\Windows\\system32\\services.exe",
+                    "entity_id": "2AF2AD1313577E13",
                     "hash": {
                         "sha1": "d7a213f3cfee2a8a191769eb33847953be51de54",
                         "sha256": "dfbea9e8c316d9bc118b454b0c722cd674c30d0a256340200e2c3a7480cba674"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-threat-intelligence-indicator.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-threat-intelligence-indicator.log-expected.json
@@ -29,6 +29,7 @@
             },
             "process": {
                 "command_line": "-D",
+                "entity_id": "09edcd06-faa9-1575-1f8b-46a5ad0ac0fe",
                 "hash": {
                     "sha1": "4fe13081b31b55176af7dee8354ea18ad3ca4c59"
                 },

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-url.log-expected.json
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/_dev/test/pipeline/test-url.log-expected.json
@@ -23,6 +23,7 @@
             },
             "process": {
                 "command_line": "C:\\ProgramFiles(x86)\\Microsoft\\important_stuff\\stuff.EXE\\",
+                "entity_id": "E1471D24880BECFA",
                 "hash": {
                     "md5": "ac5ebf6878c1226542453aea56e451a2",
                     "sha1": "186fdd875432f3af106eb973fbc871240f35964e",
@@ -31,6 +32,7 @@
                 "name": "sourcelink5.exe",
                 "parent": {
                     "command_line": "C:\\MetSrc\\nssm.exe",
+                    "entity_id": "632D1A24880BECFA",
                     "hash": {
                         "sha1": "47c112c23c7bdf2af24a20bd512f91ff6af76bc6",
                         "sha256": "f689ee9af94b00e9e3f0bb072b34caaf207f32dcb4f5782fc9ca351df9a06c97"

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -1539,6 +1539,10 @@ processors:
       field: json.src.process.parent.uid
       target_field: sentinel_one_cloud_funnel.event.src.process.parent.uid
       ignore_missing: true
+  - set:
+      field: process.parent.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.parent.uid
+      ignore_empty_value: true
   - rename:
       field: json.src.process.parent.userSid
       target_field: sentinel_one_cloud_funnel.event.src.process.parent.user.sid
@@ -1864,6 +1868,10 @@ processors:
       field: json.src.process.uid
       target_field: sentinel_one_cloud_funnel.event.src.process.uid
       ignore_missing: true
+  - set:
+      field: process.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.uid
+      ignore_empty_value: true
   - rename:
       field: json.packet.id
       target_field: sentinel_one_cloud_funnel.event.packet_id
@@ -2522,6 +2530,10 @@ processors:
   - rename:
       field: json.tgt.process.userSid
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.sid
+      ignore_missing: true
+  - rename:
+      field: json.tgt.process.uid
+      target_field: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_missing: true
   - append:
       field: related.user

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -464,6 +464,17 @@ processors:
       copy_from: sentinel_one_cloud_funnel.event.src.process.pid
       ignore_empty_value: true
   - convert:
+      field: json.tgt.process.pid
+      tag: 'convert_json_tgt_process_pid'
+      target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
+      ignore_missing: true
+      type: string
+      if: ctx.json?.tgt?.process?.pid != ''
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - convert:
       field: json.src.process.rUserUid
       tag: 'convert_json_src_process_rUserUid'
       target_field: sentinel_one_cloud_funnel.event.src.process.r_user.uid
@@ -1650,6 +1661,21 @@ processors:
       value: '{{{sentinel_one_cloud_funnel.event.tgt.process.r_user.uid}}}'
       allow_duplicates: false
       if: ctx.sentinel_one_cloud_funnel?.event?.tgt?.process?.r_user?.uid != null
+  - convert:
+      field: json.src.process.tid
+      tag: 'convert_json_src_process_tid'
+      target_field: sentinel_one_cloud_funnel.event.src.process.tid
+      type: long
+      ignore_missing: true
+      if: ctx.json?.src?.process?.tid != ''
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - set:
+      field: process.thread.id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.tid
+      ignore_empty_value: true
   - date:
       field: json.timestamp
       tag: 'date_json_timestamp'

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -281,6 +281,10 @@ processors:
       field: json.tgt.process.name
       target_field: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_missing: true
+  - set:
+      field: process.name
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
+      ignore_empty_value: true
   - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
@@ -335,6 +339,14 @@ processors:
       field: json.tgt.process.subsystem
       target_field: sentinel_one_cloud_funnel.event.tgt.process.subsystem
       ignore_missing: true
+  - set:
+      field: process.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
+      ignore_empty_value: true
+  - set:
+      field: process.parent.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.uid
+      ignore_empty_value: true
   - rename:
       field: json.tgt.process.uid
       target_field: sentinel_one_cloud_funnel.event.tgt.process.uid

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -347,18 +347,20 @@ processors:
       field: json.tgt.process.uid
       target_field: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_missing: true
-  - set:
-      field: process.entity_id
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
-      ignore_empty_value: true
-  - set:
-      field: process.parent.entity_id
-      copy_from: sentinel_one_cloud_funnel.event.src.process.uid
-      ignore_empty_value: true
   - rename:
       field: json.tgt.process.verifiedStatus
       target_field: sentinel_one_cloud_funnel.event.tgt.process.verified_status
       ignore_missing: true
+  - remove:
+      field:
+      - process.parent
+  - rename:
+      field: process
+      target_field: process.parent
+  - set:
+      field: process.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
+      ignore_empty_value: true
   - set:
       field: process.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.cmd_line
@@ -375,62 +377,10 @@ processors:
       field: process.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
       ignore_empty_value: true
-  - set:
-      field: process.parent.command_line
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.parent.cmd_line
-      ignore_empty_value: true
-  - set:
-      field: process.parent.hash.md5
-      copy_from: sentinel_one_cloud_funnel.event.os_src_process.image.md5
-      ignore_empty_value: true
-  - set:
-      field: process.parent.hash.sha1
-      copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha1
-      ignore_empty_value: true
-  - set:
-      field: process.parent.hash.sha256
-      copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha256
-      ignore_empty_value: true
-  - set:
-      field: process.parent.name
-      copy_from: sentinel_one_cloud_funnel.event.src.process.name
-      ignore_empty_value: true
-  - set:
-      field: process.parent.pid
-      copy_from: sentinel_one_cloud_funnel.event.src.process.pid
-      ignore_empty_value: true
-  - set:
-      field: process.parent.real_user.id
-      copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.uid
-      ignore_empty_value: true
-  - set:
-      field: process.parent.real_user.name
-      copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.name
-      ignore_empty_value: true
-  - set:
-      field: process.parent.start
-      copy_from: sentinel_one_cloud_funnel.event.src.process.start_time
-      ignore_empty_value: true
-  - set:
-      field: process.parent.title
-      copy_from: sentinel_one_cloud_funnel.event.src.process.display_name
-      ignore_empty_value: true
-  - set:
-      field: process.parent.user.id
-      copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.uid
-      ignore_empty_value: true
-  - set:
-      field: process.parent.user.name
-      copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.name
-      ignore_empty_value: true
-  - set:
-      field: process.parent.user.name
-      copy_from: sentinel_one_cloud_funnel.event.src.process.user.name
-      ignore_empty_value: true
-  - set:
-      field: process.pid
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
-      ignore_empty_value: true
+#  - set:
+#      field: process.pid
+#      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
+#      ignore_empty_value: true
   - set:
       field: process.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -85,7 +85,6 @@ processors:
       field: process.thread.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - rename:
       field: json.tgt.process.user
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.name
@@ -290,7 +289,6 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
@@ -353,12 +351,10 @@ processors:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.entity_id
       copy_from: sentinel_one_cloud_funnel.event.src.process.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - rename:
       field: json.tgt.process.verifiedStatus
       target_field: sentinel_one_cloud_funnel.event.tgt.process.verified_status
@@ -367,128 +363,102 @@ processors:
       field: process.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.cmd_line
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.md5
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha1
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.parent.cmd_line
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.os_src_process.image.md5
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha1
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha256
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.pid
       copy_from: sentinel_one_cloud_funnel.event.src.process.pid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.start
       copy_from: sentinel_one_cloud_funnel.event.src.process.start_time
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.title
       copy_from: sentinel_one_cloud_funnel.event.src.process.display_name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.pid
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.start
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.start_time
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.title
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.name
       ignore_empty_value: true
-      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
-
 on_failure:
   - append:
       field: error.message

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -289,11 +289,10 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
-  - convert:
+  - rename:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
       target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
-      type: string
       ignore_missing: true
       if: ctx.json?.tgt?.process?.pid != ''
       on_failure:
@@ -377,10 +376,6 @@ processors:
       field: process.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
       ignore_empty_value: true
-#  - set:
-#      field: process.pid
-#      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
-#      ignore_empty_value: true
   - set:
       field: process.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid
@@ -396,6 +391,10 @@ processors:
   - set:
       field: process.title
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
+      ignore_empty_value: true
+  - set:
+      field: process.pid
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_empty_value: true
   - set:
       field: process.user.id

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -289,11 +289,12 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
-  - rename:
+  - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
       target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_missing: true
+      type: long
       if: ctx.json?.tgt?.process?.pid != ''
       on_failure:
         - append:
@@ -357,6 +358,21 @@ processors:
       field: process
       target_field: process.parent
   - set:
+      field: process.pid
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
+      ignore_empty_value: true
+  - convert:
+      field: json.tgt.process.pid
+      tag: 'convert_json_tgt_process_pid'
+      target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
+      ignore_missing: true
+      type: string
+      if: ctx.json?.tgt?.process?.pid != ''
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - set:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_empty_value: true
@@ -391,10 +407,6 @@ processors:
   - set:
       field: process.title
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
-      ignore_empty_value: true
-  - set:
-      field: process.pid
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_empty_value: true
   - set:
       field: process.user.id

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -85,7 +85,7 @@ processors:
       field: process.thread.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - rename:
       field: json.tgt.process.user
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.name
@@ -290,7 +290,7 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
@@ -353,12 +353,12 @@ processors:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.entity_id
       copy_from: sentinel_one_cloud_funnel.event.src.process.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - rename:
       field: json.tgt.process.verifiedStatus
       target_field: sentinel_one_cloud_funnel.event.tgt.process.verified_status
@@ -367,127 +367,127 @@ processors:
       field: process.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.cmd_line
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.md5
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha1
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.parent.cmd_line
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.os_src_process.image.md5
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha1
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha256
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.pid
       copy_from: sentinel_one_cloud_funnel.event.src.process.pid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.start
       copy_from: sentinel_one_cloud_funnel.event.src.process.start_time
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.title
       copy_from: sentinel_one_cloud_funnel.event.src.process.display_name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.pid
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.start
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.start_time
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.title
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'Process Creation'
+      if: ctx.sentinel_one_cloud_funnel?.event?.type == 'Process Creation'
 
 on_failure:
   - append:

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -81,6 +81,11 @@ processors:
       field: process.thread.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.tid
       ignore_empty_value: true
+  - set:
+      field: process.thread.id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
   - rename:
       field: json.tgt.process.user
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.name
@@ -285,6 +290,7 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
   - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
@@ -339,22 +345,150 @@ processors:
       field: json.tgt.process.subsystem
       target_field: sentinel_one_cloud_funnel.event.tgt.process.subsystem
       ignore_missing: true
-  - set:
-      field: process.entity_id
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
-      ignore_empty_value: true
-  - set:
-      field: process.parent.entity_id
-      copy_from: sentinel_one_cloud_funnel.event.src.process.uid
-      ignore_empty_value: true
   - rename:
       field: json.tgt.process.uid
       target_field: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_missing: true
+  - set:
+      field: process.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.entity_id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
   - rename:
       field: json.tgt.process.verifiedStatus
       target_field: sentinel_one_cloud_funnel.event.tgt.process.verified_status
       ignore_missing: true
+  - set:
+      field: process.command_line
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.cmd_line
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.hash.md5
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.md5
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.hash.sha1
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha1
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.hash.sha256
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.command_line
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.parent.cmd_line
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.hash.md5
+      copy_from: sentinel_one_cloud_funnel.event.os_src_process.image.md5
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.hash.sha1
+      copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha1
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.hash.sha256
+      copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha256
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.name
+      copy_from: sentinel_one_cloud_funnel.event.src.process.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.pid
+      copy_from: sentinel_one_cloud_funnel.event.src.process.pid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.real_user.id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.real_user.name
+      copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.start
+      copy_from: sentinel_one_cloud_funnel.event.src.process.start_time
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.title
+      copy_from: sentinel_one_cloud_funnel.event.src.process.display_name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.user.id
+      copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.user.name
+      copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.parent.user.name
+      copy_from: sentinel_one_cloud_funnel.event.src.process.user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.pid
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.real_user.id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.real_user.name
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.start
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.start_time
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.title
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.user.id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.uid
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.user.name
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+  - set:
+      field: process.user.name
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.name
+      ignore_empty_value: true
+      if: ctx.json?.event.type == 'ProcessCreation'
+
 on_failure:
   - append:
       field: error.message

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -333,6 +333,10 @@ processors:
       type: long
       ignore_missing: true
   - set:
+      field: process.thread.id
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
+      ignore_empty_value: true
+  - set:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_empty_value: true

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -405,10 +405,6 @@ processors:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.user.name
       ignore_empty_value: true
-  - set:
-      field: process.user.name
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.name
-      ignore_empty_value: true
 on_failure:
   - append:
       field: error.message

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -66,34 +66,10 @@ processors:
       value: '{{{file.hash.sha1}}}'
       allow_duplicates: false
       if: ctx.file?.hash?.sha1 != null
-  - convert:
-      field: json.src.process.tid
-      tag: 'convert_json_src_process_tid'
-      target_field: sentinel_one_cloud_funnel.event.src.process.tid
-      type: long
-      ignore_missing: true
-      if: ctx.json?.src?.process?.tid != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - set:
-      field: process.thread.id
-      copy_from: sentinel_one_cloud_funnel.event.src.process.tid
-      ignore_empty_value: true
-  - set:
-      field: process.thread.id
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
-      ignore_empty_value: true
   - rename:
       field: json.tgt.process.user
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.name
       ignore_missing: true
-  - append:
-      field: process.user.name
-      value: '{{{sentinel_one_cloud_funnel.event.tgt.process.user.name}}}'
-      allow_duplicates: false
-      if: ctx.sentinel_one_cloud_funnel?.event?.tgt?.process?.user?.name != null
   - append:
       field: related.user
       value: '{{{sentinel_one_cloud_funnel.event.tgt.process.user.name}}}'
@@ -285,21 +261,6 @@ processors:
       field: json.tgt.process.name
       target_field: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_missing: true
-  - set:
-      field: process.name
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
-      ignore_empty_value: true
-  - convert:
-      field: json.tgt.process.pid
-      tag: 'convert_json_tgt_process_pid'
-      target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
-      ignore_missing: true
-      type: long
-      if: ctx.json?.tgt?.process?.pid != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - rename:
       field: json.tgt.process.publisher
       target_field: sentinel_one_cloud_funnel.event.tgt.process.publisher
@@ -357,21 +318,20 @@ processors:
   - rename:
       field: process
       target_field: process.parent
+  - append:
+      field: process.user.name
+      value: '{{{sentinel_one_cloud_funnel.event.tgt.process.user.name}}}'
+      allow_duplicates: false
+      if: ctx.sentinel_one_cloud_funnel?.event?.tgt?.process?.user?.name != null
   - set:
-      field: process.pid
-      copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
+      field: process.name
+      copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
   - convert:
-      field: json.tgt.process.pid
-      tag: 'convert_json_tgt_process_pid'
-      target_field: sentinel_one_cloud_funnel.event.tgt.process.pid
+      field: sentinel_one_cloud_funnel.event.tgt.process.pid
+      target_field: process.pid
+      type: long
       ignore_missing: true
-      type: string
-      if: ctx.json?.tgt?.process?.pid != ''
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - set:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid

--- a/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
+++ b/packages/sentinel_one_cloud_funnel/data_stream/event/elasticsearch/ingest_pipeline/pipeline-process.yml
@@ -85,7 +85,7 @@ processors:
       field: process.thread.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.tid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - rename:
       field: json.tgt.process.user
       target_field: sentinel_one_cloud_funnel.event.tgt.process.user.name
@@ -290,7 +290,7 @@ processors:
       field: process.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - convert:
       field: json.tgt.process.pid
       tag: 'convert_json_tgt_process_pid'
@@ -353,12 +353,12 @@ processors:
       field: process.entity_id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.entity_id
       copy_from: sentinel_one_cloud_funnel.event.src.process.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - rename:
       field: json.tgt.process.verifiedStatus
       target_field: sentinel_one_cloud_funnel.event.tgt.process.verified_status
@@ -367,127 +367,127 @@ processors:
       field: process.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.cmd_line
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.md5
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha1
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.image.sha256
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.command_line
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.parent.cmd_line
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.hash.md5
       copy_from: sentinel_one_cloud_funnel.event.os_src_process.image.md5
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha1
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha1
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.hash.sha256
       copy_from: sentinel_one_cloud_funnel.event.src.process.image.sha256
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.pid
       copy_from: sentinel_one_cloud_funnel.event.src.process.pid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.r_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.start
       copy_from: sentinel_one_cloud_funnel.event.src.process.start_time
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.title
       copy_from: sentinel_one_cloud_funnel.event.src.process.display_name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.user.id
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.e_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.parent.user.name
       copy_from: sentinel_one_cloud_funnel.event.src.process.user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.pid
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.pid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.real_user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.real_user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.r_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.start
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.start_time
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.title
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.display_name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.user.id
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.uid
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
   - set:
       field: process.user.name
       copy_from: sentinel_one_cloud_funnel.event.tgt.process.e_user.name
       ignore_empty_value: true
-      if: ctx.json?.event.type == 'ProcessCreation'
+      if: ctx.json?.event.type == 'Process Creation'
 
 on_failure:
   - append:

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "0.9.1"
+version: "0.10.0"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "0.9.0"
+version: "0.9.1"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]


### PR DESCRIPTION
### Proposed commit message:
```
[sentinel_one_cloud_funnel] `process.*` changes for Analyzer (#8608)

In order to support Analyzer:
- Populate the `process.entity_id` field.
- For process creation events, populate `process.*` fields with
  target/new process information rather than source/parent information.
```
---
**Earlier title**: [EDR Workflows] Adjust Sentinel One Cloud Funnel mappings to support Analyzer - entity_id
**Earlier description**:

This PR adds mapping to `process.entity_id` and `process.parent.entity_id` in default.yml. 

Moreover it overwrites `process.parent` with `src.process` data, and process with `tgt.process` for `process-pipeline.yml`

There was a suggestion that we might actually also map `event.type` more dynamically, because now it's just set to [info]. But this can be done in the future :) 

Kibana changes:
https://github.com/elastic/kibana/pull/170829
Closes:
https://github.com/elastic/security-team/issues/7999
