### PR TITLE
Add disk io metrics to fields.yml

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.51.0"
+  changes:
+    - description: Add fields for IO metrics in system/process
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8621
 - version: "1.50.0"
   changes:
     - description: Fix the message parsing failure in syslog datastream.

--- a/packages/system/data_stream/process/fields/fields.yml
+++ b/packages/system/data_stream/process/fields/fields.yml
@@ -97,6 +97,30 @@
           metric_type: gauge
           description: |
             The hard limit on the number of file descriptors opened by the process. The hard limit can only be raised by root.
+    - name: io
+      type: group
+      fields:
+        - name: cancelled_write_bytes
+          type: long
+          description: The number of bytes this process cancelled, or caused not to be written.
+        - name: read_bytes
+          type: long
+          description: The number of bytes fetched from the storage layer.
+        - name: write_bytes
+          type: long
+          description: The number of bytes written to the storage layer.
+        - name: read_char
+          type: long
+          description: The number of bytes read from read(2) and similar syscalls.
+        - name: write_char
+          type: long
+          description: The number of bytes sent to syscalls for writing.
+        - name: read_ops
+          type: long
+          description: The count of read-related syscalls.
+        - name: write_ops
+          type: long
+          description: The count of write-related syscalls.
     - name: cgroup
       type: group
       fields:

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: system
 title: System
-version: 1.50.0
+version: 1.51.0
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Adds disk IO metrics to fields.yml, as these fields are now in metricbeat.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
