### PR TITLE
[apache_tomcat] Improve access pipeline performance by split grok and switch to dissect

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Improve apache_tomcat.access pipeline performance
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8718
 - version: "1.1.1"
   changes:
     - description: Improve wording on milliseconds in apache_tomcat time field 

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Improve apache_tomcat.access pipeline performance
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8718
+      link: https://github.com/elastic/integrations/pull/8723
 - version: "1.1.1"
   changes:
     - description: Improve wording on milliseconds in apache_tomcat time field 

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -52,10 +52,11 @@ processors:
       field: _tmp.grok
       tag: 'grok_parse_log2'
       patterns:
-        - '^([0-9] )*\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
+        - '^([0-9] )*"%{DATA:http.request.referrer}" "%{DATA_NOQUOTE:user_agent.original}(")*$'
       pattern_definitions:
-        CONN_STATUS: "[X+-]"
+        DATA_NOQUOTE: '[^"]*'
       ignore_missing: true
+      ignore_failure: true
       if: ctx._tmp?.grok != null
       on_failure:
         - append:
@@ -69,7 +70,7 @@ processors:
       pattern_definitions:
         CONN_STATUS: "[X+-]"
       ignore_missing: true
-      if: ctx._tmp?.grok != null && ctx.http?.request?.referrer != null
+      if: ctx._tmp?.grok != null && ctx.http?.request?.referrer == null
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
   - dissect:
       field: event.original
       tag: 'dissect_event_original'
-      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \"%{http.request.method} %{url.original} HTTP/%{http.version}\" %{_tmp.dissectgrok}'
+      pattern: "%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \\\"%{http.request.method} %{url.original} HTTP/%{http.version}\\\" %{_tmp.dissectgrok}"
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
   - dissect:
       field: event.original
       tag: 'dissect_event_original'
-      pattern: "%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \\\"%{http.request.method} %{url.original} HTTP/%{http.version}\\\" %{_tmp.dissectgrok}"
+      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] "%{http.request.method} %{url.original} HTTP/%{http.version}" %{_tmp.dissectgrok}''
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
   - dissect:
       field: event.original
       tag: 'dissect_event_original'
-      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] "%{http.request.method} %{url.original} HTTP/%{http.version}" %{_tmp.dissectgrok}''
+      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] "%{http.request.method} %{url.original} HTTP/%{http.version}" %{_tmp.dissectgrok}'
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -21,24 +21,55 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: 'ctx.event?.original == null'
-  - grok:
+  - dissect:
       field: event.original
-      tag: 'grok_parse_log'
+      tag: 'dissect_event_original'
+      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \"%{http.request.method} %{url.original} HTTP/%{http.version}\" %{_tmp.dissectgrok}'  
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - grok:
+      field: _tmp.sourceorusername
+      tag: 'grok_parse_log_sourceoruser'
       patterns:
-        - '^(%{IP:source.ip}|%{DATA:source.user.name}) %{DATA:apache_tomcat.access.http.ident} %{DATA:apache_tomcat.access.http.useragent} \[%{DATA:_tmp.timestamp}\] \"%{DATA:http.request.method} %{DATA:url.original} HTTP\/%{DATA:http.version}\" %{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp.grok})?$'
+        - '^(%{IP:source.ip}|%{DATA:source.user.name})$'
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+  - grok:
+      field: _tmp.dissectgrok
+      tag: 'grok_parse_log_dissectgrok'
+      patterns:
+        - '^%{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp.grok})?$'
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+
+  - grok:
+      field: _tmp.grok
+      tag: 'grok_parse_log2'
+      patterns:
+        - '^([0-9] )*\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
+      pattern_definitions:
+        CONN_STATUS: "[X+-]"
+      ignore_missing: true
+      if: ctx._tmp?.grok != null
       on_failure:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
   - grok:
       field: _tmp.grok
-      tag: 'grok_parse_log2'
+      tag: 'grok_parse_log3'
       patterns:
         - '(?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
-        - '\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
       pattern_definitions:
         CONN_STATUS: "[X+-]"
       ignore_missing: true
+      if: ctx._tmp?.grok != null && ctx.http?.request?.referrer != null
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -47,30 +47,15 @@ processors:
         - append:
             field: error.message
             value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-
   - grok:
       field: _tmp.grok
       tag: 'grok_parse_log2'
       patterns:
-        - '^([0-9] )*"%{DATA:http.request.referrer}" "%{DATA_NOQUOTE:user_agent.original}(")*$'
-      pattern_definitions:
-        DATA_NOQUOTE: '[^"]*'
-      ignore_missing: true
-      ignore_failure: true
-      if: ctx._tmp?.grok != null
-      on_failure:
-        - append:
-            field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
-  - grok:
-      field: _tmp.grok
-      tag: 'grok_parse_log3'
-      patterns:
         - '(?:%{IP:apache_tomcat.access.ip.local}%{SPACE})?(?:%{CONN_STATUS:apache_tomcat.access.connection_status}%{SPACE})?(?:%{NUMBER:apache_tomcat.access.response_time}%{SPACE})?\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}\" X-Forwarded-For=\"%{DATA:_tmp.header_forwarder}(\")*$'
+        - '\"%{DATA:http.request.referrer}\" \"%{DATA:user_agent.original}(\")*$'
       pattern_definitions:
         CONN_STATUS: "[X+-]"
       ignore_missing: true
-      if: ctx._tmp?.grok != null && ctx.http?.request?.referrer == null
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -24,7 +24,7 @@ processors:
   - dissect:
       field: event.original
       tag: 'dissect_event_original'
-      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \"%{http.request.method} %{url.original} HTTP/%{http.version}\" %{_tmp.dissectgrok}'  
+      pattern: '%{_tmp.sourceorusername} %{apache_tomcat.access.http.ident} %{apache_tomcat.access.http.useragent} [%{_tmp.timestamp}] \"%{http.request.method} %{url.original} HTTP/%{http.version}\" %{_tmp.dissectgrok}'
       on_failure:
         - append:
             field: error.message

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.1.1"
+version: "1.2.0"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
Restructuring apache_tomcat.access ingest pipeline to use dissect as first step and split grok into multiple processors to improve perfomance.
On test-env the ingest performance was more den doubled, from ~0.899ms per Document (average) to ~0.253ms per Document (average)

![image](https://github.com/elastic/integrations/assets/145989254/13ee34a6-56a7-4cd9-9fa9-54e7cce0b671)
