### PR TITLE
[TCP/UDP] Add missing ECS syslog mapping

### DIFF
--- a/packages/tcp/changelog.yml
+++ b/packages/tcp/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.18.0
+  changes:
+    - description: Added `log.syslog.msgid` and `log.syslog.structured_data` to ECS mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8870
 - version: 1.17.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/tcp/data_stream/generic/fields/ecs.yml
+++ b/packages/tcp/data_stream/generic/fields/ecs.yml
@@ -15,6 +15,8 @@
   external: ecs
 - name: log.syslog.hostname
   external: ecs
+- name: log.syslog.msgid
+  external: ecs
 - name: log.syslog.priority
   external: ecs
 - name: log.syslog.procid
@@ -22,6 +24,8 @@
 - name: log.syslog.severity.code
   external: ecs
 - name: log.syslog.severity.name
+  external: ecs
+- name: log.syslog.structured_data
   external: ecs
 - name: log.syslog.version
   external: ecs

--- a/packages/tcp/manifest.yml
+++ b/packages/tcp/manifest.yml
@@ -3,7 +3,7 @@ name: tcp
 title: Custom TCP Logs
 description: Collect raw TCP data from listening TCP port with Elastic Agent.
 type: integration
-version: "1.17.0"
+version: "1.18.0"
 conditions:
   kibana:
     version: "^8.2.1"

--- a/packages/udp/changelog.yml
+++ b/packages/udp/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.18.0
+  changes:
+    - description: Added `log.syslog.msgid` and `log.syslog.structured_data` to ECS mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8870
 - version: 1.17.0
   changes:
     - description: ECS version updated to 8.11.0.

--- a/packages/udp/data_stream/generic/fields/ecs.yml
+++ b/packages/udp/data_stream/generic/fields/ecs.yml
@@ -15,6 +15,8 @@
   external: ecs
 - name: log.syslog.hostname
   external: ecs
+- name: log.syslog.msgid
+  external: ecs
 - name: log.syslog.priority
   external: ecs
 - name: log.syslog.procid
@@ -22,6 +24,8 @@
 - name: log.syslog.severity.code
   external: ecs
 - name: log.syslog.severity.name
+  external: ecs
+- name: log.syslog.structured_data
   external: ecs
 - name: log.syslog.version
   external: ecs

--- a/packages/udp/manifest.yml
+++ b/packages/udp/manifest.yml
@@ -3,7 +3,7 @@ name: udp
 title: Custom UDP Logs
 description: Collect raw UDP data from listening UDP port with Elastic Agent.
 type: integration
-version: "1.17.0"
+version: "1.18.0"
 conditions:
   kibana:
     version: "^8.2.1"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

It has been reported an error in the Custom UDP integration. Since `log.syslog.structured_data` is not defined in the ECS template, each subfield in this object is mapped and indexed separately potentially leading to a mapping explosion. 

This PR adds the missing log.syslog.* ECS mappings to the ECS template in UDP and TCP integrations, so the content of `log.syslog.structured_data` is mapped as a single field. 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
```
cd packages/tcp && elastic-package test
cd packages/udp && elastic-package test
```
