### PR TITLE
[etcd] Enable TSDB for metrics datastream

### DIFF
--- a/packages/etcd/_dev/deploy/variants.yml
+++ b/packages/etcd/_dev/deploy/variants.yml
@@ -1,8 +1,4 @@
 variants:
   etcd_3_5_1:
     SERVICE_VERSION: 3.5.1
-  etcd_3_3_8:
-    SERVICE_VERSION: 3.3.8
-  etcd_3:
-    SERVICE_VERSION: 3
 default: etcd_3_5_1

--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.8.0"
+  changes:
+    - description: Enable time series data streams for the metrics datasets. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.7.0"
   changes:
     - description: Switch to Prometheus metricset, add ECS fields, dimensions mappings and metric types.

--- a/packages/etcd/changelog.yml
+++ b/packages/etcd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Enable time series data streams for the metrics datasets. This improves storage usage and query performance. For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8649
 - version: "0.7.0"
   changes:
     - description: Switch to Prometheus metricset, add ECS fields, dimensions mappings and metric types.

--- a/packages/etcd/data_stream/metrics/manifest.yml
+++ b/packages/etcd/data_stream/metrics/manifest.yml
@@ -26,3 +26,5 @@ streams:
         required: false
         show_user: true
         default: ["etcd_server_has_leader", "etcd_server_leader_changes_seen_total", "etcd_server_proposals_committed_total", "etcd_server_proposals_pending", "etcd_server_proposals_failed_total", "process_start_time_seconds", "grpc_server_started_total", "grpc_server_handled_total", "etcd_mvcc_db_total_size_in_bytes", "etcd_disk_wal_fsync_duration_seconds", "etcd_disk_backend_commit_duration_seconds", "go_memstats_alloc_bytes", "etcd_network_client_grpc_sent_bytes_total", "etcd_network_client_grpc_received_bytes_total", "etcd_network_peer_round_trip_time_seconds", "etcd_server_proposals_applied_total", "etcd_network_peer_received_bytes_total", "etcd_network_peer_sent_bytes_total", "etcd_network_peer_sent_failures_total", "etcd_network_peer_received_failures_total", "etcd_debugging_store_writes_total", "etcd_debugging_store_expires_total", "etcd_debugging_store_reads_total", "etcd_debugging_store_watchers"]
+elasticsearch:
+  index_mode: "time_series"

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.7.0"
+    version: "^8.8.0"
   elastic:
     subscription: basic
 icons:

--- a/packages/etcd/manifest.yml
+++ b/packages/etcd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: etcd
 title: etcd
-version: "0.7.0"
+version: "0.8.0"
 description: Collect metrics from etcd instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message


- Enable time series data streams for the metrics datasets.
- This improves storage usage and query performance.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist
- [x] Package testing
- [x] Disablement & Rollover testing

## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry

## Related issues

- Relates https://github.com/elastic/integrations/issues/8327

## Screenshots

https://github.com/elastic/integrations/pull/8438#issue-1984441530

## TSDB Testkit output

https://github.com/elastic/integrations/pull/8438#issue-1984441530
