### PR TITLE
[o365] Fix dashboard panel filters

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.2"
+  changes:
+    - description: Fix dashboard panel filters
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8983
 - version: "2.2.1"
   changes:
     - description: Prevent tenant ID being rendered into debug logs.

--- a/packages/o365/kibana/dashboard/o365-712e2c00-685d-11ea-8d6a-292ef5d68366.json
+++ b/packages/o365/kibana/dashboard/o365-712e2c00-685d-11ea-8d6a-292ef5d68366.json
@@ -21,10 +21,16 @@
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "",
                         "references": [
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-051e93f9-a0af-4048-8b2b-c0f80afef037",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "1f7c266f-4644-40a7-8d95-093ce57f0bde",
                                 "type": "index-pattern"
                             }
                         ],
@@ -59,11 +65,34 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "1f7c266f-4644-40a7-8d95-093ce57f0bde",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "o365.audit"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "o365.audit"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset:\"o365.audit\" "
+                                "query": ""
                             },
                             "visualization": {
                                 "layerId": "051e93f9-a0af-4048-8b2b-c0f80afef037",
@@ -88,15 +117,21 @@
                 "panelIndex": "b6942e2a-81dc-40e4-a932-8b7a864b28bc",
                 "title": "Audit Event Count [Logs o365]",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "",
                         "references": [
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-5f7c5274-a250-4841-8da4-02409d1dec5a",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "e660b65c-3095-4031-92b8-6e7d33b77934",
                                 "type": "index-pattern"
                             }
                         ],
@@ -173,11 +208,34 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "e660b65c-3095-4031-92b8-6e7d33b77934",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "o365.audit"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "o365.audit"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset:\"o365.audit\" "
+                                "query": ""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -262,15 +320,21 @@
                 },
                 "panelIndex": "9673e6df-4b1e-4771-b1c6-c41c9bfc7272",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "",
                         "references": [
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-4f66319b-8f8c-4e74-b285-e81462d8508c",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "86705eef-7a2e-45c2-8ec0-b0cfd99357b0",
                                 "type": "index-pattern"
                             }
                         ],
