### PR TITLE
[imperva] Undefined log.file.* fields breaking tests for filestream inputs

### DIFF
--- a/packages/imperva/changelog.yml
+++ b/packages/imperva/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.21.0"
+  changes:
+    - description: Adapt fields for changes in file system info.
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/8469
 - version: 0.20.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/imperva/data_stream/securesphere/_dev/test/system/test-logfile-config.yml
+++ b/packages/imperva/data_stream/securesphere/_dev/test/system/test-logfile-config.yml
@@ -6,3 +6,9 @@ data_stream:
       - "{{SERVICE_LOGS_DIR}}/*imperva*.log"
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+numeric_keyword_fields:
+  - log.file.device_id
+  - log.file.inode
+  - log.file.idxhi
+  - log.file.idxlo
+  - log.file.vol

--- a/packages/imperva/data_stream/securesphere/fields/beats.yml
+++ b/packages/imperva/data_stream/securesphere/fields/beats.yml
@@ -4,6 +4,27 @@
 - name: log.offset
   type: long
   description: Log offset.
+- name: log.file
+  type: group
+  fields:
+    - name: device_id
+      type: keyword
+      description: ID of the device containing the filesystem where the file resides.
+    - name: fingerprint
+      type: keyword
+      description: The sha256 fingerprint identity of the file when fingerprinting is enabled.
+    - name: inode
+      type: keyword
+      description: Inode number of the log file.
+    - name: idxhi
+      type: keyword
+      description: The high-order part of a unique identifier that is associated with a file. (Windows-only)
+    - name: idxlo
+      type: keyword
+      description: The low-order part of a unique identifier that is associated with a file. (Windows-only)
+    - name: vol
+      type: keyword
+      description: The serial number of the volume that contains a file. (Windows-only)
 - name: tags
   type: keyword
   description: User defined tags.

--- a/packages/imperva/data_stream/securesphere/fields/fields.yml
+++ b/packages/imperva/data_stream/securesphere/fields/fields.yml
@@ -82,7 +82,3 @@
       type: keyword
     - name: version
       type: keyword
-- name: log.file.device_id
-  type: long
-- name: log.file.inode
-  type: long

--- a/packages/imperva/data_stream/securesphere/sample_event.json
+++ b/packages/imperva/data_stream/securesphere/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2023-10-05T18:33:02.000Z",
     "agent": {
-        "ephemeral_id": "72a3940a-ff8f-4dbe-996c-683be2bf9c9d",
-        "id": "68d423e3-c562-46ac-aebf-08e6f6ce9e0f",
+        "ephemeral_id": "94608df6-6778-4ec4-99dc-d0cd37d583d8",
+        "id": "0412638f-dd94-4c0e-b349-e99a0886d9f0",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -16,7 +16,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "68d423e3-c562-46ac-aebf-08e6f6ce9e0f",
+        "id": "0412638f-dd94-4c0e-b349-e99a0886d9f0",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -24,7 +24,7 @@
         "agent_id_status": "verified",
         "code": "User logged in",
         "dataset": "imperva.securesphere",
-        "ingested": "2023-10-10T12:08:14Z",
+        "ingested": "2023-12-01T09:10:18Z",
         "kind": "event",
         "original": "\u003c14\u003eCEF:0|Imperva Inc.|SecureSphere|15.1.0|User logged in|User admin logged in from 81.2.69.142.|High|suser=admin rt=Oct 05 2023 18:33:02 cat=SystemEvent",
         "severity": 7
@@ -54,7 +54,7 @@
     },
     "log": {
         "source": {
-            "address": "172.18.0.6:38727"
+            "address": "192.168.249.7:48857"
         }
     },
     "message": "User admin logged in from 81.2.69.142.",

--- a/packages/imperva/docs/README.md
+++ b/packages/imperva/docs/README.md
@@ -212,8 +212,12 @@ An example event for `securesphere` looks as following:
 | imperva.securesphere.transport_protocol |  | keyword |
 | imperva.securesphere.version |  | keyword |
 | input.type | Type of filebeat input. | keyword |
