### PR TITLE
[Infoblox NIOS] Update timestamp parsing logic

### DIFF
--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix timestamp issue when logstash output is used.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/8767
 - version: "1.19.2"
   changes:
     - description: Fix exclude_files pattern.

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.19.3"
   changes:
-    - description: Fix timestamp issue when logstash output is used.
+    - description: Update timestamp parsing logic to avoid `@timestamp > event.created`.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/8767
 - version: "1.19.2"

--- a/packages/infoblox_nios/changelog.yml
+++ b/packages/infoblox_nios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.3"
+  changes:
+    - description: Fix timestamp issue when logstash output is used.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.19.2"
   changes:
     - description: Fix exclude_files pattern.

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -23,6 +23,7 @@ processors:
       ignore_failure: true
   - date:
       field: _tmp.timestamp
+      target_field: event.created
       timezone: '{{{event.timezone}}}'
       if: ctx.event?.timezone != null
       formats:
@@ -35,7 +36,7 @@ processors:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
-      field: event.created
+      field: _tmp.timestamp
       if: ctx.event?.timezone == null
       target_field: event.created
       formats:
@@ -71,10 +72,18 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_dns" }}'
       if: ctx.infoblox_nios?.log?.type == 'DNS'
+  # `override: true` is required since @timestamp could've been present if logstash output is used early in the pipeline.
   - set:
       field: '@timestamp'
       value: '{{{event.created}}}'
-      if: "ctx['@timestamp'] == null && ctx.event?.created != null"
+      if: "ctx.event?.created != null"
+      override: true
+  # `override: true` is required if independent pipelines has its own timestamp. This makes @timestamp < event.created conforming to ECS.
+  - set:
+      field: '@timestamp'
+      value: '{{{_tmp.sub_timestamp}}}'
+      if: "ctx._tmp?.sub_timestamp != null"
+      override: true
   - convert:
       field: _tmp.host.ip
       if: ctx._tmp?.host?.ip != null && ctx._tmp.host.ip != ''

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -72,7 +72,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_dns" }}'
       if: ctx.infoblox_nios?.log?.type == 'DNS'
-  # `override: true` is required since @timestamp could've been present if logstash output is used early in the pipeline.
+  # `override: true` is required since @timestamp could've been present early in the pipeline.
   - set:
       field: '@timestamp'
       value: '{{{event.created}}}'

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,8 +12,8 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
         - "^%{GREEDYDATA:message}$"
   - rename:
       field: _conf.tz_offset
@@ -22,7 +22,7 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - date:
-      field: _tmp.timestamp
+      field: event.created
       target_field: event.created
       timezone: '{{{event.timezone}}}'
       if: ctx.event?.timezone != null
@@ -36,7 +36,7 @@ processors:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
-      field: _tmp.timestamp
+      field: event.created
       if: ctx.event?.timezone == null
       target_field: event.created
       formats:
@@ -72,17 +72,17 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "pipeline_dns" }}'
       if: ctx.infoblox_nios?.log?.type == 'DNS'
-  # `override: true` is required since @timestamp could've been present early in the pipeline.
+  # Since logstash sets the @timestamp if not present, `override: true` is required to overwrite the value with event timestamp.
   - set:
       field: '@timestamp'
       value: '{{{event.created}}}'
       if: "ctx.event?.created != null"
       override: true
-  # `override: true` is required if independent pipelines has its own timestamp. This makes @timestamp < event.created conforming to ECS.
+  # If individual pipelines has timestamp, they should take priority. This makes @timestamp < event.created conforming to ECS.
   - set:
       field: '@timestamp'
