### PR TITLE
aws: fix query range calculation for GuardDuty datastream

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.11.3"
+  changes:
+    - description: Fix query range calculation for GuardDuty datastream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8882
 - version: "2.11.2"
   changes:
     - description: Remove hardcoded event.dataset field and use ecs instead.

--- a/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/guardduty/agent/stream/httpjson.yml.hbs
@@ -29,11 +29,11 @@ request.transforms:
       value_type: json
   - set:
       target: body.findingCriteria.criterion.updatedAt.greaterThan
-      value: '[[((parseDate .cursor.last_execution_datetime).Truncate (parseDuration "1h")).UnixMilli]]'
-      default: '[[((now (parseDuration "-{{initial_interval}}")).Truncate (parseDuration "1h")).UnixMilli]]'
+      value: '[[((parseDate .cursor.last_execution_datetime)).UnixMilli]]'
+      default: '[[((now (parseDuration "-{{initial_interval}}"))).UnixMilli]]'
   - set:
       target: body.findingCriteria.criterion.updatedAt.lessThan
-      value: '[[((now).Truncate (parseDuration "1h")).UnixMilli]]'
+      value: '[[((now)).UnixMilli]]'
   - set:
       target: header.Authorization
       value: '[[$now := (now)]][[(sprintf "AWS4-HMAC-SHA256 Credential={{access_key_id}}/%s/{{aws_region}}/guardduty/aws4_request, SignedHeaders=host;x-amz-date, Signature=%s" (formatDate ($now) "20060102") (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" (hexDecode (hmac "sha256" "AWS4{{secret_access_key}}" (formatDate ($now) "20060102"))) "{{aws_region}}")) "guardduty")) "aws4_request")) "AWS4-HMAC-SHA256\n" (formatDate ($now) "20060102T150405Z") "\n" (sprintf "%s/%s\n" (formatDate ($now) "20060102") "{{aws_region}}/guardduty/aws4_request") (hash "sha256" "POST\n" "/detector/{{detector_id}}/findings\n" "\n" "host:guardduty.{{aws_region}}.{{tld}}\n" (sprintf "x-amz-date:%s\n\n" (formatDate ($now) "20060102T150405Z")) "host;x-amz-date\n" (hash "sha256" (sprintf `%s` .body)))))]]'

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.11.2
+version: 2.11.3
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The calculations for `findingCriteria.criterion.updatedAt.*Than` included a time truncation with the resolution of an hour. This has the effect that if there was no successful execution of the `last_execution_datetime template` the `greaterThan` and `lessThan` values would be equal 1 in hour/initial_interval times, resulting in spurious requests that required satisfaction of a null set. The truncation also prevents progression of the criteria for 1 - (1 in hour/initial_interval) HTTPJSON periodic request cycles.

Not marking as closing the issue as I think there are still problems with the template evaluation that are not currently diagnosable with HTTPJSON's existing template logging (will be able to look at this when v8.11 is more prevalent ).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- For #8601

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
