### PR TITLE
[o365] Add note about Token URL in the setup guide

### DIFF
--- a/packages/o365/_dev/build/docs/README.md
+++ b/packages/o365/_dev/build/docs/README.md
@@ -7,7 +7,7 @@ This integration is for [Microsoft Office 365](https://docs.microsoft.com/en-us/
 To use this package you need to [enable `Audit Log`](https://learn.microsoft.com/en-us/purview/audit-log-enable-disable) and register an application in [Microsoft Entra ID (formerly known as Azure Active Directory)](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id).
 
 Once the application is registered, configure and/or note the following to setup O365 Elastic integration:
-1. Note `Application (client) ID` and the `Directory (tenant) ID` in the registered application's `Overview` page. 
+1. Note `Application (client) ID` and the `Directory (tenant) ID` in the registered application's `Overview` page.
 2. Create a new secret to configure the authentication of your application. 
     - Navigate to `Certificates & Secrets` section.
     - Click `New client secret` and provide some description to create new secret.
@@ -27,6 +27,7 @@ Once the secret is created and permissions are granted by admin, setup Elastic A
 - Add `Directory (tenant) ID` noted in Step 1 into `Directory (tenant) ID` parameter. This is required field.
 - Add `Application (client) ID` noted in Step 1 into `Application (client) ID` parameter. This is required field.
 - Add the secret `Value` noted in Step 2 into `Client Secret` parameter. This is required field.
+- Oauth2 Token URL can be added to generate the tokens during the oauth2 flow. If not provided, above `Directory (tenant) ID` will be used for oauth2 token generation.
 - Modify any other parameters as necessary.
 
 

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.29.2
+  changes:
+    - description: Add note to docs about configuring the Token URL.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8795
 - version: 1.29.1
   changes:
     - description: Add required permissions to docs.

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -7,7 +7,7 @@ This integration is for [Microsoft Office 365](https://docs.microsoft.com/en-us/
 To use this package you need to [enable `Audit Log`](https://learn.microsoft.com/en-us/purview/audit-log-enable-disable) and register an application in [Microsoft Entra ID (formerly known as Azure Active Directory)](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id).
 
 Once the application is registered, configure and/or note the following to setup O365 Elastic integration:
-1. Note `Application (client) ID` and the `Directory (tenant) ID` in the registered application's `Overview` page. 
+1. Note `Application (client) ID` and the `Directory (tenant) ID` in the registered application's `Overview` page.
 2. Create a new secret to configure the authentication of your application. 
     - Navigate to `Certificates & Secrets` section.
     - Click `New client secret` and provide some description to create new secret.
@@ -27,6 +27,7 @@ Once the secret is created and permissions are granted by admin, setup Elastic A
 - Add `Directory (tenant) ID` noted in Step 1 into `Directory (tenant) ID` parameter. This is required field.
 - Add `Application (client) ID` noted in Step 1 into `Application (client) ID` parameter. This is required field.
 - Add the secret `Value` noted in Step 2 into `Client Secret` parameter. This is required field.
+- Oauth2 Token URL can be added to generate the tokens during the oauth2 flow. If not provided, above `Directory (tenant) ID` will be used for oauth2 token generation.
 - Modify any other parameters as necessary.
 
 

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "1.29.1"
+version: "1.29.2"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

From a suggestion in an SDH, a note in the setup guide has been added explaining that the Token URL can be added to generate auth tokens. Otherwise, the Tenant ID is used for that purpose, which is a required field.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