@@ -332,11 +396,34 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "86705eef-7a2e-45c2-8ec0-b0cfd99357b0",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "o365.audit"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "o365.audit"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "data_stream.dataset:\"o365.audit\" "
+                                "query": ""
                             },
                             "visualization": {
                                 "layers": [
@@ -387,11 +474,12 @@
                 "panelIndex": "70ab7239-c65c-41da-8242-da61750745d7",
                 "title": "Audit Event Type [Logs o365]",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "description": "",
                         "references": [
                             {
                                 "id": "logs-*",
@@ -400,7 +488,12 @@
                             },
                             {
                                 "id": "logs-*",
-                                "name": "2c47b554-eafa-4209-ad42-afc5b207be0b",
+                                "name": "020d0487-163c-45ed-95ca-5c643e903632",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "e48f699a-8e4e-4e8e-957c-aceec5f283a9",
                                 "type": "index-pattern"
                             }
                         ],
@@ -498,7 +591,7 @@
                                         "alias": null,
                                         "disabled": false,
                                         "field": "event.category",
-                                        "index": "2c47b554-eafa-4209-ad42-afc5b207be0b",
+                                        "index": "020d0487-163c-45ed-95ca-5c643e903632",
                                         "key": "event.category",
                                         "negate": false,
                                         "params": {
@@ -509,6 +602,28 @@
                                     "query": {
                                         "match_phrase": {
                                             "event.category": "authentication"
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "e48f699a-8e4e-4e8e-957c-aceec5f283a9",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "o365.audit"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "o365.audit"
                                         }
                                     }
                                 }
@@ -562,16 +677,16 @@
                 "panelIndex": "9ae12e73-92f2-43a6-b847-2a7b1939709c",
                 "title": "Top users by authentication outcome",
                 "type": "lens",
-                "version": "8.7.1"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
                         "description": "",
                         "layerListJSON": "[{\"alpha\":1,\"id\":\"0b910b6c-77c8-4223-892a-1ebf69b0ccb4\",\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"isAutoSelect\":true,\"type\":\"EMS_TMS\",\"lightModeDefault\":\"road_map\"},\"style\":{},\"type\":\"EMS_VECTOR_TILE\",\"visible\":true},{\"alpha\":0.75,\"id\":\"acc53b7b-3411-406b-9371-6fa62b6b9365\",\"label\":null,\"maxZoom\":24,\"minZoom\":0,\"sourceDescriptor\":{\"applyGlobalQuery\":true,\"geoField\":\"source.geo.location\",\"id\":\"3ba31ffc-7051-44bf-96a0-a684020cd2a3\",\"requestType\":\"point\",\"resolution\":\"FINE\",\"type\":\"ES_GEO_GRID\",\"indexPatternRefName\":\"layer_1_source_index_pattern\"},\"style\":{\"isTimeAware\":true,\"properties\":{\"fillColor\":{\"options\":{\"color\":\"Yellow to Red\",\"colorCategory\":\"palette_0\",\"field\":{\"name\":\"doc_count\",\"origin\":\"source\"},\"fieldMetaOptions\":{\"isEnabled\":true,\"sigma\":3},\"type\":\"ORDINAL\",\"useCustomColorRamp\":false},\"type\":\"DYNAMIC\"},\"icon\":{\"options\":{\"value\":\"airfield\"},\"type\":\"STATIC\"},\"iconOrientation\":{\"options\":{\"orientation\":0},\"type\":\"STATIC\"},\"iconSize\":{\"options\":{\"field\":{\"name\":\"doc_count\",\"origin\":\"source\"},\"fieldMetaOptions\":{\"isEnabled\":true,\"sigma\":3},\"maxSize\":32,\"minSize\":8},\"type\":\"DYNAMIC\"},\"labelBorderColor\":{\"options\":{\"color\":\"#FFFFFF\"},\"type\":\"STATIC\"},\"labelBorderSize\":{\"options\":{\"size\":\"SMALL\"}},\"labelColor\":{\"options\":{\"color\":\"#000000\"},\"type\":\"STATIC\"},\"labelSize\":{\"options\":{\"size\":14},\"type\":\"STATIC\"},\"labelText\":{\"options\":{\"field\":{\"name\":\"doc_count\",\"origin\":\"source\"}},\"type\":\"DYNAMIC\"},\"lineColor\":{\"options\":{\"color\":\"#FFF\"},\"type\":\"STATIC\"},\"lineWidth\":{\"options\":{\"size\":0},\"type\":\"STATIC\"},\"symbolizeAs\":{\"options\":{\"value\":\"circle\"}}},\"type\":\"VECTOR\"},\"type\":\"GEOJSON_VECTOR\",\"visible\":true}]",
-                        "mapStateJSON": "{\"center\":{\"lat\":30.87292,\"lon\":16.67387},\"filters\":[],\"query\":{\"language\":\"kuery\",\"query\":\"data_stream.dataset:\\\"o365.audit\\\" \"},\"refreshConfig\":{\"interval\":0,\"isPaused\":false},\"timeFilters\":{\"from\":\"2020-02-05T03:25:59.045Z\",\"to\":\"2020-02-29T10:59:01.067Z\"},\"zoom\":2.88,\"settings\":{\"autoFitToDataBounds\":false}}",
+                        "mapStateJSON": "{\"adHocDataViews\":[],\"zoom\":1.88,\"center\":{\"lon\":-48.94209,\"lat\":42.68781},\"timeFilters\":{\"from\":\"now-30m\",\"to\":\"now\"},\"refreshConfig\":{\"isPaused\":false,\"interval\":0},\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filters\":[{\"meta\":{\"disabled\":false,\"negate\":false,\"alias\":null,\"index\":\"logs-*\",\"key\":\"data_stream.dataset\",\"field\":\"data_stream.dataset\",\"params\":{\"query\":\"o365.audit\"},\"type\":\"phrase\"},\"query\":{\"match_phrase\":{\"data_stream.dataset\":\"o365.audit\"}},\"$state\":{\"store\":\"appState\"}}],\"settings\":{\"autoFitToDataBounds\":false,\"backgroundColor\":\"#ffffff\",\"customIcons\":[],\"disableInteractive\":false,\"disableTooltipControl\":false,\"hideToolbarOverlay\":false,\"hideLayerControl\":false,\"hideViewControl\":false,\"initialLocation\":\"LAST_SAVED_LOCATION\",\"fixedLocation\":{\"lat\":0,\"lon\":0,\"zoom\":2},\"browserLocation\":{\"zoom\":2},\"keydownScrollZoom\":false,\"maxZoom\":24,\"minZoom\":0,\"showScaleControl\":false,\"showSpatialFilters\":true,\"showTimesliderToggleButton\":true,\"spatialFiltersAlpa\":0.3,\"spatialFiltersFillColor\":\"#DA8B45\",\"spatialFiltersLineColor\":\"#DA8B45\"}}",
                         "title": "Client Geo Map [Logs o365 audit]",
-                        "uiStateJSON": "{\"isLayerTOCOpen\":true,\"openTOCDetails\":[]}"
+                        "uiStateJSON": "{\"isLayerTOCOpen\":false,\"openTOCDetails\":[]}"
                     },
                     "enhancements": {},
                     "hiddenLayers": [],
@@ -593,7 +708,7 @@
                 "panelIndex": "15fe975b-6b8b-4445-872d-e06c041e2c31",
                 "title": "Client geolocation map",
                 "type": "map",
-                "version": "8.7.1"
+                "version": "8.10.1"
             },
             {
                 "embeddableConfig": {
@@ -610,23 +725,26 @@
                 "panelRefName": "panel_481f1778-caad-4971-b598-bb61c94bf998",
                 "title": "Data Loss Prevention alerts",
                 "type": "search",
-                "version": "8.7.1"
+                "version": "8.10.1"
             }
         ],
         "timeRestore": false,
         "title": "[Logs o365] Audit Dashboard",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-11T02:43:17.837Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-01-25T14:33:11.892Z",
     "id": "o365-712e2c00-685d-11ea-8d6a-292ef5d68366",
