### PR TITLE
[Oracle] Document alternate method of adding runtime library path

### DIFF
--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -24,7 +24,7 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If Elastic Agent is running as a systemd service and using `ldconfig` is not an option to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
+If Elastic Agent is running as a systemd service and not using `ldconfig` is an option, to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
 
 > Prerequisites: Ensure that you have administrative privileges to modify the Elastic Agent systemd service configuration.
 
@@ -42,10 +42,10 @@ Steps:
 4. Save the changes made to the configured `EnvironmentFile`.
 
 5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
-     `systemctl restart elastic-agent.service`
 
+      `systemctl restart elastic-agent.service`
 
-> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where  required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where the required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -35,9 +35,9 @@ Steps:
 
 2. Open the elastic-agent.service file in your preferred text editor, find the `EnvironmentFile` key (commonly found at `/etc/sysconfig/elastic-agent`), and verify its contents, as these configurations are essential for the elastic-agent's runtime environment initialization. If the EnvironmentFile is absent, create it and set the necessary permissions to ensure the elastic-agent has full access.  
 
-3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e., `/etc/systemd/system/elastic-agent.service`)
+3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e. `/etc/systemd/system/elastic-agent.service`)
 
-         LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1
+      `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
 
 4. Save the changes made to the configured `EnvironmentFile`.
 
@@ -45,7 +45,7 @@ Steps:
      `systemctl restart elastic-agent.service`
 
 
-Note: Ensure that you replace /opt/oracle/instantclient_21_1 with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -45,7 +45,7 @@ Steps:
      `systemctl restart elastic-agent.service`
 
 
-> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where  required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 
@@ -69,8 +69,6 @@ The supported configuration takes one of the forms
 Examples of supported configurations are as below:
 - `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
 - `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
-
-
 
 ## Compatibility
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -24,6 +24,28 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
+If the Elastic Agent is running as a systemd service and there are limitations in running ldconfig, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+
+Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
+
+Steps:
+1. Check the status of the Elastic Agent systemd service by running the following command:
+   `systemctl status elastic-agent.service`
+   Take note of the path to the elastic-agent.service file, which is typically located in the systemd service directory. Example path: `/etc/systemd/system/elastic-agent.service`
+
+2. Open and view the content of the `elastic-agent.service file` using your preferred text editor. Look for the `EnvironmentFile` key, which is usually empty by default. Example path to the EnvironmentFile: `/etc/sysconfig/elastic-agent`
+
+3. Add the LD_LIBRARY_PATH environment variable to the EnvironmentFile. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the /opt/oracle/instantclient_21_1 directory, add the following line to the EnvironmentFile
+   `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
+
+4. Save the changes made to the `EnvironmentFile`.
+
+5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
+     `systemctl restart elastic-agent.service`
+
+
+Note: Ensure that you replace /opt/oracle/instantclient_21_1 with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+
 ####  Enable Listener
 
 The Oracle listener is a service that runs on the database host and receives requests from Oracle clients. Make sure that [Listener](https://docs.oracle.com/cd/B19306_01/network.102/b14213/lsnrctl.htm) is be running. 
@@ -46,6 +68,8 @@ The supported configuration takes one of the forms
 Examples of supported configurations are as below:
 - `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
 - `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
+
+
 
 ## Compatibility
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -24,21 +24,22 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If the Elastic Agent is running as a systemd service and there are limitations in running `ldconfig` command, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+If Elastic Agent is running as a systemd service and using `ldconfig` is not an option to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
 
-Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
+> Prerequisites: Ensure that you have administrative privileges to modify the Elastic Agent systemd service configuration.
 
 Steps:
 1. Check the status of the Elastic Agent systemd service by running the following command:
    `systemctl status elastic-agent.service`
    Take note of the path to the elastic-agent.service file, which is typically located in the systemd service directory. Example path: `/etc/systemd/system/elastic-agent.service`
 
-2. Open and view the content of the `elastic-agent.service file` using your preferred text editor. Look for the `EnvironmentFile` key, which is usually empty by default. Example path to the EnvironmentFile: `/etc/sysconfig/elastic-agent`
+2. Open the elastic-agent.service file in your preferred text editor, find the `EnvironmentFile` key (commonly found at `/etc/sysconfig/elastic-agent`), and verify its contents, as these configurations are essential for the elastic-agent's runtime environment initialization. If the EnvironmentFile is absent, create it and set the necessary permissions to ensure the elastic-agent has full access.  
 
-3. Add the LD_LIBRARY_PATH environment variable to the EnvironmentFile. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the /opt/oracle/instantclient_21_1 directory, add the following line to the EnvironmentFile
-   `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
+3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e., `/etc/systemd/system/elastic-agent.service`)
 
-4. Save the changes made to the `EnvironmentFile`.
+         LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1
+
+4. Save the changes made to the configured `EnvironmentFile`.
 
 5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
      `systemctl restart elastic-agent.service`

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -24,7 +24,7 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If the Elastic Agent is running as a systemd service and there are limitations in running ldconfig, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+If the Elastic Agent is running as a systemd service and there are limitations in running `ldconfig` command, you can set the library search path using an alternate method. Follow the steps below to achieve this.
 
 Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
 

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 1.23.1
+- version: 1.24.0
   changes:
     - description: Document alternate method of adding runtime library path.
       type: enhancement

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 1.24.0
+- version: 1.23.1
   changes:
     - description: Document alternate method of adding runtime library path.
       type: enhancement

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: 1.24.0
+- version: 1.24.1
   changes:
     - description: Document alternate method of adding runtime library path.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8754
 - version: 1.23.0
   changes:
     - description: Add custom number formatting to visualizations.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.24.0
+  changes:
+    - description: Document alternate method of adding runtime library path.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 1.23.0
   changes:
     - description: Add custom number formatting to visualizations.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: 1.24.1
+- version: 1.24.0
   changes:
     - description: Document alternate method of adding runtime library path.
       type: enhancement

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -24,7 +24,7 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If Elastic Agent is running as a systemd service and using `ldconfig` is not an option to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
+If Elastic Agent is running as a systemd service and not using `ldconfig` is an option, to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
 
 > Prerequisites: Ensure that you have administrative privileges to modify the Elastic Agent systemd service configuration.
 
@@ -42,10 +42,10 @@ Steps:
 4. Save the changes made to the configured `EnvironmentFile`.
 
 5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
-     `systemctl restart elastic-agent.service`
 
+      `systemctl restart elastic-agent.service`
 
-> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where  required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where the required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -35,9 +35,9 @@ Steps:
 
 2. Open the elastic-agent.service file in your preferred text editor, find the `EnvironmentFile` key (commonly found at `/etc/sysconfig/elastic-agent`), and verify its contents, as these configurations are essential for the elastic-agent's runtime environment initialization. If the EnvironmentFile is absent, create it and set the necessary permissions to ensure the elastic-agent has full access.  
 
-3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e., `/etc/systemd/system/elastic-agent.service`)
+3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e. `/etc/systemd/system/elastic-agent.service`)
 
-         LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1
+      `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
 
 4. Save the changes made to the configured `EnvironmentFile`.
 
@@ -45,7 +45,7 @@ Steps:
      `systemctl restart elastic-agent.service`
 
 
-Note: Ensure that you replace /opt/oracle/instantclient_21_1 with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -45,7 +45,7 @@ Steps:
      `systemctl restart elastic-agent.service`
 
 
-> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+> Note: Ensure that you replace `/opt/oracle/instantclient_21_1` with the actual path to the directory where  required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
 
 ####  Enable Listener
 
@@ -69,8 +69,6 @@ The supported configuration takes one of the forms
 Examples of supported configurations are as below:
 - `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
 - `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
-
-
 
 ## Compatibility
 

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -24,6 +24,28 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
+If the Elastic Agent is running as a systemd service and there are limitations in running ldconfig, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+
+Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
+
+Steps:
+1. Check the status of the Elastic Agent systemd service by running the following command:
+   `systemctl status elastic-agent.service`
+   Take note of the path to the elastic-agent.service file, which is typically located in the systemd service directory. Example path: `/etc/systemd/system/elastic-agent.service`
+
+2. Open and view the content of the `elastic-agent.service file` using your preferred text editor. Look for the `EnvironmentFile` key, which is usually empty by default. Example path to the EnvironmentFile: `/etc/sysconfig/elastic-agent`
+
+3. Add the LD_LIBRARY_PATH environment variable to the EnvironmentFile. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the /opt/oracle/instantclient_21_1 directory, add the following line to the EnvironmentFile
+   `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
+
+4. Save the changes made to the `EnvironmentFile`.
+
+5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
+     `systemctl restart elastic-agent.service`
+
+
+Note: Ensure that you replace /opt/oracle/instantclient_21_1 with the actual path to the directory where your required libraries (`libclntsh.so`) are located. This will set the library search path for the Elastic Agent service to include the specified directory, allowing it to locate the required libraries.
+
 ####  Enable Listener
 
 The Oracle listener is a service that runs on the database host and receives requests from Oracle clients. Make sure that [Listener](https://docs.oracle.com/cd/B19306_01/network.102/b14213/lsnrctl.htm) is be running. 
@@ -46,6 +68,8 @@ The supported configuration takes one of the forms
 Examples of supported configurations are as below:
 - `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
 - `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
+
+
 
 ## Compatibility
 

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -24,21 +24,22 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If the Elastic Agent is running as a systemd service and there are limitations in running `ldconfig` command, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+If Elastic Agent is running as a systemd service and using `ldconfig` is not an option to update the links to the shared libraries, you can use the `LD_LIBRARY_PATH` environment variable instead. Follow these steps to ensure Elastic Agent and its spawned processes respect the `LD_LIBRARY_PATH` environment variable.
 
-Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
+> Prerequisites: Ensure that you have administrative privileges to modify the Elastic Agent systemd service configuration.
 
 Steps:
 1. Check the status of the Elastic Agent systemd service by running the following command:
    `systemctl status elastic-agent.service`
    Take note of the path to the elastic-agent.service file, which is typically located in the systemd service directory. Example path: `/etc/systemd/system/elastic-agent.service`
 
-2. Open and view the content of the `elastic-agent.service file` using your preferred text editor. Look for the `EnvironmentFile` key, which is usually empty by default. Example path to the EnvironmentFile: `/etc/sysconfig/elastic-agent`
+2. Open the elastic-agent.service file in your preferred text editor, find the `EnvironmentFile` key (commonly found at `/etc/sysconfig/elastic-agent`), and verify its contents, as these configurations are essential for the elastic-agent's runtime environment initialization. If the EnvironmentFile is absent, create it and set the necessary permissions to ensure the elastic-agent has full access.  
 
-3. Add the LD_LIBRARY_PATH environment variable to the EnvironmentFile. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the /opt/oracle/instantclient_21_1 directory, add the following line to the EnvironmentFile
-   `LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1`
+3. Add the LD_LIBRARY_PATH environment variable to the configured `EnvironmentFile`. You can set it to the directory where libraries (`libclntsh.so`) are located. For example, if your libraries are in the `/opt/oracle/instantclient_21_1 directory`, add the following line to the `EnvironmentFile` (i.e., `/etc/systemd/system/elastic-agent.service`)
 
-4. Save the changes made to the `EnvironmentFile`.
+         LD_LIBRARY_PATH=/opt/oracle/instantclient_21_1
+
+4. Save the changes made to the configured `EnvironmentFile`.
 
 5. Restart the Elastic Agent systemd service to apply the changes by running the following command:
      `systemctl restart elastic-agent.service`

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -24,7 +24,7 @@ Oracle Instant Client enables development and deployment of applications that co
 
 The OCI library install few Client Shared Libraries that must be referenced on the machine where Metricbeat is installed. Please follow the [Oracle Client Installation link](https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html#GUID-D3DCB4FB-D3CA-4C25-BE48-3A1FB5A22E84) link for OCI Instant Client set up. The OCI Instant Client is available with the Oracle Universal Installer, RPM file or ZIP file. Download links can be found at the [Oracle Instant Client Download page](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
-If the Elastic Agent is running as a systemd service and there are limitations in running ldconfig, you can set the library search path using an alternate method. Follow the steps below to achieve this.
+If the Elastic Agent is running as a systemd service and there are limitations in running `ldconfig` command, you can set the library search path using an alternate method. Follow the steps below to achieve this.
 
 Prerequisites: Ensure that you have administrative privileges to make changes to the Elastic Agent systemd service configuration.
 

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.23.0"
+version: "1.24.0"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.24.0"
+version: "1.23.1"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.23.1"
+version: "1.24.0"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

Setting the runtime library path is essential for Oracle Integration to work. 
Document additional methods of setting the runtime library path by setting values in elastic-agent configuration. 


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist


## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry


## Related issues

https://github.com/elastic/integrations/issues/8750

## Screenshots

<img width="745" alt="image" src="https://github.com/elastic/integrations/assets/101976829/2d62097a-fa0b-442b-a432-b63926746391">

