### PR TITLE
Update schedule daily version to 8.12-SNAPSHOT

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -27,14 +27,14 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version v8.12.0"
+  - label: "Check integrations local stacks - Stack Version v8.12"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 8.12.0-SNAPSHOT
+        STACK_VERSION: 8.12-SNAPSHOT
     depends_on:
       - step: "check"
         allow_failure: false

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -36,12 +36,12 @@ pipeline {
             )
           }
         }
-        stage('with stack v8.12.0') {
+        stage('with stack v8.12') {
           steps {
             build(
               job: env.INTEGRATION_JOB,
               parameters: [
-                stringParam(name: 'stackVersion', value: '8.12.0-SNAPSHOT'),
+                stringParam(name: 'stackVersion', value: '8.12-SNAPSHOT'),
                 booleanParam(name: 'force_check_all', value: true),
                 booleanParam(name: 'skip_publishing', value: true),
               ],


### PR DESCRIPTION
## Proposed commit message

Update version used in schedule daily jobs to be 8.12-SNAPSHOT.

Tested locally with:
```shell
elastic-package stack up -v -d --version 8.12-SNAPSHOT
```


## Related issues

- Relates #8471 
- Relates #8560
