### PR TITLE
[oracle] README updates regarding DSN formats

### DIFF
--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -62,18 +62,23 @@ Then, Metricbeat can be launched.
 
 ### Oracle DSN Configuration
 
-The supported configuration takes the form
+The following two configuration formats are supported:
 ```
 oracle://<user>:<password>@<connection_string>
+user="<user>" password="<password>" connectString="<connection_string>" sysdba=<true|false>
 ```
 
-For example:
-
+Example values are:
 ```
 oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1
+user="sys" password="Oradoc_db1" connectString="0.0.0.0:1521/ORCLCDB.localdomain" sysdba=true
 ```
 
-Special characters, for example in the password, should be URL encoded.
+In the first, URL-based format, special characters should be URL encoded.
+
+In the seoncd, logfmt-encoded DSN format, if the password contains a backslash
+character (`\`), it must be escaped with another backslash. For example, if the
+password is `my\_password`, it must be written as `my\\_password`.
 
 ## Compatibility
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -62,13 +62,18 @@ Then, Metricbeat can be launched.
 
 ### Oracle DSN Configuration
 
-The supported configuration takes one of the forms
-- `oracle://<user>:<password>@<connection_string>`
-- `<user>:<password>@<connection_string>`
+The supported configuration takes the form
+```
+oracle://<user>:<password>@<connection_string>
+```
 
-Examples of supported configurations are as below:
-- `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
-- `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
+For example:
+
+```
+oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1
+```
+
+Special characters, for example in the password, should be URL encoded.
 
 ## Compatibility
 

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.24.2
+  changes:
+    - description: README updates regarding DSN formats.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8841
 - version: 1.24.1
   changes:
     - description: Make Oracle DSN configuration details more discoverable.

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -62,18 +62,23 @@ Then, Metricbeat can be launched.
 
 ### Oracle DSN Configuration
 
-The supported configuration takes the form
+The following two configuration formats are supported:
 ```
 oracle://<user>:<password>@<connection_string>
+user="<user>" password="<password>" connectString="<connection_string>" sysdba=<true|false>
 ```
 
-For example:
-
+Example values are:
 ```
 oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1
+user="sys" password="Oradoc_db1" connectString="0.0.0.0:1521/ORCLCDB.localdomain" sysdba=true
 ```
 
-Special characters, for example in the password, should be URL encoded.
+In the first, URL-based format, special characters should be URL encoded.
+
+In the seoncd, logfmt-encoded DSN format, if the password contains a backslash
+character (`\`), it must be escaped with another backslash. For example, if the
+password is `my\_password`, it must be written as `my\\_password`.
 
 ## Compatibility
 

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -62,13 +62,18 @@ Then, Metricbeat can be launched.
 
 ### Oracle DSN Configuration
 
-The supported configuration takes one of the forms
-- `oracle://<user>:<password>@<connection_string>`
-- `<user>:<password>@<connection_string>`
+The supported configuration takes the form
+```
+oracle://<user>:<password>@<connection_string>
+```
 
-Examples of supported configurations are as below:
-- `oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
-- `sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1`
+For example:
+
+```
+oracle://sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1
+```
+
+Special characters, for example in the password, should be URL encoded.
 
 ## Compatibility
 

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.24.1"
+version: "1.24.2"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[oracle] README updates regarding DSN formats (#8841)

- Remove unsupported DSN format.
- Add note about URL encoding special characters.
- Add logfmt-encoded DSN format.
```

## Discussion

The `oracle` integration uses Filebeat's `sql` input. That uses the [GO DRiver for ORacle DB](https://github.com/godror/godror) to parse Oracle DSNs. When supplied with the removed format, it parses the joined username and password as only a username, with no password, as demonstrated by the following script.

<details>
<summary>DSN parsing script</summary>

Script:
```go
package main

import (
	"fmt"

	"github.com/godror/godror"
)

func main() {
	params, err := godror.ParseDSN("sys:Oradoc_db1@0.0.0.0:1521/ORCLCDB.localdomain?sysdba=1")
	if err != nil {
		fmt.Println(err)
	} else {
		fmt.Println(params.Username)
		fmt.Println(params.Password.Secret())
	}
}
```

Output:
```
sys:Oradoc_db1

```
</details>

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).