-    "migrationVersion": {
-        "dashboard": "8.7.0"
-    },
+    "managed": false,
     "references": [
         {
             "id": "logs-*",
             "name": "b6942e2a-81dc-40e4-a932-8b7a864b28bc:indexpattern-datasource-layer-051e93f9-a0af-4048-8b2b-c0f80afef037",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "b6942e2a-81dc-40e4-a932-8b7a864b28bc:1f7c266f-4644-40a7-8d95-093ce57f0bde",
             "type": "index-pattern"
         },
         {
@@ -636,7 +754,17 @@
         },
         {
             "id": "logs-*",
+            "name": "9673e6df-4b1e-4771-b1c6-c41c9bfc7272:e660b65c-3095-4031-92b8-6e7d33b77934",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
             "name": "70ab7239-c65c-41da-8242-da61750745d7:indexpattern-datasource-layer-4f66319b-8f8c-4e74-b285-e81462d8508c",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "70ab7239-c65c-41da-8242-da61750745d7:86705eef-7a2e-45c2-8ec0-b0cfd99357b0",
             "type": "index-pattern"
         },
         {
@@ -646,7 +774,12 @@
         },
         {
             "id": "logs-*",
-            "name": "9ae12e73-92f2-43a6-b847-2a7b1939709c:2c47b554-eafa-4209-ad42-afc5b207be0b",
+            "name": "9ae12e73-92f2-43a6-b847-2a7b1939709c:020d0487-163c-45ed-95ca-5c643e903632",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "9ae12e73-92f2-43a6-b847-2a7b1939709c:e48f699a-8e4e-4e8e-957c-aceec5f283a9",
             "type": "index-pattern"
         },
         {
@@ -658,7 +791,13 @@
             "id": "o365-8b8e5a10-6886-11ea-8d6a-292ef5d68366",
             "name": "481f1778-caad-4971-b598-bb61c94bf998:panel_481f1778-caad-4971-b598-bb61c94bf998",
             "type": "search"
+        },
+        {
+            "id": "o365-security-solution-default",
+            "name": "tag-ref-security-solution-default",
+            "type": "tag"
         }
     ],
-    "type": "dashboard"
+    "type": "dashboard",
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/o365/kibana/search/o365-8b8e5a10-6886-11ea-8d6a-292ef5d68366.json
+++ b/packages/o365/kibana/search/o365-8b8e5a10-6886-11ea-8d6a-292ef5d68366.json
@@ -110,12 +110,10 @@
         "title": "Data Loss Prevention [Logs o365]",
         "version": 1
     },
-    "coreMigrationVersion": "8.7.1",
-    "created_at": "2023-07-11T02:24:40.433Z",
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-01-25T14:25:10.706Z",
     "id": "o365-8b8e5a10-6886-11ea-8d6a-292ef5d68366",
-    "migrationVersion": {
-        "search": "8.0.0"
-    },
+    "managed": true,
     "references": [
         {
             "id": "logs-*",
@@ -136,7 +134,13 @@
             "id": "logs-*",
             "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[2].meta.index",
             "type": "index-pattern"
+        },
+        {
+            "id": "o365-security-solution-default",
+            "name": "tag-ref-security-solution-default",
+            "type": "tag"
         }
     ],
-    "type": "search"
+    "type": "search",
+    "typeMigrationVersion": "8.0.0"
 }

--- a/packages/o365/kibana/tag/o365-security-solution-default.json
+++ b/packages/o365/kibana/tag/o365-security-solution-default.json
@@ -1,0 +1,14 @@
+{
+    "attributes": {
+        "color": "#FEC514",
+        "description": "Tag defined in package-spec",
+        "name": "Security Solution"
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-01-24T15:38:38.681Z",
+    "id": "o365-security-solution-default",
+    "managed": false,
+    "references": [],
+    "type": "tag",
+    "typeMigrationVersion": "8.0.0"
+}

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "2.2.1"
+version: "2.2.2"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -7,7 +7,7 @@ format_version: "3.0.0"
 categories: [security, productivity_security]
 conditions:
   kibana:
-    version: ^8.7.1
+    version: ^8.10.1
 icons:
   - src: /img/logo-integrations-microsoft-365.svg
     title: Microsoft Office 365


### PR DESCRIPTION
## Proposed commit message

```
[o365] Fix dashboard panel filters (#8983)

- Added missing `data_stream.dataset: "o365.audit"` filter to the
  "Top users by authentication outcome" panel.
- Replaced `data_stream.dataset: "o365.audit"` as a query with an
  equivalent filter in other panels.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #8970