### PR TITLE
[Cloud Security] revert to have disabled fields removed

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,6 +6,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.7.4"
+  changes:
+    - description: Revert to have diabled fields removed
+      type: bugfix
+      link: tbd
 - version: "1.7.3"
   changes:
     - description: Revert mappings for disabled fields

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,7 +10,7 @@
   changes:
     - description: Revert to have diabled fields removed
       type: bugfix
-      link: tbd
+      link: https://github.com/elastic/integrations/pull/8822
 - version: "1.7.3"
   changes:
     - description: Revert mappings for disabled fields

--- a/packages/cloud_security_posture/data_stream/findings/fields/resource.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/resource.yml
@@ -9,7 +9,3 @@
       type: keyword
     - name: sub_type
       type: keyword
-    - name: raw
-      type: object
-      object_type: keyword
-      enabled: false

--- a/packages/cloud_security_posture/data_stream/findings/fields/result.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/result.yml
@@ -3,11 +3,3 @@
   fields:
     - name: evaluation
       type: keyword
-    - name: evidence
-      type: object
-      object_type: keyword
-      enabled: false
-    - name: expected
-      type: object
-      object_type: keyword
-      enabled: false

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.7.3"
+version: "1.7.4"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Those fields were removed in 1.7.1 [[Cloud Security] Remove disabled fields](https://github.com/elastic/integrations/pull/8679/files#top) but then brought back in 1.7.3 [[Cloud security] rollback disabled fields mappings](https://github.com/elastic/integrations/pull/8812/files#top) after discovering an issue in serverless which seemed related to the changes around these fields [[Bug][Cloud Security] Transform fail to index documents after package upgrade](https://github.com/elastic/security-team/issues/8328#top)

After investigation, there was no evidence that the issue discovered affects ESS release, therefore to avoid last-minute changes before the release, this PR is reverting the revert, to get back to the state that was well tested during the QA cycle


