### PR TITLE
[Nginx] Fix stubstatus benchmark

### DIFF
--- a/packages/nginx/_dev/benchmark/rally/stubstatus-benchmark/template.ndjson
+++ b/packages/nginx/_dev/benchmark/rally/stubstatus-benchmark/template.ndjson
@@ -5,7 +5,7 @@
 {{- $agentEphemeralid := generate "agent.ephemeral_id" }}
 {{- $service_address := generate "service.address" }}
 {
-    "@timestamp": "{{ $timestamp.Format "2006-01-02T15:04:05.000Z" }}",
+    "@timestamp": "{{ $timestamp.Format "2006-01-02T15:04:05.000Z07:00" }}",
     "agent": {
         "ephemeral_id": "{{ $agentEphemeralid }}",
         "id": "{{ $agentId }}",


### PR DESCRIPTION
When ingesting data with the `stream` command, the current track failed with the following error:

```
{"errors":true,"took":0,"ingest_took":1,"items":[{"create":{"_index":"metrics-nginx.stubstatus-ep","_id":null,"status":400,"error":{"type":"illegal_argument_exception","reason":"the document timestamp [2024-01-17T13:58:56.000Z] is outside of ranges of currently writable indices [[2024-01-17T10:46:15.000Z,2024-01-17T13:33:47.000Z]]"}}}
```

The reason was, that the timestamp used did not contain any timezone so it was in UTC. TSDB automatically sets up a range based on `now` for the local setup so when you were too far out from UTC ingestion failed. Adding the local timezone to the timezone fixes this and also ensures data that is ingested with `stream` shows up as "current" data in Discover.

To test this, run the following command:

```
elastic-package benchmark stream --benchmark stubstatus-benchmark -v
```

This should also work with the 15min prefill as the timestamp set by TSDB for the first index is in the past.
