### PR TITLE
[ti_opencti] Update for OpenCTI v5.12.24 GraphQL schema change

### DIFF
--- a/packages/ti_opencti/_dev/build/docs/README.md
+++ b/packages/ti_opencti/_dev/build/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It was initially developed using OpenCTI version 5.10.1 and updated for verison 5.12.X.
+It has been updated for OpenCTI version 5.12.24.
 
 ## Setup
 

--- a/packages/ti_opencti/_dev/build/docs/README.md
+++ b/packages/ti_opencti/_dev/build/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It has been updated for OpenCTI version 5.12.24.
+It has been updated for OpenCTI version 5.12.24 and requires that version or later.
 
 ## Setup
 

--- a/packages/ti_opencti/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_opencti/_dev/deploy/docker/files/config.yml
@@ -36,33 +36,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -109,33 +97,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -182,33 +158,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -277,33 +241,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -350,33 +302,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -423,33 +363,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -518,33 +446,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },
@@ -591,30 +507,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "killChainPhases": {
                         "edges": []
                       },
@@ -664,33 +571,21 @@ rules:
                         "identity_class": "organization",
                         "name": "CthulhuSPRL.be"
                       },
-                      "objectMarking": {
-                        "edges": [
-                          {
-                            "node": {
-                              "definition_type": "TLP",
-                              "definition": "TLP:GREEN"
-                            }
-                          }
-                        ]
-                      },
-                      "objectLabel": {
-                        "edges": [
-                          {
-                            "node": {
-                              "value": "information-credibility-6"
-                            }
-                          },
-                          {
-                            "node": {
-                              "value": "osint"
-                            }
-                          }
-                        ]
-                      },
-                      "killChainPhases": {
-                        "edges": []
-                      },
+                      "objectMarking": [
+                        {
+                          "definition_type": "TLP",
+                          "definition": "TLP:GREEN"
+                        }
+                      ],
+                      "objectLabel": [
+                        {
+                          "value": "information-credibility-6"
+                        },
+                        {
+                          "value": "osint"
+                        }
+                      ],
+                      "killChainPhases": [],
                       "externalReferences": {
                         "edges": []
                       },

--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.0"
+  changes:
+    - description: Update for OpenCTI v5.12.24 GraphQL schema change
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9088
 - version: "1.1.0"
   changes:
     - description: Add support for IOC expiration

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-cryptocurrency-wallet.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-cryptocurrency-wallet.json
@@ -23,68 +23,42 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "rat"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "stealer"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "themida"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "cryptocurrencies"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "ekipa"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "aurora"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "aurora stealer"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "ekipa rat"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "rilide"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "rat"
+                },
+                {
+                    "value": "stealer"
+                },
+                {
+                    "value": "themida"
+                },
+                {
+                    "value": "cryptocurrencies"
+                },
+                {
+                    "value": "ekipa"
+                },
+                {
+                    "value": "aurora"
+                },
+                {
+                    "value": "aurora stealer"
+                },
+                {
+                    "value": "ekipa rat"
+                },
+                {
+                    "value": "rilide"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-domain-name-with-external-reference.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-domain-name-with-external-reference.json
@@ -29,24 +29,16 @@
             },
             "id": "fcfa872e-a8b6-4525-847e-f3c756b70035",
             "is_inferred": false,
