### PR TITLE
[ti_opencti] Support OpenCTI 5.12.X by removing filters parameter

### DIFF
--- a/packages/ti_opencti/_dev/build/docs/README.md
+++ b/packages/ti_opencti/_dev/build/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It was developed using OpenCTI version 5.10.1.
+It was initially developed using OpenCTI version 5.10.1 and updated for verison 5.12.X.
 
 ## Setup
 

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.3"
+  changes:
+    - description: Support OpenCTI 5.12.X by removing filters parameter
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8744
 - version: "0.3.2"
   changes:
     - description: Fix processing of externalReferences.

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -77,7 +77,6 @@ state:
       $search: String
       $first: Int!
       $after: ID
-      $filters: [IndicatorsFiltering]
       $orderBy: IndicatorsOrdering
       $orderMode: OrderingMode
     ) {
@@ -85,7 +84,6 @@ state:
         search: $search
         first: $first
         after: $after
-        filters: $filters
         orderBy: $orderBy
         orderMode: $orderMode
       ) {

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It was developed using OpenCTI version 5.10.1.
+It was initially developed using OpenCTI version 5.10.1 and updated for verison 5.12.X.
 
 ## Setup
 

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: ti_opencti
 title: OpenCTI
-version: "0.3.2"
+version: "0.3.3"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
[ti_opencti] Support OpenCTI 5.12 by removing filters parameter (#8744)

In version 5.12, OpenCTI made breaking changes to how its filters work:
  https://docs.opencti.io/5.12.X/reference/filters-migration/

The GraphQL query used in the OpenCTI integration had unused placeholder
parameters for filters, which made the query invalid for 5.12. By
removing the filter parameters, the integration will for 5.12, as well
as earlier versions.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

The change in this PR can be manually tested by building and installing the integration, and consuming data from the [public demo instance of OpenCTI](https://demo.opencti.io/) (free account required).

Outside of Elastic, the new version of the GraphQL query can be tested in the [GraphQL playground](https://demo.opencti.io/graphql) of the demo instance.

The old query returns:
```json
{
  "errors": [
    {
      "message": "Unknown type \"IndicatorsFiltering\". Did you mean \"IndicatorsOrdering\"?",
      "locations": [
        {
          "line": 1,
          "column": 93
        }
      ],
      "extensions": {
        "code": "GRAPHQL_VALIDATION_FAILED"
      }
    }
  ]
}
```

The new query returns data as expected:
```
{
  "data": {
    "indicators": {
      "edges": [
        { ...
```

## Related issues

- Closes #8743
