### PR TITLE
[Oracle] README updates regarding mandatory user permission

### DIFF
--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -96,13 +96,23 @@ The `database_audit` dataset collects Oracle Audit logs.
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+ 
+- `SYS.DBA_DATA_FILES`
+- `SYS.DBA_TEMP_FILES`
+- `DBA_FREE_SPACE`
+
 {{fields "tablespace"}}
 
 {{event "tablespace"}}
 
 ### Sysmetrics 
 
-The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below
+The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
+
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+
+- `V$SYSMETRIC`
 
 {{fields "sysmetric"}}
 
@@ -112,6 +122,11 @@ The system metrics value captured for the most current time interval for the lon
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
+To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+
+- `V$SGASTAT`
+- `V$PGASTAT`
+
 {{fields "memory"}}
 
 {{event "memory"}}
@@ -120,6 +135,10 @@ A Program Global Area (PGA) is a memory region that contains data and control in
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
 
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+
+- `V$SYSSTAT`
+
 {{fields "system_statistics"}}
 
 {{event "system_statistics"}}
@@ -127,6 +146,16 @@ The System Global Area (SGA) is a group of shared memory structures that contain
 ### Performance Metrics
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
+
+To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+
+- `V$BUFFER_POOL_STATISTICS`
+- `V$SESSTAT`
+- `V$SYSSTAT`
+- `V$LIBRARYCACHE`
+- `DBA_JOBS`
+- `GV$SESSION`
+- `V$SYSTEM_WAIT_CLASS`
 
 {{fields "performance"}}
 

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -96,7 +96,7 @@ The `database_audit` dataset collects Oracle Audit logs.
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
-To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
  
 - `SYS.DBA_DATA_FILES`
 - `SYS.DBA_TEMP_FILES`
@@ -110,7 +110,7 @@ To collect the Tablespace metrics, Oracle integration relies on a specific set o
 
 The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
 
-To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
 
 - `V$SYSMETRIC`
 
@@ -122,7 +122,7 @@ To collect the Sysmetrics metrics, Oracle integration relies on a specific set o
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
-To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
 
 - `V$SGASTAT`
 - `V$PGASTAT`
@@ -135,7 +135,7 @@ To collect the Memory metrics, Oracle integration relies on a specific set of vi
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
 
-To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
 
 - `V$SYSSTAT`
 
@@ -147,7 +147,7 @@ To collect the System Statistics metrics, Oracle integration relies on a specifi
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
 
-To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
 
 - `V$BUFFER_POOL_STATISTICS`
 - `V$SESSTAT`

--- a/packages/oracle/_dev/build/docs/README.md
+++ b/packages/oracle/_dev/build/docs/README.md
@@ -96,7 +96,7 @@ The `database_audit` dataset collects Oracle Audit logs.
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
-To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
  
 - `SYS.DBA_DATA_FILES`
 - `SYS.DBA_TEMP_FILES`
@@ -108,9 +108,9 @@ To collect the Tablespace metrics, Oracle integration relies on a specific set o
 
 ### Sysmetrics 
 
-The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
+The system metrics value captured for the most current time interval for the long duration (60-seconds) are listed in the following table. 
 
-To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following view:
 
 - `V$SYSMETRIC`
 
@@ -122,7 +122,7 @@ To collect the Sysmetrics metrics, Oracle integration relies on a specific set o
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
-To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Memory metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
 
 - `V$SGASTAT`
 - `V$PGASTAT`
@@ -135,7 +135,7 @@ To collect the Memory metrics, Oracle integration relies on a specific set of vi
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
 
-To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following view:
 
 - `V$SYSSTAT`
 
@@ -147,7 +147,7 @@ To collect the System Statistics metrics, Oracle integration relies on a specifi
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
 
-To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Performance metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
 
 - `V$BUFFER_POOL_STATISTICS`
 - `V$SESSTAT`

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.24.3
+  changes:
+    - description: README updates regarding mandatory user permission.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/8841
 - version: 1.24.2
   changes:
     - description: README updates regarding DSN formats.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: README updates regarding mandatory user permission.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/8841
+      link: https://github.com/elastic/integrations/pull/1
 - version: 1.24.2
   changes:
     - description: README updates regarding DSN formats.

--- a/packages/oracle/changelog.yml
+++ b/packages/oracle/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: README updates regarding mandatory user permission.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9104
 - version: 1.24.2
   changes:
     - description: README updates regarding DSN formats.

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -321,7 +321,7 @@ An example event for `database_audit` looks as following:
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
-To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
  
 - `SYS.DBA_DATA_FILES`
 - `SYS.DBA_TEMP_FILES`
@@ -482,9 +482,9 @@ An example event for `tablespace` looks as following:
 
 ### Sysmetrics 
 
-The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
+The system metrics value captured for the most current time interval for the long duration (60-seconds) are listed in the following table. 
 
-To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following view:
 
 - `V$SYSMETRIC`
 