-      value: '{{{_tmp.sub_timestamp}}}'
-      if: "ctx._tmp?.sub_timestamp != null"
+      value: '{{{_tmp.timestamp}}}'
+      if: "ctx._tmp?.timestamp != null"
       override: true
   - convert:
       field: _tmp.host.ip

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,8 +12,8 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
-        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:event.created}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+%{NOTSPACE:host.domain}\\s+%{IP:_tmp.host.ip}\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
+        - "^<%{NUMBER:log.syslog.priority:long}>%{SYSLOGTIMESTAMP:_tmp.timestamp}\\s+(%{IP:_tmp.host.ip}|%{NOTSPACE:host.domain})\\s+%{DATA:infoblox_nios.log.service_name}\\[?%{NUMBER:process.pid:long}?\\]?:\\s+%{GREEDYDATA:message}$"
         - "^%{GREEDYDATA:message}$"
   - rename:
       field: _conf.tz_offset
@@ -22,19 +22,15 @@ processors:
       ignore_missing: true
       ignore_failure: true
   - date:
-      field: event.created
+      field: _tmp.timestamp
       timezone: '{{{event.timezone}}}'
       if: ctx.event?.timezone != null
-      target_field: event.created
       formats:
         - MMM  d HH:mm:ss
         - MMM dd HH:mm:ss
         - MMM d HH:mm:ss
         - dd-MMM-yyyy HH:mm:ss.SSS
       on_failure:
-        - remove:
-            field: event.created
-            ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -23,15 +23,18 @@ processors:
       ignore_failure: true
   - date:
       field: event.created
-      target_field: event.created
       timezone: '{{{event.timezone}}}'
       if: ctx.event?.timezone != null
+      target_field: event.created
       formats:
         - MMM  d HH:mm:ss
         - MMM dd HH:mm:ss
         - MMM d HH:mm:ss
         - dd-MMM-yyyy HH:mm:ss.SSS
       on_failure:
+        - remove:
+            field: event.created
+            ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -5,34 +5,34 @@ processors:
       field: message
       if: ctx.message.contains('Created') || ctx.message.contains('Modified') || ctx.message.contains('Deleted')
       patterns:
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{DATA:infoblox_nios.log.audit.object.name} %{DATA:infoblox_nios.log.audit.object.value}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{DATA:infoblox_nios.log.audit.object.name} %{DATA:infoblox_nios.log.audit.object.value}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - grok:
       field: message
       if: ctx.message.contains('Called')
       patterns:
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{WORD:infoblox_nios.log.audit.object.name}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{WORD:infoblox_nios.log.audit.object.name}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - grok:
       field: message
       if: ctx.event?.action == null
       patterns:
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - - %{GREEDYDATA:details}$"
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:_tmp.sub_timestamp} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - - %{GREEDYDATA:details}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.timestamp} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - date:
-      field: _tmp.sub_timestamp
-      target_field: _tmp.sub_timestamp
-      if: ctx._tmp?.sub_timestamp != null
+      field: _tmp.timestamp
+      target_field: _tmp.timestamp
+      if: ctx._tmp?.timestamp != null
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: _tmp.sub_timestamp
+            field: _tmp.timestamp
             ignore_missing: true
         - append:
             field: error.message

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -5,33 +5,34 @@ processors:
       field: message
       if: ctx.message.contains('Created') || ctx.message.contains('Modified') || ctx.message.contains('Deleted')
       patterns:
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{DATA:infoblox_nios.log.audit.object.name} %{DATA:infoblox_nios.log.audit.object.value}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{DATA:infoblox_nios.log.audit.object.name} %{DATA:infoblox_nios.log.audit.object.value}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - grok:
       field: message
       if: ctx.message.contains('Called')
       patterns:
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{WORD:infoblox_nios.log.audit.object.name}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{WORD:infoblox_nios.log.audit.object.name}:? %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - grok:
       field: message
       if: ctx.event?.action == null
       patterns:
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - - %{GREEDYDATA:details}$"
-        - "^%{GREEDYDATA:timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
-        - "^%{GREEDYDATA:timestamp} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} - - %{GREEDYDATA:details}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} \\[%{DATA:user.name}\\]: %{DATA:event.action} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
+        - "^%{GREEDYDATA:_tmp.sub_timestamp} %{GREEDYDATA:infoblox_nios.log.audit.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.audit.message}$"
   - date:
