### PR TITLE
[ti_opencti] Keep expected nulls, improve error handling

### DIFF
--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.5"
+  changes:
+    - description: Keep expected nulls, improve error handling
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8875
 - version: "0.3.4"
   changes:
     - description: Tolerate suffixes on the OpenCTI instance URL

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -55,15 +55,24 @@ program: |
       }
     }.encode_json()
   }).do_request().as(resp,
-    bytes(resp.Body).decode_json().as(body, state.with({
-      "events": body.data.indicators.edges.map(e, e.node.with(
-        has(state.preserve_original_event) && state.preserve_original_event ?
-          { "event": { "original": e.node.encode_json() } } :
-          {}
-      )),
-      "want_more": body.data.indicators.pageInfo.hasNextPage,
-      "cursor": { "value": body.data.indicators.pageInfo.endCursor },
-    }))
+    bytes(resp.Body).decode_json().as(body,
+      has(body.errors) && size(body.errors) > 0 ?
+        state.with({
+          "events": [{
+            "error": { "message": body.errors.map(e, e.message) },
+            "event": { "original": body.encode_json() }
+          }]
+        }) :
+        state.with({
+          "events": body.data.indicators.edges.map(e, e.node.with(
+            has(state.preserve_original_event) && state.preserve_original_event ?
+              { "event": { "original": e.node.encode_json() } } :
+              {}
+          )),
+          "want_more": body.data.indicators.pageInfo.hasNextPage,
+          "cursor": { "value": body.data.indicators.pageInfo.endCursor },
+        })
+    )
   )
 redact:
   fields:

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -28,6 +28,7 @@ processors:
 {{processors}}
 {{/if}}
 fields_under_root: true
+keep_null: true
 fields:
   _conf:
     url: {{url}}

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -41,7 +41,8 @@ program: |
       "Content-Type": ["application/json"]
     }).with(
       has(state.api_key) && size(state.api_key) > 0 ?
-        { "Authorization": ["Bearer " + state.api_key] } :
+        { "Authorization": ["Bearer " + state.api_key] }
+      :
         {}
     )
   }).with({
@@ -62,11 +63,13 @@ program: |
             "error": { "message": body.errors.map(e, e.message) },
             "event": { "original": body.encode_json() }
           }]
-        }) :
+        })
+      :
         state.with({
           "events": body.data.indicators.edges.map(e, e.node.with(
             has(state.preserve_original_event) && state.preserve_original_event ?
-              { "event": { "original": e.node.encode_json() } } :
+              { "event": { "original": e.node.encode_json() } }
+            :
               {}
           )),
           "want_more": body.data.indicators.pageInfo.hasNextPage,

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -2,6 +2,14 @@
 description: Pipeline for processing indicators
 processors:
 
+  ###############################################
+  # Send errors from CEL to the failure handler #
+  ###############################################
+
+  - fail:
+      if: ctx.error?.message != null
+      message: "Error during CEL program evaluation"
+
   ####################
   # Event ECS fields #
   ####################

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: ti_opencti
 title: OpenCTI
-version: "0.3.4"
+version: "0.3.5"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
[ti_opencti] Keep expected nulls, improve error handling (#8875)

* Set `keep_null: true` to avoid loss of fields between the CEL
  program and the ingest pipeline.
* Handle server responses with errors gracefully in the CEL program
  and in the ingest pipeline.  
```

## Why set `keep_null: true`?

While ingesting from the public demo instance of OpenCTI, I observed a large number of errors, containing the message `Processor "rename" with tag "" in pipeline \"logs-ti_opencti.indicator-0.3.4" failed with message "field [description] doesn't exist"`. The `event.original` value showed that `description` key existed and had a `null` value, and the pipeline did [correctly handle](https://github.com/elastic/integrations/blob/2f76c8a9c9a796c0e04adc84c6b524f88d7d3e35/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml#L109-L114) null descriptions.

There was a pipeline test example that [included a null description](https://github.com/elastic/integrations/blob/2f76c8a9c9a796c0e04adc84c6b524f88d7d3e35/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-process.json#L16) that was processed correctly.

The GraphQL query requested the description field and received it with a null value, but Beats removed it because the `keep_null` setting defaults to `false`. Avoiding changes between output from the CEL expression and input to the ingest pipeline seems less surprising and resolves the observed errors.

## Why change error handling?

The OpenCTI server may respond with an error message. For example, for an authentication/authorization error it will respond it will HTTP status code of `200` and a body as follows:

```
{
  "errors": [
    {
      "message": "You must be logged in to do this.",
      "name": "AUTH_REQUIRED",
      "time_thrown": "2024-01-12T10:47:28.810Z",
      "data": {
        "http_status": 401,
        "genre": "TECHNICAL"
      }
    }
  ],
  "data": {
    "indicators": null
  }
}
```

The CEL expression [assumed](https://github.com/elastic/integrations/blob/2f76c8a9c9a796c0e04adc84c6b524f88d7d3e35/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs#L58) that `.data.indicators` is an array (as it is in a successful empty response). That led to an error message of `failed eval: no such key: edges` and later `Processor "rename" with tag "" in pipeline "logs-ti_opencti.indicator-0.3.4" failed with message "field [created] doesn't exist"`.

The improved CEL expression handles this situation gracefully by detecting the error and capturing more information about it, and then the pipeline logic marks it as a failure without trying to apply processing steps that require a full, correct document. The indexed document will now include the following helpful information:

```
"error.message": [
  "You must be logged in to do this.",
  "Processor \"conditional\" with tag \"\" in pipeline \"logs-ti_opencti.indicator-0.3.4\" failed with message \"Error during CEL program evaluation\"\n"
],
"event.original": [
  "{\"data\":{\"indicators\":null},\"errors\":[{\"data\":{\"genre\":\"TECHNICAL\",\"http_status\":401},\"message\":\"You must be logged in to do this.\",\"name\":\"AUTH_REQUIRED\",\"time_thrown\":\"2024-01-12T11:28:01.679Z\"}]}"
],
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

* Build and install.
* Add a policy with credentials for https://demo.opencti.io/.
* Try with the wrong API key to generate an error.