### PR TITLE
[Synthetics] Bump to 1.2.1

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,6 +1,16 @@
 # newer versions go on top
 - version: "1.2.1"
   changes:
+    - description: Revert previous pre-release
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9056
+- version: "1.2.0-rc1"
+  changes:
+    - description: Adopt package spec v3
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8546
+- version: "1.1.1"
+  changes:
     - description: Fix meta container mapping
       type: bugfix
       link: https://github.com/elastic/integrations/pull/8239

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: "1.2.0-rc1"
-  changes:
-    - description: Adopt package spec v3
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/8546
 - version: "1.1.1"
   changes:
     - description: Fix meta container mapping

--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.1.1"
+- version: "1.2.1"
   changes:
     - description: Fix meta container mapping
       type: bugfix

--- a/packages/synthetics/data_stream/browser/fields/common.yml
+++ b/packages/synthetics/data_stream/browser/fields/common.yml
@@ -15,7 +15,6 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/browser/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser/fields/ecs.yml
@@ -168,7 +168,6 @@
     - name: answers
       level: extended
       type: object
-      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/browser/fields/http.yml
+++ b/packages/synthetics/data_stream/browser/fields/http.yml
@@ -22,7 +22,6 @@
 
         - name: headers.*
           type: object
-          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/browser/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser/fields/summary.yml
@@ -11,27 +11,24 @@
       type: integer
       description: >
         The number of endpoints that failed
-
     - name: status
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: "A unique token used to group checks across attempts.        \n"
+      description: >
+        A unique token used to group checks across attempts.        
+

--- a/packages/synthetics/data_stream/browser/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser/fields/synthetics.yml
@@ -14,7 +14,6 @@
         Indexed used for creating total order of all events in this invocation.
 
     - name: payload
-      object_type: keyword
       type: object
       enabled: false
     - name: blob

--- a/packages/synthetics/data_stream/browser/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "365d"

--- a/packages/synthetics/data_stream/browser/manifest.yml
+++ b/packages/synthetics/data_stream/browser/manifest.yml
@@ -9,12 +9,10 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "url.full.keyword"
-            - "monitor.id"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "url.full.keyword"
+          - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetic monitor check
@@ -54,7 +52,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: '"@every 3m"'
+        default: "\"@every 3m\""
       - name: service.name
         type: text
         title: APM Service Name

--- a/packages/synthetics/data_stream/browser_network/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/common.yml
@@ -15,7 +15,6 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/browser_network/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/ecs.yml
@@ -168,7 +168,6 @@
     - name: answers
       level: extended
       type: object
-      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/browser_network/fields/http.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/http.yml
@@ -38,7 +38,6 @@
 
         - name: headers.*
           type: object
-          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/browser_network/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/summary.yml
@@ -11,27 +11,23 @@
       type: integer
       description: >
         The number of endpoints that failed
-
     - name: status
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: "A unique token used to group checks across attempts.  \n"
+      description: >
+        A unique token used to group checks across attempts.  

--- a/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_network/fields/synthetics.yml
@@ -15,7 +15,6 @@
 
     - name: payload
       type: object
-      object_type: text
       enabled: false
     - name: blob
       type: binary

--- a/packages/synthetics/data_stream/browser_network/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_network/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "14d"

--- a/packages/synthetics/data_stream/browser_network/manifest.yml
+++ b/packages/synthetics/data_stream/browser_network/manifest.yml
@@ -9,14 +9,12 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "url.full.keyword"
-            - "http.request.url.keyword"
-            - "http.response.headers.etag"
-            - "monitor.id"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "url.full.keyword"
+          - "http.request.url.keyword"
+          - "http.response.headers.etag"
+          - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors network information

--- a/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/common.yml
@@ -15,7 +15,6 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/ecs.yml
@@ -168,7 +168,6 @@
     - name: answers
       level: extended
       type: object
-      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/browser_screenshot/fields/summary.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/summary.yml
@@ -16,23 +16,19 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: >-
+      description: >
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/fields/synthetics.yml
@@ -15,7 +15,6 @@
 
     - name: payload
       type: object
-      object_type: text
       enabled: false
     - name: blob
       type: binary

--- a/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "14d"