-| log.file.device_id |  | long |
-| log.file.inode |  | long |
+| log.file.device_id | ID of the device containing the filesystem where the file resides. | keyword |
+| log.file.fingerprint | The sha256 fingerprint identity of the file when fingerprinting is enabled. | keyword |
+| log.file.idxhi | The high-order part of a unique identifier that is associated with a file. (Windows-only) | keyword |
+| log.file.idxlo | The low-order part of a unique identifier that is associated with a file. (Windows-only) | keyword |
+| log.file.inode | Inode number of the log file. | keyword |
+| log.file.vol | The serial number of the volume that contains a file. (Windows-only) | keyword |
 | log.offset | Log offset. | long |
 | log.source.address | Source address from which the log event was read / sent from. | keyword |
 | tags | User defined tags. | keyword |

--- a/packages/imperva/docs/README.md
+++ b/packages/imperva/docs/README.md
@@ -93,8 +93,8 @@ An example event for `securesphere` looks as following:
 {
     "@timestamp": "2023-10-05T18:33:02.000Z",
     "agent": {
-        "ephemeral_id": "72a3940a-ff8f-4dbe-996c-683be2bf9c9d",
-        "id": "68d423e3-c562-46ac-aebf-08e6f6ce9e0f",
+        "ephemeral_id": "94608df6-6778-4ec4-99dc-d0cd37d583d8",
+        "id": "0412638f-dd94-4c0e-b349-e99a0886d9f0",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.10.1"
@@ -108,7 +108,7 @@ An example event for `securesphere` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "68d423e3-c562-46ac-aebf-08e6f6ce9e0f",
+        "id": "0412638f-dd94-4c0e-b349-e99a0886d9f0",
         "snapshot": false,
         "version": "8.10.1"
     },
@@ -116,7 +116,7 @@ An example event for `securesphere` looks as following:
         "agent_id_status": "verified",
         "code": "User logged in",
         "dataset": "imperva.securesphere",
-        "ingested": "2023-10-10T12:08:14Z",
+        "ingested": "2023-12-01T09:10:18Z",
         "kind": "event",
         "original": "\u003c14\u003eCEF:0|Imperva Inc.|SecureSphere|15.1.0|User logged in|User admin logged in from 81.2.69.142.|High|suser=admin rt=Oct 05 2023 18:33:02 cat=SystemEvent",
         "severity": 7
@@ -146,7 +146,7 @@ An example event for `securesphere` looks as following:
     },
     "log": {
         "source": {
-            "address": "172.18.0.6:38727"
+            "address": "192.168.249.7:48857"
         }
     },
     "message": "User admin logged in from 81.2.69.142.",

--- a/packages/imperva/manifest.yml
+++ b/packages/imperva/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: imperva
 title: Imperva
-version: "0.20.0"
+version: "0.21.0"
 description: Collect logs from Imperva devices with Elastic Agent.
 categories: ["network", "security"]
 type: integration


### PR DESCRIPTION
Type of change
- Enhancement
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## What does this PR do?
Issue:
```
FAILURE DETAILS:
imperva/securesphere logfile:
[0] parsing field value failed: field "log.file.device_id"'s Go type, string, does not match the expected field type: long (field value: 68)
[1] parsing field value failed: field "log.file.inode"'s Go type, string, does not match the expected field type: long (field value: 98)
```
- Resolve above issue by updating log.file.* fields to keyword and added new filestream fields to prevent a field type mismatch error.

<!-- Mandatory
Explain here the changes you made on the PR.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/imperva directory.
- Run the following command to run tests.
> elastic-package test 
<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
- Closes #8469 
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


## Screenshots
![image](https://github.com/elastic/integrations/assets/123942854/981a8b92-a736-4168-adf2-502d9be80f52)

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
