### PR TITLE
[hashicorp_vault,zeek] Set sensitive values as secret

### DIFF
--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.0"
+  changes:
+    - description: Set sensitive values as secret.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8725
 - version: "1.22.2"
   changes:
     - description: Changed owners

--- a/packages/hashicorp_vault/changelog.yml
+++ b/packages/hashicorp_vault/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8725
+      link: https://github.com/elastic/integrations/pull/9126
 - version: "1.22.2"
   changes:
     - description: Changed owners

--- a/packages/hashicorp_vault/data_stream/metrics/manifest.yml
+++ b/packages/hashicorp_vault/data_stream/metrics/manifest.yml
@@ -20,12 +20,13 @@ streams:
           - http://localhost:8200
         description: Vault addresses to monitor. `/v1/sys/metrics?format=prometheus` is automatically appended.
       - name: vault_token
-        type: text
+        type: password
         title: Vault Token
         multi: false
         required: true
         show_user: true
         description: A Vault token with read access to the /sys/metrics API.
+        secret: true
       - name: processors
         type: yaml
         title: Processors

--- a/packages/hashicorp_vault/manifest.yml
+++ b/packages/hashicorp_vault/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.0"
+format_version: "3.0.2"
 name: hashicorp_vault
 title: Hashicorp Vault
-version: "1.22.2"
+version: "1.23.0"
 description: Collect logs and metrics from Hashicorp Vault with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - iam
 conditions:
   kibana:
-    version: "^8.9.0"
+    version: "^8.12.0"
 screenshots:
   - src: /img/hashicorp_vault-audit-dashboard.png
     title: Audit Log Dashboard

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8725
+      link: https://github.com/elastic/integrations/pull/9126
 - version: "2.22.4"
   changes:
     - description: Prevent null dereference exceptions for missing fields.

--- a/packages/zeek/changelog.yml
+++ b/packages/zeek/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.23.0"
+  changes:
+    - description: Set sensitive values as secret.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8725
 - version: "2.22.4"
   changes:
     - description: Prevent null dereference exceptions for missing fields.

--- a/packages/zeek/manifest.yml
+++ b/packages/zeek/manifest.yml
@@ -1,6 +1,6 @@
 name: zeek
 title: Zeek
-version: "2.22.4"
+version: "2.23.0"
 description: Collect logs from Zeek with Elastic Agent.
 type: integration
 icons:
@@ -8,11 +8,11 @@ icons:
     title: zeek
     size: 214x203
     type: image/svg+xml
-format_version: "3.0.0"
+format_version: "3.0.2"
 categories: [network, security]
 conditions:
   kibana:
-    version: ^8.7.1
+    version: ^8.12.0
 screenshots:
   - src: /img/kibana-zeek.png
     title: kibana zeek
@@ -59,6 +59,7 @@ policy_templates:
             title: Splunk REST API Password
             show_user: true
             required: false
+            secret: true
           - name: token
             type: password
             title: Splunk Authorization Token
@@ -68,6 +69,7 @@ policy_templates:
               and password.
             show_user: true
             required: false
+            secret: true
           - name: ssl
             type: yaml
             title: SSL Configuration


### PR DESCRIPTION
## Proposed commit message

- Set sensitive values in hashicorp_vault and zeek packages
- Updated package-spec to 3.0.2 to leverage secrets validation checks.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
elastic-package test
```

## Related issues

- Relates elastic/security-team#7388