@@ -929,7 +929,7 @@ An example event for `sysmetric` looks as following:
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
-To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Memory metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
 
 - `V$SGASTAT`
 - `V$PGASTAT`
@@ -1079,7 +1079,7 @@ An example event for `memory` looks as following:
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
 
-To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following view:
 
 - `V$SYSSTAT`
 
@@ -1360,7 +1360,7 @@ An example event for `system_statistics` looks as following:
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
 
-To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
+To collect the Performance metrics, Oracle integration relies on a specific set of views. Make sure that the user configured within the Oracle DSN configuration has `READ` access permissions to the following views:
 
 - `V$BUFFER_POOL_STATISTICS`
 - `V$SESSTAT`

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -321,7 +321,7 @@ An example event for `database_audit` looks as following:
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
-To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
  
 - `SYS.DBA_DATA_FILES`
 - `SYS.DBA_TEMP_FILES`
@@ -484,7 +484,7 @@ An example event for `tablespace` looks as following:
 
 The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
 
-To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
 
 - `V$SYSMETRIC`
 
@@ -929,7 +929,7 @@ An example event for `sysmetric` looks as following:
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
-To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
 
 - `V$SGASTAT`
 - `V$PGASTAT`
@@ -1079,7 +1079,7 @@ An example event for `memory` looks as following:
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
 
-To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the view mentioned below.
 
 - `V$SYSSTAT`
 
@@ -1360,7 +1360,7 @@ An example event for `system_statistics` looks as following:
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
 
-To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DSN configuration has `READ` access permissions to the views listed below.
 
 - `V$BUFFER_POOL_STATISTICS`
 - `V$SESSTAT`

--- a/packages/oracle/docs/README.md
+++ b/packages/oracle/docs/README.md
@@ -321,6 +321,12 @@ An example event for `database_audit` looks as following:
 
 Tablespace metrics describes the tablespace usage metrics of all types of tablespaces in the oracle database.
 
+To collect the Tablespace metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+ 
+- `SYS.DBA_DATA_FILES`
+- `SYS.DBA_TEMP_FILES`
+- `DBA_FREE_SPACE`
+
 **Exported fields**
 
 | Field | Description | Type | Unit | Metric Type |
@@ -476,7 +482,11 @@ An example event for `tablespace` looks as following:
 
 ### Sysmetrics 
 
-The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below
+The system metrics value captured for the most current time interval for the long duration (60-seconds) are mentioned below. 
+
+To collect the Sysmetrics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+
+- `V$SYSMETRIC`
 
 **Exported fields**
 
@@ -919,6 +929,11 @@ An example event for `sysmetric` looks as following:
 
 A Program Global Area (PGA) is a memory region that contains data and control information for a server process. It is nonshared memory created by Oracle Database when a server process is started. Access to the PGA is exclusive to the server process. Metrics concerning Program Global Area (PGA) memory are mentioned below.
 
+To collect the Memory metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+
+- `V$SGASTAT`
+- `V$PGASTAT`
+
 **Exported fields**
 
 | Field | Description | Type | Unit | Metric Type |
@@ -1063,6 +1078,10 @@ An example event for `memory` looks as following:
 ### System Statistics Metrics 
 
 The System Global Area (SGA) is a group of shared memory structures that contain data and control information for one Oracle Database instance. Metrics concerning System Global Area (SGA) memory are mentioned below.
+
+To collect the System Statistics metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the view mentioned below.
+
+- `V$SYSSTAT`
 
 **Exported fields**
 
@@ -1340,6 +1359,16 @@ An example event for `system_statistics` looks as following:
 ### Performance Metrics
 
 Performance metrics give an overview of where time is spent in the system and enable comparisons of wait times across the system.
+
+To collect the Performance metrics, Oracle integration relies on a specific set of views. It is important to verify that the user configured within the Oracle DNS configuration has `READ` access permissions to the views listed below.
+
+- `V$BUFFER_POOL_STATISTICS`
+- `V$SESSTAT`
+- `V$SYSSTAT`
+- `V$LIBRARYCACHE`
+- `DBA_JOBS`
+- `GV$SESSION`
+- `V$SYSTEM_WAIT_CLASS`
 
 **Exported fields**
 

--- a/packages/oracle/manifest.yml
+++ b/packages/oracle/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: oracle
 title: "Oracle"
-version: "1.24.2"
+version: "1.24.3"
 description: Collect Oracle Audit Log, Performance metrics, Tablespace metrics, Sysmetrics metrics, System statistics metrics, memory metrics from Oracle database.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

README updates regarding mandatory user permission.
This helps to assign permissions to Oracle user for configuring Oracle Integration



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist


- [x] elastic-package stack up -v -d --services package-registry
- [x] Manual content verification

## How to test this PR locally

elastic-package build
elastic-package stack up -v -d --services package-registry


## Related issues

- Closes https://github.com/elastic/ingest-docs/issues/226

## Screenshots

<img width="900" alt="image" src="https://github.com/elastic/integrations/assets/101976829/9071e089-bfc4-44d0-923c-93012604130d">