### PR TITLE
[elastic_agent] Add additional output metrics to dashboards

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.19.0"
   changes:
-    - description: Add output metrics
+    - description: "Add more detailed output metrics: events.failed, events.toomany, events.dropped and batches.split"
       type: enhancement
       link: https://github.com/elastic/integrations/pull/8834
 - version: "1.18.0"

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Add output metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8834
 - version: "1.18.0"
   changes:
     - description: Add metrics dashboard for httpjson, http_endpoint, filestream and CEL, fix decimal numbers on certain counters, add field mappings for filebeat_input.id, and component fields to filebeat_input logs

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-fields.yml
@@ -88,3 +88,15 @@
                   description: >
                     Number of write errors
 
+            - name: batches
+              type: group
+              description: >
+                Batches counters
+
+              fields:
+                - name: split
+                  type: long
+                  metric_type: counter
+                  description: >
+                    Number of batches split because they were too large
+

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -49,8 +49,7 @@
                         "title": "",
                         "type": "markdown",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 27,
@@ -62,7 +61,7 @@
                 "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
                 "title": "Table of Contents",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -172,8 +171,7 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 9,
@@ -185,7 +183,7 @@
                 "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
                 "title": "[Elastic Agent] CPU Usage",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -335,8 +333,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -348,7 +345,7 @@
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -470,8 +467,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -483,7 +479,7 @@
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -661,8 +657,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -674,7 +669,7 @@
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -860,8 +855,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -873,7 +867,7 @@
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1052,8 +1046,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1065,7 +1058,7 @@
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1243,8 +1236,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1256,7 +1248,7 @@
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1437,8 +1429,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1450,7 +1441,7 @@
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1620,8 +1611,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1633,7 +1623,7 @@
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1808,8 +1798,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1821,7 +1810,7 @@
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                 "title": "[Elastic Agent] Queue depth",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -1964,8 +1953,7 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 9,
@@ -1977,7 +1965,7 @@
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
                 "type": "visualization",
-                "version": "8.9.0"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -2162,20 +2150,811 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
                     "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
-                    "x": 24,
+                    "x": 0,
                     "y": 63
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens",
-                "version": "8.9.0"
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "d00ed1f2-4e48-4558-9497-108aea7b49b0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Output Drops",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of beat.stats.libbeat.output.events.dropped",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.dropped"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "d00ed1f2-4e48-4558-9497-108aea7b49b0",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output dropped",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "invalid events that were dropped by the output",
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "c05734e3-158a-43d4-9cf5-47a5300f21e1",
+                    "w": 24,
+                    "x": 24,
+                    "y": 72
+                },
+                "panelIndex": "c05734e3-158a-43d4-9cf5-47a5300f21e1",
+                "title": "[Elastic Agent] Output dropped",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "e10299ae-c535-41b1-ad24-495f10be50d0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Output Failed",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of beat.stats.libbeat.output.events.failed",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.failed"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "e10299ae-c535-41b1-ad24-495f10be50d0",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output failed events",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "number of events that failed in output",
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "23f691f8-a3dc-4be4-b786-e6bdb2f40fb3",
+                    "w": 24,
+                    "x": 24,
+                    "y": 63
+                },
+                "panelIndex": "23f691f8-a3dc-4be4-b786-e6bdb2f40fb3",
+                "title": "[Elastic Agent] Output failed events",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "b04570f3-bf30-472e-ba76-fd8460895657",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Output TooMany",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of beat.stats.libbeat.output.events.toomany",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.events.toomany"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "b04570f3-bf30-472e-ba76-fd8460895657",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output dropped",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "number of too many responses from the output",
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "d9ee0451-90b4-452f-adad-9a594a39be02",
+                    "w": 24,
+                    "x": 0,
+                    "y": 81
+                },
+                "panelIndex": "d9ee0451-90b4-452f-adad-9a594a39be02",
+                "title": "[Elastic Agent] Output TooMany",
+                "type": "lens",
+                "version": "8.10.1"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "a5325b6a-a847-4bdc-a855-1dd18f37e1a9",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ad65be36-0be3-4937-8f41-ec9e48adfce6": {
+                                            "columnOrder": [
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353",
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb",
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                            ],
+                                            "columns": {
+                                                "49cd060d-6f21-4d81-ad6b-1c8462c97353": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Beat types",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "beat.type"
+                                                },
+                                                "e201a210-6e89-4d72-9d9c-a00b036fb0eb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "data_stream.dataset : \"elastic_agent.*\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Output Batches Split",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "f5cbe487-2a43-425b-9cd1-40283e5e596c"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "f5cbe487-2a43-425b-9cd1-40283e5e596c": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of beat.stats.libbeat.output.batches.split",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "beat.stats.libbeat.output.batches.split"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "a5325b6a-a847-4bdc-a855-1dd18f37e1a9",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e201a210-6e89-4d72-9d9c-a00b036fb0eb"
+                                        ],
+                                        "layerId": "ad65be36-0be3-4937-8f41-ec9e48adfce6",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "cb2f461c-587a-4f6a-8ad4-e4b0f61c9541",
+                                        "xAccessor": "49cd060d-6f21-4d81-ad6b-1c8462c97353"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Output dropped",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "number of batches that had to be split because they were too large",
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "d55ebadf-8314-4c8e-b9c2-9334248ad118",
+                    "w": 24,
+                    "x": 24,
+                    "y": 81
+                },
+                "panelIndex": "d55ebadf-8314-4c8e-b9c2-9334248ad118",
+                "title": "[Elastic Agent] Output batches split",
+                "type": "lens",
+                "version": "8.10.1"
             }
         ],
         "timeRestore": false,
@@ -2183,9 +2962,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-12-11T11:37:02.295Z",
+    "created_at": "2024-01-05T16:38:31.548Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -2290,6 +3069,46 @@
         {
             "id": "metrics-*",
             "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c05734e3-158a-43d4-9cf5-47a5300f21e1:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "c05734e3-158a-43d4-9cf5-47a5300f21e1:d00ed1f2-4e48-4558-9497-108aea7b49b0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "23f691f8-a3dc-4be4-b786-e6bdb2f40fb3:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "23f691f8-a3dc-4be4-b786-e6bdb2f40fb3:e10299ae-c535-41b1-ad24-495f10be50d0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d9ee0451-90b4-452f-adad-9a594a39be02:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d9ee0451-90b4-452f-adad-9a594a39be02:b04570f3-bf30-472e-ba76-fd8460895657",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d55ebadf-8314-4c8e-b9c2-9334248ad118:indexpattern-datasource-layer-ad65be36-0be3-4937-8f41-ec9e48adfce6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d55ebadf-8314-4c8e-b9c2-9334248ad118:a5325b6a-a847-4bdc-a855-1dd18f37e1a9",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.18.0
+version: 1.19.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

Add dashboards for the following metrics to the `[Elastic Agent] Agent metrics` Dashboard.

- beat.stats.libbeat.output.events.failed
- beat.stats.libbeat.output.events.toomany
- beat.stats.libbeat.output.events.dropped
- beat.stats.libbeat.output.batches.split

All four of these are useful to see if your agent is having non-fatal errors when using the output which can result in degraded performance.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

- checkout PR
- `cd packages/elastic_agent`
- `elastic-package stack up --version <8.11.2 or greater> -d`

View the `[Elastic Agent] Agent metrics` Dashboard

## Related issues

- Relates elastic/elastic-agent#3826

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
<img width="1686" alt="Screenshot 2024-01-05 at 11 43 03" src="https://github.com/elastic/integrations/assets/57081003/73792d26-27ef-45fe-97c3-42a3b9d9ddd0">
