### PR TITLE
[ti_cif3] Clean up null handling

### DIFF
--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.2"
+  changes:
+    - description: Clean up null handling
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9148
 - version: "1.10.1"
   changes:
     - description: Changed owners

--- a/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
@@ -124,13 +124,13 @@ processors:
       field: cif3.indicator
       target_field: threat.indicator.network.cidr
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && (ctx.cif3?.indicator_ipv4_mask != null || ctx.cif3?.indicator_ipv6_mask != null)"
+      if: "(ctx.cif3?.indicator_ipv4_mask != null || ctx.cif3?.indicator_ipv6_mask != null) && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - convert:
       field: cif3.indicator
       type: ip
       target_field: threat.indicator.ip
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.indicator_ipv4_mask == null && ctx.cif3?.indicator_ipv6_mask == null"
+      if: "ctx.cif3?.indicator_ipv4_mask == null && ctx.cif3?.indicator_ipv6_mask == null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - append:
       field: related.ip
       value: "{{{ threat.indicator.ip }}}"
@@ -139,37 +139,37 @@ processors:
       field: cif3.cc
       target_field: threat.indicator.geo.country_iso_code
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.cc != null"
+      if: "ctx.cif3?.cc != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.asn
       target_field: threat.indicator.as.number
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.asn != null"
+      if: "ctx.cif3?.asn != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.asn_desc
       target_field: threat.indicator.as.organization.name
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.asn_desc != null"
+      if: "ctx.cif3?.asn_desc != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.latitude
       target_field: threat.indicator.geo.location.lat
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.latitude != null"
+      if: "ctx.cif3?.latitude != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.longitude
       target_field: threat.indicator.geo.location.lon
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.longitude != null"
+      if: "ctx.cif3?.longitude != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.region
       target_field: threat.indicator.geo.region_name
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.region != null"
+      if: "ctx.cif3?.region != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
   - rename:
       field: cif3.timezone
       target_field: threat.indicator.geo.timezone
       ignore_missing: true
-      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.timezone != null"
+      if: "ctx.cif3?.timezone != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type)"
 
   ## URL indicator operations
   - set:

--- a/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
@@ -69,7 +69,7 @@ processors:
   - set:
       field: threat.indicator.type
       value: file
-      if: "['md5', 'sha1', 'sha256', 'sha512', 'ssdeep'].contains(ctx.cif3?.itype) && ctx.cif3?.tags?.contains('ja3') != true"
+      if: "ctx.cif3?.tags?.contains('ja3') != true && ['md5', 'sha1', 'sha256', 'sha512', 'ssdeep'].contains(ctx.cif3?.itype)"
   - rename:
       field: cif3.indicator
       target_field: threat.indicator.tls.client.ja3

--- a/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_cif3/data_stream/feed/elasticsearch/ingest_pipeline/default.yml
@@ -69,21 +69,21 @@ processors:
   - set:
       field: threat.indicator.type
       value: file
-      if: "['md5', 'sha1', 'sha256', 'sha512', 'ssdeep'].contains(ctx.cif3?.itype) && !ctx.cif3?.tags.contains('ja3')"
+      if: "['md5', 'sha1', 'sha256', 'sha512', 'ssdeep'].contains(ctx.cif3?.itype) && ctx.cif3?.tags?.contains('ja3') != true"
   - rename:
       field: cif3.indicator
       target_field: threat.indicator.tls.client.ja3
       ignore_missing: true
-      if: "ctx.cif3?.itype == 'md5' && ctx.cif3?.tags.contains('ja3')"
+      if: "ctx.cif3?.itype == 'md5' && ctx.cif3?.tags?.contains('ja3') == true"
   - rename:
       field: cif3.indicator
       target_field: threat.indicator.file.pe.imphash
       ignore_missing: true
-      if: "ctx.cif3?.itype == 'md5' && ctx.cif3?.tags.contains('imphash')"
+      if: "ctx.cif3?.itype == 'md5' && ctx.cif3?.tags?.contains('imphash') == true"
   - append:
       field: related.hash
       value: "{{{ threat.indicator.file.hash.pe.imphash }}}"
-      if: ctx?.threat?.indicator?.file?.pe?.imphash != null
+      if: ctx.threat?.indicator?.file?.pe?.imphash != null
   - rename:
       field: cif3.indicator
       target_field: _tmp.hashvalue
@@ -124,13 +124,13 @@ processors:
       field: cif3.indicator
       target_field: threat.indicator.network.cidr
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && (ctx.cif3?.indicator_ipv4_mask != null || ctx.cif3?.indicator_ipv6_mask != null)"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && (ctx.cif3?.indicator_ipv4_mask != null || ctx.cif3?.indicator_ipv6_mask != null)"
   - convert:
       field: cif3.indicator
       type: ip
       target_field: threat.indicator.ip
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.indicator_ipv4_mask == null && ctx.cif3?.indicator_ipv6_mask == null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.indicator_ipv4_mask == null && ctx.cif3?.indicator_ipv6_mask == null"
   - append:
       field: related.ip
       value: "{{{ threat.indicator.ip }}}"
@@ -139,37 +139,37 @@ processors:
       field: cif3.cc
       target_field: threat.indicator.geo.country_iso_code
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.cc != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.cc != null"
   - rename:
       field: cif3.asn
       target_field: threat.indicator.as.number
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.asn != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.asn != null"
   - rename:
       field: cif3.asn_desc
       target_field: threat.indicator.as.organization.name
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.asn_desc != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.asn_desc != null"
   - rename:
       field: cif3.latitude
       target_field: threat.indicator.geo.location.lat
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.latitude != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.latitude != null"
   - rename:
       field: cif3.longitude
       target_field: threat.indicator.geo.location.lon
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.longitude != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.longitude != null"
   - rename:
       field: cif3.region
       target_field: threat.indicator.geo.region_name
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.region != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.region != null"
   - rename:
       field: cif3.timezone
       target_field: threat.indicator.geo.timezone
       ignore_missing: true
-      if: "ctx.threat?.indicator?.type != null && ['ipv4-addr', 'ipv6-addr'].contains(ctx.threat.indicator.type) && ctx.cif3?.timezone != null"
+      if: "['ipv4-addr', 'ipv6-addr'].contains(ctx.threat?.indicator?.type) && ctx.cif3?.timezone != null"
 
   ## URL indicator operations
   - set:
@@ -225,7 +225,7 @@ processors:
   - append:
       field: related.hosts
       value: "{{{ threat.indicator.url.domain }}}"
-      if: ctx?.threat?.indicator?.url?.domain != null
+      if: ctx.threat?.indicator?.url?.domain != null
 
   ######################
   #     Confidence     #
@@ -319,7 +319,7 @@ processors:
       if: "ctx.cif3?.rdata == ''"
   - remove:
       field: event.original
-      if: "ctx.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      if: "ctx.tags?.contains('preserve_original_event') != true"
       ignore_failure: true
       ignore_missing: true
   - remove:

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.10.1"
+version: "1.10.2"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[ti_cif3] Clean up null handling (#)

- Remove redundant null-safe access to ctx.
- Make access after null-safe access also be null-safe.
- Combine 'not null and is/not value' checks.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #8646