### PR TITLE
Cisco ISE fixes for monitoring data purge and additional example for alarm

### DIFF
--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Fix for alarm events with custom grok pattern
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8739
+    - description: Added support for Monitoring data purge audit events
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8739
 - version: "1.21.1"
   changes:
     - description: Fix exclude_files pattern.

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log
@@ -21,3 +21,4 @@
 <178>Sep 26 02:15:47 abcdefghihklm002 CISE_Alarm WARN: Profiler SNMP Request Failure : Server= abcdefghihklm003; NAD Address=10.111.11.111; Error Message=Request timed out.
 <179>Sep 26 02:15:47 abcdefghihklm002 CISE_Alarm INFO: EAP Connection Timeout : Server=aaaaaaaa05nm001; NAS IP Address=216.160.83.56; NAS Identifier=N/A
 <178>Sep 24 16:03:27 abcdefghihklm002 CISE_Alarm WARN: Dynamic Authorization Failed for Device : Server=safsfasdsacdefg001; Calling Station Id=C0:25:AA:AA:AA:CA; Network device IP=89.160.20.128; Network Device Name=AAAA-1111-1; Failure Reason=11213 No response received from Network Access Device after sending a Dynamic Authorization request
+<182>Dec 11 10:13:45 abcdefghihklm002 CISE_Alarm INFO: Satellite Authorization Renewal success

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log-expected.json
@@ -1042,6 +1042,41 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-12-11T10:13:45.000Z",
+            "cisco_ise": {
+                "log": {
+                    "category": {
+                        "name": "CISE_Alarm"
+                    },
+                    "log_severity_level": "INFO"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "original": "<182>Dec 11 10:13:45 abcdefghihklm002 CISE_Alarm INFO: Satellite Authorization Renewal success\""
+            },
+            "host": {
+                "hostname": "abcdefghihklm002"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 182
+                }
+            },
+            "message": "Satellite Authorization Renewal success\"",
+            "related": {
+                "hosts": [
+                    "abcdefghihklm002"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-cise-alarm.log-expected.json
@@ -1058,7 +1058,7 @@
             },
             "event": {
                 "kind": "event",
-                "original": "<182>Dec 11 10:13:45 abcdefghihklm002 CISE_Alarm INFO: Satellite Authorization Renewal success\""
+                "original": "<182>Dec 11 10:13:45 abcdefghihklm002 CISE_Alarm INFO: Satellite Authorization Renewal success"
             },
             "host": {
                 "hostname": "abcdefghihklm002"
@@ -1068,7 +1068,7 @@
                     "priority": 182
                 }
             },
