### PR TITLE
[TI_MISP] Adding new UI options for attributes to ti_misp

### DIFF
--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.0"
+  changes:
+    - description: Added attribute limit option to the UI
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8943
 - version: "1.29.1"
   changes:
     - description: Changed owners

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -30,9 +30,11 @@ request.transforms:
 - set:
     target: body.page
     value: 1
+{{#if limit}}
 - set:
     target: body.limit
-    value: 10
+    value: {{limit}}
+{{/if}}
 {{#if enforce_warning_list}}
 - set:
     target: body.enforceWarninglist

--- a/packages/ti_misp/data_stream/threat_attributes/manifest.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/manifest.yml
@@ -18,6 +18,14 @@ streams:
         required: true
         show_user: true
         description: The API token used to access the MISP instance.
+      - name: limit
+        type: text
+        title: Attributes Limit
+        multi: false
+        required: true
+        show_user: true
+        default: 10
+        description: Configures how many attributes are returned for each API request.
       - name: initial_interval
         type: text
         title: Initial interval

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.29.1"
+version: "1.30.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

For users that wants to fetch a lot of historical data the pagination will take forever, let's keep the default limit as it was before, but allow overriding it in case it is required, this was not possible before.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

