### PR TITLE
[netscout,radware] Deprecate integrations

### DIFF
--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate package.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9074
 - version: "0.19.1"
   changes:
     - description: Fix exclude_files pattern.

--- a/packages/netscout/changelog.yml
+++ b/packages/netscout/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.20.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.19.1"
   changes:
     - description: Fix exclude_files pattern.

--- a/packages/netscout/manifest.yml
+++ b/packages/netscout/manifest.yml
@@ -1,12 +1,12 @@
 format_version: 2.7.0
 name: netscout
-title: Arbor Peakflow SP Logs
-version: "0.19.1"
-description: Collect and parse logs from Netscout Arbor Peakflow SP with Elastic Agent.
+title: Arbor Peakflow SP Logs (Deprecated)
+version: "0.20.0"
+description: Deprecated. Netscout Arbor Peakflow SP is no longer supported.
 categories: ["security", "network"]
 type: integration
 conditions:
-  kibana.version: "^7.14.1 || ^8.0.0"
+  kibana.version: "^8.8.0"
 policy_templates:
   - name: sightline
     title: Arbor Peakflow SP

--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.19.0"
+  changes:
+    - description: Deprecate package.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.18.2"
   changes:
     - description: Changed owners

--- a/packages/radware/changelog.yml
+++ b/packages/radware/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Deprecate package.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9074
 - version: "0.18.2"
   changes:
     - description: Changed owners

--- a/packages/radware/manifest.yml
+++ b/packages/radware/manifest.yml
@@ -1,12 +1,12 @@
 format_version: 2.7.0
 name: radware
-title: Radware DefensePro Logs
-version: "0.18.2"
-description: Collect defensePro logs from Radware devices with Elastic Agent.
+title: Radware DefensePro Logs (Deprecated)
+version: "0.19.0"
+description: Deprecated. Radware DefensePro Logs is no longer supported.
 categories: ["security"]
 type: integration
 conditions:
-  kibana.version: "^7.14.0 || ^8.0.0"
+  kibana.version: "^8.8.0"
 policy_templates:
   - name: defensepro
     title: Radware DefensePro


### PR DESCRIPTION
## Proposed commit message

- Deprecate the netscout and radware integrations

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
