### PR TITLE
[kibana] Add memory utilization metric

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: Add memory utilization metric
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8044
 - version: "2.5.0"
   changes:
     - description: Make Stack Monitoring metrics GA

--- a/packages/kibana/data_stream/stats/fields/fields.yml
+++ b/packages/kibana/data_stream/stats/fields/fields.yml
@@ -72,6 +72,20 @@
                   type: long
                 - name: used_in_bytes
                   type: long
+            - name: cpuacct
+              type: group
+              fields:
+                - name: control_group
+                  type: keyword
+                - name: usage_nanos
+                  type: long
+            - name: cgroup_memory
+              type: group
+              fields:
+                - name: current_in_bytes
+                  type: long
+                - name: swap_current_in_bytes
+                  type: long
             - name: load
               type: group
               fields:
@@ -89,6 +103,10 @@
           type: group
           fields:
             - name: memory.resident_set_size.bytes
+              type: long
+            - name: memory.array_buffers.bytes
+              type: long
+            - name: memory.external.bytes
               type: long
             - name: uptime.ms
               type: long

--- a/packages/kibana/data_stream/stats/sample_event.json
+++ b/packages/kibana/data_stream/stats/sample_event.json
@@ -96,6 +96,12 @@
                     },
                     "resident_set_size": {
                         "bytes": 716869632
+                    },
+                    "array_buffers": {
+                        "bytes": 2197869632
+                    },
+                    "external": {
+                        "bytes": 4890295460
                     }
                 },
                 "uptime": {

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -558,6 +558,10 @@ Stats data stream uses the stats endpoint of Kibana, which is available in 6.4 b
 | kibana.stats.index | Name of Kibana's internal index | keyword |
 | kibana.stats.kibana.status |  | keyword |
 | kibana.stats.name | Kibana instance name | keyword |
+| kibana.stats.os.cgroup_memory.current_in_bytes |  | long |
+| kibana.stats.os.cgroup_memory.swap_current_in_bytes |  | long |
+| kibana.stats.os.cpuacct.control_group |  | keyword |
+| kibana.stats.os.cpuacct.usage_nanos |  | long |
 | kibana.stats.os.distro |  | keyword |
 | kibana.stats.os.distroRelease |  | keyword |
 | kibana.stats.os.load.15m |  | half_float |
@@ -572,6 +576,8 @@ Stats data stream uses the stats endpoint of Kibana, which is available in 6.4 b
 | kibana.stats.process.event_loop_utilization.active |  | double |
 | kibana.stats.process.event_loop_utilization.idle |  | double |
 | kibana.stats.process.event_loop_utilization.utilization |  | double |
+| kibana.stats.process.memory.array_buffers.bytes |  | long |
+| kibana.stats.process.memory.external.bytes |  | long |
 | kibana.stats.process.memory.heap.size_limit.bytes | Max. old space size allocated to Node.js process, in bytes | long |
 | kibana.stats.process.memory.heap.total.bytes | Total heap allocated to process in bytes | long |
 | kibana.stats.process.memory.heap.uptime.ms | Uptime of process in milliseconds | long |
@@ -713,6 +719,12 @@ An example event for `stats` looks as following:
                     },
                     "resident_set_size": {
                         "bytes": 716869632
+                    },
+                    "array_buffers": {
+                        "bytes": 2197869632
+                    },
+                    "external": {
+                        "bytes": 4890295460
                     }
                 },
                 "uptime": {

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.5.0
+version: 2.5.1
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
Adds mappings for new Kibana memory fields added in https://github.com/elastic/kibana/pull/172146 to the monitoring templates.

Corresponding Beats PR: https://github.com/elastic/beats/pull/37232