-            "killChainPhases": {
-                "edges": null
-            },
+            "killChainPhases": [],
             "lang": "en",
             "modified": "2023-11-09T23:22:20.586Z",
             "name": "freelifetimexxxdates.com",
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "spam"
-                        }
-                    }
-                ]
-            },
-            "objectMarking": {
-                "edges": null
-            },
+            "objectLabel": [
+                {
+                    "value": "spam"
+                }
+            ],
+            "objectMarking": [],
             "observables": {
                 "edges": [
                     {

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-domain-name.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-domain-name.json
@@ -23,33 +23,21 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "iran"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "oilrig"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "iran"
+                },
+                {
+                    "value": "oilrig"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-email-addr.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-email-addr.json
@@ -23,33 +23,21 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "ransomware"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "gryphon"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "ransomware"
+                },
+                {
+                    "value": "gryphon"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-email-message.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-email-message.json
@@ -23,28 +23,18 @@
                 "identity_class": "organization",
                 "name": "CIRCL"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "malware"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "malware"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-file-with-name.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-file-with-name.json
@@ -23,28 +23,18 @@
                 "identity_class": "organization",
                 "name": "CthulhuSPRL.be"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "osint"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "osint"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-file-with-sha256.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-file-with-sha256.json
@@ -23,53 +23,33 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:GREEN"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "malware"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "unit42"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "steganography"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "stegbaus"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "runpe"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "loader"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:GREEN"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "malware"
+                },
+                {
+                    "value": "unit42"
+                },
+                {
+                    "value": "steganography"
+                },
+                {
+                    "value": "stegbaus"
+                },
+                {
+                    "value": "runpe"
+                },
+                {
+                    "value": "loader"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-hostname.json
@@ -23,128 +23,78 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:GREEN"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "android"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "macosx"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "watering hole"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "tran duy linh"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "spearphishing"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "scarlet mimic"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "fakem"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "mnkit"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "crypticconvo"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "mobileorder"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "raidbase"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "skiboot"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "psylo"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "uyghurs"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "wingd"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "fakehighfive"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "brutishcommand"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "subtractthis"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "fullthrottle"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "piggyback"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "fakefish"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:GREEN"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "android"
+                },
+                {
+                    "value": "macosx"
+                },
+                {
+                    "value": "watering hole"
+                },
+                {
+                    "value": "tran duy linh"
+                },
+                {
+                    "value": "spearphishing"
+                },
+                {
+                    "value": "scarlet mimic"
+                },
+                {
+                    "value": "fakem"
+                },
+                {
+                    "value": "mnkit"
+                },
+                {
+                    "value": "crypticconvo"
+                },
+                {
+                    "value": "mobileorder"
+                },
+                {
+                    "value": "raidbase"
+                },
+                {
+                    "value": "skiboot"
+                },
+                {
+                    "value": "psylo"
+                },
+                {
+                    "value": "uyghurs"
+                },
+                {
+                    "value": "wingd"
+                },
+                {
+                    "value": "fakehighfive"
+                },
+                {
+                    "value": "brutishcommand"
+                },
+                {
+                    "value": "subtractthis"
+                },
+                {
+                    "value": "fullthrottle"
+                },
+                {
+                    "value": "piggyback"
+                },
+                {
+                    "value": "fakefish"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr.json
@@ -23,53 +23,33 @@
                 "identity_class": "organization",
                 "name": "MalwareMustDie"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "malware"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "linux"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "botnet"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "password brute forcing"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "machine-access-control"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "ongoing"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "malware"
+                },
+                {
+                    "value": "linux"
+                },
+                {
+                    "value": "botnet"
+                },
+                {
+                    "value": "password brute forcing"
+                },
+                {
+                    "value": "machine-access-control"
+                },
+                {
+                    "value": "ongoing"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv6-addr.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv6-addr.json
@@ -23,38 +23,24 @@
                 "identity_class": "organization",
                 "name": "CIRCL"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "osint"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "blog-post"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "testing"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "osint"
+                },
+                {
+                    "value": "blog-post"
+                },
+                {
+                    "value": "testing"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-mutex.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-mutex.json
@@ -23,63 +23,39 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "office"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "turla"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "sofacy"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt28"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "0day"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "fireeye"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "netwire"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "gamefish"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "office"
+                },
+                {
+                    "value": "turla"
+                },
+                {
+                    "value": "sofacy"
+                },
+                {
+                    "value": "apt28"
+                },
+                {
+                    "value": "0day"
+                },
+                {
+                    "value": "fireeye"
+                },
+                {
+                    "value": "netwire"
+                },
+                {
+                    "value": "gamefish"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-phone-number.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-phone-number.json
@@ -23,28 +23,18 @@
                 "identity_class": "organization",
                 "name": "CIRCL"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "scam"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "scam"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-process.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-process.json
@@ -23,15 +23,9 @@
                 "identity_class": "tester",
                 "name": "Manual"
             },
-            "objectMarking": {
-                "edges": []
-            },
-            "objectLabel": {
-                "edges": []
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [],
+            "objectLabel": [],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-unknown.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-unknown.json
@@ -23,96 +23,60 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "rat"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "kaspersky"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "windows"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "israel"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "india"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "keylogger"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "hawkeye"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "cybergate"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "nanocore"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "darkcomet"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "grabit"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "cyborg"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": [
-                    {
-                        "node": {
-                            "kill_chain_name": "mitre-attack",
-                            "phase_name": "defense-evasion"
-                        }
-                    },
-                    {
-                        "node": {
-                            "kill_chain_name": "mitre-attack",
-                            "phase_name": "collection"
-                        }
-                    }
-                ]
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "rat"
+                },
+                {
+                    "value": "kaspersky"
+                },
+                {
+                    "value": "windows"
+                },
+                {
+                    "value": "israel"
+                },
+                {
+                    "value": "india"
+                },
+                {
+                    "value": "keylogger"
+                },
+                {
+                    "value": "hawkeye"
+                },
+                {
+                    "value": "cybergate"
+                },
+                {
+                    "value": "nanocore"
+                },
+                {
+                    "value": "darkcomet"
+                },
+                {
+                    "value": "grabit"
+                },
+                {
+                    "value": "cyborg"
+                }
+            ],
+            "killChainPhases": [
+                {
+                    "kill_chain_name": "mitre-attack",
+                    "phase_name": "defense-evasion"
+                },
+                {
+                    "kill_chain_name": "mitre-attack",
+                    "phase_name": "collection"
+                }
+            ],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-url.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-url.json
@@ -23,153 +23,93 @@
                 "identity_class": "organization",
                 "name": "AlienVault"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:GREEN"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "isspace"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "flash"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "menupass"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "sofacy"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "hacking team"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "sednit"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt12"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt3"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "ups"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "wekby"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "httpbrowser"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt18"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "evilgrab"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "plugx"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt10"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "gh0st"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "t5000"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "dnscalc"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "conimes"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "apt20"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "california roll"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "shadowserver"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "terminator"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "emdivi"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "linopid"
