### PR TITLE
Updating k8s integration benchamrks with more realistic cpu/mem metrics

### DIFF
--- a/packages/kubernetes/_dev/benchmark/rally/container-benchmark/config.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/container-benchmark/config.yml
@@ -37,10 +37,23 @@ fields:
     range:
       min: 0
       max: 10000
-  - name: Percentage
+  - name: PercentageMemory
     range:
       min: 0
-      max: 5000
+      max: 100
     fuzziness: 0.005
+  - name: PercentageCPU
+    range:
+      min: 0
+      max: 100
+    fuzziness: 0.005
+  - name: Usage
+    range:
+      min: 100000
+      max: 9000000000
+  - name: Nanocores
+    range:
+      min: 100000
+      max: 9000000
   - name: container.name
     enum: ["web", "default-http-backend", "dnsmasq", "csi-driver", "web", "web", "web", "prometheus", "konnectivity-agent", "sidecar", "kubedns", "metrics-server-nanny", "web", "web", "fluentbit", "autoscaler", "gke-metrics-agent", "elastic-agent", "web", "kube-state-metrics", "metrics-server", "fluentbit", "elastic-agent", "web", "prometheus-to-sd-exporter"]

--- a/packages/kubernetes/_dev/benchmark/rally/container-benchmark/fields.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/container-benchmark/fields.yml
@@ -22,8 +22,14 @@
   type: long
 - name: Ip
   type: ip
-- name: Percentage
+- name: PercentageMemory
   type: double
+- name: PercentageCPU
+  type: double
+- name: Usage
+  type: integer
+- name: Nanocores
+  type: integer
 - name: rangeofid
   type: integer
 - name: agent.snapshot

--- a/packages/kubernetes/_dev/benchmark/rally/container-benchmark/template.ndjson
+++ b/packages/kubernetes/_dev/benchmark/rally/container-benchmark/template.ndjson
@@ -5,19 +5,22 @@
 {{- $agentEphemeralid := generate "agent.ephemeral_id" -}}
 {{- $timestamp := generate "timestamp" }}
 {{- $faults := generate "faults" -}}
