### PR TITLE
[o365] Add error.message ECS field mapping

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add error.message ECS field mapping.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8964
 - version: "2.1.1"
   changes:
     - description: Changed owners

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.2"
+  changes:
+    - description: Add error.message ECS field mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.1"
   changes:
     - description: Changed owners

--- a/packages/o365/data_stream/audit/_dev/test/pipeline/test-platform-attribute-events.json
+++ b/packages/o365/data_stream/audit/_dev/test/pipeline/test-platform-attribute-events.json
@@ -1,20 +1,20 @@
 {
-  "events": [
-    {
-      "event": {
-        "original": "{\"Platform\":1}"
-      },
-      "o365audit": {
-        "Platform": "1"
-      }
-    },
-    {
-      "event": {
-        "original": "{\"Platform\":\"Mac\"}"
-      },
-      "o365audit": {
-        "Platform": "Mac"
-      }
-    }
-  ]
+    "events": [
+        {
+            "event": {
+                "original": "{\"Platform\":1}"
+            },
+            "o365audit": {
+                "Platform": "1"
+            }
+        },
+        {
+            "event": {
+                "original": "{\"Platform\":\"Mac\"}"
+            },
+            "o365audit": {
+                "Platform": "Mac"
+            }
+        }
+    ]
 }

--- a/packages/o365/data_stream/audit/fields/ecs.yml
+++ b/packages/o365/data_stream/audit/fields/ecs.yml
@@ -15,6 +15,8 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.message
+- external: ecs
   name: event.action
 - external: ecs
   name: event.category

--- a/packages/o365/docs/README.md
+++ b/packages/o365/docs/README.md
@@ -203,6 +203,7 @@ An example event for `audit` looks as following:
 | destination.user.email | User email address. | keyword |
 | destination.user.id | Unique identifier of the user. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
+| error.message | Error message. | match_only_text |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
 | event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "2.1.1"
+version: "2.1.2"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

- Add the error.message field to the ECS mappings
- When not explicitly mapped in ecs.yml, error.message will assume a default type of keyword which conflicts with the ECS-defined type of match_only_text.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
