### PR TITLE
[cisco_ios] Add support for last message repeated logs

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.0"
+  changes:
+    - description: Add support for repeated messages logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.24.1"
   changes:
     - description: Changed owners

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-asr920.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-asr920.log-expected.json
@@ -284,7 +284,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-03T08:11:02.204Z",
+            "@timestamp": "2024-08-03T08:11:02.204Z",
             "cisco": {
                 "ios": {
                     "facility": "LINEPROTO",
@@ -326,7 +326,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-03T08:08:47.142Z",
+            "@timestamp": "2024-08-03T08:08:47.142Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL_CE-SECURITY",
@@ -405,7 +405,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-03T08:04:47.140Z",
+            "@timestamp": "2024-08-03T08:04:47.140Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL_CE-SECURITY",
@@ -488,7 +488,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-03T08:09:55.769Z",
+            "@timestamp": "2024-08-03T08:09:55.769Z",
             "cisco": {
                 "ios": {
                     "facility": "SNMP-SW1",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-badauth.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-badauth.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2023-12-08T20:07:53.081Z",
+            "@timestamp": "2024-12-08T20:07:53.081Z",
             "cisco": {
                 "ios": {
                     "facility": "TCP",
@@ -62,7 +62,7 @@
             ]
         },
         {
-            "@timestamp": "2023-12-08T20:07:53.081Z",
+            "@timestamp": "2024-12-08T20:07:53.081Z",
             "cisco": {
                 "ios": {
                     "facility": "TCP",
@@ -123,7 +123,7 @@
             ]
         },
         {
-            "@timestamp": "2023-12-08T20:07:53.081Z",
+            "@timestamp": "2024-12-08T20:07:53.081Z",
             "cisco": {
                 "ios": {
                     "facility": "TCP",
@@ -183,7 +183,7 @@
             ]
         },
         {
-            "@timestamp": "2023-12-08T20:07:53.081Z",
+            "@timestamp": "2024-12-08T20:07:53.081Z",
             "cisco": {
                 "ios": {
                     "facility": "TCP",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1,7 +1,7 @@
 {
     "expected": [
         {
-            "@timestamp": "2023-02-08T04:00:47.272Z",
+            "@timestamp": "2024-02-08T04:00:47.272Z",
             "cisco": {
                 "ios": {
                     "access_list": "177",
@@ -63,7 +63,7 @@
             ]
         },
         {
-            "@timestamp": "2023-02-09T04:00:47.272Z",
+            "@timestamp": "2024-02-09T04:00:47.272Z",
             "cisco": {
                 "ios": {
                     "access_list": "INBOUND-ON-F11",
@@ -128,7 +128,7 @@
             ]
         },
         {
-            "@timestamp": "2023-02-10T04:00:47.272Z",
+            "@timestamp": "2024-02-10T04:00:47.272Z",
             "cisco": {
                 "ios": {
                     "access_list": "171",
@@ -189,7 +189,7 @@
             ]
         },
         {
-            "@timestamp": "2023-05-03T19:11:32.619Z",
+            "@timestamp": "2024-05-03T19:11:32.619Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL-IPv6-E0/0-IN/10",
@@ -270,7 +270,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:41:39.326Z",
+            "@timestamp": "2024-06-20T02:41:39.326Z",
             "cisco": {
                 "ios": {
                     "access_list": "177",
@@ -334,7 +334,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:41:44.921Z",
+            "@timestamp": "2024-06-20T02:41:44.921Z",
             "cisco": {
                 "ios": {
                     "access_list": "151",
@@ -400,7 +400,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:42:27.342Z",
+            "@timestamp": "2024-06-20T02:42:27.342Z",
             "cisco": {
                 "ios": {
                     "access_list": "177",
@@ -464,7 +464,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:42:28.374Z",
+            "@timestamp": "2024-06-20T02:42:28.374Z",
             "cisco": {
                 "ios": {
                     "facility": "SEC",
@@ -502,7 +502,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:42:33.340Z",
+            "@timestamp": "2024-06-20T02:42:33.340Z",
             "cisco": {
                 "ios": {
                     "access_list": "177",
@@ -566,7 +566,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:43:08.454Z",
+            "@timestamp": "2024-06-20T02:43:08.454Z",
             "cisco": {
                 "ios": {
                     "access_list": "150",
@@ -642,7 +642,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:43:28.403Z",
+            "@timestamp": "2024-06-20T02:43:28.403Z",
             "cisco": {
                 "ios": {
                     "facility": "SEC",
@@ -680,7 +680,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:43:28.403Z",
+            "@timestamp": "2024-06-20T02:43:28.403Z",
             "cisco": {
                 "ios": {
                     "access_list": "150",
@@ -746,7 +746,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-20T02:43:29.451Z",
+            "@timestamp": "2024-06-20T02:43:29.451Z",
             "cisco": {
                 "ios": {
                     "access_list": "150",
@@ -822,7 +822,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T18:06:03.424Z",
+            "@timestamp": "2024-03-24T18:06:03.424Z",
             "cisco": {
                 "ios": {
                     "action": "Login",
@@ -882,7 +882,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T18:06:00.364Z",
+            "@timestamp": "2024-03-24T18:06:00.364Z",
             "cisco": {
                 "ios": {
                     "action": "exited",
@@ -943,7 +943,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T17:37:39.000Z",
+            "@timestamp": "2024-03-24T17:37:39.000Z",
             "cisco": {
                 "ios": {
                     "action": "Join",
@@ -1008,7 +1008,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T17:37:39.000Z",
+            "@timestamp": "2024-03-24T17:37:39.000Z",
             "cisco": {
                 "ios": {
                     "action": "Join",
@@ -1076,7 +1076,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T12:09:35.367Z",
+            "@timestamp": "2024-03-24T12:09:35.367Z",
             "cisco": {
                 "ios": {
                     "facility": "OSPF",
@@ -1114,7 +1114,7 @@
             ]
         },
         {
-            "@timestamp": "2023-03-24T12:06:47.099Z",
+            "@timestamp": "2024-03-24T12:06:47.099Z",
             "cisco": {
                 "ios": {
                     "facility": "CCH323",
@@ -1152,7 +1152,7 @@
             ]
         },
         {
-            "@timestamp": "2023-07-11T09:34:00.020Z",
+            "@timestamp": "2024-07-11T09:34:00.020Z",
             "cisco": {
                 "ios": {
                     "access_list": "internet_in_gig0",
@@ -1219,7 +1219,7 @@
             ]
         },
         {
-            "@timestamp": "2023-07-11T09:31:03.762Z",
+            "@timestamp": "2024-07-11T09:31:03.762Z",
             "cisco": {
                 "ios": {
                     "access_list": "110",
@@ -1286,7 +1286,7 @@
             ]
         },
         {
-            "@timestamp": "2023-07-11T09:34:00.334Z",
+            "@timestamp": "2024-07-11T09:34:00.334Z",
             "cisco": {
                 "ios": {
                     "access_list": "internet_in_gig0",
@@ -1353,7 +1353,7 @@
             ]
         },
         {
-            "@timestamp": "2023-07-11T09:34:00.209Z",
+            "@timestamp": "2024-07-11T09:34:00.209Z",
             "cisco": {
                 "ios": {
                     "access_list": "internet_in_gig0",
@@ -1420,7 +1420,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-10T23:34:58.206Z",
+            "@timestamp": "2024-06-10T23:34:58.206Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL",
@@ -1484,7 +1484,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-10T23:34:58.206Z",
+            "@timestamp": "2024-06-10T23:34:58.206Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL_TEST",
@@ -1550,7 +1550,7 @@
             ]
         },
         {
-            "@timestamp": "2023-06-10T23:35:28.207Z",
+            "@timestamp": "2024-06-10T23:35:28.207Z",
             "cisco": {
                 "ios": {
                     "access_list": "ACL_TEST",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-date-format.log-expected.json
@@ -379,7 +379,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-06T22:11:43.398Z",
+            "@timestamp": "2024-01-06T22:11:43.398Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -421,7 +421,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-06T22:11:43.398Z",
+            "@timestamp": "2024-01-06T22:11:43.398Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -463,7 +463,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-06T22:11:43.000Z",
+            "@timestamp": "2024-01-06T22:11:43.000Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -505,7 +505,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-06T22:11:43.000Z",
+            "@timestamp": "2024-01-06T22:11:43.000Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -547,7 +547,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-16T22:11:43.398Z",
+            "@timestamp": "2024-01-16T22:11:43.398Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -589,7 +589,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-16T22:11:43.398Z",
+            "@timestamp": "2024-01-16T22:11:43.398Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -631,7 +631,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-16T22:11:43.000Z",
+            "@timestamp": "2024-01-16T22:11:43.000Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -673,7 +673,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-16T22:11:43.000Z",
+            "@timestamp": "2024-01-16T22:11:43.000Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",
@@ -715,7 +715,7 @@
             ]
         },
         {
-            "@timestamp": "2023-01-16T22:11:43.000Z",
+            "@timestamp": "2024-01-16T22:11:43.000Z",
             "cisco": {
                 "ios": {
                     "facility": "FOO",

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
@@ -7,3 +7,4 @@
 <191>2637087: rt401-rk30409: Aug 18 07:15:04.461 CEST: NTP Core (NOTICE): Clock is synchronized.
 <190>3352436: 3352457: Aug 12 2023 12:14:24.412 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807766185951588 %FW-6-SESS_AUDIT_TRAIL: (target:class) (ZP_PROCESS_TO_CORPORATE:CM_PROCESS_TO_CORPORATE):Stop dns session: initiator (10.50.14.44:33207) sent 48 bytes -- responder (10.120.42.6:53) sent 40 bytes, from GigabitEthernet10/0/2.6
 <190>3352460: 3352481: Aug 12 2023 12:15:33.963 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807835737559120 %FW-6-DROP_PKT: Dropping tcp pkt from GigabitEthernet1/0/2.6 10.50.14.44:53836 => 89.160.20.128:80(target:class)-(ZP_PROCESS_TO_CORPORATE:class-default) due to Policy drop:classify result with ip ident 13017 tcp flag 0x2, seq 4266642156, ack 0
+<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -188,7 +188,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-18T07:15:04.461Z",
+            "@timestamp": "2024-08-18T07:15:04.461Z",
             "cisco": {
                 "ios": {
                     "message_count": 2637085
@@ -226,7 +226,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-18T07:15:04.461Z",
+            "@timestamp": "2024-08-18T07:15:04.461Z",
             "cisco": {
                 "ios": {
                     "message_count": 2637086
@@ -264,7 +264,7 @@
             ]
         },
         {
-            "@timestamp": "2023-08-18T07:15:04.461Z",
+            "@timestamp": "2024-08-18T07:15:04.461Z",
             "cisco": {
                 "ios": {
                     "message_count": 2637087
@@ -441,6 +441,38 @@
             "source": {
                 "ip": "10.50.14.44",
                 "port": 53836
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-18T07:15:04.461Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times.",
+                "provider": "firewall",
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "rt401-rk30409",
+                    "priority": 191
+                }
+            },
+            "message": "last message repeated 66 times.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -36,8 +36,10 @@ processors:
       patterns:
         - '%{DATA:_temp_.header} %%{GREEDYDATA:message}'
         - '%{DATA:_temp_.header} %{NTP_MESSAGE:ntp_message}'
+        - '%{DATA:_temp_.header} %{REPEATED_MESSAGE:repeated_message}'
       pattern_definitions:
         NTP_MESSAGE: 'NTP %{GREEDYDATA}'
+        REPEATED_MESSAGE: 'last message repeated %{INT} times.'
       tag: dissect_header
   - grok:
       field: _temp_.header
@@ -166,6 +168,11 @@ processors:
       target_field: message
       tag: rename_ntp_message
       if: ctx.ntp_message != null
+  - rename:
+      field: repeated_message
+      target_field: message
+      tag: rename_repeated_message
+      if: ctx.repeated_message != null
   - convert:
       field: event.severity
       type: long


### PR DESCRIPTION
## Proposed commit message

- Add support for handling log messages with "last message repeated N times"
- Add test case
- Regenerated test expected files

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_ios
elastic-package test
```

## Related issues

- Closes #8989 
