### PR TITLE
[apache_tomcat.access] Restructure Grok pattern and ingest pipeline to improve performance

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Improve apacht_tomcat.access pipeline performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8615
 - version: "1.0.0"
   changes:
     - description: Make Apache Tomcat GA.

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.0.1"
+- version: "1.1.0"
   changes:
     - description: Improve apacht_tomcat.access pipeline performance
       type: enhancement

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.1.0"
   changes:
-    - description: Improve apacht_tomcat.access pipeline performance
+    - description: Improve apache_tomcat.access pipeline performance
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8615
 - version: "1.0.0"

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -25,7 +25,7 @@ processors:
       field: event.original
       tag: 'grok_parse_log'
       patterns:
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{DATA:destination.bytes}(%{GREEDYDATA:_tmp_grok})?$'
+        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}(%{GREEDYDATA:_tmp_grok})?$'
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -32,13 +32,14 @@ processors:
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - grok:
       field: _tmp_grok
-      tag: 'grok_parse_log'
+      tag: 'grok_parse_log2'
       patterns:
         - '(?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
         - '\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
       pattern_definitions:
         CONN_STATUS: "[X+-]"
       ignore_missing: true
+      if: ctx._tmp_grok != null
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -25,7 +25,7 @@ processors:
       field: event.original
       tag: 'grok_parse_log'
       patterns:
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}(%{GREEDYDATA:_tmp_grok})?$'
+        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp_grok})?$'
       on_failure:
         - append:
             field: error.message
@@ -39,7 +39,6 @@ processors:
       pattern_definitions:
         CONN_STATUS: "[X+-]"
       ignore_missing: true
-      if: ctx._tmp_grok != null
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -25,15 +25,27 @@ processors:
       field: event.original
       tag: 'grok_parse_log'
       patterns:
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{DATA:destination.bytes} (?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{DATA:destination.bytes} \"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{DATA:destination.bytes}$'
-      pattern_definitions:
-        CONN_STATUS: "[X+-]"
+        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{DATA:destination.bytes}(%{GREEDYDATA:_tmp_grok})?$'
       on_failure:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - grok:
+      field: _tmp_grok
+      tag: 'grok_parse_log'
+      patterns:
+        - '(?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
+        - '\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
+      pattern_definitions:
+        CONN_STATUS: "[X+-]"
+      ignore_missing: true
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - remove:
+      field: _tmp_grok
+      ignore_missing: true
   - append:
       field: related.ip
       value: '{{{source.ip}}}'

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -25,13 +25,13 @@ processors:
       field: event.original
       tag: 'grok_parse_log'
       patterns:
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp_grok})?$'
+        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp.grok})?$'
       on_failure:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - grok:
-      field: _tmp_grok
+      field: _tmp.grok
       tag: 'grok_parse_log2'
       patterns:
         - '(?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
@@ -43,9 +43,6 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - remove:
-      field: _tmp_grok
-      ignore_missing: true
   - append:
       field: related.ip
       value: '{{{source.ip}}}'

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.0.1"
+version: "1.1.0"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.0.0"
+version: "1.0.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
The customer is using this Integration on an ESS and had ~10-14ms per doc average processing Time.
![image](https://github.com/elastic/integrations/assets/145989254/b3938936-386e-470a-8fbf-2cadeff0f8ef)
After taking a look at the pipeline definition I recognised the "inefficient" way how the grok processing is done.
First test of restructuring the grok process (without changing what it is doing, just how it is done) I had an average of 0-5-0.-7ms, so a huge performance improvement with just a little restructuring.
![image](https://github.com/elastic/integrations/assets/145989254/e2a3b9a1-c779-4851-b322-a0e0d2da1aff)