### PR TITLE
[Nginx] Improve generated error message

### DIFF
--- a/packages/nginx/_dev/benchmark/rally/error-benchmark/config.yml
+++ b/packages/nginx/_dev/benchmark/rally/error-benchmark/config.yml
@@ -17,3 +17,18 @@ fields:
     range:
       min: 1
       max: 100000
+  - name: request.method
+    enum: ["POST", "GET", "PUT", "DELETE"]
+  - name: request.path
+    enum:
+      - "/favicon.ico"
+      - "/index.html"
+      - "/foo/bar.php"
+  - name: referer.host.name
+    enum:
+      - "localhost"
+      - "google.com"
+  - name: host.name
+    enum:
+      - "localhost"
+      - "elastic.co"

--- a/packages/nginx/_dev/benchmark/rally/error-benchmark/fields.yml
+++ b/packages/nginx/_dev/benchmark/rally/error-benchmark/fields.yml
@@ -26,3 +26,9 @@
   type: long
 - name: timestamp
   type: date
+- name: request.method
+  type: keyword
+- name: request.path
+  type: keyword
+- name: referer.host.name
+  type: keyword

--- a/packages/nginx/_dev/benchmark/rally/error-benchmark/template.ndjson
+++ b/packages/nginx/_dev/benchmark/rally/error-benchmark/template.ndjson
@@ -7,6 +7,7 @@
 {{- $pid := generate "process.pid" }}
 {{- $threadId := generate "thread.id" }}
 {{- $connectionId := generate "connection_id" }}
+{{- $requestPath := generate "request.path" }}
 {
     "@timestamp": "{{ $timestamp.Format "2006-01-02T15:04:05.000Z" }}",
     "agent": {
@@ -65,7 +66,7 @@
         },
         "offset": 0
     },
-    "message": "{{$timestamp.Format "2006/01/02 15:04:05"}} [{{ $logLevel }}] {{ $pid }}#{{ $threadId }}: *{{ $connectionId }} {{generate "message"}}",
+    "message": "{{$timestamp.Format "2006/01/02 15:04:05"}} [{{ $logLevel }}] {{ $pid }}#{{ $threadId }}: *{{ $connectionId }} open() \"/usr/local/Cellar/nginx/1.10.2_1/html{{ $requestPath }}\" failed (2: No such file or directory), client: 127.0.0.1, server: localhost, request: \"{{ generate "request.method" }} {{ $requestPath }} HTTP/1.1\", host: \"{{ generate "host.name" }}:8080\", referrer: \"http://{{ generate "referer.host.name" }}:8080/\"",
     "tags": [
         "nginx-error"
     ]


### PR DESCRIPTION
In https://github.com/elastic/integrations/pull/8762 error log generation was added. The message was a random message generated. This changes it to have a partially more realistic message generated based on some actual logs. The enum values for the different fields are hardcoded. It would be nice to have for host, ip and paths some partially random generation that could be used as function with cardinality.
