### PR TITLE
[Enhancement] Add azure.billing filter to dashboard to improve performance

### DIFF
--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.3.1
+  changes:
+    - description: Add filter to improve performance.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8652
 - version: 1.3.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/azure_billing/kibana/dashboard/azure_billing-d3efeb30-c1c7-11ea-b7e7-0f48178cdb3c.json
+++ b/packages/azure_billing/kibana/dashboard/azure_billing-d3efeb30-c1c7-11ea-b7e7-0f48178cdb3c.json
@@ -10,7 +10,28 @@
         "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [{
+                    "meta": {
+                        "disabled": false,
+                        "negate": false,
+                        "alias": null,
+                        "key": "data_stream.dataset",
+                        "field": "data_stream.dataset",
+                        "params": {
+                            "query": "azure.billing"
+                        },
+                        "type": "phrase",
+                        "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index"
+                    },
+                    "query": {
+                        "match_phrase": {
+                            "data_stream.dataset": "azure.billing"
+                        }
+                    },
+                    "$state": {
+                        "store": "appState"
+                    }
+                }],
                 "query": {
                     "language": "kuery",
                     "query": ""

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.3.0"
+version: "1.3.1"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
Added global datastream filter to improve dashboard speed and utilization of the cluster. According to the [dashboard guideline](https://github.com/elastic/integrations/blob/43d3ba0422800bfe416bd4a1ef00b78ef2a9f9d0/docs/dashboard_guidelines.md#visualizations-should-contain-a-filter).

closes #6946 