-      field: timestamp
-      if: ctx.timestamp != null
+      field: _tmp.sub_timestamp
+      target_field: _tmp.sub_timestamp
+      if: ctx._tmp?.sub_timestamp != null
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: timestamp
+            field: _tmp.sub_timestamp
             ignore_missing: true
         - append:
             field: error.message
@@ -129,7 +130,6 @@ processors:
       field:
         - details
         - audit
-        - timestamp
       ignore_missing: true
   - append:
       field: related.user

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -14,38 +14,38 @@ processors:
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA:client.domain}\\): transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*CEF:0\\|Infoblox\\|NIOS\\|%{GREEDYDATA:infoblox_nios.log.dns.version}\\|RPZ-%{DATA:dns.answers.type}\\|%{DATA:infoblox_nios.log.dns.answers_policy}\\|\\d+\\|app=DNS dst=%{IP:server.ip} src=%{IP:client.ip} spt=%{NUMBER:client.port:long} view=%{DATA:infoblox_nios.log.dns.view_name} qtype=%{WORD:dns.question.type} msg=%{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.sub_timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.sub_timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.dns.message}$"
       pattern_definitions:
         CLIENT: 'client (?:%{DATA} )?%{IP:client.ip}#%{NUMBER:client.port:long}:?'
         VIEW: 'view %{DATA:infoblox_nios.log.view}: '
   - date:
-      field: _tmp.sub_timestamp
-      target_field: _tmp.sub_timestamp
-      if: ctx._tmp?.sub_timestamp != null && ctx.event?.timezone != null
+      field: _tmp.timestamp
+      target_field: _tmp.timestamp
+      if: ctx._tmp?.timestamp != null && ctx.event?.timezone != null
       timezone: '{{{event.timezone}}}'
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: _tmp.sub_timestamp
+            field: _tmp.timestamp
             ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
-      field: _tmp.sub_timestamp
-      target_field: _tmp.sub_timestamp
-      if: ctx._tmp?.sub_timestamp != null && ctx.event?.timezone == null
+      field: _tmp.timestamp
+      target_field: _tmp.timestamp
+      if: ctx._tmp?.timestamp != null && ctx.event?.timezone == null
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: _tmp.sub_timestamp
+            field: _tmp.timestamp
             ignore_missing: true
         - append:
             field: error.message

--- a/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
+++ b/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/pipeline_dns.yml
@@ -14,36 +14,38 @@ processors:
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} \\(%{DATA:client.domain}\\): transfer of '%{DATA:dns.question.name}/%{DATA:dns.question.class}': %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*CEF:0\\|Infoblox\\|NIOS\\|%{GREEDYDATA:infoblox_nios.log.dns.version}\\|RPZ-%{DATA:dns.answers.type}\\|%{DATA:infoblox_nios.log.dns.answers_policy}\\|\\d+\\|app=DNS dst=%{IP:server.ip} src=%{IP:client.ip} spt=%{NUMBER:client.port:long} view=%{DATA:infoblox_nios.log.dns.view_name} qtype=%{WORD:dns.question.type} msg=%{GREEDYDATA:infoblox_nios.log.dns.message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
-        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.sub_timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags} %{GREEDYDATA:repeat_message}$"
+        - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{GREEDYDATA:_tmp.sub_timestamp} %{CLIENT} %{DATA:network.transport}: %{VIEW}?query: %{DATA:dns.question.name} %{DATA:dns.question.class} %{WORD:dns.question.type} response: %{DATA:dns.response_code} %{DATA:infoblox_nios.log.dns.header_flags}$"
         - "^(%{NOTSPACE:infoblox_nios.log.dns.category}:)?\\s*%{CLIENT} %{GREEDYDATA:infoblox_nios.log.dns.message}$"
         - "^%{GREEDYDATA:infoblox_nios.log.dns.message}$"
       pattern_definitions:
         CLIENT: 'client (?:%{DATA} )?%{IP:client.ip}#%{NUMBER:client.port:long}:?'
         VIEW: 'view %{DATA:infoblox_nios.log.view}: '
   - date:
