### PR TITLE
[Squid] Add http.request.body.bytes to ecs mappings

### DIFF
--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -2,7 +2,7 @@
 - version: "0.19.3"
   changes:
     - description: Add http.request.body.bytes to ECS mappings.
-      type: bug
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/8981
 - version: "0.19.2"
   changes:

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.19.3"
+  changes:
+    - description: Add http.request.body.bytes to ECS mappings.
+      type: bug
+      link: 
 - version: "0.19.2"
   changes:
     - description: Changed owners

--- a/packages/squid/changelog.yml
+++ b/packages/squid/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add http.request.body.bytes to ECS mappings.
       type: bug
-      link: 
+      link: https://github.com/elastic/integrations/pull/8981
 - version: "0.19.2"
   changes:
     - description: Changed owners

--- a/packages/squid/data_stream/log/fields/ecs.yml
+++ b/packages/squid/data_stream/log/fields/ecs.yml
@@ -111,6 +111,8 @@
 - external: ecs
   name: host.name
 - external: ecs
+  name: http.request.body.bytes
+- external: ecs
   name: http.request.method
 - external: ecs
   name: http.request.referrer

--- a/packages/squid/docs/README.md
+++ b/packages/squid/docs/README.md
@@ -77,6 +77,7 @@ The `log` dataset collects Squid logs.
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
+| http.request.body.bytes | Size in bytes of the request body. | long |
 | http.request.method | HTTP request method. The value should retain its casing from the original event. For example, `GET`, `get`, and `GeT` are all considered valid values for this field. | keyword |
 | http.request.referrer | Referrer for this HTTP request. | keyword |
 | input.type | Type of Filebeat input. | keyword |

--- a/packages/squid/manifest.yml
+++ b/packages/squid/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.7.0
 name: squid
 title: Squid Logs
-version: "0.19.2"
+version: "0.19.3"
 description: Collect and parse logs from Squid devices with Elastic Agent.
 categories: ["security", "network", "proxy_security"]
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

* Add http.request.body.bytes to ECS mappings.
* http.request.body.bytes is currently being mapped by default to keyword which is incompatible with the ECS mapping (long) which causes en error in Data Quality check.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Add ECS mappings
2. Ingest data
3. Run Data Quality check to validate it does not find the mappings of http.request.body.bytes incompatible with expected value.

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
![squid](https://github.com/elastic/integrations/assets/157019701/ae7db8e0-ec94-4527-884d-d059b4aea57e)
