### PR TITLE
[azure_metrics] Enable tsds on all remaining datastreams

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Enable time series data streams for all metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8520
+      link: https://github.com/elastic/integrations/pull/8680
 - version: "1.3.0"
   changes:
     - description: Allow rerouting of Azure metrics events to a different data stream.

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.0"
+  changes:
+    - description: Enable time series data streams for all metrics dataset. This dramatically reduces storage for metrics and is expected to progressively improve query [performance](https://www.elastic.co/blog/70-percent-storage-savings-for-metrics-with-elastic-observability). For more details, see https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8520
 - version: "1.3.0"
   changes:
     - description: Allow rerouting of Azure metrics events to a different data stream.

--- a/packages/azure_metrics/data_stream/compute_vm/manifest.yml
+++ b/packages/azure_metrics/data_stream/compute_vm/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Compute VM
     description: Collect Compute VM metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/compute_vm_scaleset/manifest.yml
+++ b/packages/azure_metrics/data_stream/compute_vm_scaleset/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Compute VM Scaleset
     description: Collect Compute VM Scaleset metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/container_instance/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_instance/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Container Instance
     description: Collect Container Instance metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/container_registry/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_registry/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Container Registry
     description: Collect Container Registry metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/container_service/manifest.yml
+++ b/packages/azure_metrics/data_stream/container_service/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Container Service
     description: Collect Container Service metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/database_account/manifest.yml
+++ b/packages/azure_metrics/data_stream/database_account/manifest.yml
@@ -26,7 +26,8 @@ streams:
         show_user: true
     title: Database Account
     description: Collect Database Account metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/data_stream/monitor/manifest.yml
+++ b/packages/azure_metrics/data_stream/monitor/manifest.yml
@@ -24,7 +24,8 @@ streams:
               namespace: "Microsoft.DocumentDb/databaseAccounts"
     title: Monitor
     description: Collect Monitor metrics
-# Ensures agents have permissions to write data to `metrics-*-*`
 elasticsearch:
+  index_mode: "time_series"
+  # Ensures agents have permissions to write data to `metrics-*-*`
   dynamic_dataset: true
   dynamic_namespace: true

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.3.0
+version: 1.4.0
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
@@ -20,7 +20,7 @@ categories:
   - observability
   - azure
 conditions:
-  kibana.version: "^8.10.2"
+  kibana.version: "^8.11.2"
 vars:
   - name: client_id
     type: text


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Enable tsds on all remaining datastreams

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

Tested with `TSDB-migration-test-kit`
1. install integration version `1.3.0` - gather some data
2. upgrade integration to `1.4.0`.
3. to run `TSDB-migration-test-kit` set settings:
```
"docs_index": 0,   ## an index 000001 (tsds not enabled yet)
"settings_mappings_index": 1,  ## use settings from the index `000002` (tsds enabled)
```

## Related issues

- Closes https://github.com/elastic/integrations/issues/7140

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
