### PR TITLE
Add capabilities to synthetics packages

### DIFF
--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -25,6 +25,9 @@ policy_templates:
         title: Browser
         description: Perform an Browser check
 conditions:
+  elastic:
+    capabilities:
+      - "uptime"
   kibana:
     version: "^8.11.0"
 icons:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -28,6 +28,7 @@ conditions:
   elastic:
     capabilities:
       - "uptime"
+    subscription: "basic"
   kibana:
     version: "^8.11.0"
 icons:

--- a/packages/synthetics_dashboards/changelog.yml
+++ b/packages/synthetics_dashboards/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Update to Package Spec v3
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9066
 - version: "1.0.0"
   changes:
     - description: initial release

--- a/packages/synthetics_dashboards/kibana/dashboard/synthetics_dashboards-e465c570-1561-11ee-9d3b-15ab835418fd.json
+++ b/packages/synthetics_dashboards/kibana/dashboard/synthetics_dashboards-e465c570-1561-11ee-9d3b-15ab835418fd.json
@@ -242,11 +242,13 @@
                                     }
                                 }
                             ],
-                            "internalReferences": [{
-                                "id": "synthetics-dashboards-integration-adhoc",
-                                "name": "indexpattern-datasource-layer-65aa1d2b-0064-4055-a37f-6144a7d1f3c7",
-                                "type": "index-pattern"
-                            }],
+                            "internalReferences": [
+                                {
+                                    "id": "synthetics-dashboards-integration-adhoc",
+                                    "name": "indexpattern-datasource-layer-65aa1d2b-0064-4055-a37f-6144a7d1f3c7",
+                                    "type": "index-pattern"
+                                }
+                            ],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -643,11 +645,13 @@
                                     }
                                 }
                             ],
-                            "internalReferences": [{
-                                "id": "synthetics-dashboards-integration-adhoc",
-                                "name": "indexpattern-datasource-layer-65aa1d2b-0064-4055-a37f-6144a7d1f3c7",
-                                "type": "index-pattern"
-                            }],
+                            "internalReferences": [
+                                {
+                                    "id": "synthetics-dashboards-integration-adhoc",
+                                    "name": "indexpattern-datasource-layer-65aa1d2b-0064-4055-a37f-6144a7d1f3c7",
+                                    "type": "index-pattern"
+                                }
+                            ],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -833,11 +837,13 @@
                                     }
                                 }
                             ],
-                            "internalReferences": [{
-                                "id": "synthetics-dashboards-integration-adhoc",
-                                "name": "indexpattern-datasource-layer-42ee11c3-ab9a-4b73-a2ba-65c4ad273b2d",
-                                "type": "index-pattern"
-                            }],
+                            "internalReferences": [
+                                {
+                                    "id": "synthetics-dashboards-integration-adhoc",
+                                    "name": "indexpattern-datasource-layer-42ee11c3-ab9a-4b73-a2ba-65c4ad273b2d",
+                                    "type": "index-pattern"
+                                }
+                            ],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1062,11 +1068,13 @@
                                     }
                                 }
                             ],
-                            "internalReferences": [{
-                                "id": "synthetics-dashboards-integration-adhoc",
-                                "name": "indexpattern-datasource-layer-unifiedHistogram",
-                                "type": "index-pattern"
-                            }],
+                            "internalReferences": [
+                                {
+                                    "id": "synthetics-dashboards-integration-adhoc",
+                                    "name": "indexpattern-datasource-layer-unifiedHistogram",
+                                    "type": "index-pattern"
+                                }
+                            ],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -1386,11 +1394,13 @@
                                     }
                                 }
                             ],
-                            "internalReferences": [{
-                                "id": "synthetics-dashboards-integration-adhoc",
-                                "name": "indexpattern-datasource-layer-e1869c68-3f80-4b33-b75f-f9668b5bcd94",
-                                "type": "index-pattern"
-                            }],
+                            "internalReferences": [
+                                {
+                                    "id": "synthetics-dashboards-integration-adhoc",
+                                    "name": "indexpattern-datasource-layer-e1869c68-3f80-4b33-b75f-f9668b5bcd94",
+                                    "type": "index-pattern"
+                                }
+                            ],
                             "query": {
                                 "language": "kuery",
                                 "query": ""

--- a/packages/synthetics_dashboards/manifest.yml
+++ b/packages/synthetics_dashboards/manifest.yml
@@ -1,20 +1,23 @@
-format_version: 1.0.0
+format_version: 3.0.4
 name: synthetics_dashboards
 title: Elastic Synthetics Dashboards
 description: Explore Elastic Synthetics metrics with these dashboards.
-version: 1.0.0
+version: 1.0.1
 categories: ["observability"]
-release: ga
 type: integration
-license: basic
+source:
+  license: Elastic-2.0
 conditions:
   elastic:
     capabilities:
       - "uptime"
-  kibana.version: "^8.10.1"
+    subscription: basic
+  kibana:
+    version: "^8.10.1"
 icons:
   - src: /img/uptime-logo-color-64px.svg
     size: 16x16
     type: image/svg+xml
 owner:
+  type: elastic
   github: elastic/obs-ux-infra_services-team

--- a/packages/synthetics_dashboards/manifest.yml
+++ b/packages/synthetics_dashboards/manifest.yml
@@ -8,6 +8,9 @@ release: ga
 type: integration
 license: basic
 conditions:
+  elastic:
+    capabilities:
+      - "uptime"
   kibana.version: "^8.10.1"
 icons:
   - src: /img/uptime-logo-color-64px.svg


### PR DESCRIPTION
## Proposed commit message

Add capabilities to synthetics packages so they are not available in offerings that miss these capabilities.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
       **Not added because this would release a new version, that would not be filtered because of [special case](https://github.com/elastic/kibana/blob/11fe56b58636fa7fccfd871b8caccb882c888bc1/x-pack/plugins/fleet/server/services/epm/registry/index.ts#L99-L106) in Kibana.**
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Ensure that `uptime` is enough and we don't need to add a `synthetics` capability.
  - https://github.com/elastic/integrations/pull/9066/files#r1479623917
  - [x] If needed to add new capability, remember to update buildkite [around here](https://github.com/elastic/integrations/blob/6e49397a14b7a3fb4291999dffbaf0e5a6b37892/.buildkite/scripts/common.sh#L353).
- [x] Ensure that observability deployments have this capability.
  - https://github.com/elastic/kibana/pull/176285 