### PR TITLE
[PostgreSQL]: Improve wording on milliseconds

### DIFF
--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Fix wording on milliseconds.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8705
 - version: "1.17.1"
   changes:
     - description: Replaced `postgresql.activity.query` with `postgresql.activity.query_id` as TSDS dimension field to support query length greater than 1024.

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.17.2"
   changes:
-    - description: Fix wording on milliseconds.
+    - description: Improve wording on milliseconds.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8705
 - version: "1.17.1"

--- a/packages/postgresql/data_stream/statement/fields/fields.yml
+++ b/packages/postgresql/data_stream/statement/fields/fields.yml
@@ -37,22 +37,22 @@
       type: float
       metric_type: gauge
       description: |
-        Total number of milliseconds spent running query.
+        The total amount of time in milliseconds spent running query.
     - name: query.time.min.ms
       type: float
       metric_type: gauge
       description: |
-        Minimum number of milliseconds spent running query.
+        Minimum amount of time in milliseconds spent running query.
     - name: query.time.max.ms
       type: float
       metric_type: gauge
       description: |
-        Maximum number of milliseconds spent running query.
+        Maximum amount of time in milliseconds spent running query.
     - name: query.time.mean.ms
       type: long
       metric_type: gauge
       description: |
-        Mean number of milliseconds spent running query.
+        Mean amount of time in milliseconds spent running query.
     - name: query.time.stddev.ms
       type: long
       metric_type: gauge

--- a/packages/postgresql/docs/README.md
+++ b/packages/postgresql/docs/README.md
@@ -808,11 +808,11 @@ An example event for `statement` looks as following:
 | postgresql.statement.query.memory.temp.written | Total number of temp block cache written by the query. | long | counter |
 | postgresql.statement.query.rows | Total number of rows returned by query. | long | counter |
 | postgresql.statement.query.text | Query text | keyword |  |
-| postgresql.statement.query.time.max.ms | Maximum number of milliseconds spent running query. | float | gauge |
-| postgresql.statement.query.time.mean.ms | Mean number of milliseconds spent running query. | long | gauge |
-| postgresql.statement.query.time.min.ms | Minimum number of milliseconds spent running query. | float | gauge |
+| postgresql.statement.query.time.max.ms | Maximum amount of time in milliseconds spent running query. | float | gauge |
+| postgresql.statement.query.time.mean.ms | Mean amount of time in milliseconds spent running query. | long | gauge |
+| postgresql.statement.query.time.min.ms | Minimum amount of time in milliseconds spent running query. | float | gauge |
 | postgresql.statement.query.time.stddev.ms | Population standard deviation of time spent running query, in milliseconds. | long | gauge |
-| postgresql.statement.query.time.total.ms | Total number of milliseconds spent running query. | float | gauge |
+| postgresql.statement.query.time.total.ms | The total amount of time in milliseconds spent running query. | float | gauge |
 | postgresql.statement.user.id | OID of the user logged into the backend that ran the query. | long |  |
 | service.address | Address where data about this service was collected from. This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets). | keyword |  |
 | service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: postgresql
 title: PostgreSQL
-version: "1.17.1"
+version: "1.17.2"
 description: Collect logs and metrics from PostgreSQL servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR proposes a better wording for the fields `query.time.total.ms`, `query.time.min.ms`, `query.time.max.ms`, and `query.time.mean.ms`.

Relates [#123](https://github.com/elastic/integrations/issues/7950)
