### PR TITLE
Tolerate suffixes on the OpenCTI instance URL

### DIFF
--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.4"
+  changes:
+    - description: Tolerate suffixes on the OpenCTI instance URL
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8791
 - version: "0.3.3"
   changes:
     - description: Support OpenCTI 5.12.X by removing filters parameter

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -32,7 +32,10 @@ fields:
   _conf:
     url: {{url}}
 program: |
-  request("POST", state.url + "/graphql").with({
+  request(
+    "POST",
+    state.url.trim_suffix("graphql").trim_suffix("/") + "/graphql"
+  ).with({
     "Header": ({
       "Content-Type": ["application/json"]
     }).with(

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: ti_opencti
 title: OpenCTI
-version: "0.3.3"
+version: "0.3.4"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
Tolerate suffixes on the OpenCTI instance URL (#8791)

Although a base URL such as 'https://demo.opencti.io' is requested in
the integration settings, we will also tolerate URLs with a trailing
forward slash or '/graphql' path.
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Manually test against the OpenCTI [public demo instance](https://demo.opencti.io).