--- a/packages/synthetics/data_stream/browser_screenshot/manifest.yml
+++ b/packages/synthetics/data_stream/browser_screenshot/manifest.yml
@@ -9,11 +9,9 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "monitor.id"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "monitor.id"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/browser
     title: Synthetics monitors screenshot information

--- a/packages/synthetics/data_stream/http/fields/common.yml
+++ b/packages/synthetics/data_stream/http/fields/common.yml
@@ -15,11 +15,10 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
-    Common monitor fields.
+    Common monitor fields.   
 
   fields:
     - name: type
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/http/fields/ecs.yml
+++ b/packages/synthetics/data_stream/http/fields/ecs.yml
@@ -168,7 +168,6 @@
     - name: answers
       level: extended
       type: object
-      object_type: keyword
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
     - name: answers.class
       level: extended
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/http/fields/http.yml
+++ b/packages/synthetics/data_stream/http/fields/http.yml
@@ -22,7 +22,6 @@
 
         - name: headers.*
           type: object
-          object_type: keyword
           enabled: false
           description: >
             The canonical headers of the monitored HTTP response.

--- a/packages/synthetics/data_stream/http/fields/summary.yml
+++ b/packages/synthetics/data_stream/http/fields/summary.yml
@@ -16,23 +16,19 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: >-
+      description: >
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/http/fields/tls.yml
+++ b/packages/synthetics/data_stream/http/fields/tls.yml
@@ -6,8 +6,10 @@
   fields:
     - name: certificate_not_valid_before
       type: date
+      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
+      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/http/lifecycle.yml
+++ b/packages/synthetics/data_stream/http/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "365d"

--- a/packages/synthetics/data_stream/http/manifest.yml
+++ b/packages/synthetics/data_stream/http/manifest.yml
@@ -9,12 +9,10 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "monitor.id"
-            - "url.full.keyword"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "monitor.id"
+          - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/http
     title: Synthetic monitor check
@@ -54,7 +52,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: '"@every 3m"'
+        default: "\"@every 3m\""
       - name: urls
         type: text
         title: URL
@@ -243,7 +241,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true
+        show_user: true   
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/data_stream/icmp/fields/common.yml
+++ b/packages/synthetics/data_stream/icmp/fields/common.yml
@@ -15,7 +15,6 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/icmp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/icmp/fields/ecs.yml
@@ -169,7 +169,6 @@
       level: extended
       type: object
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
-      object_type: keyword
     - name: answers.class
       level: extended
       type: keyword
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/icmp/fields/summary.yml
+++ b/packages/synthetics/data_stream/icmp/fields/summary.yml
@@ -16,23 +16,19 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: >-
+      description: >
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/icmp/fields/tls.yml
+++ b/packages/synthetics/data_stream/icmp/fields/tls.yml
@@ -6,8 +6,10 @@
   fields:
     - name: certificate_not_valid_before
       type: date
+      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
+      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/icmp/lifecycle.yml
+++ b/packages/synthetics/data_stream/icmp/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "365d"

--- a/packages/synthetics/data_stream/icmp/manifest.yml
+++ b/packages/synthetics/data_stream/icmp/manifest.yml
@@ -9,12 +9,10 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "monitor.id"
-            - "url.full.keyword"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "monitor.id"
+          - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/icmp
     title: Synthetic monitor check
@@ -54,7 +52,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: '"@every 3m"'
+        default: "\"@every 3m\""
       - name: wait
         type: text
         title: Wait
@@ -118,7 +116,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true
+        show_user: true   
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/data_stream/tcp/fields/common.yml
+++ b/packages/synthetics/data_stream/tcp/fields/common.yml
@@ -15,7 +15,6 @@
   object_type: keyword
   description: >
     The meta fields allow you to add additional information to a monitor.
-
 - name: monitor
   type: group
   description: >
@@ -59,6 +58,7 @@
         IP of service being monitored. If service is monitored by hostname, the `ip` field contains the resolved ip address for the current host.
 
     - name: status
+      required: true
       type: keyword
       description: >
         Indicator if monitor could validate the service to be available.

--- a/packages/synthetics/data_stream/tcp/fields/ecs.yml
+++ b/packages/synthetics/data_stream/tcp/fields/ecs.yml
@@ -169,7 +169,6 @@
       level: extended
       type: object
       description: "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields."
