### PR TITLE
Update CODEOWNERS with separate Stack Monitoring team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,7 @@
 /packages/barracuda @elastic/security-service-integrations
 /packages/barracuda_cloudgen_firewall @elastic/security-service-integrations
 /packages/beaconing @elastic/ml-ui @elastic/sec-applied-ml
-/packages/beat @elastic/infra-monitoring-ui
+/packages/beat @elastic/stack-monitoring
 /packages/bitdefender @elastic/security-service-integrations
 /packages/bitwarden @elastic/security-service-integrations
 /packages/bluecoat @elastic/sec-deployment-and-devices
@@ -141,8 +141,8 @@
 /packages/docker @elastic/obs-cloudnative-monitoring
 /packages/elastic_agent @elastic/elastic-agent
 /packages/elastic_package_registry @elastic/ecosystem
-/packages/elasticsearch @elastic/infra-monitoring-ui
-/packages/enterprisesearch @elastic/infra-monitoring-ui
+/packages/elasticsearch @elastic/stack-monitoring
+/packages/enterprisesearch @elastic/stack-monitoring
 /packages/entityanalytics_entra_id @elastic/security-service-integrations
 /packages/entityanalytics_okta @elastic/security-service-integrations
 /packages/eset_protect @elastic/security-service-integrations
@@ -210,14 +210,14 @@
 /packages/kafka @elastic/obs-infraobs-integrations
 /packages/kafka_log @elastic/obs-infraobs-integrations
 /packages/keycloak @elastic/security-service-integrations
-/packages/kibana @elastic/infra-monitoring-ui
+/packages/kibana @elastic/stack-monitoring
 /packages/kubernetes @elastic/obs-cloudnative-monitoring
 /packages/kubernetes/kibana @elastic/obs-cloudnative-monitoring @elastic/kibana-visualizations
 /packages/lastpass @elastic/security-service-integrations
 /packages/linux @elastic/elastic-agent-data-plane
 /packages/lmd @elastic/ml-ui @elastic/sec-applied-ml
 /packages/log @elastic/elastic-agent-data-plane
-/packages/logstash @elastic/infra-monitoring-ui
+/packages/logstash @elastic/stack-monitoring
 /packages/lyve_cloud @elastic/security-service-integrations
 /packages/m365_defender @elastic/security-service-integrations
 /packages/mattermost @elastic/security-service-integrations
@@ -251,7 +251,7 @@
 /packages/pfsense @elastic/sec-deployment-and-devices
 /packages/php_fpm @elastic/obs-infraobs-integrations
 /packages/ping_one @elastic/security-service-integrations
-/packages/platform_observability @elastic/infra-monitoring-ui
+/packages/platform_observability @elastic/stack-monitoring
 /packages/postgresql @elastic/obs-infraobs-integrations
 /packages/prisma_cloud @elastic/security-service-integrations
 /packages/problemchild @elastic/ml-ui @elastic/sec-applied-ml


### PR DESCRIPTION
Adds [stack-monitoring](https://github.com/orgs/elastic/teams/stack-monitoring) and removed `infra-monitoring-ui` (which is being deprecated), to review Stack Monitoring changes.

## Checklist
- [ ] ~~I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.~~
- [ ] ~~I have verified that all data streams collect metrics or logs.~~
- [ ] ~~I have added an entry to my package's `changelog.yml` file.~~
- [ ] ~~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~