### PR TITLE
[System]: Improve wording on milliseconds

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.50.1"
   changes:
-    - description: Fix the wording on milliseconds.
+    - description: Improve the wording on milliseconds.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8706
 - version: "1.50.0"

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.50.1"
+  changes:
+    - description: Fix the wording on milliseconds.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8706
 - version: "1.50.0"
   changes:
     - description: Fix the message parsing failure in syslog datastream.

--- a/packages/system/data_stream/diskio/fields/fields.yml
+++ b/packages/system/data_stream/diskio/fields/fields.yml
@@ -36,14 +36,14 @@
       type: long
       metric_type: counter
       description: |
-        The total number of milliseconds spent by all reads.
+        The total amount of time in milliseconds spent by all reads.
     - name: write.time
       type: long
       metric_type: counter
       description: |
-        The total number of milliseconds spent by all writes.
+        The total amount of time in milliseconds spent by all writes.
     - name: io.time
       type: long
       metric_type: counter
       description: |
-        The total number of of milliseconds spent doing I/Os.
+        The total amount of time in milliseconds spent doing I/Os.

--- a/packages/system/docs/README.md
+++ b/packages/system/docs/README.md
@@ -1413,15 +1413,15 @@ This data should be available without elevated permissions.
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
-| system.diskio.io.time | The total number of of milliseconds spent doing I/Os. | long |  | counter |
+| system.diskio.io.time | The total amount of time in milliseconds spent doing I/Os. | long |  | counter |
 | system.diskio.name | The disk name. | keyword |  |  |
 | system.diskio.read.bytes | The total number of bytes read successfully. On Linux this is the number of sectors read multiplied by an assumed sector size of 512. | long | byte | counter |
 | system.diskio.read.count | The total number of reads completed successfully. | long |  | counter |
-| system.diskio.read.time | The total number of milliseconds spent by all reads. | long |  | counter |
+| system.diskio.read.time | The total amount of time in milliseconds spent by all reads. | long |  | counter |
 | system.diskio.serial_number | The disk's serial number. This may not be provided by all operating systems. | keyword |  |  |
 | system.diskio.write.bytes | The total number of bytes written successfully. On Linux this is the number of sectors written multiplied by an assumed sector size of 512. | long | byte | counter |
 | system.diskio.write.count | The total number of writes completed successfully. | long |  | counter |
-| system.diskio.write.time | The total number of milliseconds spent by all writes. | long |  | counter |
+| system.diskio.write.time | The total amount of time in milliseconds spent by all writes. | long |  | counter |
 
 
 ### Filesystem

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: system
 title: System
-version: 1.50.0
+version: 1.50.1
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This PR proposes a better wording for the fields `read.time`, `write.time`, and `io.time`.

Relates [#123](https://github.com/elastic/integrations/issues/7950)