-{{- $pct := generate "Percentage" -}}
+{{- $pctmem := generate "PercentageMemory" }}
+{{- $pctcpu := generate "PercentageCPU" }}
+{{- $usage := generate "Usage" -}}
+{{- $nanocores := generate "Nanocores" -}}
 {{- $rangeofid := generate "rangeofid" -}}
 {{- $nodeid := div $rangeofid 110 -}}
 {{- $name :=  generate "container.name" -}}
 {  "@timestamp": "{{$timestamp.Format "2006-01-02T15:04:05.999999Z07:00"}}",
    "container":{
       "memory":{
-         "usage": {{divf $pct 1000000}}
+         "usage": {{divf $pctmem 100}}
       },
       "name":"{{ $name }}",
       "runtime":"containerd",
       "cpu":{
-         "usage": {{divf $pct 1000000}}
+         "usage": {{divf $pctcpu 100}}
       },
       "id":"container-{{ $rangeofid }}"
    },
@@ -31,11 +34,11 @@
             "majorpagefaults": {{ $faults }},
             "usage":{
                "node":{
-                  "pct": {{divf $pct 1000000}}
+                  "pct": {{divf $pctmem 100}}
                },
                "bytes": {{generate "Bytes"}},
                "limit":{
-                  "pct": {{divf $pct 1000000}}
+                  "pct": {{divf $pctmem 100}}
                }
             },
             "available":{
@@ -44,7 +47,7 @@
             "workingset":{
                "bytes": {{generate "Bytes"}},
                "limit":{
-                  "pct": {{divf $pct 1000000}}
+                  "pct": {{divf $pctmem 100}}
                }
             },
             "pagefaults": "{{ $faults }}"
@@ -67,14 +70,14 @@
          "cpu":{
             "usage":{
                "core":{
-                  "ns": 41129679
+                  "ns": {{mul $usage 1000}}
                },
                "node":{
-                  "pct": {{divf $pct 1000000}}
+                  "pct": {{divf $pctcpu 100}}
                },
-               "nanocores":0,
+               "nanocores":{{mul $nanocores 1000}},
                "limit":{
-                  "pct": {{divf $pct 1000000}}
+                  "pct": {{divf $pctcpu 100}}
                }
             }
          },

--- a/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/config.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/config.yml
@@ -37,8 +37,17 @@ fields:
     range:
       min: 9000
       max: 10000
-  - name: Percentage
+  - name: PercentageMemory
     range:
       min: 0
-      max: 5000
+      max: 100
     fuzziness: 0.005
+  - name: PercentageCPU
+    range:
+      min: 0
+      max: 100
+    fuzziness: 0.005
+  - name: Nanocores
+    range:
+      min: 100000
+      max: 9000000

--- a/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/fields.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/fields.yml
@@ -26,7 +26,11 @@
   type: integer
 - name: Ip
   type: ip
-- name: Percentage
+- name: PercentageMemory
   type: double
+- name: PercentageCPU
+  type: double
+- name: Nanocores
+  type: integer
 - name: agent.snapshot
   type: boolean

--- a/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/template.ndjson
+++ b/packages/kubernetes/_dev/benchmark/rally/pod-benchmark/template.ndjson
@@ -8,7 +8,9 @@
 {{- $txbytes := generate "container.network.egress.bytes" }}
 {{- $rangeofid := generate "rangeofid" }}
 {{- $nodeid := div $rangeofid 110 -}}
-{{- $pct := generate "Percentage" }}
+{{- $pctmem := generate "PercentageMemory" }}
+{{- $pctcpu := generate "PercentageCPU" }}
+{{- $nanocores := generate "Nanocores" -}}
 {  "@timestamp": "{{$timestamp.Format `2006-01-02T15:04:05.999999Z07:00`}}",
    "container":{
       "network":{
@@ -60,11 +62,11 @@
             "major_page_faults":0,
             "usage":{
                "node":{
-                  "pct": "{{divf $pct 1000000}}"
+                  "pct": "{{divf $pctmem 100}}"
                },
                "bytes": "{{generate `Bytes`}}",
                "limit":{
-                  "pct":"{{divf $pct 1000000}}"
+                  "pct":"{{divf $pctmem 100}}"
                }
             },
             "available":{
@@ -74,7 +76,7 @@
             "working_set":{
                "bytes": "{{generate `Bytes`}}",
                "limit":{
-                  "pct": "{{divf $pct 1000000}}"
+                  "pct": "{{divf $pctmem 100}}"
                }
             }
          },
@@ -83,11 +85,11 @@
          "cpu":{
             "usage":{
                "node":{
-                  "pct":0
+                  "pct":{{divf $pctcpu 100}}
                },
-               "nanocores":0,
+               "nanocores":{{mul $nanocores 1000}},
                "limit":{
-                  "pct":0
+                  "pct":{{divf $pctcpu 100}}
                }
             }
          },


### PR DESCRIPTION
- Enhancement

## Proposed commit message

- WHAT: Updating benchmark templates to align with changes proposed in [PR 126](https://github.com/elastic/elastic-integration-corpus-generator-tool/pull/126/files)
- WHY:  Template files that are used in integrations are the ones that will be used from now on from elastic-package command

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. elastic-package stack up -d -vvv --version=8.13.0-SNAPSHOT
2. Build elastic-package from main
3. Clone this PR
4. cd into `integrations/packages/kubernetes`
5. /Users/andreasgkizas/elastic/elastic-package/elastic-package benchmark rally --benchmark container-benchmark --dry-run --rally-track-output-dir results/container/

## Related issues

- Relates #https://github.com/elastic/elastic-integration-corpus-generator-tool/pull/126
- Relates https://github.com/elastic/observability-dev/issues/2977
