### PR TITLE
Add null and ignore_missing check to handle event.original field.

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.14.1
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: 0.14.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: 0.14.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -15,7 +15,7 @@ processors:
       field: event.original
       value: "{{{message}}}"
       ignore_empty_value: true
-      ignore_failure: true
+      if: 'ctx.event?.original == null'
   - grok:
       field: message
       pattern_definitions:

--- a/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -16,6 +16,7 @@ processors:
       value: "{{{message}}}"
       ignore_empty_value: true
       ignore_failure: true
+      if: 'ctx.event?.original == null'
   - grok:
       field: message
       pattern_definitions:

--- a/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/activemq/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -15,7 +15,6 @@ processors:
       field: event.original
       value: "{{{message}}}"
       ignore_empty_value: true
-      ignore_failure: true
       if: 'ctx.event?.original == null'
   - grok:
       field: message

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "0.14.0"
+version: "0.14.1"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:

--- a/packages/coredns/changelog.yml
+++ b/packages/coredns/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.6.1
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/coredns/changelog.yml
+++ b/packages/coredns/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: 0.6.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/coredns/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/coredns/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -8,6 +8,7 @@ processors:
       field: event.original
       copy_from: message
       ignore_empty_value: true
+      if: 'ctx.event?.original == null'
   - set:
       field: event.created
       copy_from: "@timestamp"

--- a/packages/coredns/manifest.yml
+++ b/packages/coredns/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: coredns
 title: "CoreDNS"
-version: "0.6.0"
+version: "0.6.1"
 description: "Collect logs from CoreDNS instances with Elastic Agent."
 type: integration
 categories:

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: "1.2.3"
   changes:
     - description: Remove forwarded tag from metrics data stream.

--- a/packages/ibmmq/changelog.yml
+++ b/packages/ibmmq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.4"
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: "1.2.3"
   changes:
     - description: Remove forwarded tag from metrics data stream.

--- a/packages/ibmmq/data_stream/errorlog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ibmmq/data_stream/errorlog/elasticsearch/ingest_pipeline/default.yml
@@ -89,7 +89,7 @@ processors:
     field: message
     target_field: event.original
     ignore_missing: true
-    ignore_failure: true
+    if: 'ctx.event?.original == null'
 - remove:
     field:
     - log_timestamp

--- a/packages/ibmmq/manifest.yml
+++ b/packages/ibmmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: ibmmq
 title: IBM MQ
-version: "1.2.3"
+version: "1.2.4"
 license: basic
 description: Collect logs and metrics from IBM MQ with Elastic Agent.
 type: integration

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.12.1
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: 1.12.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: 1.12.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/pipeline-json.yml
+++ b/packages/mongodb/data_stream/log/elasticsearch/ingest_pipeline/pipeline-json.yml
@@ -21,6 +21,8 @@ processors:
 - rename:
     field: message
     target_field: event.original
+    ignore_missing: true
+    if: 'ctx.event?.original == null'
 - rename:
     field: mongodb.log.msg
     target_field: message

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.12.0"
+version: "1.12.1"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: "0.12.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.12.1"
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: "0.12.0"
   changes:
     - description: Limit request tracer log count to five.

--- a/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    copy_from: message
+    value: '{{{message}}}'
     ignore_empty_value: true
     if: 'ctx.event?.original == null'
 - fingerprint:

--- a/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/apex/elasticsearch/ingest_pipeline/default.yml
@@ -7,9 +7,9 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    value: '{{{message}}}'
-    ignore_failure: true
+    copy_from: message
     ignore_empty_value: true
+    if: 'ctx.event?.original == null'
 - fingerprint:
     fields:
     - json.REQUEST_ID

--- a/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    copy_from: message
+    value: '{{{message}}}'
     ignore_empty_value: true
     if: 'ctx.event?.original == null'
 - fingerprint:

--- a/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_rest/elasticsearch/ingest_pipeline/default.yml
@@ -7,9 +7,9 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    value: '{{{message}}}'
-    ignore_failure: true
+    copy_from: message
     ignore_empty_value: true
+    if: 'ctx.event?.original == null'
 - fingerprint:
     fields:
     - json.REQUEST_ID

--- a/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    copy_from: message
+    value: '{{{message}}}'
     ignore_empty_value: true
     if: 'ctx.event?.original == null'
 - set:

--- a/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/login_stream/elasticsearch/ingest_pipeline/default.yml
@@ -7,9 +7,9 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    value: '{{{message}}}'
-    ignore_failure: true
+    copy_from: message
     ignore_empty_value: true
+    if: 'ctx.event?.original == null'
 - set:
     field: salesforce.login.access_mode
     value: Stream

--- a/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
@@ -7,7 +7,7 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    copy_from: message
+    value: '{{{message}}}'
     ignore_empty_value: true
     if: 'ctx.event?.original == null'
 - fingerprint:

--- a/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/logout_rest/elasticsearch/ingest_pipeline/default.yml
@@ -7,9 +7,9 @@ processors:
     ignore_failure: true
 - set:
     field: event.original
-    value: '{{{message}}}'
-    ignore_failure: true
+    copy_from: message
     ignore_empty_value: true
+    if: 'ctx.event?.original == null'
 - fingerprint:
     fields:
     - json.REQUEST_ID

--- a/packages/salesforce/data_stream/logout_stream/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/logout_stream/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
     field: message
     target_field: event.original
     ignore_missing: true
-    ignore_failure: true
+    if: 'ctx.event?.original == null'
 - set:
     field: salesforce.logout.access_mode
     value: Stream

--- a/packages/salesforce/data_stream/setupaudittrail/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/salesforce/data_stream/setupaudittrail/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
     field: message
     target_field: event.original
     ignore_missing: true
-    ignore_failure: true
+    if: 'ctx.event?.original == null'
 - set:
     field: salesforce.setup_audit_trail.access_mode
     value: "REST"

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: salesforce
 title: Salesforce
-version: "0.12.0"
+version: "0.12.1"
 description: Collect logs from Salesforce with Elastic Agent.
 type: integration
 categories:

--- a/packages/spring_boot/changelog.yml
+++ b/packages/spring_boot/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: "1.2.0"
   changes:
     - description: Add support for GC datastream on Spring Boot 2.x with LTS JDK versions 11, 17, and 21.

--- a/packages/spring_boot/changelog.yml
+++ b/packages/spring_boot/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: "1.2.0"
   changes:
     - description: Add support for GC datastream on Spring Boot 2.x with LTS JDK versions 11, 17, and 21.

--- a/packages/spring_boot/data_stream/audit_events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/spring_boot/data_stream/audit_events/elasticsearch/ingest_pipeline/default.yml
@@ -8,6 +8,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - set:
       field: event.dataset
       value: spring_boot.audit_events

--- a/packages/spring_boot/data_stream/http_trace/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/spring_boot/data_stream/http_trace/elasticsearch/ingest_pipeline/default.yml
@@ -8,6 +8,7 @@ processors:
       field: message
       target_field: event.original
       ignore_missing: true
+      if: 'ctx.event?.original == null'
   - json:
       field: event.original
       target_field: json

--- a/packages/spring_boot/manifest.yml
+++ b/packages/spring_boot/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: spring_boot
 title: Spring Boot
-version: "1.2.0"
+version: "1.2.1"
 description: This Elastic integration collects logs and metrics from Spring Boot integration.
 type: integration
 categories:

--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.9.2"
+  changes:
+    - description: Add null and ignore_missing check to handle event.original field.
+      type: bugfix
+      link: tba
 - version: 1.9.1
   changes:
     - description: Update the README with limitations in Virtual Machine metrics.

--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add null and ignore_missing check to handle event.original field.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/8624
 - version: 1.9.1
   changes:
     - description: Update the README with limitations in Virtual Machine metrics.

--- a/packages/vsphere/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/vsphere/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
   - rename:
       field: message
       target_field: event.original
+      ignore_missing: true
+      if: 'ctx.event?.original == null'
   - grok:
       description: Parse syslog header
       field: event.original

--- a/packages/vsphere/manifest.yml
+++ b/packages/vsphere/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: vsphere
 title: VMware vSphere
-version: "1.9.1"
+version: "1.9.2"
 description: This Elastic integration collects metrics and logs from vSphere/vCenter servers
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This PR add null and ignore_missing check to handle event.original field in multiple packages which are as follows:

- ActiveMQ
- CoreDns
- IBMMQ
- MongoDB
- Salesforce
- Spring_Boot
- vSphere


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues


- Relates #7822 

## Screenshots


