### PR TITLE
[Keycloak] Make parsers configurable to support multiline logs

### DIFF
--- a/packages/keycloak/_dev/build/docs/README.md
+++ b/packages/keycloak/_dev/build/docs/README.md
@@ -18,6 +18,10 @@ to your configuration XML file (ie standalone.xml) under the path below
     </profile>
 </server>
 ```
+
+Note:
+- Keycloak log files could contain multiline logs. In order to process them, the [multiline configuration](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html) should be added to the parsers section when deploying the integration.
+
 ## Logs
 
 ### log

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.20.0
+  changes:
+    - description: Make parsers configurable for Keycloak logs.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8857
 - version: 1.19.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -6,3 +6,7 @@ fields:
   _tmp:
     tz_offset: America/Chicago
     only_user_events: false
+multiline:
+  first_line_pattern: '^\d{4}-\d{2}-\d{2}'
+  negate: true
+  match: after

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log
@@ -19,7 +19,6 @@
 2021-10-22 22:16:12,150 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=CLIENT_SCOPE, resourcePath=client-scopes/3b4139b4-66e1-4309-88c1-63ee5abc93a6
 2021-10-22 22:45:12,592 DEBUG [org.keycloak.events] (default task-8) type=LOGOUT, realmId=test, clientId=null, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, redirect_uri=https://www.example.com/auth/admin/test/console/#/realms/test/admin-events, authSessionParentId=bae6e56e-368f-4809-89f3-48cfb6279f5e, authSessionTabId=GbBi74IWYc4
 2021-10-22 22:46:14,913 DEBUG [org.keycloak.events] (default task-1) operationType=DELETE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/d043d5af-6100-483a-9c41-b1a30d5149f7
-2021-10-22 23:05:03,371 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/a57cd49f-fdfd-4d25-9fd2-2a46de44a9e6/children
 2023-08-22 07:19:22,081 ERROR [com.example.BaseUserProvider] (default task-8) Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)
     at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)
     at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
@@ -27,3 +26,4 @@
     at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
     at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
     at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
+2021-10-22 23:05:03,371 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/a57cd49f-fdfd-4d25-9fd2-2a46de44a9e6/children

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log
@@ -20,3 +20,10 @@
 2021-10-22 22:45:12,592 DEBUG [org.keycloak.events] (default task-8) type=LOGOUT, realmId=test, clientId=null, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, redirect_uri=https://www.example.com/auth/admin/test/console/#/realms/test/admin-events, authSessionParentId=bae6e56e-368f-4809-89f3-48cfb6279f5e, authSessionTabId=GbBi74IWYc4
 2021-10-22 22:46:14,913 DEBUG [org.keycloak.events] (default task-1) operationType=DELETE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/d043d5af-6100-483a-9c41-b1a30d5149f7
 2021-10-22 23:05:03,371 DEBUG [org.keycloak.events] (default task-8) operationType=CREATE, realmId=test, clientId=7bcaf1cb-820a-40f1-91dd-75ced03ef03b, userId=ce637d23-b89c-4fca-9088-1aea1d053e19, ipAddress=10.2.2.156, resourceType=GROUP, resourcePath=groups/a57cd49f-fdfd-4d25-9fd2-2a46de44a9e6/children
+2023-08-22 07:19:22,081 ERROR [com.example.BaseUserProvider] (default task-8) Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)
+    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)
+    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
+    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)
+    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
+    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
+    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -1060,6 +1060,29 @@
             }
         },
         {
+            "@timestamp": "2023-08-22T07:19:22.081-05:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "2023-08-22 07:19:22,081 ERROR [com.example.BaseUserProvider] (default task-8) Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)\n    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)\n    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)\n    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)\n    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)\n    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)\n    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)",
+                "timezone": "America/Chicago"
+            },
+            "log": {
+                "level": "ERROR",
+                "logger": "com.example.BaseUserProvider"
+            },
+            "message": "Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)",
+            "process": {
+                "thread": {
+                    "name": "default task-8"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2021-10-22T23:05:03.371-05:00",
             "ecs": {
                 "version": "8.11.0"
@@ -1125,29 +1148,6 @@
             "user": {
                 "id": "ce637d23-b89c-4fca-9088-1aea1d053e19"
             }
-        },
-        {
-            "@timestamp": "2023-08-22T07:19:22.081-05:00",
-            "ecs": {
-                "version": "8.11.0"
-            },
-            "event": {
-                "original": "2023-08-22 07:19:22,081 ERROR [com.example.BaseUserProvider] (default task-8) Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)\n    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)\n    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)\n    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)\n    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)\n    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)\n    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)",
-                "timezone": "America/Chicago"
-            },
-            "log": {
-                "level": "ERROR",
-                "logger": "com.example.BaseUserProvider"
-            },
-            "message": "Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)",
-            "process": {
-                "thread": {
-                    "name": "default task-8"
-                }
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
         }
     ]
 }

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -1125,6 +1125,29 @@
             "user": {
                 "id": "ce637d23-b89c-4fca-9088-1aea1d053e19"
             }
+        },
+        {
+            "@timestamp": "2023-08-22T07:19:22.081-05:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "original": "2023-08-22 07:19:22,081 ERROR [com.example.BaseUserProvider] (default task-8) Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)\n    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)\n    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)\n    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)\n    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)\n    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)\n    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)",
+                "timezone": "America/Chicago"
+            },
+            "log": {
+                "level": "ERROR",
+                "logger": "com.example.BaseUserProvider"
+            },
+            "message": "Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)",
+            "process": {
+                "thread": {
+                    "name": "default task-8"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/keycloak/data_stream/log/agent/stream/filestream.yml.hbs
+++ b/packages/keycloak/data_stream/log/agent/stream/filestream.yml.hbs
@@ -13,13 +13,13 @@ tags:
 publisher_pipeline.disable_host: true
 {{/contains}}
 prospector.scanner.exclude_files: ['\.gz$']
-processors:
-{{#if processors}}
-{{processors}}
-{{/if}}
 {{#if parsers}}
 parsers:
 {{parsers}}
+{{/if}}
+processors:
+{{#if processors}}
+{{processors}}
 {{/if}}
 - add_locale: ~
 - add_fields:

--- a/packages/keycloak/data_stream/log/agent/stream/filestream.yml.hbs
+++ b/packages/keycloak/data_stream/log/agent/stream/filestream.yml.hbs
@@ -17,6 +17,10 @@ processors:
 {{#if processors}}
 {{processors}}
 {{/if}}
+{{#if parsers}}
+parsers:
+{{parsers}}
+{{/if}}
 - add_locale: ~
 - add_fields:
     target: _tmp

--- a/packages/keycloak/data_stream/log/manifest.yml
+++ b/packages/keycloak/data_stream/log/manifest.yml
@@ -52,6 +52,19 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: parsers
+        type: yaml
+        title: Parsers
+        description: |
+          This option expects a list of parsers that the payload has to go through. For more information, see [Parsers](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#_parsers).
+        required: false
+        show_user: true
+        multi: false
+        default: |
+          - multiline:
+              pattern: '^\d{4}-\w{2}-\d{2}'
+              negate: true
+              match: after
 
     template_path: "filestream.yml.hbs"
     title: Keycloak logs

--- a/packages/keycloak/docs/README.md
+++ b/packages/keycloak/docs/README.md
@@ -18,6 +18,10 @@ to your configuration XML file (ie standalone.xml) under the path below
     </profile>
 </server>
 ```
+
+Note:
+- Keycloak log files could contain multiline logs. In order to process them, the [multiline configuration](https://www.elastic.co/guide/en/beats/filebeat/current/multiline-examples.html) should be added to the parsers section when deploying the integration.
+
 ## Logs
 
 ### log

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.19.0"
+version: "1.20.0"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

In order to process multiline logs, this pull request makes the parsers configurable for the Keycloak integration.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Added multiline cases to pipeline tests

## Screenshots
<img width="434" alt="image" src="https://github.com/elastic/integrations/assets/29475387/40da96f8-44ca-4ab5-b9aa-05860004c991">