-            "message": "Satellite Authorization Renewal success\"",
+            "message": "Satellite Authorization Renewal success",
             "related": {
                 "hosts": [
                     "abcdefghihklm002"

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log
@@ -1,0 +1,1 @@
+<182>Dec 12 05:11:05 cisco-ise-host CISE_MONITORING_DATA_PURGE_AUDIT 2023-12-12 04:16:26.526 +0100 60198 INFO null: MnT purge event occurred, MESSAGE=Total Data threshold_space = 265 GB, used_space = 5 GB

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log-expected.json
@@ -38,7 +38,10 @@
             "log": {
                 "level": "info",
                 "syslog": {
-                    "priority": 182
+                    "priority": 182,
+                    "severity": {
+                        "name": "info"
+                    }
                 }
             },
             "message": "2023-12-12 04:16:26.526 +0100 60198 INFO null: MnT purge event occurred, MESSAGE=Total Data threshold_space = 265 GB, used_space = 5 GB",

--- a/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log-expected.json
+++ b/packages/cisco_ise/data_stream/log/_dev/test/pipeline/test-pipeline-monitoring-data-purge-audit.log-expected.json
@@ -1,0 +1,55 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2023-12-12T04:16:26.526+01:00",
+            "cisco_ise": {
+                "log": {
+                    "category": {
+                        "name": "CISE_MONITORING_DATA_PURGE_AUDIT"
+                    },
+                    "log_details": {
+                        "threshold_space": "265 GB"
+                    },
+                    "message": {
+                        "code": "60198",
+                        "description": "null: MnT purge event occurred"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "data_purge",
+                "category": [
+                    "process"
+                ],
+                "code": "60198",
+                "kind": "event",
+                "original": "<182>Dec 12 05:11:05 cisco-ise-host CISE_MONITORING_DATA_PURGE_AUDIT 2023-12-12 04:16:26.526 +0100 60198 INFO null: MnT purge event occurred, MESSAGE=Total Data threshold_space = 265 GB, used_space = 5 GB",
+                "timezone": "+0100",
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "cisco-ise-host"
+            },
+            "log": {
+                "level": "info",
+                "syslog": {
+                    "priority": 182
+                }
+            },
+            "message": "2023-12-12 04:16:26.526 +0100 60198 INFO null: MnT purge event occurred, MESSAGE=Total Data threshold_space = 265 GB, used_space = 5 GB",
+            "related": {
+                "hosts": [
+                    "cisco-ise-host"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -30,9 +30,18 @@ processors:
       pattern_definitions:
         NOTCOLON: '[^:]*?'
       on_failure:
-        - append:
-            field: error.message
-            value: '{{{ _ingest.on_failure_processor_tag }}}: {{{_ingest.on_failure_message}}}'
+        - grok:
+            description: "Events like: 'INFO: Satellite Authorization Renewal success'"
+            field: _tmp.message
+            tag: grok_message_details_fallback
+            if: ctx._tmp?.message != null
+            patterns:
+                - '^%{WORD:cisco_ise.log.log_severity_level}: %{GREEDYDATA:message}'
+                - '^%{GREEDYDATA:message}'
+            on_failure:
+                - append:
+                    field: error.message
+                    value: '{{{ _ingest.on_failure_processor_tag }}}: {{{_ingest.on_failure_message}}}'
   - trim:
       field: message
       ignore_failure: true
@@ -141,6 +150,9 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_alarm" }}'
       if: ctx.cisco_ise?.log?.category?.name == "CISE_Alarm"
+  - pipeline:
+      name: '{{ IngestPipeline "pipeline_monitoring_data_purge_audit" }}'
+      if: ctx.cisco_ise?.log?.category?.name == "CISE_MONITORING_DATA_PURGE_AUDIT"
   - set:
       field: host.ip
       value: ['{{{host.ip}}}']

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_alarm.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_alarm.yml
@@ -1,146 +1,147 @@
 ---
 processors:
-  - set:
-      field: event.kind
-      value: event
-
-  - kv:
-      tag: kv_alarm_message_details
-      field: message
-      target_field: cisco_ise.log.log_details_raw
-      field_split: '; '
-      value_split: '='
-      trim_key: ' '
-      trim_value: ' '
-      ignore_failure: true
-      if: ctx.message != null
-  - script:
-      tag: scrip_alarm_message_clean_spaces
-      lang: painless
-      if: ctx.cisco_ise?.log?.log_details_raw != null
-      source: |-
+- set:
+    field: event.kind
+    value: event
+- kv:
+    tag: kv_alarm_message_details
+    field: message
+    target_field: cisco_ise.log.log_details_raw
+    field_split: '; '
+    value_split: '='
+    trim_key: ' '
+    trim_value: ' '
+    ignore_failure: true
+    if: ctx.message != null
+- script:
+    tag: scrip_alarm_message_clean_spaces
+    lang: painless
+    if: ctx.cisco_ise?.log?.log_details_raw != null
+    source: |-
         def c = [:];
         ctx.cisco_ise.log.log_details_raw.forEach((k, v) -> c[k.replace(' ', '_').toLowerCase()] = v);
         ctx.cisco_ise.log.log_details_raw = c;
-
-  - dissect:
-      field: cisco_ise.log.log_details_raw.message
-      tag: dissect_alarm_queue_link_error_host_details
-      if: ctx.cisco_ise?.log?.log_details_raw?.message != null && ctx.event?.action == "Queue Link Error"
-      pattern: 'From %{source.address} To %{destination.address}'
-      on_failure:
-        - append:
-            field: error.message
-            value: '{{{ _ingest.on_failure_processor_tag }}}: {{{_ingest.on_failure_message}}} with "{{{message}}}"'
-  - rename:
-      tag: dissect_alarm_queue_link_error_host_cause
-      field: cisco_ise.log.log_details_raw.cause
-      target_field: cisco_ise.log.cause
-      ignore_failure: true
-
-  - rename:
-      field: cisco_ise.log.log_details_raw.server
-      target_field: server.address
-      ignore_failure: true
-      ignore_missing: true
-  - convert:
-      field: cisco_ise.log.log_details_raw.nad_address
-      type: ip
-      target_field: _tmp.nad_ip
-      ignore_failure: true
-      ignore_missing: true
+- dissect:
+    field: cisco_ise.log.log_details_raw.message
+    tag: dissect_alarm_queue_link_error_host_details
+    if: ctx.cisco_ise?.log?.log_details_raw?.message != null && ctx.event?.action == "Queue Link Error"
+    pattern: 'From %{source.address} To %{destination.address}'
+    on_failure:
+    - append:
+        field: error.message
+        value: '{{{ _ingest.on_failure_processor_tag }}}: {{{_ingest.on_failure_message}}} with "{{{message}}}"'
+- rename:
+    tag: dissect_alarm_queue_link_error_host_cause
+    field: cisco_ise.log.log_details_raw.cause
+    target_field: cisco_ise.log.cause
+    ignore_failure: true
+- rename:
+    field: cisco_ise.log.log_details_raw.server
+    target_field: server.address
+    ignore_failure: true
+    ignore_missing: true
+- convert:
+    field: cisco_ise.log.log_details_raw.nad_address
+    type: ip
+    target_field: _tmp.nad_ip
+    ignore_failure: true
+    ignore_missing: true
+- append:
+    field: related.ip
+    value: '{{{_tmp.nad_ip}}}'
+    allow_duplicates: false
+    if: ctx._tmp?.nad_ip != null
+- rename:
+    tag: dissect_alarm_profiler_snmp_request_failure_cause
+    field: cisco_ise.log.log_details_raw.error_message
+    target_field: cisco_ise.log.error_message
+    ignore_failure: true
+- append:
+    field: related.hosts
+    value: '{{{source.address}}}'
+    allow_duplicates: false
+    if: ctx.source?.address != null && ctx.source.address != ''
+- append:
+    field: related.hosts
+    value: '{{{destination.address}}}'
+    allow_duplicates: false
+    if: ctx.destination?.address != null && ctx.destination.address != ''
+- append:
+    field: related.hosts
+    value: '{{{server.address}}}'
+    allow_duplicates: false
+    if: ctx.server?.address != null && ctx.server.address != ''
+- rename:
+    field: cisco_ise.log.log_details_raw.nas_ip_address
+    target_field: cisco_ise.log.nas_ip_address
+    ignore_failure: true
+    ignore_missing: true
+- convert:
+    field: cisco_ise.log.nas_ip_address
+    type: ip
+    target_field: _tmp.nas_ip
+    ignore_failure: true
+    ignore_missing: true
+- append:
+    field: related.ip
+    value: '{{{_tmp.nas_ip}}}'
+    allow_duplicates: false
+    if: ctx._tmp?.nas_ip != null
+- rename:
+    field: cisco_ise.log.log_details_raw.nas_identifier
+    target_field: cisco_ise.log.nas_identifier
+    ignore_failure: true
+    ignore_missing: true
+- rename:
+    field: cisco_ise.log.log_details_raw.failure_reason
+    target_field: cisco_ise.log.failure_reason
+    ignore_failure: true
+    ignore_missing: true
+- rename:
+    field: cisco_ise.log.log_details_raw.network_device_name
+    target_field: cisco_ise.log.network_device_name
+    ignore_failure: true
+    ignore_missing: true
+- rename:
+    field: cisco_ise.log.log_details_raw.calling_station_id
+    target_field: cisco_ise.log.calling_station_id
+    ignore_failure: true
+    ignore_missing: true
+- gsub:
+    field: cisco_ise.log.calling_station_id
+    pattern: '[-:.]'
+    replacement: '-'
+    ignore_failure: true
+    ignore_missing: true
+- uppercase:
+    field: cisco_ise.log.calling_station_id
+    ignore_failure: true
+    ignore_missing: true
+- append:
+    field: server.mac
+    value: '{{{cisco_ise.log.calling_station_id}}}'
+    allow_duplicates: false
+    if: ctx.cisco_ise?.log?.calling_station_id != null
+- convert:
+    field: cisco_ise.log.log_details_raw.network_device_ip
+    type: ip
+    target_field: _tmp.dev_ip
+    ignore_failure: true
+    ignore_missing: true
+- rename:
+    field: _tmp.dev_ip
+    target_field: cisco_ise.log.network_device_ip
+    ignore_failure: true
+    ignore_missing: true
+- append:
+    field: related.ip
+    value: '{{{cisco_ise.log.network_device_ip}}}'
+    allow_duplicates: false
+    if: ctx.cisco_ise?.log?.network_device_ip != null
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
   - append:
-      field: related.ip
-      value: '{{{_tmp.nad_ip}}}'
-      allow_duplicates: false
-      if: ctx._tmp?.nad_ip != null
-  - rename:
-      tag: dissect_alarm_profiler_snmp_request_failure_cause
-      field: cisco_ise.log.log_details_raw.error_message
-      target_field: cisco_ise.log.error_message
-      ignore_failure: true
-
-  - append:
-      field: related.hosts
-      value: '{{{source.address}}}'
-      allow_duplicates: false
-      if: ctx.source?.address != null && ctx.source.address != ''
-  - append:
-      field: related.hosts
-      value: '{{{destination.address}}}'
-      allow_duplicates: false
-      if: ctx.destination?.address != null && ctx.destination.address != ''
-  - append:
-      field: related.hosts
-      value: '{{{server.address}}}'
-      allow_duplicates: false
-      if: ctx.server?.address != null && ctx.server.address != ''
-
-  - rename:
-      field: cisco_ise.log.log_details_raw.nas_ip_address
-      target_field: cisco_ise.log.nas_ip_address
-      ignore_failure: true
-      ignore_missing: true
-  - convert:
-      field: cisco_ise.log.nas_ip_address
-      type: ip
-      target_field: _tmp.nas_ip
-      ignore_failure: true
-      ignore_missing: true
-  - append:
-      field: related.ip
-      value: '{{{_tmp.nas_ip}}}'
-      allow_duplicates: false
-      if: ctx._tmp?.nas_ip != null
-  - rename:
-      field: cisco_ise.log.log_details_raw.nas_identifier
-      target_field: cisco_ise.log.nas_identifier
-      ignore_failure: true
-      ignore_missing: true
-
-  - rename:
-      field: cisco_ise.log.log_details_raw.failure_reason
-      target_field: cisco_ise.log.failure_reason
-      ignore_failure: true
-      ignore_missing: true
-  - rename:
-      field: cisco_ise.log.log_details_raw.network_device_name
-      target_field: cisco_ise.log.network_device_name
-      ignore_failure: true
-      ignore_missing: true
-  - rename:
-      field: cisco_ise.log.log_details_raw.calling_station_id
-      target_field: cisco_ise.log.calling_station_id
-      ignore_failure: true
-      ignore_missing: true
-  - gsub:
-      field: cisco_ise.log.calling_station_id
-      pattern: '[-:.]'
-      replacement: '-'
-      ignore_failure: true
-      ignore_missing: true
-  - uppercase:
-      field: cisco_ise.log.calling_station_id
-      ignore_failure: true
-      ignore_missing: true
-  - append:
-      field: server.mac
-      value: '{{{cisco_ise.log.calling_station_id}}}'
-      allow_duplicates: false
-      if: ctx.cisco_ise?.log?.calling_station_id != null
-  - convert:
-      field: cisco_ise.log.log_details_raw.network_device_ip
-      type: ip
-      target_field: _tmp.dev_ip
-      ignore_failure: true
-      ignore_missing: true
-  - rename:
-      field: _tmp.dev_ip
-      target_field: cisco_ise.log.network_device_ip
-      ignore_failure: true
-      ignore_missing: true
-  - append:
-      field: related.ip
-      value: '{{{cisco_ise.log.network_device_ip}}}'
-      allow_duplicates: false
-      if: ctx.cisco_ise?.log?.network_device_ip != null
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_monitoring_data_purge_audit.yml
+++ b/packages/cisco_ise/data_stream/log/elasticsearch/ingest_pipeline/pipeline_monitoring_data_purge_audit.yml
@@ -1,0 +1,101 @@
+---
+processors:
+- set:
+    field: "event.kind"
+    value: "event"
+- grok:
+    field: "message"
+    patterns:
+    - "^%{TIMESTAMP_ISO8601:_tmp.timestamp} %{ISO8601_TIMEZONE:event.timezone} %{DATA:cisco_ise.log.message.code}\
+      \ %{DATA:log.syslog.severity.name} %{DATA:cisco_ise.log.message.description},\
+      \ %{GREEDYDATA:cisco_ise.log.log_details_raw},"
+- grok:
+    field: "cisco_ise.log.message.description"
+    if: "ctx.cisco_ise?.log?.message?.description != null && ctx.cisco_ise.log.message.description\
+      \ != ''"
+    patterns:
+    - "^%{DATA:event.action}:"
+    ignore_failure: true
+- kv:
+    field: "cisco_ise.log.log_details_raw"
+    target_field: "cisco_ise.log.log_details"
+    field_split: ", "
+    value_split: "="
+    ignore_failure: true
+- dissect:
+    field: "cisco_ise.log.log_details.MESSAGE"
+    pattern: "Total Data threshold_space = %{cisco_ise.log.log_details.threshold_space}"
+    ignore_missing: true
+    ignore_failure: true
+- date:
+    field: "_tmp.timestamp"
+    formats:
+    - "yyyy-MM-dd HH:mm:ss.SSS"
+    - "yyyy-MM-dd HH:mm:ss.SSSSSS"
+    - "MMM  d HH:mm:ss"
+    - "MMM dd HH:mm:ss"
+    - "MMM d HH:mm:ss"
+    on_failure:
+    - remove:
+        field: "_tmp.timestamp"
+        ignore_missing: true
+    - append:
+        field: "error.message"
+        value: "{{{_ingest.on_failure_message}}}"
+- date:
+    if: "ctx.event?.timezone != null && ctx.event.timezone != ''"
+    field: "_tmp.timestamp"
+    formats:
+    - "yyyy-MM-dd HH:mm:ss.SSS"
+    - "yyyy-MM-dd HH:mm:ss.SSSSSS"
+    - "MMM  d HH:mm:ss"
+    - "MMM dd HH:mm:ss"
+    - "MMM d HH:mm:ss"
+    timezone: "{{{event.timezone}}}"
+    on_failure:
+    - remove:
+        field: "_tmp.timestamp"
+        ignore_missing: true
+    - append:
+        field: "error.message"
+        value: "{{{_ingest.on_failure_message}}}"
+- set:
+    field: "event.action"
+    value: "data_purge"
+    if: "ctx?.event?.action == 'null'"
+- append:
+    field: "event.category"
+    value: "process"
+    ignore_failure: true
+- append:
+    field: "event.type"
+    value:
+      - "info"
+- lowercase:
+    field: "log.syslog.severity.name"
+- set:
+    field: "log.level"
+    copy_from: "log.syslog.severity.name"
+    if: ctx.log?.syslog?.severity?.name != null
+- rename:
+    field: "cisco_ise.log.log_details.used_space "
+    target_field: "cisco_ise.log.log_details.used_space"
+    ignore_missing: true
+- trim:
+    field: "cisco_ise.log.log_details.used_space"
+    ignore_missing: true
+- remove:
+    field: "cisco_ise.log.log_details.MESSAGE"
+    if: "ctx?.cisco_ise?.log?.log_details?.threshold_space != null"
+    ignore_failure: true
+- rename:
+    field: "cisco_ise.log.log_details.MESSAGE"
+    target_field: "cisco_ise.log.log_details.message"
+    ignore_missing: true
+on_failure:
+  - set:
+      field: event.kind
+      value: pipeline_error
+  - append:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_ise
 title: Cisco ISE
-version: "1.21.1"
+version: "1.22.0"
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Hi,

the ISE alarms can also be like this:
```
<182>Dec 11 10:13:45 abcdefghihklm002 CISE_Alarm INFO: Satellite Authorization Renewal success
```

which our default grok pattern:

```
  - grok:
      field: _tmp.message
      tag: grok_message_details
      if: ctx._tmp?.message != null
      patterns:
        - '^%{NOTCOLON:cisco_ise.log.log_severity_level}%{SPACE}: %{NOTCOLON:event.action}%{SPACE}: %{GREEDYDATA:message}$'
        - '^%{DATA:cisco_ise.log.message.id} %{DATA:cisco_ise.log.segment.total:long} %{DATA:cisco_ise.log.segment.number:long} %{GREEDYDATA:message}$'
```

cannot handle properly, that is why I introduced an on_failure processor to deal with a bit weirder kinds of grok patterns. I am not too much of a fan of doing an grok in the `on_failure` as in: if those don't match then this should match, but looking at it, it's the only way I can ensure that nothing of the existing is broken or altered and it is just a failsafe. Additionally, this should be helpful in regards to the logs+ project. Yes, the grok might fail, but still some renames and whatnot can work instead of stopping completely.

I also added a new type of log and added an example for it.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
ted metrics or logs