### PR TITLE
[Elasticsearch] Make "Total Storage over time" viz consistent with others by using same sourceField

### DIFF
--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.1"
+  changes:
+    - description: Make "Total Storage over time" viz consistent with others by using same sourceField
+      type: bugfix
+      link: TODO
 - version: "1.13.0"
   changes:
     - description: Add mapping for total_data_set_size

--- a/packages/elasticsearch/changelog.yml
+++ b/packages/elasticsearch/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Make "Total Storage over time" viz consistent with others by using same sourceField
       type: bugfix
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/8931/
 - version: "1.13.0"
   changes:
     - description: Add mapping for total_data_set_size

--- a/packages/elasticsearch/kibana/dashboard/elasticsearch-b1399af0-628c-11ee-9c63-732d7f759a7a.json
+++ b/packages/elasticsearch/kibana/dashboard/elasticsearch-b1399af0-628c-11ee-9c63-732d7f759a7a.json
@@ -712,13 +712,13 @@
                                                     "key": "metricset.name",
                                                     "negate": false,
                                                     "params": {
-                                                        "query": "index_summary"
+                                                        "query": "cluster_stats"
                                                     },
                                                     "type": "phrase"
                                                 },
                                                 "query": {
                                                     "match_phrase": {
-                                                        "metricset.name": "index_summary"
+                                                        "metricset.name": "cluster_stats"
                                                     }
                                                 }
                                             },
@@ -1048,7 +1048,7 @@
                     "y": 7
                 },
                 "panelIndex": "f72d74ff-8466-4251-8670-06c7f72faebe",
-                "title": "Total Bytes per node (data_content role)",
+                "title": "Total Bytes per node (data_content role) - Top 100",
                 "type": "lens",
                 "version": "8.10.2"
             },

--- a/packages/elasticsearch/kibana/dashboard/elasticsearch-b1399af0-628c-11ee-9c63-732d7f759a7a.json
+++ b/packages/elasticsearch/kibana/dashboard/elasticsearch-b1399af0-628c-11ee-9c63-732d7f759a7a.json
@@ -634,7 +634,7 @@
                                                         }
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "elasticsearch.index.summary.total.store.size.bytes"
+                                                    "sourceField": "elasticsearch.cluster.stats.indices.store.size.bytes"
                                                 },
                                                 "28f5ba94-f0af-43a8-83b1-373df938e63b": {
                                                     "dataType": "string",

--- a/packages/elasticsearch/manifest.yml
+++ b/packages/elasticsearch/manifest.yml
@@ -1,6 +1,6 @@
 name: elasticsearch
 title: Elasticsearch
-version: 1.13.0
+version: 1.13.1
 description: Elasticsearch Integration
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

The visualizations in the Elasticsearch storage dashboards rely on the `elasticsearch.cluster.stats.indices.store.size.bytes` field, but one visualization, "Total Storage over time", was using `elasticsearch.index.summary.total.store.size.bytes` instead, causing values to be inconsistent across the dashboard.
This commit eliminates this inconsistency.

-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Start a stack using `elastic-package` and install the integration. Confirm that this particular viz shows different totals compared to the rest. After introducing this change one can observe that the visualization is no longer showing a different total.


## Screenshots


### Before 

You can see inconsistent Y axis values

<img width="764" alt="Screenshot 2024-01-18 at 16 01 58" src="https://github.com/elastic/integrations/assets/31809/e16de7e2-3d01-481c-b8fe-f6b997061db5">

### After 

<img width="760" alt="Screenshot 2024-01-18 at 15 59 14" src="https://github.com/elastic/integrations/assets/31809/10e42ae4-c046-4845-9a46-bbc4c05eb5a6">
