### PR TITLE
BUG - Update default.yml - change GROK pattern of _temp_.srcuser & .dstuser

### DIFF
--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -109,7 +109,7 @@ processors:
         - '^%{USERNAME:source.user.name}@%{HOSTNAME:source.user.domain}$'
         - '^%{USERNAME:source.user.name}$'
       pattern_definitions:
-        USERNAME: '[ a-zA-Z0-9._-]+[$]?'
+        USERNAME: '[ a-zA-Z0-9.:_-]+[$]?'
       if: ctx._temp_?.srcuser != null
 
   - grok:
@@ -121,7 +121,7 @@ processors:
         - '^%{USERNAME:destination.user.name}@%{HOSTNAME:destination.user.domain}$'
         - '^%{USERNAME:destination.user.name}$'
       pattern_definitions:
-        USERNAME: '[ a-zA-Z0-9._-]+[$]?'
+        USERNAME: '[ a-zA-Z0-9.:_-]+[$]?'
       if: ctx._temp_?.dstuser != null
 
   - set:


### PR DESCRIPTION
Type of change:
- Bug

## Proposed commit message

Explenation:
We did get error messages on a few logs from Palo Alto THREAT logs. 
We encouter the error:
Provided Grok expressions do not match field value: [<name>: <ip adres>] conditional

After some investigation it was related to the 6th place in the syslog so it is related to the field " _temp_.srcuser" and it was missing the ":"
So I have added ":" to the GROK pattern of _temp_.srcuser and _temp_.dstuser. 

After this the problem was solved. 

Please add this so in the new updates I don't need to edit the ingest pipeline manually


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

test it with adding an keyfield value with ":" in it in the 6th place of the syslog so the csv will parse it in the _tmp_.srcuser field. 
See the following order in the category THREAT: 
      "field": "message",
      "target_fields": [
        "panw.panos.source.ip",
        "panw.panos.destination.ip",
        "panw.panos.source.nat.ip",
        "panw.panos.destination.nat.ip",
        "panw.panos.ruleset",
        "_temp_.srcuser",
        "_temp_.dstuser",


## Related issues
- not defined

## Screenshots
- N/A