### PR TITLE
[Kubernetes] Add major/minor version to api server and kubelet version to state node

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.55.2
+  changes:
+    - description: Add major and minor version to API server data stream and kubelet version to state_node.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8697
 - version: 1.55.1
   changes:
     - description: Modify the field definitions to reference ECS.

--- a/packages/kubernetes/data_stream/apiserver/fields/fields.yml
+++ b/packages/kubernetes/data_stream/apiserver/fields/fields.yml
@@ -1,6 +1,14 @@
 - name: kubernetes.apiserver
   type: group
   fields:
+    - name: major.version
+      type: keyword
+      description: >
+        API Server major version.
+    - name: minor.version
+      type: keyword
+      description: >
+        API Server minor version.
     - name: request.resource
       dimension: true
       type: keyword

--- a/packages/kubernetes/data_stream/state_node/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_node/fields/fields.yml
@@ -1,6 +1,11 @@
 - name: kubernetes.node
   type: group
   fields:
+    - name: kubelet.version
+      type: keyword
+      description: >
+        Kubelet version.
+
     - name: status
       type: group
       fields:

--- a/packages/kubernetes/docs/kube-apiserver.md
+++ b/packages/kubernetes/docs/kube-apiserver.md
@@ -212,6 +212,8 @@ An example event for `apiserver` looks as following:
 | kubernetes.apiserver.audit.rejected.count | Number of audit rejected events | long |  | counter |
 | kubernetes.apiserver.client.request.count | Number of requests as client | long |  | counter |
 | kubernetes.apiserver.etcd.object.count | Number of kubernetes objects at etcd | long |  | gauge |
+| kubernetes.apiserver.major.version | API Server major version. | keyword |  |  |
+| kubernetes.apiserver.minor.version | API Server minor version. | keyword |  |  |
 | kubernetes.apiserver.process.cpu.sec | CPU seconds | double |  | counter |
 | kubernetes.apiserver.process.fds.open.count | Number of open file descriptors | long |  | gauge |
 | kubernetes.apiserver.process.memory.resident.bytes | Bytes in resident memory | long | byte | gauge |

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -1274,6 +1274,7 @@ An example event for `state_node` looks as following:
 | kubernetes.node.cpu.allocatable.cores | Node CPU allocatable cores | float |  | gauge |
 | kubernetes.node.cpu.capacity.cores | Node CPU capacity cores | long |  | gauge |
 | kubernetes.node.hostname | Kubernetes hostname as reported by the node’s kernel | keyword |  |  |
+| kubernetes.node.kubelet.version | Kubelet version. | keyword |  |  |
 | kubernetes.node.memory.allocatable.bytes | Node allocatable memory in bytes | long | byte | gauge |
 | kubernetes.node.memory.capacity.bytes | Node memory capacity in bytes | long | byte | gauge |
 | kubernetes.node.name | Kubernetes node name | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.55.1
+version: 1.55.2
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - containers
   - kubernetes
 conditions:
-  kibana.version: "^8.11.0"
+  kibana.version: "^8.12.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
Fields are available in 8.12.0 version, scheduled for the 16th.


## Proposed commit message

- WHAT: Add major/minor version to api server and kubelet version to state node
- WHY:  requested https://github.com/elastic/beats/issues/36888


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Closes https://github.com/elastic/beats/issues/36888.

## Screenshots

API server:
![Screenshot from 2024-01-08 10-34-42](https://github.com/elastic/integrations/assets/113898685/49ba05de-2c6f-4305-ba54-6641a75256c8)


State node:
![Screenshot from 2024-01-08 10-35-18](https://github.com/elastic/integrations/assets/113898685/ed8a5096-e793-40af-8833-37cb42491293)

