### PR TITLE
[O11y][Kubernetes] Rally benchmark `kubernetes.state_pod`

### DIFF
--- a/packages/kubernetes/_dev/benchmark/rally/state_pod-benchmark.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/state_pod-benchmark.yml
@@ -1,0 +1,14 @@
+---
+description: Benchmark 20000 kubernetes.state_pod events ingested
+data_stream:
+  name: state_pod
+corpora:
+  generator:
+    total_events: 20000
+    template:
+      type: gotext
+      path: ./statepod-benchmark/template.ndjson
+    config:
+      path: ./statepod-benchmark/config.yml
+    fields:
+      path: ./statepod-benchmark/fields.yml

--- a/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/config.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/config.yml
@@ -5,6 +5,10 @@ fields:
     range:
       min: 1
       max: 1000000
+  - name: rangeofid
+    range:
+      min: 0
+      max: 10000
   - name: status_phase
     enum: ["running", "pending", "succeeded", "failed", "unknown"]
   - name: status_scheduled

--- a/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/config.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/config.yml
@@ -1,0 +1,11 @@
+fields:
+  - name: timestamp
+    period: 60m
+  - name: event_duration
+    range:
+      min: 1
+      max: 1000000
+  - name: status_phase
+    enum: ["running", "pending", "succeeded", "failed", "unknown"]
+  - name: status_scheduled
+    enum: ["true", "false", "unknown"]

--- a/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/fields.yml
+++ b/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/fields.yml
@@ -1,0 +1,12 @@
+- name: Ip
+  type: ip
+- name: timestamp
+  type: date
+- name: rangeofid
+  type: integer
+- name: event_duration
+  type: long
+- name: status_phase
+  type: keyword
+- name: status_scheduled
+  type: keyword

--- a/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/template.ndjson
+++ b/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/template.ndjson
@@ -121,14 +121,8 @@
             "platform": "centos"
         },
         "containerized": true,
-        "ip": [
-            "192.168.244.7"
-        ],
         "name": "kubernetes-scale-123456",
         "id": "85e35c2b5e1b39ba72393a6baf6ee7cd",
