### PR TITLE
[Auth0]: Improve wording on milliseconds

### DIFF
--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 1.14.1
   changes:
-    - description: Fix wording on elapsed time in milliseconds.
+    - description: Improve wording on elapsed time in milliseconds.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8702
 - version: 1.14.0

--- a/packages/auth0/changelog.yml
+++ b/packages/auth0/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.14.1
+  changes:
+    - description: Fix wording on elapsed time in milliseconds.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8702
 - version: 1.14.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/auth0/data_stream/logs/fields/fields.yml
+++ b/packages/auth0/data_stream/logs/fields/fields.yml
@@ -82,7 +82,7 @@
                   description: Time at which the operation was completed
                 - name: elapsedTime
                   type: long
-                  description: Number of milliseconds the operation took to complete.
+                  description: The total amount of time in milliseconds the operation took to complete.
                 - name: stats
                   type: group
                   description: login stats

--- a/packages/auth0/docs/README.md
+++ b/packages/auth0/docs/README.md
@@ -73,7 +73,7 @@ The Auth0 logs dataset provides events from Auth0 log stream. All Auth0 log even
 | auth0.logs.data.location_info.time_zone | Time zone name as found in the [tz database](https://www.iana.org/time-zones). | keyword |
 | auth0.logs.data.log_id | Unique log event identifier | keyword |
 | auth0.logs.data.login.completedAt | Time at which the operation was completed | date |
-| auth0.logs.data.login.elapsedTime | Number of milliseconds the operation took to complete. | long |
+| auth0.logs.data.login.elapsedTime | The total amount of time in milliseconds the operation took to complete. | long |
 | auth0.logs.data.login.initiatedAt | Time at which the operation was initiated | date |
 | auth0.logs.data.login.stats.loginsCount | Total number of logins performed by the user | long |
 | auth0.logs.data.scope | Scope permissions applied to the event. | keyword |

--- a/packages/auth0/manifest.yml
+++ b/packages/auth0/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: auth0
 title: "Auth0"
-version: "1.14.0"
+version: "1.14.1"
 description: Collect logs from Auth0 with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR proposes a better wording for the field `elapsedTime`.
Relates [#123](https://github.com/elastic/integrations/issues/7950)