-                        }
-                    },
-                    {
-                        "node": {
-                            "value": "hothot"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:GREEN"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "isspace"
+                },
+                {
+                    "value": "flash"
+                },
+                {
+                    "value": "menupass"
+                },
+                {
+                    "value": "sofacy"
+                },
+                {
+                    "value": "hacking team"
+                },
+                {
+                    "value": "sednit"
+                },
+                {
+                    "value": "apt12"
+                },
+                {
+                    "value": "apt3"
+                },
+                {
+                    "value": "ups"
+                },
+                {
+                    "value": "wekby"
+                },
+                {
+                    "value": "httpbrowser"
+                },
+                {
+                    "value": "apt18"
+                },
+                {
+                    "value": "evilgrab"
+                },
+                {
+                    "value": "plugx"
+                },
+                {
+                    "value": "apt10"
+                },
+                {
+                    "value": "gh0st"
+                },
+                {
+                    "value": "t5000"
+                },
+                {
+                    "value": "dnscalc"
+                },
+                {
+                    "value": "conimes"
+                },
+                {
+                    "value": "apt20"
+                },
+                {
+                    "value": "california roll"
+                },
+                {
+                    "value": "shadowserver"
+                },
+                {
+                    "value": "terminator"
+                },
+                {
+                    "value": "emdivi"
+                },
+                {
+                    "value": "linopid"
+                },
+                {
+                    "value": "hothot"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-user-agent.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-user-agent.json
@@ -23,28 +23,18 @@
                 "identity_class": "organization",
                 "name": "CIRCL"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "malware"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "malware"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key.json
@@ -23,28 +23,18 @@
                 "identity_class": "organization",
                 "name": "CIRCL"
             },
-            "objectMarking": {
-                "edges": [
-                    {
-                        "node": {
-                            "definition_type": "TLP",
-                            "definition": "TLP:CLEAR"
-                        }
-                    }
-                ]
-            },
-            "objectLabel": {
-                "edges": [
-                    {
-                        "node": {
-                            "value": "technical-report"
-                        }
-                    }
-                ]
-            },
-            "killChainPhases": {
-                "edges": []
-            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "technical-report"
+                }
+            ],
+            "killChainPhases": [],
             "externalReferences": {
                 "edges": []
             },

