### PR TITLE
[Cisco FTD] added nullcheck for Network Directionality when zones aren't configured

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.0.3"
+  changes:
+    - description: Added nullcheck for Network Directionality when zones aren't configured
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8883
 - version: "3.0.2"
   changes:
     - description: Fix the handling of spaces in 113005 messages.

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2114,7 +2114,8 @@ processors:
   - script:
       description: Calculate network.direction if zones are not configured
       lang: painless
-      if: "ctx?.tags?.contains('private_is_internal') &&
+      if: "ctx?.tags != null && 
+           ctx?.tags?.contains('private_is_internal') &&
            ctx?.source?.ip != null &&
            ctx?.destination?.ip != null &&
           (ctx?._temp_?.external_zones == null ||

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2114,12 +2114,12 @@ processors:
   - script:
       description: Calculate network.direction if zones are not configured
       lang: painless
-      if: "ctx?.tags != null && 
-           ctx?.tags?.contains('private_is_internal') &&
-           ctx?.source?.ip != null &&
-           ctx?.destination?.ip != null &&
-          (ctx?._temp_?.external_zones == null ||
-           ctx?._temp_?.internal_zones == null)"
+      if: "ctx.tags != null && 
+           ctx.tags.contains('private_is_internal') &&
+           ctx.source?.ip != null &&
+           ctx.destination?.ip != null &&
+          (ctx._temp_?.external_zones == null ||
+           ctx._temp_?.internal_zones == null)"
       source: |
         boolean isPrivateCIDR(def ip) {
           CIDR class_a_network = new CIDR('10.0.0.0/8');

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.0.2"
+version: "3.0.3"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory



This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
Hello Folk, 

I have added one additional nullcheck for the cisco-ftd integration due to experiencing a bug. In certain configurations, it was possible to experience an processing error, causing the integration to crash out on this part. This additional nullcheck is a quick and easy solution with virtually no impact on performance and causing no breaking changes. 

I would also like to recommend to add a pipeline test for the future, to test these changes based on a conversation with @bhapas 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

