### PR TITLE
[Apache Tomcat]: Improve wording on milliseconds

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Improve wording on milliseconds in apache_tomcat time field 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8701
 - version: "1.1.0"
   changes:
     - description: Improve apache_tomcat.access pipeline performance

--- a/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
@@ -164,7 +164,7 @@
                   fields:
                     - name: ms
                       type: double
-                      description: The number of milliseconds to sleep between runs of the idle connection validation/cleaner thread.
+                      description: The total amount of time in milliseconds to sleep between runs of the idle connection validation/cleaner thread.
                       unit: ms
                       metric_type: gauge
             - name: validate

--- a/packages/apache_tomcat/docs/README.md
+++ b/packages/apache_tomcat/docs/README.md
@@ -838,7 +838,7 @@ An example event for `connection_pool` looks as following:
 | apache_tomcat.connection_pool.connection.rollback_on_return | The pool can terminate the transaction by calling rollback on the connection. | boolean |  |  |
 | apache_tomcat.connection_pool.connection.test_on_return | The indication of whether objects will be validated before being returned to the pool. | boolean |  |  |
 | apache_tomcat.connection_pool.connection.test_while_idle | Introspected attribute testWhileIdle. | boolean |  |  |
-| apache_tomcat.connection_pool.connection.time_betwen_eviction_run.time.ms | The number of milliseconds to sleep between runs of the idle connection validation/cleaner thread. | double | ms | gauge |
+| apache_tomcat.connection_pool.connection.time_betwen_eviction_run.time.ms | The total amount of time in milliseconds to sleep between runs of the idle connection validation/cleaner thread. | double | ms | gauge |
 | apache_tomcat.connection_pool.connection.validate | Validate connections from this pool. | double |  | gauge |
 | apache_tomcat.connection_pool.lifo | Last In First Out connections. | boolean |  |  |
 | apache_tomcat.connection_pool.max.total | Maximum total of connection pool. | double |  | gauge |

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.1.0"
+version: "1.1.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
This PR proposes a better wording for the field `ms`.
Relates [#123](https://github.com/elastic/integrations/issues/7950)
