### PR TITLE
[MySQL] Fix performance benchmarking

### DIFF
--- a/packages/mysql/_dev/benchmark/rally/performance-benchmark/template.ndjson
+++ b/packages/mysql/_dev/benchmark/rally/performance-benchmark/template.ndjson
@@ -15,7 +15,7 @@
 {{- $digest := generate "digest_text" }}
 {{- $service_address := generate "service_address" }}
 {
-    "@timestamp": "{{ $timestamp.Format "2006-01-02T15:04:05.000Z" }}",
+    "@timestamp": "{{ $timestamp.Format "2006-01-02T15:04:05.000Z07:00" }}",
     "agent": {
         "ephemeral_id": "{{ $agentEphemeralid }}",
         "id": "{{ $agentId }}",


### PR DESCRIPTION
Following the changes in this [PR](https://github.com/elastic/integrations/pull/8914), checked for the remaining packages which require the change. Found only 1 data stream in which the fix needs to be made. Please go through the above linked PR for the fix done.