### PR TITLE
Azure Logs - Extend storage account settings

### DIFF
--- a/packages/azure/_dev/build/docs/README.md
+++ b/packages/azure/_dev/build/docs/README.md
@@ -230,25 +230,21 @@ Select the **subscription** and the **event hub namespace** you previously creat
 
 ### Create a Storage account container
 
-The Elastic Agent stores the consumer group information (state, position, or offset) in a Storage account container. Making this information available to all agents allows them to share the logs processing and resume from the last processed logs after a restart.
+The Elastic Agent stores the consumer group information (state, position, or offset) in a storage account container. Making this information available to all agents allows them to share the logs processing and resume from the last processed logs after a restart.
 
-To create the Storage account:
+NOTE: Use the storage account as a checkpoint store only.
 
-1. Sign in to the [Azure Portal](https://portal.azure.com/).
-1. Search for and select **Storage accounts**.
-1. Under **Project details**, select a subscription and a resource group.
-1. Under **Instance details**, enter a **Storage account name**.
-1. Select **Create**.
+To create the storage account:
 
-Take note of the **Storage account name**, which you will use later when specifying the **storage_account** in the integration settings.
+1. Sign in to the [Azure Portal](https://portal.azure.com/) and create your storage account.
+1. While configuring your project details, make sure you select the following recommended default settings:
+   - Hierarchical namespace: disabled
+   - Minimum TLS version: Version 1.2
+   - Access tier: Hot
+   - Enable soft delete for blobs: disabled
+   - Enable soft delete for containers: disabled
 
-When the new Storage account is ready, you can look for the access keys:
-
-1. Select the Storage account.
-1. In **Security + networking** select **Access keys**.
-1. In the **key1** section, click on the **Show** button and copy the **Key** value.
-
-Take note of the **Key** value, which you will use later when specifying the **storage_account_key** in the integration settings.
+1. When the new storage account is ready, you need to take note of the storage account name and the storage account access keys, as you will use them later to authenticate your Elastic application’s requests to this storage account.
 
 This is the final diagram of the a setup for collecting Activity logs from the Azure Monitor service.
 

--- a/packages/azure/changelog.yml
+++ b/packages/azure/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.2"
+  changes:
+    - description: Update Azure logs documentation.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8666
 - version: "1.8.1"
   changes:
     - description: Update AD Logs documentation.

--- a/packages/azure/docs/README.md
+++ b/packages/azure/docs/README.md
@@ -230,25 +230,21 @@ Select the **subscription** and the **event hub namespace** you previously creat
 
 ### Create a Storage account container
 
-The Elastic Agent stores the consumer group information (state, position, or offset) in a Storage account container. Making this information available to all agents allows them to share the logs processing and resume from the last processed logs after a restart.
+The Elastic Agent stores the consumer group information (state, position, or offset) in a storage account container. Making this information available to all agents allows them to share the logs processing and resume from the last processed logs after a restart.
 
-To create the Storage account:
+NOTE: Use the storage account as a checkpoint store only.
 
-1. Sign in to the [Azure Portal](https://portal.azure.com/).
-1. Search for and select **Storage accounts**.
-1. Under **Project details**, select a subscription and a resource group.
-1. Under **Instance details**, enter a **Storage account name**.
-1. Select **Create**.
+To create the storage account:
 
-Take note of the **Storage account name**, which you will use later when specifying the **storage_account** in the integration settings.
+1. Sign in to the [Azure Portal](https://portal.azure.com/) and create your storage account.
+1. While configuring your project details, make sure you select the following recommended default settings:
+   - Hierarchical namespace: disabled
+   - Minimum TLS version: Version 1.2
+   - Access tier: Hot
+   - Enable soft delete for blobs: disabled
+   - Enable soft delete for containers: disabled
 
-When the new Storage account is ready, you can look for the access keys:
-
-1. Select the Storage account.
-1. In **Security + networking** select **Access keys**.
-1. In the **key1** section, click on the **Show** button and copy the **Key** value.
-
-Take note of the **Key** value, which you will use later when specifying the **storage_account_key** in the integration settings.
+1. When the new storage account is ready, you need to take note of the storage account name and the storage account access keys, as you will use them later to authenticate your Elastic application’s requests to this storage account.
 
 This is the final diagram of the a setup for collecting Activity logs from the Azure Monitor service.
 

--- a/packages/azure/manifest.yml
+++ b/packages/azure/manifest.yml
@@ -1,6 +1,6 @@
 name: azure
 title: Azure Logs
-version: 1.8.1
+version: 1.8.2
 description: This Elastic integration collects logs from Azure
 type: integration
 icons:


### PR DESCRIPTION
On the [Azure Logs](https://docs.elastic.co/integrations/azure) integration doc page, this PR:
- Updates the storage account requirements 
- Simplifies the setup procedure

This doc fix impacts the following Azure doc pages as well:
├── activitylogs
├── application_gateway
├── auditlogs
├── eventhub
├── firewall_logs
├── identity_protection
├── platformlogs
├── provisioning
├── signinlogs
└── springcloudlogs

Closes https://github.com/elastic/integrations/issues/7586

Doc preview:
![image](https://github.com/elastic/integrations/assets/46651782/b5309591-24d9-49b6-b74d-e94f1d5649b2)

