### PR TITLE
Remove unused variables to manage elastic-package output

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -10,8 +10,6 @@ env:
   YQ_VERSION: 'v4.35.2'
   # Elastic package settings
   # Manage docker output/logs
-  ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI: "true"  # to be removed after next elastic-package release
-  ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION: "true"  # to be removed after next elastic-package release
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
   # Default license to use by `elastic-package build`
   ELASTIC_PACKAGE_REPOSITORY_LICENSE: "licenses/Elastic-2.0.txt"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,8 +12,6 @@ env:
   GH_CLI_VERSION: "2.29.0"
   # Elastic package settings
   # Manage docker output/logs
-  ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI: "true"  # to be removed after next elastic-package release
-  ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION: "true"  # to be removed after next elastic-package release
   ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT: "true"
   # Default license to use by `elastic-package build`
   ELASTIC_PACKAGE_REPOSITORY_LICENSE: "licenses/Elastic-2.0.txt"


### PR DESCRIPTION
## Proposed commit message

Remove unused environment variables removed in `elastic-package` version `v0.96.0`:
- ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI
- ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION

These variables have been deprecated in favor of ELASTIC_PACKAGE_COMPOSE_DISABLE_VERBOSE_OUTPUT.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #8952