--- a/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -140,27 +140,15 @@ state:
         name
       }
       objectMarking {
-        edges {
-          node {
-            definition_type
-            definition
-          }
-        }
+        definition_type
+        definition
       }
       objectLabel {
-        edges {
-          node {
-            value
-          }
-        }
+        value
       }
       killChainPhases {
-        edges {
-          node {
-            phase_name
-            kill_chain_name
-          }
-        }
+        phase_name
+        kill_chain_name
       }
       externalReferences(first: 100) {
         edges {

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -165,10 +165,10 @@ processors:
 
   - gsub:
       if: |
-        ctx.objectMarking.edges != null &&
-        !ctx.objectMarking.edges.isEmpty() &&
-        ctx.objectMarking.edges[0].node.definition_type == "TLP"
-      field: objectMarking.edges.0.node.definition
+        ctx.objectMarking != null &&
+        !ctx.objectMarking.isEmpty() &&
+        ctx.objectMarking[0].definition_type == "TLP"
+      field: objectMarking.0.definition
       pattern: '^TLP:'
       replacement: ''
       target_field: threat.indicator.marking.tlp
@@ -176,23 +176,23 @@ processors:
       field: objectMarking
 
   - foreach:
-      field: objectLabel.edges
+      field: objectLabel
       ignore_missing: true
       processor:
         append:
           field: tags
-          value: "{{{_ingest._value.node.value}}}"
+          value: "{{{_ingest._value.value}}}"
           allow_duplicates: false
   - remove:
       field: objectLabel
 
   - foreach:
-      field: killChainPhases.edges
+      field: killChainPhases
       ignore_missing: true
       processor:
         append:
           field: opencti.indicator.kill_chain_phase
-          value: "[{{{_ingest._value.node.kill_chain_name}}}] {{{_ingest._value.node.phase_name}}}"
+          value: "[{{{_ingest._value.kill_chain_name}}}] {{{_ingest._value.phase_name}}}"
   - remove:
       field: killChainPhases
 

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It was initially developed using OpenCTI version 5.10.1 and updated for verison 5.12.X.
+It has been updated for OpenCTI version 5.12.24.
 
 ## Setup
 

--- a/packages/ti_opencti/docs/README.md
+++ b/packages/ti_opencti/docs/README.md
@@ -15,7 +15,7 @@ Each event in the log data stream collected by the OpenCTI integration is an ind
 
 This integration requires Filebeat version 8.9.0, or later.
 
-It has been updated for OpenCTI version 5.12.24.
+It has been updated for OpenCTI version 5.12.24 and requires that version or later.
 
 ## Setup
 

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: ti_opencti
 title: OpenCTI
-version: "1.1.0"
+version: "2.0.0"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
[ti_opencti] Update for OpenCTI v5.12.24 GraphQL schema change (#9088)

There were breaking changes to the GraphQL schema in OpenCTI v5.12.24,
due to a change in sub list loading strategy.

The previous GraphQL query does not work on OpenCTI v5.12.24 (and
presumably later) and the updated query in this change will not work
on earlier versions of OpenCTI.

For more information, please refer to:

- https://github.com/OpenCTI-Platform/opencti/releases/tag/5.12.24
- https://github.com/OpenCTI-Platform/opencti/pull/5721
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

#### Run the automated tests

```
elastic-package build
elastic-package install
elastic-package test -v
```

#### Manually test the integration

* Build and install.
* Add a policy with credentials for https://demo.opencti.io/.

#### Manually test the query only

Copy the [updated GraphQL query](https://github.com/chrisberkhout/elastic-integrations/blob/ti_opencti-update-graphql/packages/ti_opencti/data_stream/indicator/agent/stream/cel.yml.hbs#L92-L423), run it in the demo instance [GraphQL Playground](https://demo.opencti.io/graphql), with query variables as follows:

```json
{
  "first": 3,
  "orderBy": "modified",
  "after": null,
  "orderMode":"asc"
}
```