### PR TITLE
Make Oracle DSN configuration details more discoverable

### DIFF
--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -60,7 +60,7 @@ If the listener is not running, use the command to start:
 
 Then, Metricbeat can be launched.
 
-*Oracle DSN Configuration*
+### Oracle DSN Configuration
 
 The supported configuration takes one of the forms
 - `oracle://<user>:<password>@<connection_string>`

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.24.1
+  changes:
+    - description: Make Oracle DSN configuration details more discoverable.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8948
 - version: 1.24.0
   changes:
     - description: Document alternate method of adding runtime library path.

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -60,7 +60,7 @@ If the listener is not running, use the command to start:
 
 Then, Metricbeat can be launched.
 
-*Oracle DSN Configuration*
+### Oracle DSN Configuration
 
 The supported configuration takes one of the forms
 - `oracle://<user>:<password>@<connection_string>`

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.24.0"
+version: "1.24.1"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION
This PR applies Header level 3 to the **Oracle DSN Configuration** section to make it more discoverable.
Closes [#123](https://github.com/elastic/integrations/issues/8607)