-      field: timestamp
-      if: ctx.timestamp != null && ctx.event?.timezone != null
+      field: _tmp.sub_timestamp
+      target_field: _tmp.sub_timestamp
+      if: ctx._tmp?.sub_timestamp != null && ctx.event?.timezone != null
       timezone: '{{{event.timezone}}}'
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: timestamp
+            field: _tmp.sub_timestamp
             ignore_missing: true
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
   - date:
-      field: timestamp
-      if: ctx.timestamp != null && ctx.event?.timezone == null
+      field: _tmp.sub_timestamp
+      target_field: _tmp.sub_timestamp
+      if: ctx._tmp?.sub_timestamp != null && ctx.event?.timezone == null
       formats:
         - dd-MMM-yyyy HH:mm:ss.SSS
         - yyyy-MM-dd HH:mm:ss.SSS'Z'
       on_failure:
         - remove:
-            field: timestamp
+            field: _tmp.sub_timestamp
             ignore_missing: true
         - append:
             field: error.message
@@ -249,7 +251,6 @@ processors:
       if: ctx.dns?.question != null
   - remove:
       field:
-        - timestamp
         - repeat_message
         - dns.question.domain
       ignore_missing: true

--- a/packages/infoblox_nios/manifest.yml
+++ b/packages/infoblox_nios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: infoblox_nios
 title: Infoblox NIOS
-version: "1.19.2"
+version: "1.19.3"
 description: Collect logs from Infoblox NIOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
There are 2 style of log formats (regards to how timestamps are handled).
1. `<29>Mar 21 09:53:51 infoblox.localdomain httpd[]: 2022-03-18 13:24:41.705Z [admin]: ........`
2. `<30>Mar 27 08:32:59 infoblox.localdomain dhcpd[2567]: ............`

**Event 1**: Contains 2 timestamps inside the log. In current default pipeline, the first timestamp `Mar 21 09:53:51` is set as `event.created` and then individual pipelines sets second timestamp as `@timestamp` if present.
**Event 2**: Contains 1 timestamp inside the log. In current default pipeline, the only timestamp `Mar 27 08:32:59` is set as `event.created` and a [set processor](https://github.com/elastic/integrations/blob/main/packages/infoblox_nios/data_stream/log/elasticsearch/ingest_pipeline/default.yml#L78-L81) copies that into `@timestamp` if `@timestamp` is not already present from individual pipelines.


But, when Logstash is involved in between Agent and Elasticsearch, it adds `@timestamp` to the event before ingest pipeline. Hence, the logs format 2, i.e., containing single timestamp, skips the set processor leading to incorrect `@timestamp` values and also not conforming to ECS norm [@timestamp < event.created < event.ingested](https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-created:~:text=%40timestamp%20%3C%20event.created%20%3C%20event.ingested).

This PR fixes the problem by:
1. Modifying individual pipelines to not set `@timestamp` inside them.
2. Set `override: true` in the default pipeline, thus overriding the value of `@timestamp` with event's timestamp.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
`elastic-package stack down && elastic-package build && elastic-package stack up --version=8.11.0 -d -v  --services=elasticsearch && eval "$(elastic-package stack shellinit)" && elastic-package test pipeline --generate -v`
```
Run pipeline tests for the package
--- Test results for package: infoblox_nios - START ---
╭───────────────┬─────────────┬───────────┬────────────────┬────────┬──────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME      │ RESULT │ TIME ELAPSED │
├───────────────┼─────────────┼───────────┼────────────────┼────────┼──────────────┤
│ infoblox_nios │ log         │ pipeline  │ test-audit.log │ PASS   │  12.847542ms │
│ infoblox_nios │ log         │ pipeline  │ test-dhcp.log  │ PASS   │  16.714875ms │
│ infoblox_nios │ log         │ pipeline  │ test-dns.log   │ PASS   │  10.268166ms │
╰───────────────┴─────────────┴───────────┴────────────────┴────────┴──────────────╯
--- Test results for package: infoblox_nios - END   ---
Done
```
