### PR TITLE
[ti_misp] Pagination fixes

### DIFF
--- a/packages/ti_misp/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_misp/_dev/deploy/docker/files/config.yml
@@ -1,5 +1,231 @@
 rules:
-  - path: /events/restSearch
+  - path: /events/restSearch # sequence 3, page 1 (repeats)
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"limit":"10","page":"1","returnFormat":"json","timestamp":"1621599936"/
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "response": []
+          }
+  - path: /events/restSearch # sequence 2, page 2
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"1621592532"/
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "response": []
+          }
+  - path: /events/restSearch # sequence 2, page 1
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"limit":"10","page":"1","returnFormat":"json","timestamp":"1621592532"/
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "response": [
+              {
+                "Event": {
+                  "Attribute": [
+                    {
+                      "Galaxy": [],
+                      "ShadowAttribute": [],
+                      "category": "Network activity",
+                      "comment": "Conext for domain type attribute event 2",
+                      "deleted": false,
+                      "disable_correlation": false,
+                      "distribution": "5",
+                      "event_id": "3632",
+                      "first_seen": null,
+                      "id": "266260",
+                      "last_seen": null,
+                      "object_id": "0",
+                      "object_relation": null,
+                      "sharing_group_id": "0",
+                      "timestamp": "1621588744",
+                      "to_ids": true,
+                      "type": "domain",
+                      "uuid": "a52a1b47-a580-4f33-96ba-939cf9146c9b",
+                      "value": "baddom.madeup.local"
+                    }
+                  ],
+                  "EventReport": [],
+                  "Galaxy": [],
+                  "Object": [],
+                  "Org": {
+                    "id": "1",
+                    "local": true,
+                    "name": "ORGNAME",
+                    "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
+                  },
+                  "Orgc": {
+                    "id": "1",
+                    "local": true,
+                    "name": "ORGNAME",
+                    "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
+                  },
+                  "RelatedEvent": [
+                    {
+                      "Event": {
+                        "Org": {
+                          "id": "1",
+                          "name": "ORGNAME",
+                          "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
+                        },
+                        "Orgc": {
+                          "id": "2",
+                          "name": "CIRCL",
+                          "uuid": "55f6ea5e-2c60-40e5-964f-47a8950d210f"
+                        },
+                        "analysis": "2",
+                        "date": "2018-03-26",
+                        "distribution": "3",
+                        "id": "684",
+                        "info": "OSINT - Forgot About Default Accounts? No Worries, GoScanSSH Didn’t",
+                        "org_id": "1",
+                        "orgc_id": "2",
+                        "published": true,
+                        "threat_level_id": "3",
+                        "timestamp": "1523865236",
+                        "uuid": "5acdb4d0-b534-4713-9612-4a1d950d210f"
+                      }
+                    }
+                  ],
+                  "ShadowAttribute": [],
+                  "analysis": "0",
+                  "attribute_count": "4",
+                  "date": "2021-05-21",
+                  "disable_correlation": false,
+                  "distribution": "1",
+                  "event_creator_email": "admin@admin.test",
+                  "extends_uuid": "",
+                  "id": "3632",
+                  "info": "Test event 2 just more atrributes",
+                  "locked": false,
+                  "org_id": "1",
+                  "orgc_id": "1",
+                  "proposal_email_lock": false,
+                  "publish_timestamp": "0",
+                  "published": false,
+                  "sharing_group_id": "0",
+                  "threat_level_id": "2",
+                  "timestamp": "1621598836",
+                  "uuid": "efbca287-edb5-4ad7-b8e4-fe9da514a763"
+                }
+              },
+              {
+                "Event": {
+                  "id": "2",
+                  "orgc_id": "2",
+                  "org_id": "1",
+                  "date": "2014-10-03",
+                  "threat_level_id": "2",
+                  "info": "OSINT New Indicators of Compromise for APT Group Nitro Uncovered blog post by Palo Alto Networks",
+                  "published": true,
+                  "uuid": "54323f2c-e50c-4268-896c-4867950d210b",
+                  "attribute_count": "29",
+                  "analysis": "2",
+                  "timestamp": "1621599936",
+                  "distribution": "3",
+                  "proposal_email_lock": false,
+                  "locked": false,
+                  "publish_timestamp": "1610622316",
+                  "sharing_group_id": "0",
+                  "disable_correlation": false,
+                  "extends_uuid": "",
+                  "Org": {
+                    "id": "1",
+                    "name": "ORGNAME",
+                    "uuid": "5877549f-ea76-4b91-91fb-c72ad682b4a5",
+                    "local": true
+                  },
+                  "Orgc": {
+                    "id": "2",
+                    "name": "CthulhuSPRL.be",
+                    "uuid": "55f6ea5f-fd34-43b8-ac1d-40cb950d210f",
+                    "local": false
+                  },
+                  "Attribute": [
+                    {
+                      "id": "12394",
+                      "type": "domain",
+                      "category": "Network activity",
+                      "to_ids": false,
+                      "uuid": "572b4ab3-1af0-4d91-9cd5-07a1c0a8ab16",
+                      "event_id": "22",
+                      "distribution": "5",
+                      "timestamp": "1462454963",
+                      "comment": "",
+                      "sharing_group_id": "0",
+                      "deleted": false,
+                      "disable_correlation": false,
+                      "object_id": "0",
+                      "object_relation": null,
+                      "first_seen": null,
+                      "last_seen": null,
+                      "value": "whatsapp.com",
+                      "Galaxy": [],
+                      "ShadowAttribute": []
+                    }
+                  ],
+                  "ShadowAttribute": [],
+                  "RelatedEvent": [],
+                  "Galaxy": [],
+                  "Object": [],
+                  "EventReport": [],
+                  "Tag": [
+                    {
+                      "id": "1",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "exportable": true,
+                      "user_id": "0",
+                      "hide_tag": false,
+                      "numerical_value": null,
+                      "is_galaxy": false,
+                      "is_custom_galaxy": false,
+                      "local": 0
+                    },
+                    {
+                      "id": "2",
+                      "name": "tlp:green",
+                      "colour": "#339900",
+                      "exportable": true,
+                      "user_id": "0",
+                      "hide_tag": false,
+                      "numerical_value": null,
+                      "is_galaxy": false,
+                      "is_custom_galaxy": false,
+                      "local": 0
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+  - path: /events/restSearch # sequence 1, page 2
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "response": []
+          }
+  - path: /events/restSearch # sequence 1, page 1
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -142,208 +368,6 @@ rules:
                 }
               }
             ]
-          }
-  - path: /events/restSearch
-    methods: ["POST"]
-    request_headers:
-      Authorization: "test"
-      Content-Type: application/json
-    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
-    responses:
-      - status_code: 200
-        body: |-
-          {
-            "response": [
-              {
-                "Event": {
-                  "Attribute": [
-                    {
-                      "Galaxy": [],
-                      "ShadowAttribute": [],
-                      "category": "Network activity",
-                      "comment": "Conext for domain type attribute event 2",
-                      "deleted": false,
-                      "disable_correlation": false,
-                      "distribution": "5",
-                      "event_id": "3632",
-                      "first_seen": null,
-                      "id": "266260",
-                      "last_seen": null,
-                      "object_id": "0",
-                      "object_relation": null,
-                      "sharing_group_id": "0",
-                      "timestamp": "1621588744",
-                      "to_ids": true,
-                      "type": "domain",
-                      "uuid": "a52a1b47-a580-4f33-96ba-939cf9146c9b",
-                      "value": "baddom.madeup.local"
-                    }
-                  ],
-                  "EventReport": [],
-                  "Galaxy": [],
-                  "Object": [],
-                  "Org": {
-                    "id": "1",
-                    "local": true,
-                    "name": "ORGNAME",
-                    "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
-                  },
-                  "Orgc": {
-                    "id": "1",
-                    "local": true,
-                    "name": "ORGNAME",
-                    "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
-                  },
-                  "RelatedEvent": [
-                    {
-                      "Event": {
-                        "Org": {
-                          "id": "1",
-                          "name": "ORGNAME",
-                          "uuid": "78acad2d-cc2d-4785-94d6-b428a0070488"
-                        },
-                        "Orgc": {
-                          "id": "2",
-                          "name": "CIRCL",
-                          "uuid": "55f6ea5e-2c60-40e5-964f-47a8950d210f"
-                        },
-                        "analysis": "2",
-                        "date": "2018-03-26",
-                        "distribution": "3",
-                        "id": "684",
-                        "info": "OSINT - Forgot About Default Accounts? No Worries, GoScanSSH Didn’t",
-                        "org_id": "1",
-                        "orgc_id": "2",
-                        "published": true,
-                        "threat_level_id": "3",
-                        "timestamp": "1523865236",
-                        "uuid": "5acdb4d0-b534-4713-9612-4a1d950d210f"
-                      }
-                    }
-                  ],
-                  "ShadowAttribute": [],
-                  "analysis": "0",
-                  "attribute_count": "4",
-                  "date": "2021-05-21",
-                  "disable_correlation": false,
-                  "distribution": "1",
-                  "event_creator_email": "admin@admin.test",
-                  "extends_uuid": "",
-                  "id": "3632",
-                  "info": "Test event 2 just more atrributes",
-                  "locked": false,
-                  "org_id": "1",
-                  "orgc_id": "1",
-                  "proposal_email_lock": false,
-                  "publish_timestamp": "0",
-                  "published": false,
-                  "sharing_group_id": "0",
-                  "threat_level_id": "2",
-                  "timestamp": "1621588836",
-                  "uuid": "efbca287-edb5-4ad7-b8e4-fe9da514a763"
-                }
-              },
-              {
-                "Event": {
-                  "id": "2",
-                  "orgc_id": "2",
-                  "org_id": "1",
-                  "date": "2014-10-03",
-                  "threat_level_id": "2",
-                  "info": "OSINT New Indicators of Compromise for APT Group Nitro Uncovered blog post by Palo Alto Networks",
-                  "published": true,
-                  "uuid": "54323f2c-e50c-4268-896c-4867950d210b",
-                  "attribute_count": "29",
-                  "analysis": "2",
-                  "timestamp": "1412579577",
-                  "distribution": "3",
-                  "proposal_email_lock": false,
-                  "locked": false,
-                  "publish_timestamp": "1610622316",
-                  "sharing_group_id": "0",
-                  "disable_correlation": false,
-                  "extends_uuid": "",
-                  "Org": {
-                    "id": "1",
-                    "name": "ORGNAME",
-                    "uuid": "5877549f-ea76-4b91-91fb-c72ad682b4a5",
-                    "local": true
-                  },
-                  "Orgc": {
-                    "id": "2",
-                    "name": "CthulhuSPRL.be",
-                    "uuid": "55f6ea5f-fd34-43b8-ac1d-40cb950d210f",
-                    "local": false
-                  },
-                  "Attribute": [
-                    {
-                      "id": "12394",
-                      "type": "domain",
-                      "category": "Network activity",
-                      "to_ids": false,
-                      "uuid": "572b4ab3-1af0-4d91-9cd5-07a1c0a8ab16",
-                      "event_id": "22",
-                      "distribution": "5",
-                      "timestamp": "1462454963",
-                      "comment": "",
-                      "sharing_group_id": "0",
-                      "deleted": false,
-                      "disable_correlation": false,
-                      "object_id": "0",
-                      "object_relation": null,
-                      "first_seen": null,
-                      "last_seen": null,
-                      "value": "whatsapp.com",
-                      "Galaxy": [],
-                      "ShadowAttribute": []
-                    }
-                  ],
-                  "ShadowAttribute": [],
-                  "RelatedEvent": [],
-                  "Galaxy": [],
-                  "Object": [],
-                  "EventReport": [],
-                  "Tag": [
-                    {
-                      "id": "1",
-                      "name": "type:OSINT",
-                      "colour": "#004646",
-                      "exportable": true,
-                      "user_id": "0",
-                      "hide_tag": false,
-                      "numerical_value": null,
-                      "is_galaxy": false,
-                      "is_custom_galaxy": false,
-                      "local": 0
-                    },
-                    {
-                      "id": "2",
-                      "name": "tlp:green",
-                      "colour": "#339900",
-                      "exportable": true,
-                      "user_id": "0",
-                      "hide_tag": false,
-                      "numerical_value": null,
-                      "is_galaxy": false,
-                      "is_custom_galaxy": false,
-                      "local": 0
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-  - path: /events/restSearch
-    methods: ["POST"]
-    request_headers:
-      Authorization: "test"
-      Content-Type: application/json
-    request_body: /^{"limit":"10","page":"3","returnFormat":"json","timestamp":"\d+"/
-    responses:
-      - status_code: 200
-        body: |-
-          {
-            "response": []
           }
   - path: /attributes/restSearch
     methods: ["POST"]

--- a/packages/ti_misp/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_misp/_dev/deploy/docker/files/config.yml
@@ -4,7 +4,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"limit":"10","page":"1","returnFormat":"json","timestamp":"1621599936"/
+    request_body: /^{"limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"1621599936"/
     responses:
       - status_code: 200
         body: |-
@@ -16,7 +16,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"1621592532"/
+    request_body: /^{"limit":"10","order":"timestamp","page":"2","returnFormat":"json","timestamp":"1621592532"/
     responses:
       - status_code: 200
         body: |-
@@ -28,7 +28,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"limit":"10","page":"1","returnFormat":"json","timestamp":"1621592532"/
+    request_body: /^{"limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"1621592532"/
     responses:
       - status_code: 200
         body: |-
@@ -218,7 +218,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
+    request_body: /^{"limit":"10","order":"timestamp","page":"2","returnFormat":"json","timestamp":"\d+"/
     responses:
       - status_code: 200
         body: |-
@@ -230,7 +230,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"limit":"10","page":"1","returnFormat":"json","timestamp":"\d+"/
+    request_body: /^{"limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"\d+"/
     responses:
       - status_code: 200
         body: |-
@@ -374,7 +374,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"includeDecayScore":"true","limit":"10","page":"1","returnFormat":"json","timestamp":"1700667505"/
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"1700667505"/
     responses:
       - status_code: 200
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
@@ -383,7 +383,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"includeDecayScore":"true","limit":"10","page":"2","returnFormat":"json","timestamp":"1412320446"/
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"2","returnFormat":"json","timestamp":"1412320446"/
     responses:
       - status_code: 200
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
@@ -392,7 +392,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"includeDecayScore":"true","limit":"10","page":"1","returnFormat":"json","timestamp":"1412320446"/
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"1412320446"/
     responses:
       - status_code: 200
         body: |-
@@ -947,7 +947,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"includeDecayScore":"true","limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"2","returnFormat":"json","timestamp":"\d+"/
     responses:
       - status_code: 200
         body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
@@ -956,7 +956,7 @@ rules:
     request_headers:
       Authorization: "test"
       Content-Type: application/json
-    request_body: /^{"includeDecayScore":"true","limit":"10","page":"1","returnFormat":"json","timestamp":"\d+"/
+    request_body: /^{"includeDecayScore":"true","limit":"10","order":"timestamp","page":"1","returnFormat":"json","timestamp":"\d+"/
     responses:
       - status_code: 200
         body: |-

--- a/packages/ti_misp/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_misp/_dev/deploy/docker/files/config.yml
@@ -369,7 +369,589 @@ rules:
               }
             ]
           }
-  - path: /attributes/restSearch
+  - path: /attributes/restSearch # sequence 3, page 1 (repeats)
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"includeDecayScore":"true","limit":"10","page":"1","returnFormat":"json","timestamp":"1700667505"/
+    responses:
+      - status_code: 200
+        body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
+  - path: /attributes/restSearch # sequence 2, page 2
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"includeDecayScore":"true","limit":"10","page":"2","returnFormat":"json","timestamp":"1412320446"/
+    responses:
+      - status_code: 200
+        body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
+  - path: /attributes/restSearch # sequence 2, page 1
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"includeDecayScore":"true","limit":"10","page":"1","returnFormat":"json","timestamp":"1412320446"/
+    responses:
+      - status_code: 200
+        body: |-
+          {
+            "response": {
+              "Attribute": [
+                {
+                  "id": "3",
+                  "event_id": "1",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "link",
+                  "to_ids": false,
+                  "uuid": "542e4cbe-12a4-4345-b0a4-1fda950d210b",
+                  "timestamp": "1412320447",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "https://gist.githubusercontent.com/andrewsmhay/de1cdc63d04c2bbf8c12/raw/f20402cf5a0c646c63c4521f60587703fe654443/iplist",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1",
+                    "info": "OSINT ShellShock scanning IPs from OpenDNS",
+                    "orgc_id": "2",
+                    "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
+                  }
+                },
+                {
+                  "id": "4",
+                  "event_id": "1",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "text",
+                  "to_ids": false,
+                  "uuid": "542e4ccc-b8fc-44af-959d-6ead950d210b",
+                  "timestamp": "1412320460",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "Shellshock",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1",
+                    "info": "OSINT ShellShock scanning IPs from OpenDNS",
+                    "orgc_id": "2",
+                    "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
+                  }
+                },
+                {
+                  "id": "5",
+                  "event_id": "1",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "comment",
+                  "to_ids": false,
+                  "uuid": "542e4ce7-6120-41c0-8793-e90e950d210b",
+                  "timestamp": "1412320487",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "Data encoded by David AndrÃ©",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1",
+                    "info": "OSINT ShellShock scanning IPs from OpenDNS",
+                    "orgc_id": "2",
+                    "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
+                  }
+                },
+                {
+                  "id": "266922",
+                  "event_id": "1279",
+                  "object_id": "20246",
+                  "object_relation": "sha1",
+                  "category": "Payload delivery",
+                  "type": "sha1",
+                  "to_ids": true,
+                  "uuid": "84850997-631c-44ea-ac71-5f8bb4e6e1f0",
+                  "timestamp": "1696914151",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "c514799ffdc38d48b7e90b8b6a324c354d1fd2a2",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1279",
+                    "info": "FormBook campaign",
+                    "orgc_id": "3",
+                    "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
+                  },
+                  "Object": {
+                    "id": "20246",
+                    "distribution": "5",
+                    "sharing_group_id": "0"
+                  },
+                  "Tag": [
+                    {
+                      "id": "10",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "204",
+                      "name": "osint:lifetime=\"perpetual\"",
+                      "colour": "#0071c3",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "540",
+                      "name": "osint:certainty=\"50\"",
+                      "colour": "#0087e8",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "11",
+                      "name": "tlp:white",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1051",
+                      "name": "tlp:clear",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "338",
+                      "name": "misp-galaxy:tool=\"FormBook\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1056",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "474",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    }
+                  ]
+                },
+                {
+                  "id": "266790",
+                  "event_id": "1279",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "Network activity",
+                  "type": "url",
+                  "to_ids": true,
+                  "uuid": "78f6d250-c68d-42df-8083-b55e4d20779e",
+                  "timestamp": "1686914587",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://www.doordelivery.life/km37/",
+                  "decay_score": [
+                    {
+                      "score": -0,
+                      "base_score": 0,
+                      "decayed": true,
+                      "DecayingModel": {
+                        "id": "1",
+                        "name": "test-decay-model"
+                      }
+                    },
+                    {
+                      "score": 0,
+                      "base_score": 50,
+                      "decayed": true,
+                      "DecayingModel": {
+                        "id": "2",
+                        "name": "test-decay-model-2"
+                      }
+                    }
+                  ],
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1279",
+                    "info": "FormBook campaign",
+                    "orgc_id": "3",
+                    "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
+                  },
+                  "Tag": [
+                    {
+                      "id": "10",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "204",
+                      "name": "osint:lifetime=\"perpetual\"",
+                      "colour": "#0071c3",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "540",
+                      "name": "osint:certainty=\"50\"",
+                      "colour": "#0087e8",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "11",
+                      "name": "tlp:white",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1051",
+                      "name": "tlp:clear",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "338",
+                      "name": "misp-galaxy:tool=\"FormBook\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1056",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "474",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    }
+                  ]
+                },
+                {
+                  "id": "266793",
+                  "event_id": "1279",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "Network activity",
+                  "type": "url",
+                  "to_ids": true,
+                  "uuid": "efa8a550-bc25-4d93-abcd-1c00eaa4acdd",
+                  "timestamp": "1686914588",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://www.blueridgebedracks.com/km37/",
+                  "decay_score": [
+                    {
+                      "score": -0,
+                      "base_score": 0,
+                      "decayed": false,
+                      "DecayingModel": {
+                        "id": "1",
+                        "name": "test-decay-model"
+                      }
+                    },
+                    {
+                      "score": 0,
+                      "base_score": 50,
+                      "decayed": false,
+                      "DecayingModel": {
+                        "id": "2",
+                        "name": "test-decay-model-2"
+                      }
+                    }
+                  ],
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1279",
+                    "info": "FormBook campaign",
+                    "orgc_id": "3",
+                    "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
+                  },
+                  "Tag": [
+                    {
+                      "id": "10",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "204",
+                      "name": "osint:lifetime=\"perpetual\"",
+                      "colour": "#0071c3",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "540",
+                      "name": "osint:certainty=\"50\"",
+                      "colour": "#0087e8",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "11",
+                      "name": "tlp:white",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1051",
+                      "name": "tlp:clear",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "338",
+                      "name": "misp-galaxy:tool=\"FormBook\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1056",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "474",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    }
+                  ]
+                },
+                {
+                  "id": "268565",
+                  "event_id": "1294",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "Network activity",
+                  "type": "url",
+                  "to_ids": true,
+                  "uuid": "ec341f4e-0f70-4569-8ac5-e35465572726",
+                  "timestamp": "1700667504",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://185.122.204.197/acb.sh",
+                  "decay_score": [
+                    {
+                      "score": 0,
+                      "base_score": 0,
+                      "decayed": true,
+                      "DecayingModel": {
+                        "id": "1",
+                        "name": "test-decay-model"
+                      }
+                    },
+                    {
+                      "score": 49.98530793883329,
+                      "base_score": 50,
+                      "decayed": false,
+                      "DecayingModel": {
+                        "id": "2",
+                        "name": "test-decay-model-2"
+                      }
+                    }
+                  ],
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1294",
+                    "info": "CVE-2023-46604 (Apache ActiveMQ) Vulnerability Exploited to Infect Systems With Cryptominers and Rootkits",
+                    "orgc_id": "3",
+                    "uuid": "df7b7020-9f17-4a3c-9824-1baa4ff67cb1"
+                  },
+                  "Tag": [
+                    {
+                      "id": "10",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "204",
+                      "name": "osint:lifetime=\"perpetual\"",
+                      "colour": "#0071c3",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "11",
+                      "name": "tlp:white",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1051",
+                      "name": "tlp:clear",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "713",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Resource Hijacking - T1496\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    }
+                  ]
+                },
+                {
+                  "id": "268570",
+                  "event_id": "1294",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "Network activity",
+                  "type": "url",
+                  "to_ids": true,
+                  "uuid": "28f55810-c61e-42d0-8565-cc7d2e7eb57c",
+                  "timestamp": "1700667505",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://194.38.22.53/libsystem.so",
+                  "decay_score": [
+                    {
+                      "score": 49.98530793883329,
+                      "base_score": 50,
+                      "decayed": false,
+                      "DecayingModel": {
+                        "id": "2",
+                        "name": "test-decay-model-2"
+                      }
+                    }
+                  ],
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1294",
+                    "info": "CVE-2023-46604 (Apache ActiveMQ) Vulnerability Exploited to Infect Systems With Cryptominers and Rootkits",
+                    "orgc_id": "3",
+                    "uuid": "df7b7020-9f17-4a3c-9824-1baa4ff67cb1"
+                  },
+                  "Tag": [
+                    {
+                      "id": "10",
+                      "name": "type:OSINT",
+                      "colour": "#004646",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "204",
+                      "name": "osint:lifetime=\"perpetual\"",
+                      "colour": "#0071c3",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "11",
+                      "name": "tlp:white",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "1051",
+                      "name": "tlp:clear",
+                      "colour": "#ffffff",
+                      "numerical_value": null,
+                      "inherited": 1
+                    },
+                    {
+                      "id": "713",
+                      "name": "misp-galaxy:mitre-attack-pattern=\"Resource Hijacking - T1496\"",
+                      "colour": "#0088cc",
+                      "numerical_value": null,
+                      "inherited": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+  - path: /attributes/restSearch # sequence 1, page 2
+    methods: ["POST"]
+    request_headers:
+      Authorization: "test"
+      Content-Type: application/json
+    request_body: /^{"includeDecayScore":"true","limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
+    responses:
+      - status_code: 200
+        body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "
+  - path: /attributes/restSearch # sequence 1, page 1
     methods: ["POST"]
     request_headers:
       Authorization: "test"
@@ -380,610 +962,61 @@ rules:
         body: |-
           {
             "response": {
-                "Attribute": [
-                  {
+              "Attribute": [
+                {
+                  "id": "1",
+                  "event_id": "1",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "link",
+                  "to_ids": false,
+                  "uuid": "542e4cbd-ee78-4a57-bfb8-1fda950d210b",
+                  "timestamp": "1412320445",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "http://labs.opendns.com/2014/10/02/opendns-and-bash/",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
                     "id": "1",
-                    "event_id": "1",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "External analysis",
-                    "type": "link",
-                    "to_ids": false,
-                    "uuid": "542e4cbd-ee78-4a57-bfb8-1fda950d210b",
-                    "timestamp": "1412320445",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "http://labs.opendns.com/2014/10/02/opendns-and-bash/",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1",
-                        "info": "OSINT ShellShock scanning IPs from OpenDNS",
-                        "orgc_id": "2",
-                        "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
-                    }
-                  },
-                  {
-                    "id": "2",
-                    "event_id": "1",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "External analysis",
-                    "type": "link",
-                    "to_ids": false,
-                    "uuid": "542e4cbe-d560-4e14-9157-1fda950d210b",
-                    "timestamp": "1412320446",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "https://gist.github.com/andrewsmhay/de1cdc63d04c2bbf8c12",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1",
-                        "info": "OSINT ShellShock scanning IPs from OpenDNS",
-                        "orgc_id": "2",
-                        "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
-                    }
-                  },
-                  {
-                    "id": "3",
-                    "event_id": "1",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "External analysis",
-                    "type": "link",
-                    "to_ids": false,
-                    "uuid": "542e4cbe-12a4-4345-b0a4-1fda950d210b",
-                    "timestamp": "1412320446",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "https://gist.githubusercontent.com/andrewsmhay/de1cdc63d04c2bbf8c12/raw/f20402cf5a0c646c63c4521f60587703fe654443/iplist",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1",
-                        "info": "OSINT ShellShock scanning IPs from OpenDNS",
-                        "orgc_id": "2",
-                        "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
-                    }
-                  },
-                  {
-                    "id": "4",
-                    "event_id": "1",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "External analysis",
-                    "type": "text",
-                    "to_ids": false,
-                    "uuid": "542e4ccc-b8fc-44af-959d-6ead950d210b",
-                    "timestamp": "1412320460",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "Shellshock",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1",
-                        "info": "OSINT ShellShock scanning IPs from OpenDNS",
-                        "orgc_id": "2",
-                        "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
-                    }
-                  },
-                  {
-                    "id": "5",
-                    "event_id": "1",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "External analysis",
-                    "type": "comment",
-                    "to_ids": false,
-                    "uuid": "542e4ce7-6120-41c0-8793-e90e950d210b",
-                    "timestamp": "1412320487",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "Data encoded by David AndrÃ©",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1",
-                        "info": "OSINT ShellShock scanning IPs from OpenDNS",
-                        "orgc_id": "2",
-                        "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
-                    }
-                  },
-                  {
-                    "id": "266790",
-                    "event_id": "1279",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "Network activity",
-                    "type": "url",
-                    "to_ids": true,
-                    "uuid": "78f6d250-c68d-42df-8083-b55e4d20779e",
-                    "timestamp": "1686914587",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "http://www.doordelivery.life/km37/",
-                    "decay_score": [
-                        {
-                            "score": -0,
-                            "base_score": 0,
-                            "decayed": true,
-                            "DecayingModel": {
-                                "id": "1",
-                                "name": "test-decay-model"
-                            }
-                        },
-                        {
-                            "score": 0,
-                            "base_score": 50,
-                            "decayed": true,
-                            "DecayingModel": {
-                                "id": "2",
-                                "name": "test-decay-model-2"
-                            }
-                        }
-                    ],
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1279",
-                        "info": "FormBook campaign",
-                        "orgc_id": "3",
-                        "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
-                    },
-                    "Tag": [
-                        {
-                            "id": "10",
-                            "name": "type:OSINT",
-                            "colour": "#004646",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "204",
-                            "name": "osint:lifetime=\"perpetual\"",
-                            "colour": "#0071c3",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "540",
-                            "name": "osint:certainty=\"50\"",
-                            "colour": "#0087e8",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "11",
-                            "name": "tlp:white",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1051",
-                            "name": "tlp:clear",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "338",
-                            "name": "misp-galaxy:tool=\"FormBook\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1056",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "474",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        }
-                    ]
-                  },
-                  {
-                    "id": "268565",
-                    "event_id": "1294",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "Network activity",
-                    "type": "url",
-                    "to_ids": true,
-                    "uuid": "ec341f4e-0f70-4569-8ac5-e35465572726",
-                    "timestamp": "1700667504",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "http://185.122.204.197/acb.sh",
-                    "decay_score": [
-                        {
-                            "score": 0,
-                            "base_score": 0,
-                            "decayed": true,
-                            "DecayingModel": {
-                                "id": "1",
-                                "name": "test-decay-model"
-                            }
-                        },
-                        {
-                            "score": 49.98530793883329,
-                            "base_score": 50,
-                            "decayed": false,
-                            "DecayingModel": {
-                                "id": "2",
-                                "name": "test-decay-model-2"
-                            }
-                        }
-                    ],
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1294",
-                        "info": "CVE-2023-46604 (Apache ActiveMQ) Vulnerability Exploited to Infect Systems With Cryptominers and Rootkits",
-                        "orgc_id": "3",
-                        "uuid": "df7b7020-9f17-4a3c-9824-1baa4ff67cb1"
-                    },
-                    "Tag": [
-                        {
-                            "id": "10",
-                            "name": "type:OSINT",
-                            "colour": "#004646",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "204",
-                            "name": "osint:lifetime=\"perpetual\"",
-                            "colour": "#0071c3",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "11",
-                            "name": "tlp:white",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1051",
-                            "name": "tlp:clear",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "713",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Resource Hijacking - T1496\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        }
-                    ]
-                  },
-                  {
-                    "id": "266793",
-                    "event_id": "1279",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "Network activity",
-                    "type": "url",
-                    "to_ids": true,
-                    "uuid": "efa8a550-bc25-4d93-abcd-1c00eaa4acdd",
-                    "timestamp": "1686914587",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "http://www.blueridgebedracks.com/km37/",
-                    "decay_score": [
-                        {
-                            "score": -0,
-                            "base_score": 0,
-                            "decayed": false,
-                            "DecayingModel": {
-                                "id": "1",
-                                "name": "test-decay-model"
-                            }
-                        },
-                        {
-                            "score": 0,
-                            "base_score": 50,
-                            "decayed": false,
-                            "DecayingModel": {
-                                "id": "2",
-                                "name": "test-decay-model-2"
-                            }
-                        }
-                    ],
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1279",
-                        "info": "FormBook campaign",
-                        "orgc_id": "3",
-                        "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
-                    },
-                    "Tag": [
-                        {
-                            "id": "10",
-                            "name": "type:OSINT",
-                            "colour": "#004646",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "204",
-                            "name": "osint:lifetime=\"perpetual\"",
-                            "colour": "#0071c3",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "540",
-                            "name": "osint:certainty=\"50\"",
-                            "colour": "#0087e8",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "11",
-                            "name": "tlp:white",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1051",
-                            "name": "tlp:clear",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "338",
-                            "name": "misp-galaxy:tool=\"FormBook\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1056",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "474",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        }
-                    ]
-                  },
-                  {
-                    "id": "268570",
-                    "event_id": "1294",
-                    "object_id": "0",
-                    "object_relation": null,
-                    "category": "Network activity",
-                    "type": "url",
-                    "to_ids": true,
-                    "uuid": "28f55810-c61e-42d0-8565-cc7d2e7eb57c",
-                    "timestamp": "1700667504",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "http://194.38.22.53/libsystem.so",
-                    "decay_score": [
-                        {
-                            "score": 49.98530793883329,
-                            "base_score": 50,
-                            "decayed": false,
-                            "DecayingModel": {
-                                "id": "2",
-                                "name": "test-decay-model-2"
-                            }
-                        }
-                    ],
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1294",
-                        "info": "CVE-2023-46604 (Apache ActiveMQ) Vulnerability Exploited to Infect Systems With Cryptominers and Rootkits",
-                        "orgc_id": "3",
-                        "uuid": "df7b7020-9f17-4a3c-9824-1baa4ff67cb1"
-                    },
-                    "Tag": [
-                        {
-                            "id": "10",
-                            "name": "type:OSINT",
-                            "colour": "#004646",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "204",
-                            "name": "osint:lifetime=\"perpetual\"",
-                            "colour": "#0071c3",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "11",
-                            "name": "tlp:white",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1051",
-                            "name": "tlp:clear",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "713",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Resource Hijacking - T1496\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        }
-                    ]
-                  },
-                  {
-                    "id": "266922",
-                    "event_id": "1279",
-                    "object_id": "20246",
-                    "object_relation": "sha1",
-                    "category": "Payload delivery",
-                    "type": "sha1",
-                    "to_ids": true,
-                    "uuid": "84850997-631c-44ea-ac71-5f8bb4e6e1f0",
-                    "timestamp": "1696914151",
-                    "distribution": "5",
-                    "sharing_group_id": "0",
-                    "comment": "",
-                    "deleted": false,
-                    "disable_correlation": false,
-                    "first_seen": null,
-                    "last_seen": null,
-                    "value": "c514799ffdc38d48b7e90b8b6a324c354d1fd2a2",
-                    "Event": {
-                        "org_id": "1",
-                        "distribution": "3",
-                        "id": "1279",
-                        "info": "FormBook campaign",
-                        "orgc_id": "3",
-                        "uuid": "f45fe125-7f3f-4335-bf74-5ab61eb5b645"
-                    },
-                    "Object": {
-                        "id": "20246",
-                        "distribution": "5",
-                        "sharing_group_id": "0"
-                    },
-                    "Tag": [
-                        {
-                            "id": "10",
-                            "name": "type:OSINT",
-                            "colour": "#004646",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "204",
-                            "name": "osint:lifetime=\"perpetual\"",
-                            "colour": "#0071c3",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "540",
-                            "name": "osint:certainty=\"50\"",
-                            "colour": "#0087e8",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "11",
-                            "name": "tlp:white",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1051",
-                            "name": "tlp:clear",
-                            "colour": "#ffffff",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "338",
-                            "name": "misp-galaxy:tool=\"FormBook\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "1056",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1566.001\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        },
-                        {
-                            "id": "474",
-                            "name": "misp-galaxy:mitre-attack-pattern=\"Spearphishing Attachment - T1193\"",
-                            "colour": "#0088cc",
-                            "numerical_value": null,
-                            "inherited": 1
-                        }
-                    ]
+                    "info": "OSINT ShellShock scanning IPs from OpenDNS",
+                    "orgc_id": "2",
+                    "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
                   }
+                },
+                {
+                  "id": "2",
+                  "event_id": "1",
+                  "object_id": "0",
+                  "object_relation": null,
+                  "category": "External analysis",
+                  "type": "link",
+                  "to_ids": false,
+                  "uuid": "542e4cbe-d560-4e14-9157-1fda950d210b",
+                  "timestamp": "1412320446",
+                  "distribution": "5",
+                  "sharing_group_id": "0",
+                  "comment": "",
+                  "deleted": false,
+                  "disable_correlation": false,
+                  "first_seen": null,
+                  "last_seen": null,
+                  "value": "https://gist.github.com/andrewsmhay/de1cdc63d04c2bbf8c12",
+                  "Event": {
+                    "org_id": "1",
+                    "distribution": "3",
+                    "id": "1",
+                    "info": "OSINT ShellShock scanning IPs from OpenDNS",
+                    "orgc_id": "2",
+                    "uuid": "542e4c9c-cadc-4f8f-bb11-6d13950d210b"
+                  }
+                }
               ]
             }
           }
-  - path: /attributes/restSearch
-    methods: ["POST"]
-    request_headers:
-      Authorization: "test"
-      Content-Type: application/json
-    request_body: /^{"limit":"10","page":"2","returnFormat":"json","timestamp":"\d+"/
-    responses:
-      - status_code: 200
-        body: "{\n  \"response\": {\n    \"Attribute\": []\n  }\n}  "

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -8,7 +8,7 @@
   changes:
     - description: Added attribute limit option to the UI
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8943
+      link: https://github.com/elastic/integrations/pull/9064
 - version: "1.29.1"
   changes:
     - description: Changed owners

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.0"
+  changes:
+    - description: Pagination fixes
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9073
 - version: "1.30.1"
   changes:
     - description: Add recent new field to latest_ioc transform dest

--- a/packages/ti_misp/data_stream/threat/_dev/test/system/test-default-config.yml
+++ b/packages/ti_misp/data_stream/threat/_dev/test/system/test-default-config.yml
@@ -6,8 +6,8 @@ data_stream:
     preserve_original_event: true
     url: http://{{Hostname}}:{{Port}}
     api_token: test
-    interval: 10m
-    initial_interval: 10m
+    interval: 1s
+    initial_interval: 10s
     enable_request_tracer: true
 assert:
   hit_count: 3

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -46,6 +46,9 @@ request.transforms:
       [[- end -]]
     default: '[[ (now (parseDuration "-{{initial_interval}}")).Unix ]]'
 - set:
+    target: body.order
+    value: timestamp
+- set:
     # Ignored by MISP, set as a workaround to make it available in response.pagination.
     target: url.params.timestamp
     value: '[[.body.timestamp]]'

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -38,7 +38,12 @@ request.transforms:
     value: json
 - set:
     target: body.timestamp
-    value: '[[.cursor.timestamp.Unix]]'
+    value: >-
+      [[- if index .cursor "timestamp" -]]
+        [[- .cursor.timestamp -]]
+      [[- else -]]
+        [[- .last_response.url.params.Get "timestamp" -]]
+      [[- end -]]
     default: '[[ (now (parseDuration "-{{initial_interval}}")).Unix ]]'
 - set:
     # Ignored by MISP, set as a workaround to make it available in response.pagination.

--- a/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-default-config.yml
+++ b/packages/ti_misp/data_stream/threat_attributes/_dev/test/system/test-default-config.yml
@@ -6,8 +6,8 @@ data_stream:
     preserve_original_event: true
     url: http://{{Hostname}}:{{Port}}
     api_token: test
-    interval: 10m
-    initial_interval: 10m
+    interval: 1s
+    initial_interval: 10s
     enable_request_tracer: true
     ioc_expiration_duration: 5d
 assert:

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -74,7 +74,7 @@ response.pagination:
     value: '[[.last_response.url.params.Get "timestamp"]]'
 cursor:
   timestamp:
-    value: '[[.last_event.Attribute.timestamp]]'
+    value: '[[.last_event.timestamp]]'
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -59,6 +59,9 @@ request.transforms:
 - set:
     target: body.includeDecayScore
     value: true
+- set:
+    target: body.order
+    value: timestamp
 
 response.split:
   target: body.response.Attribute

--- a/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat_attributes/agent/stream/httpjson.yml.hbs
@@ -45,7 +45,12 @@ request.transforms:
     value: json
 - set:
     target: body.timestamp
-    value: '[[.cursor.timestamp.Unix]]'
+    value: >-
+      [[- if index .cursor "timestamp" -]]
+        [[- .cursor.timestamp -]]
+      [[- else -]]
+        [[- .last_response.url.params.Get "timestamp" -]]
+      [[- end -]]
     default: '[[ (now (parseDuration "-{{initial_interval}}")).Unix ]]'
 - set:
     # Ignored by MISP, set as a workaround to make it available in response.pagination.

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.30.1"
+version: "1.31.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

```
[ti_misp] Pagination fixes (#9073)

This change fixes several bugs in pagination logic.

For the threat (events) and threat_attributes (attributes) data streams:

* Access the timestamp correctly in the cursor data, as a string not a
  `time.Time` value.
* Reuse the initial timestamp value until a new one comes from the
  server (rather resetting it with `initial_inteveral` until a
  timestamp appears in the cursor data).
* Add `"order":"timestamp"` parameter to requests, so that MISP queries
  the database with an explicit ORDER BY clause.
* Adjust the system test stubs so that the tests cover several page
  sequences, require correct timestamp values after the first sequence,
  and match with the new `order` parameter.

For the threat_attributes (attributes) data stream only:

* Correct the expression for extracting the timestamp from an event,
  to account for the fact that the split uses `keep_parent: false`.

Also:

* Correct the PR link in an earlier change log entry.
```

## Discussion

While the system tests do now require that later page sequences use the correct timestamp values, I relied on manual checks to validate that the timestamp value won't be reinitialized following an empty page before data arrives. I used MISP v2.4.183, via `misp-docker`, as described below.

Adding the `order` parameter changes the SQL query generated by MISP as follows (for events):
```diff
 SELECT `Event`.`id`, `Event`.`attribute_count`
 FROM `misp`.`events` AS `Event`
 WHERE `Event`.`timestamp` >= 1707200151
+ORDER BY `Event`.`timestamp` asc
 LIMIT 10
```
The `order` parameter is mentioned in MISP's [main documentation](https://www.circl.lu/doc/misp/automation/#search) but not in it's [OpenAI documentation](https://www.misp-project.org/openapi/#tag/Events). The documentation says it's "Only available for `/events/restSearch`", but in fact the `restSearch` code is shared and it works for `/attributes/restSearch` as well.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

The following is a guide for how to run MISP locally, observe its interactions with the database and run the Elastic MISP integration against that local instance.

### MISP: Configure, run and generate an API token

- Clone https://github.com/misp/misp-docker.
- To enable SQL logging in MariaDB, edit `docker-compse.yml` and under `services.db` add `command: --general-log --general-log-file=general.log`.
- Follow the `misp-docker` README's Getting Started instructions.
- In MISP, Administration > List Auth Keys, add a new key and copy its value.

### MISP: Load data and query

- In MISP, Sync Actions > Feeds, click "Load default feed metadata", enable some feeds and click "Fetch all events" on them.
- In MISP, API > Rest client, you can construct and run queries. It can generate cURL commands (to which you may need to add the `--insecure` option).

### SQL logs

Tail the MariaDB log and highlight queries of interest (`SELECT`s with a `LIMIT` that's not `1`), as follows:

```
docker exec -it misp-docker-db-1 tail -f /var/lib/mysql/general.log | \
  grep -P 'SELECT .* LIMIT (?!1[^\d])\d+|$'
```

### MISP integration in Elastic

When adding a MISP integration policy use the following settings:

- MISP URL: https://172.17.0.1 (special IP for the docker host)
- MISP API Token: F2wJWSS4qhRyVOdjMemTNiMW9W9dqdEFgGPjJIGP (from earlier setup)
- Initial Interval: 0s (or more)
- Interval: 10s
- Preserve original event: yes
- SSL: "verification_mode: none"
- Enable request tracing: yes

### MISP: other settings (optional)

Additional settings can be added to `misp-docker/core/files/configure_misp.sh`, for example:
```
sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q -f "debug" 2
sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting -q -f "site_admin_debug" true
```

Setting `debug` to `2` will show a summary of SQL queries at the bottom of the page in the browser, but to see all queries, including those generated by API requests, use MariaDB's general log as above.

Check live settings as follows:
```
docker exec misp-docker-misp-core-1 \
  bash -c 'sudo -u www-data /var/www/MISP/app/Console/cake Admin getSetting'
```

Change a live setting as follows:
```
docker exec misp-docker-misp-core-1 \
  bash -c 'sudo -u www-data /var/www/MISP/app/Console/cake Admin setSetting --force "debug" 2'
```

## Related issues

- Closes #8554