### PR TITLE
Universal Profiling: add privileges section

### DIFF
--- a/packages/universal_profiling_agent/changelog.yml
+++ b/packages/universal_profiling_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 8.12.0
+  changes:
+    - description: Add privileges section and update to 3.0.2 format
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8651
 - version: 8.9.0
   changes:
     - description: Promote package for GA

--- a/packages/universal_profiling_agent/manifest.yml
+++ b/packages/universal_profiling_agent/manifest.yml
@@ -1,12 +1,14 @@
 name: profiler_agent
 title: Universal Profiling Agent
-version: 8.9.0
+version: 8.12.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
-  kibana.version: ^8.9.0
-  elastic.subscription: basic
-format_version: 1.1.0
+  kibana:
+    version: ^8.12.0
+  elastic:
+    subscription: basic
+format_version: 3.0.2
 icons:
   - size: 48x46
     src: /img/profiler-logo-color-48px.svg
@@ -38,6 +40,7 @@ policy_templates:
             required: true
             show_user: true
             type: text
+            secret: true
           - name: profiler.connect_proxy
             title: Connect proxy
             description: URL to proxy connections in the form of http[s]://<user>:<password>@<server name/ip>:<port>
@@ -54,6 +57,10 @@ policy_templates:
             show_user: true
             type: text
     multiple: false
+agent:
+  privileges:
+    root: true
 type: integration
 owner:
   github: elastic/profiling
+  type: elastic


### PR DESCRIPTION
## Proposed commit message

Starting with the release of 8.12 [Kibana will show the required privileges](https://github.com/elastic/kibana/pull/170478) of integrations. Universal Profiling Agent requires `root` privileges to run.

