### PR TITLE
[o365] Expose OAuth2 token scopes configuration value

### DIFF
--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "2.1.3"
+- version: "2.2.0"
   changes:
     - description: Expose OAuth2 token scopes configuration value.
       type: enhancement

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.3"
+  changes:
+    - description: Expose OAuth2 token scopes configuration value.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.2"
   changes:
     - description: Add error.message ECS field mapping.

--- a/packages/o365/changelog.yml
+++ b/packages/o365/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Expose OAuth2 token scopes configuration value.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/8986
 - version: "2.1.2"
   changes:
     - description: Add error.message ECS field mapping.

--- a/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/o365/data_stream/audit/agent/stream/cel.yml.hbs
@@ -3,7 +3,10 @@ auth.oauth2:
     client.id: {{client_id}}
     client.secret: {{client_secret}}
     provider: azure
-    scopes: https://manage.office.com/.default
+    scopes:
+{{#each token_scopes as |token_scope|}}
+      - {{token_scope}}
+{{/each}}
     endpoint_params: 
         grant_type: client_credentials
 {{#if token_url}}

--- a/packages/o365/data_stream/audit/manifest.yml
+++ b/packages/o365/data_stream/audit/manifest.yml
@@ -46,6 +46,15 @@ streams:
         show_user: true
         required: false
         default: https://login.microsoftonline.com
+      - name: token_scopes
+        type: text
+        title: Token Scopes
+        multi: true
+        default:
+          - "https://manage.office.com/.default"
+        description: Scopes for OAuth2 token.
+        required: true
+        show_user: false
       - name: content_types
         type: text
         title: Content Type

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "2.1.2"
+version: "2.1.3"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"

--- a/packages/o365/manifest.yml
+++ b/packages/o365/manifest.yml
@@ -1,6 +1,6 @@
 name: o365
 title: Microsoft 365
-version: "2.1.3"
+version: "2.2.0"
 description: Collect logs from Microsoft 365 with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

The OAuth2 scopes configuration is currently hard-coded for the CEL input. This change exposes it as a configuration value. The existing default has been preserved and the ability to add multiple scopes has been added.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/sdh-beats#4311

## Screenshots

<img width="566" alt="Screenshot 2024-01-25 at 12 59 33 PM" src="https://github.com/elastic/integrations/assets/90622908/f7b7f0d6-1401-49cb-933c-5f1832b7e25d">