-        "mac": [
-            "fe:ec:82:9f:29:19"
-        ],
         "architecture": "x86_64"
     },
     "metricset": {

--- a/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/template.ndjson
+++ b/packages/kubernetes/_dev/benchmark/rally/statepod-benchmark/template.ndjson
@@ -1,0 +1,144 @@
+{{- $timestamp := generate "timestamp" }}
+{{- $event_duration := generate "event_duration" }}
+{{- $rangeofid := generate "rangeofid" -}}
+{{- $nodeid := div $rangeofid 110 -}}
+{{- $status_phase := generate "status_phase" }}
+{{- $status_scheduled := generate "status_scheduled" }}
+{
+    "@timestamp": "{{$timestamp.Format "2006-01-02T15:04:05.999999Z07:00"}}",
+    "kubernetes": {
+        "node": {
+            "uid": "host-{{ $nodeid }}",
+            "hostname": "host-{{ $nodeid }}",
+            "name": "host-{{ $nodeid }}",
+            "labels": {
+                "kubernetes_io/hostname": "kubernetes-scale-123456",
+                "beta_kubernetes_io/os": "linux",
+                "kubernetes_io/arch": "amd64",
+                "kubernetes_io/os": "linux",
+                "beta_kubernetes_io/arch": "amd64"
+            }
+        },
+        "pod": {
+            "uid": "demo-pod-{{ $rangeofid }}",
+            "host_ip": "{{generate `Ip`}}",
+            "ip": "{{generate `Ip`}}",
+            "name": "demo-pod-{{ $rangeofid }}",
+            "status": {
+                "phase": "{{ $status_phase }}",
+            {{- if eq $status_phase "running"}}
+                "ready": "true",
+            {{- else if eq $status_phase "pending"}}
+                "ready": "false",
+            {{- else if eq $status_phase "failed"}}
+                "ready": "false",
+            {{- else if eq $status_phase "succeeded"}}
+                "ready": "true",
+            {{- else if eq $status_phase "unknown"}}
+                "ready": "unknown",
+            {{- end}}
+                "scheduled": "{{ $status_scheduled }}"
+            }
+
+        },
+        "namespace": "demo-{{ $rangeofid }}",
+        "namespace_uid": "demo-{{ $rangeofid }}",
+        "replicaset": {
+            "name": "demo-deployment-{{ $rangeofid }}"
+        },
+        "namespace_labels": {
+            "kubernetes_io/metadata_name": "demo-{{ $rangeofid }}"
+        },
+        "labels": {
+            "app":"demo",
+            "pod-template-hash":"{{ $rangeofid }}",
+            "app-2":"demo-2",
+            "app-1":"demo-1"
+        },
+        "deployment": {
+            "name": "demo-deployment-{{ $rangeofid }}"
+        }
+    },
+    "agent": {
+        "name": "kubernetes-scale-123456",
+        "id": "de42127b-4db8-4471-824e-a7b14f478663",
+        "ephemeral_id": "22ed892c-43bd-408a-9121-65e2f5b6a56e",
+        "type": "metricbeat",
+        "version": "8.8.0"
+    },
+    "elastic_agent": {
+        "id": "de42127b-4db8-4471-824e-a7b14f478663",
+        "version": "8.8.0",
+        "snapshot": true
+    },
+    "cloud": {
+         "provider": "gcp",
+         "availability_zone": "europe-west1-d",
+         "instance":{
+         "name":  "kubernetes-scale-123456" ,
+         "id": "de42127b-4db8-4471-824e-a7b14f478663"
+         },
+         "machine":{
+            "type":"e2-standard-4"
+         },
+         "service":{
+            "name":"GCE"
+         },
+         "project":{
+            "id":"elastic-obs-integrations-dev"
+         },
+         "account":{
+            "id":"elastic-obs-integrations-dev"
+         }
+      },
+      "orchestrator":{
+         "cluster":{
+            "name":"kubernetes-scale",
+            "url":"https://{{ generate `Ip` }}"
+         }
+      },
+    "ecs": {
+        "version": "8.0.0"
+    },
+    "data_stream": {
+        "namespace": "ep",
+        "type": "metrics",
+        "dataset": "kubernetes.state_pod"
+    },
+    "service": {
+        "address": "http://kubernetes-scale-123456:8080/metrics",
+        "type": "kubernetes"
+    },
+    "host": {
+        "hostname": "kubernetes-scale-123456",
+        "os": {
+            "kernel": "5.10.47-linuxkit",
+            "codename": "Core",
+            "name": "CentOS Linux",
+            "type": "linux",
+            "family": "redhat",
+            "version": "7 (Core)",
+            "platform": "centos"
+        },
+        "containerized": true,
+        "ip": [
+            "192.168.244.7"
+        ],
+        "name": "kubernetes-scale-123456",
+        "id": "85e35c2b5e1b39ba72393a6baf6ee7cd",
+        "mac": [
+            "fe:ec:82:9f:29:19"
+        ],
+        "architecture": "x86_64"
+    },
+    "metricset": {
+        "period": 10000,
+        "name": "state_pod"
+    },
+    "event": {
+        "duration": {{ $event_duration }},
+        "agent_id_status": "verified",
+        "module": "kubernetes",
+        "dataset": "kubernetes.state_pod"
+    }
+}


### PR DESCRIPTION
## Proposed commit message

- This PR adds benchmarking templates to the `state_pod` data stream of `Kubernetes`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.

## How to test this PR locally

Run this command from package root
- `elastic-package benchmark rally --benchmark state_pod-benchmark -v`
- `elastic-package benchmark stream --benchmark state_pod-benchmark -v`

## Related issues

- Relates #8636 

## Screenshots

```
--- Benchmark results for package: kubernetes - START ---
╭────────────────────────────────────────────────────────────────────────────────────╮
│ info                                                                               │
├────────────────────────┬───────────────────────────────────────────────────────────┤
│ benchmark              │                                       state_pod-benchmark │
│ description            │      Benchmark 20000 kubernetes.state_pod events ingested │
│ run ID                 │                      4c270392-77a3-4c11-875a-4ee173e29829 │
│ package                │                                                kubernetes │
│ start ts (s)           │                                                1707812774 │
│ end ts (s)             │                                                1707812820 │
│ duration               │                                                       46s │
│ generated corpora file │ /root/.elastic-package/tmp/rally_corpus/corpus-1190356990 │
╰────────────────────────┴───────────────────────────────────────────────────────────╯
╭────────────────────────────────────────────────────────────────────────╮
│ parameters                                                             │
├─────────────────────────────────┬──────────────────────────────────────┤
│ package version                 │                               1.56.0 │
│ data_stream.name                │                            state_pod │
│ corpora.generator.total_events  │                                20000 │
│ corpora.generator.template.path │ ./statepod-benchmark/template.ndjson │
│ corpora.generator.template.raw  │                                      │
│ corpora.generator.template.type │                               gotext │
│ corpora.generator.config.path   │      ./statepod-benchmark/config.yml │
│ corpora.generator.config.raw    │                                map[] │
│ corpora.generator.fields.path   │      ./statepod-benchmark/fields.yml │
│ corpora.generator.fields.raw    │                                map[] │
╰─────────────────────────────────┴──────────────────────────────────────╯
╭───────────╮
│ cluster i │
│ nfo       │
├───────┬───┤
│ name  │   │
│ nodes │ 0 │
╰───────┴───╯
╭───────────────────────────────────────╮
│ disk usage for index metrics-kubernet │
│ es.state_pod-ep (for all fields)      │
├──────────────────────────────┬────────┤
│ total                        │ 5.9 MB │
│ inverted_index.total         │ 928 kB │
│ inverted_index.stored_fields │ 3.5 MB │
│ inverted_index.doc_values    │ 1.1 MB │
│ inverted_index.points        │ 438 kB │
│ inverted_index.norms         │    0 B │
│ inverted_index.term_vectors  │    0 B │
│ inverted_index.knn_vectors   │    0 B │
╰──────────────────────────────┴────────╯
╭────────────────────────────────────────────────────────────────────────────────────────╮
│ pipeline metrics-kubernetes.state_pod-1.56.0 stats in node OQo_iVeVRSeYfWHrhZJ5_g      │
├────────────────────────────────────────────────┬───────────────────────────────────────┤
│ Totals                                         │ Count: 20000 | Failed: 0 | Time: 29ms │
│ pipeline (global@custom)                       │  Count: 20000 | Failed: 0 | Time: 2ms │
│ pipeline (metrics@custom)                      │  Count: 20000 | Failed: 0 | Time: 2ms │
│ pipeline (metrics-kubernetes@custom)           │  Count: 20000 | Failed: 0 | Time: 2ms │
│ pipeline (metrics-kubernetes.state_pod@custom) │  Count: 20000 | Failed: 0 | Time: 4ms │
╰────────────────────────────────────────────────┴───────────────────────────────────────╯
╭─────────────────────────────────────────────────────────────────────────────────────────────╮
│ rally stats                                                                                 │
├────────────────────────────────────────────────────────────────┬────────────────────────────┤
│ Cumulative indexing time of primary shards                     │                8.46765 min │
│ Min cumulative indexing time across primary shards             │                      0 min │
│ Median cumulative indexing time across primary shards          │    0.08625833333333334 min │
│ Max cumulative indexing time across primary shards             │     2.1194333333333333 min │
│ Cumulative indexing throttle time of primary shards            │                      0 min │
│ Min cumulative indexing throttle time across primary shards    │                      0 min │
│ Median cumulative indexing throttle time across primary shards │                    0.0 min │
│ Max cumulative indexing throttle time across primary shards    │                      0 min │
│ Cumulative merge time of primary shards                        │      4.946816666666667 min │
│ Cumulative merge count of primary shards                       │                       2783 │
│ Min cumulative merge time across primary shards                │                      0 min │
│ Median cumulative merge time across primary shards             │                    0.0 min │
│ Max cumulative merge time across primary shards                │     0.6093833333333334 min │
│ Cumulative merge throttle time of primary shards               │                 0.0598 min │
│ Min cumulative merge throttle time across primary shards       │                      0 min │
│ Median cumulative merge throttle time across primary shards    │                    0.0 min │
│ Max cumulative merge throttle time across primary shards       │                 0.0598 min │
│ Cumulative refresh time of primary shards                      │               117.6942 min │
│ Cumulative refresh count of primary shards                     │                      98008 │
│ Min cumulative refresh time across primary shards              │                      0 min │
│ Median cumulative refresh time across primary shards           │    0.04891666666666667 min │
│ Max cumulative refresh time across primary shards              │               37.39995 min │
│ Cumulative flush time of primary shards                        │     226.82090000000002 min │
│ Cumulative flush count of primary shards                       │                      86269 │
│ Min cumulative flush time across primary shards                │ 1.6666666666666667e-05 min │
│ Median cumulative flush time across primary shards             │   0.004808333333333333 min │
│ Max cumulative flush time across primary shards                │      47.68103333333333 min │
│ Total Young Gen GC time                                        │                    0.048 s │
│ Total Young Gen GC count                                       │                          4 │
│ Total Old Gen GC time                                          │                        0 s │
│ Total Old Gen GC count                                         │                          0 │
│ Store size                                                     │     0.24722508061677217 GB │
│ Translog size                                                  │   0.0002751322463154793 GB │
│ Heap used for segments                                         │                       0 MB │
│ Heap used for doc values                                       │                       0 MB │
│ Heap used for terms                                            │                       0 MB │
│ Heap used for norms                                            │                       0 MB │
│ Heap used for points                                           │                       0 MB │
│ Heap used for stored fields                                    │                       0 MB │
│ Segment count                                                  │                        642 │
│ Total Ingest Pipeline count                                    │                      20037 │
│ Total Ingest Pipeline time                                     │                    1.444 s │
│ Total Ingest Pipeline failed                                   │                          0 │
│ Min Throughput                                                 │            24548.56 docs/s │
│ Mean Throughput                                                │            24548.56 docs/s │
│ Median Throughput                                              │            24548.56 docs/s │
│ Max Throughput                                                 │            24548.56 docs/s │
│ 50th percentile latency                                        │       743.7380615156144 ms │
│ 100th percentile latency                                       │       1083.487429190427 ms │
│ 50th percentile service time                                   │       743.7380615156144 ms │
│ 100th percentile service time                                  │       1083.487429190427 ms │
│ error rate                                                     │                     0.00 % │
╰────────────────────────────────────────────────────────────────┴────────────────────────────╯

--- Benchmark results for package: kubernetes - END   ---
Done
```
