### PR TITLE
[windows.forwarded] Add fields to ECS mappings

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     -  description: Added error.message and http.request.body.bytes ECS field mapping.
        type: bugfix
-       link: https://github.com/elastic/integrations/pull/8975
+       link: https://github.com/elastic/integrations/pull/8976
 - version: "1.44.1"
   changes:
     - description: Properly parse file hashes for Sysmon event ID 26, file delete detected

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.44.2"
   changes:
-    -  description: Added error.message and http.request.body.bytes ECS field mapping.
-       type: bugfix
-       link: https://github.com/elastic/integrations/pull/8976
+    - description: Added error.message and http.request.body.bytes ECS field mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8976
 - version: "1.44.1"
   changes:
     - description: Properly parse file hashes for Sysmon event ID 26, file delete detected

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
--version: "1.44.2"
+- version: "1.44.2"
   changes:
     -  description: Added error.message and http.request.body.bytes ECS field mapping.
        type: bugfix

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+-version: "1.44.2"
+  changes:
+    -  description: Added error.message and http.request.body.bytes ECS field mapping.
+       type: bugfix
+       link: https://github.com/elastic/integrations/pull/8975
 - version: "1.44.1"
   changes:
     - description: Properly parse file hashes for Sysmon event ID 26, file delete detected

--- a/packages/windows/data_stream/forwarded/fields/ecs.yml
+++ b/packages/windows/data_stream/forwarded/fields/ecs.yml
@@ -51,6 +51,8 @@
 - external: ecs
   name: error.code
 - external: ecs
+  name: error.message
+- external: ecs
   name: event.action
 - external: ecs
   name: event.category
@@ -118,6 +120,8 @@
   name: group.name
 - external: ecs
   name: host.name
+- external: ecs
+  name: http.request.body.bytes
 - external: ecs
   name: log.file.path
 - external: ecs

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.44.1
+version: 1.44.2
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->
Bug

## Proposed commit message

<!-- Mandatory
-->

* Add fields error.message and http.request.body.bytes to the ECS mappings
* Data Quality check finds default mapping of these fields (defaults to keyword) incompatible with ECS expected mapping types of match_long_text as well as long respectively.


## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Add mappings to component template.
2. Ingest data
3. Validate mappings through devtools and correlate with ECS OR run Data Quality check in Security dashboard.


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
![error message](https://github.com/elastic/integrations/assets/157019701/b373b9f1-8be8-4568-a6e3-4416e3188a61)
![http request body bytes](https://github.com/elastic/integrations/assets/157019701/6aeb0ac0-3501-4a6d-bc6a-7c0b481d0d48)