-      object_type: keyword
     - name: answers.class
       level: extended
       type: keyword
@@ -286,6 +285,7 @@
   fields:
     - name: version
       level: core
+      required: true
       type: keyword
       ignore_above: 1024
       description: "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events."

--- a/packages/synthetics/data_stream/tcp/fields/summary.yml
+++ b/packages/synthetics/data_stream/tcp/fields/summary.yml
@@ -16,23 +16,19 @@
       type: keyword
       description: >
         The status of this check as a whole. Either up or down.
-
     - name: attempt
       type: short
       description: >
         When performing a check this number is 1 for the first check, and increments in the event of a retry.
-
     - name: max_attempts
       type: short
       description: >
         The maximum number of checks that may be performed. Note, the actual number may be smaller.
-
     - name: final_attempt
       type: boolean
       description: >
         True if no further checks will be performed in this retry group.
-
     - name: retry_group
       type: keyword
-      description: >-
+      description: >
         A unique token used to group checks across attempts.

--- a/packages/synthetics/data_stream/tcp/fields/tls.yml
+++ b/packages/synthetics/data_stream/tcp/fields/tls.yml
@@ -6,8 +6,10 @@
   fields:
     - name: certificate_not_valid_before
       type: date
+      deprecated: 7.8.0
       description: Deprecated in favor of `tls.server.x509.not_before`. Earliest time at which the connection's certificates are valid.
     - name: certificate_not_valid_after
+      deprecated: 7.8.0
       type: date
       description: Deprecated in favor of `tls.server.x509.not_after`. Latest time at which the connection's certificates are valid.
     - name: rtt

--- a/packages/synthetics/data_stream/tcp/lifecycle.yml
+++ b/packages/synthetics/data_stream/tcp/lifecycle.yml
@@ -1,1 +1,0 @@
-data_retention: "365d"

--- a/packages/synthetics/data_stream/tcp/manifest.yml
+++ b/packages/synthetics/data_stream/tcp/manifest.yml
@@ -9,12 +9,10 @@ elasticsearch:
     settings:
       index:
         codec: best_compression
-        sort:
-          field:
-            - "monitor.id"
-            - "url.full.keyword"
-  privileges:
-    indices: [auto_configure, create_doc, read]
+        sort.field:
+          - "monitor.id"
+          - "url.full.keyword"
+  privileges.indices: [auto_configure, create_doc, read]
 streams:
   - input: synthetics/tcp
     title: Synthetic monitor check
@@ -54,7 +52,7 @@ streams:
         multi: false
         required: true
         show_user: true
-        default: '"@every 3m"'
+        default: "\"@every 3m\""
       - name: hosts
         type: text
         title: Host
@@ -172,7 +170,7 @@ streams:
         title: Heartbeat mode
         multi: false
         required: false
-        show_user: true
+        show_user: true   
       - name: ipv4
         type: bool
         title: Use the ipv4 protocol

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -1,12 +1,12 @@
-format_version: 3.0.0
+format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.2.0-rc1
+version: 1.1.1
 categories: ["observability"]
+release: ga
 type: integration
-source:
-  license: Elastic-2.0
+license: basic
 policy_templates:
   - name: synthetics
     title: Elastic Synthetics
@@ -25,12 +25,10 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
-  kibana:
-    version: "^8.11.0"
+  kibana.version: "^8.11.0"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16
     type: image/svg+xml
 owner:
   github: elastic/obs-ux-infra_services-team
-  type: elastic

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.1.1
+version: 1.2.1
 categories: ["observability"]
 release: ga
 type: integration


### PR DESCRIPTION
## Proposed commit message

In https://github.com/elastic/integrations/pull/8546, we release a pre-release tagged version of the Synthetics package.

Unfortunately, we didn't realize that Kibana [programmatically disallows](https://github.com/elastic/kibana/pull/176249) the Synthetics package from using pre-release tags in the normal way.

In light of this, we're going to revert the changes we previously released and bump the package version to 1.2.1 to override the previous version (1.2.0-rc1) and ensure users continue utilizing the GA code of the package for their integrations.

Going forward, we'll target Synthetics pre-release packages to minimum 8.13.0 Kibana versions, in which we should no longer have this custom circumvention of the normal SEMVER behavior.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Does the integration work on Stateful Cloud `^8.11.0`?

