### PR TITLE
Support 'preserve_original_event' on kubernetes container logs

### DIFF
--- a/packages/kubernetes/_dev/build/docs/README.md
+++ b/packages/kubernetes/_dev/build/docs/README.md
@@ -86,11 +86,20 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations. 
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations.
 
 For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By annotating the pod with `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
+
+#### Preserve original event
+
+The agent can be configured to set the tag `preserve_original_event` on container-logs using pod annotation.
+
+For example, suppose you are routing your Nginx container logs into a dedicated dataset or namespace as described above to make use of the Nginx fleet integration. Enabling preserve_original_event on the Nginx integration will have no effect
+since the logs were shipped via kubernetes integration and not Nginx. As well, you may not want to have all original events from all Nginx pods preserved as well.
+
+By annotating the pod with `elastic.co/preserve_original_event: 'true'`, the integration will add the tag `preserve_original_event` as it would be done by the `nginx` integration otherwise.
 
 ### audit-logs
 

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Container logs preserve original content based on pod annotations.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/9036
 - version: 1.56.0
   changes:
     - description: Add new fields to API server, state_node and persistent volume claim data streams.

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.57.0
+  changes:
+    - description: Container logs preserve original content based on pod annotations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: 1.56.0
   changes:
     - description: Add new fields to API server, state_node and persistent volume claim data streams.

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-common-config.yml
@@ -6,6 +6,7 @@ fields:
     annotations:
       elastic_co/dataset: kubernetes.container_logs.nginx
       elastic_co/namespace: nginx
+      elastic_co/preserve_original_event: "true"
     labels:
       app_kubernetes_io/version: "v0.1.0"
       app_kubernetes_io/name: "myservice"

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -20,7 +20,10 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "data_stream": {
@@ -42,7 +45,10 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "data_stream": {
@@ -64,7 +70,10 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         },
         {
             "data_stream": {
@@ -86,7 +95,10 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -9,7 +9,8 @@
             "kubernetes": {
                 "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
-                    "elastic_co/namespace": "nginx"
+                    "elastic_co/namespace": "nginx",
+                    "elastic_co/preserve_original_event": "true"
                 },
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
@@ -34,7 +35,8 @@
             "kubernetes": {
                 "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
-                    "elastic_co/namespace": "nginx"
+                    "elastic_co/namespace": "nginx",
+                    "elastic_co/preserve_original_event": "true"
                 },
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
@@ -59,7 +61,8 @@
             "kubernetes": {
                 "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
-                    "elastic_co/namespace": "nginx"
+                    "elastic_co/namespace": "nginx",
+                    "elastic_co/preserve_original_event": "true"
                 },
                 "labels": {
                     "app_kubernetes_io/name": "myservice",
@@ -84,7 +87,8 @@
             "kubernetes": {
                 "annotations": {
                     "elastic_co/dataset": "kubernetes.container_logs.nginx",
-                    "elastic_co/namespace": "nginx"
+                    "elastic_co/namespace": "nginx",
+                    "elastic_co/preserve_original_event": "true"
                 },
                 "labels": {
                     "app_kubernetes_io/name": "myservice",

--- a/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
+++ b/packages/kubernetes/data_stream/container_logs/_dev/test/pipeline/test-nginx.log-expected.json
@@ -21,10 +21,7 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
+            }
         },
         {
             "data_stream": {
@@ -47,10 +44,7 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
+            }
         },
         {
             "data_stream": {
@@ -73,10 +67,7 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
+            }
         },
         {
             "data_stream": {
@@ -99,10 +90,7 @@
             "service": {
                 "name": "myservice",
                 "version": "v0.1.0"
-            },
-            "tags": [
-                "preserve_original_event"
-            ]
+            }
         }
     ]
 }

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -37,6 +37,7 @@ processors:
     fields:
       annotations.elastic_co/dataset: ${kubernetes.annotations.elastic.co/dataset|""}
       annotations.elastic_co/namespace: ${kubernetes.annotations.elastic.co/namespace|""}
+      annotations.elastic_co/preserve_original_event: ${kubernetes.annotations.elastic.co/preserve_original_event|""}
 - drop_fields:
     fields:
       - kubernetes.annotations.elastic_co/dataset
@@ -51,7 +52,17 @@ processors:
       equals:
         kubernetes.annotations.elastic_co/namespace: ""
     ignore_missing: true
-{{#if processors}}      
+- add_tags:
+    tags: ["preserve_original_event"]
+    when:
+      regexp:
+        kubernetes.annotations.elastic_co/preserve_original_event:  "^(?i)true$"
+- drop_fields:
+    fields:
+      - kubernetes.annotations.elastic_co/preserve_original_event
+    ignore_missing: true
+
+{{#if processors}}
 {{processors}}
 {{/if}}
 

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -22,14 +22,14 @@ processors:
 
   The kubernetes provider supports[^1] pods annotations, making it possible to add
   them to the event using the `include_annotations` configuration option.
-  
+
   However, adding annotations to the event is disabled by default, and it is
   not possible to enable it on Fleet-managed agents.
 
   The following processors are a workaround to add the annotations to the event
   without using the `include_annotations` configuration option.
 
-  
+
   [^1]: https://github.com/elastic/elastic-agent/blob/37ec2bb7ee1d2cc6c0fccf2f0cd0a44eb3d61efd/internal/pkg/composable/providers/kubernetes/pod.go#L311-L315
 }}
 - add_fields:
@@ -52,15 +52,21 @@ processors:
       equals:
         kubernetes.annotations.elastic_co/namespace: ""
     ignore_missing: true
-- add_tags:
-    tags: ["preserve_original_event"]
-    when:
-      regexp:
-        kubernetes.annotations.elastic_co/preserve_original_event:  "^(?i)true$"
 - drop_fields:
     fields:
       - kubernetes.annotations.elastic_co/preserve_original_event
+    when:
+      equals:
+        kubernetes.annotations.elastic_co/preserve_original_event: ""
     ignore_missing: true
+- add_tags:
+    tags: ["preserve_original_event"]
+    when:
+      and:
+        - has_fields:
+            - kubernetes.annotations.elastic_co/preserve_original_event
+        - regexp:
+            kubernetes.annotations.elastic_co/preserve_original_event: "^(?i)true$"
 
 {{#if processors}}
 {{processors}}

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -150,3 +150,8 @@
       type: keyword
       description: >-
         Kubernetes container image
+
+    - name: tags
+      type: keyword
+      description: >-
+        Tags like 'preserve_original_event'

--- a/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/base-fields.yml
@@ -150,8 +150,3 @@
       type: keyword
       description: >-
         Kubernetes container image
-
-    - name: tags
-      type: keyword
-      description: >-
-        Tags like 'preserve_original_event'

--- a/packages/kubernetes/data_stream/container_logs/fields/ecs.yml
+++ b/packages/kubernetes/data_stream/container_logs/fields/ecs.yml
@@ -26,3 +26,5 @@
   name: service.name
 - external: ecs
   name: service.version
+- external: ecs
+  name: tags

--- a/packages/kubernetes/docs/README.md
+++ b/packages/kubernetes/docs/README.md
@@ -86,11 +86,20 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 
 #### Routing
 
-The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations. 
+The container-logs data stream allows routing logs to a different *dataset* or *namespace* using pod annotations.
 
 For example, suppose you are running Nginx on your Kubernetes cluster, and you want to drive the Nginx container logs into a dedicated dataset or namespace. By annotating the pod with `elastic.co/namespace: nginx`, the integration will send all the container logs to the `nginx` namespace.
 
 To learn more about routing container-logs, see https://docs.elastic.co/integrations/kubernetes/container-logs.
+
+#### Preserve original event
+
+The agent can be configured to set the tag `preserve_original_event` on container-logs using pod annotation.
+
+For example, suppose you are routing your Nginx container logs into a dedicated dataset or namespace as described above to make use of the Nginx fleet integration. Enabling preserve_original_event on the Nginx integration will have no effect
+since the logs were shipped via kubernetes integration and not Nginx. As well, you may not want to have all original events from all Nginx pods preserved as well.
+
+By annotating the pod with `elastic.co/preserve_original_event: 'true'`, the integration will add the tag `preserve_original_event` as it would be done by the `nginx` integration otherwise.
 
 ### audit-logs
 

--- a/packages/kubernetes/docs/container-logs.md
+++ b/packages/kubernetes/docs/container-logs.md
@@ -8,17 +8,17 @@ This defaults to `/var/log/containers/*${kubernetes.container.id}.log`.
 By default only [container parser](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#_parsers) is enabled. Additional log parsers can be added as an advanced options configuration.
 
 
-## Rerouting based on pod annotations
+## Rerouting and preserve original event based on pod annotations
 
-You can customize the routing of container logs events and sending them to different datasets and namespaces using pods' annotations.
+You can customize the routing of container logs events and sending them to different datasets and namespaces,
+as well as enable `preserve_original_event` based on using pods' annotations.
 
-Routing customization can happen at:
+Customization can happen at:
 
 - pod definition time, e.g., using a deployment.
 - pod runtime, annotating pods using `kubectl`.
 
-
-### Set routing at pod definition time
+### Set at pod definition time
 
 Here is an example of an Nginx deployment where we set both `elastic.co/dataset` and `elastic.co/namespace` annotations to route the container logs to specific datasets and namespace, respectively.
 
@@ -38,6 +38,7 @@ spec:
       annotations:
         elastic.co/dataset: kubernetes.container_logs.nginx
         elastic.co/namespace: nginx
+        elastic.co/preserve_original_event: "true"
       labels:
         app: nginx
         app.kubernetes.io/name: myservice
@@ -51,10 +52,10 @@ spec:
             - containerPort: 80
 ```
 
+### Set at runtime
 
-### Set routing at runtime
-
-Suppose you want to change the container logs routing on a running container. In that case, you can annotate the pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
+Suppose you want to change the container logs routing and enable `preserve_original_event` on a running container.
+In that case, you can annotate the pod using `kubectl`, and the integration will apply it immediately sending all the following documents to the new destination:
 
 Here is an example where we route the container logs for a pod running the Elastic Agent to the `kubernetes.container_logs.agents` dataset:
 
@@ -68,19 +69,26 @@ Here's a similar example to change the namespace on a pod running Nginx:
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace=nginx
 ```
 
-You can restore the standard routing by removing the annotations:
+Here is an example to enable `preserve_original_event` on a pod running Nginx:
+
+```shell
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/preserve_original_event=true
+```
+
+You can restore the standard settings by removing the annotations:
 
 ```shell
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/dataset-
 kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/namespace-
+kubectl annotate pods elastic-agent-managed-daemonset-6p22g elastic.co/preserve_original_event-
 ```
 
 ### Annotations Reference
 
 Here are the annotations available to customize routing:
 
-
-| Label                  | Description                                              |
-| ---------------------- | -------------------------------------------------------- |
-| `elastic.co/dataset`   | Defines the target data stream's dataset for this pod.   |
-| `elastic.co/namespace` | Defines the target data stream's namespace for this pod. |
+| Label                                | Description                                                                                    |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `elastic.co/dataset`                 | Defines the target data stream's dataset for this pod.                                         |
+| `elastic.co/namespace`               | Defines the target data stream's namespace for this pod.                                       |
+| `elastic.co/preserve_original_event` | Enables 'preserve_original_event' for this pod. Use string 'true' (case-insensitive) to enable |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.9.0
 name: kubernetes
 title: Kubernetes
-version: 1.56.0
+version: 1.57.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Added support of preserve_original_event on kubernetes container logs based on pod annotations.

This is useful when events are rerouted to specific integrations, since enabling the feature there has no effect on events shipped by the kubernetes integration.

As a workaround and POC I added custom processors to the fleet configuration but I would prefer if it would be generally available. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
