### PR TITLE
[MongoDB]: Improve wording on milliseconds

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,6 +1,6 @@
 - version: 1.12.2
   changes:
-    - description: Fix wording on milliseconds.
+    - description: Improve wording on milliseconds.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8704
 - version: 1.12.1

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.12.2
+  changes:
+    - description: Fix wording on milliseconds.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8704
 - version: 1.12.1
   changes:
     - description: Add null and ignore_missing check to handle event.original field.

--- a/packages/mongodb/data_stream/status/fields/fields.yml
+++ b/packages/mongodb/data_stream/status/fields/fields.yml
@@ -650,7 +650,7 @@
           type: long
           metric_type: gauge
           description: |
-            The total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value of `flushes` and `average_ms` to provide better context for this datum.
+            The total amount of time in milliseconds that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value of `flushes` and `average_ms` to provide better context for this datum.
         - name: average.ms
           type: long
           metric_type: gauge

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -1571,7 +1571,7 @@ The fields reported are:
 | mongodb.status.background_flushing.flushes | A counter that collects the number of times the database has flushed all writes to disk. | long | counter |
 | mongodb.status.background_flushing.last.ms | The amount of time, in milliseconds, that the last flush operation took to complete. | long | gauge |
 | mongodb.status.background_flushing.last_finished | A timestamp of the last completed flush operation. | date |  |
-| mongodb.status.background_flushing.total.ms | The total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value of `flushes` and `average_ms` to provide better context for this datum. | long | gauge |
+| mongodb.status.background_flushing.total.ms | The total amount of time in milliseconds that the mongod processes have spent writing (i.e. flushing) data to disk. Because this is an absolute value, consider the value of `flushes` and `average_ms` to provide better context for this datum. | long | gauge |
 | mongodb.status.connections.available | The number of unused available incoming connections the database can provide. | long | gauge |
 | mongodb.status.connections.current | The number of connections to the database server from clients. This number includes the current shell session. Consider the value of `available` to add more context to this datum. | long | gauge |
 | mongodb.status.connections.total_created | A count of all incoming connections created to the server. This number includes connections that have since closed. | long | counter |

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.12.1"
+version: "1.12.2"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR proposes a better wording for the field `total.ms`.
Relates [#123](https://github.com/elastic/integrations/issues/7950)