### PR TITLE
[panw] Add session.start_time for ML jobs

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add session.start_time for ML jobs
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/11111
+      link: https://github.com/elastic/integrations/pull/9154
 - version: "3.21.2"
   changes:
     - description: Changed owners

--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.22.0"
+  changes:
+    - description: Add session.start_time for ML jobs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11111
 - version: "3.21.2"
   changes:
     - description: Changed owners

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-inc-threat-sample.log-expected.json
@@ -16780,6 +16780,9 @@
                 "name": "rule1",
                 "uuid": "9d9738ea-f704-4b0f-90cf-a62bcbad0236"
             },
+            "session": {
+                "start_time": "2022-11-29T12:59:46.000+10:00"
+            },
             "source": {
                 "geo": {
                     "city_name": "Changchun",
@@ -17016,6 +17019,9 @@
             "rule": {
                 "name": "rule1",
                 "uuid": "9d9738ea-f704-4b0f-90cf-a62bcbad0236"
+            },
+            "session": {
+                "start_time": "2022-11-29T12:59:46.000+10:00"
             },
             "source": {
                 "geo": {

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-tunnel-inspection-sample.log-expected.json
@@ -174,6 +174,9 @@
                 "name": "rule1",
                 "uuid": "100"
             },
+            "session": {
+                "start_time": "1000-01-01T00:00:00.000Z"
+            },
             "source": {
                 "bytes": 10,
                 "geo": {

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -330,6 +330,10 @@ processors:
         - append:
             field: error.message
             value: '{{{_ingest.on_failure_message}}}'
+  - set:
+      if: ctx.panw?.panos?.parent_session?.start_time != null
+      field: session.start_time
+      value: '{{{panw.panos.parent_session.start_time}}}'
 
 # convert IP fields as the output of the CSV processor is always a string.
   - convert:

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -319,7 +319,11 @@ processors:
         - 'yyyy/MM/dd HH:mm:ss'
         - 'strict_date_optional_time_nanos'
       on_failure: [{'append': {'field': 'error.message', 'value': '{{{ _ingest.on_failure_message }}}'}}]
-
+  - set:
+      if: ctx.panw?.panos?.parent_session?.start_time != null
+      field: session.start_time
+      value: '{{{panw.panos.parent_session.start_time}}}'
+      
 on_failure:
   - set:
       field: event.kind

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/traffic.yml
@@ -319,11 +319,7 @@ processors:
         - 'yyyy/MM/dd HH:mm:ss'
         - 'strict_date_optional_time_nanos'
       on_failure: [{'append': {'field': 'error.message', 'value': '{{{ _ingest.on_failure_message }}}'}}]
-  - set:
-      if: ctx.panw?.panos?.parent_session?.start_time != null
-      field: session.start_time
-      value: '{{{panw.panos.parent_session.start_time}}}'
-      
+
 on_failure:
   - set:
       field: event.kind

--- a/packages/panw/data_stream/panos/fields/fields.yml
+++ b/packages/panw/data_stream/panos/fields/fields.yml
@@ -1045,3 +1045,4 @@
       type: boolean
 - name: session.start_time
   type: date
+  description: Time of session start.

--- a/packages/panw/data_stream/panos/fields/fields.yml
+++ b/packages/panw/data_stream/panos/fields/fields.yml
@@ -1043,3 +1043,5 @@
       type: boolean
     - name: x_forwarded_for
       type: boolean
+- name: session.start_time
+  type: date

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -36,11 +36,11 @@ An example event for `panos` looks as following:
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "3a362c46-abee-4440-bd82-f0e41a651188",
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "ephemeral_id": "97b3b3ee-2b84-4648-9e44-e1e29f38fc93",
+        "id": "54d9c5f4-27e2-41dc-9adf-0283480b3f7e",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.10.1"
+        "version": "8.12.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -69,9 +69,9 @@ An example event for `panos` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
+        "id": "54d9c5f4-27e2-41dc-9adf-0283480b3f7e",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.12.1"
     },
     "event": {
         "action": "url_filtering",
@@ -83,7 +83,7 @@ An example event for `panos` looks as following:
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2023-09-26T16:43:58Z",
+        "ingested": "2024-02-14T21:29:24Z",
         "kind": "alert",
         "original": "<14>Nov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -103,7 +103,7 @@ An example event for `panos` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.80.7:47488"
+            "address": "172.21.0.4:45110"
         },
         "syslog": {
             "facility": {
@@ -205,7 +205,6 @@ An example event for `panos` looks as following:
         "name": "crusher"
     }
 }
-
 ```
 
 **Exported fields**

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -36,11 +36,11 @@ An example event for `panos` looks as following:
 {
     "@timestamp": "2012-04-10T04:39:56.000Z",
     "agent": {
-        "ephemeral_id": "97b3b3ee-2b84-4648-9e44-e1e29f38fc93",
-        "id": "54d9c5f4-27e2-41dc-9adf-0283480b3f7e",
+        "ephemeral_id": "3a362c46-abee-4440-bd82-f0e41a651188",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.12.1"
+        "version": "8.10.1"
     },
     "data_stream": {
         "dataset": "panw.panos",
@@ -69,9 +69,9 @@ An example event for `panos` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "54d9c5f4-27e2-41dc-9adf-0283480b3f7e",
+        "id": "f25d13cd-18cc-4e73-822c-c4f849322623",
         "snapshot": false,
-        "version": "8.12.1"
+        "version": "8.10.1"
     },
     "event": {
         "action": "url_filtering",
@@ -83,7 +83,7 @@ An example event for `panos` looks as following:
         ],
         "created": "2012-10-30T09:46:12.000Z",
         "dataset": "panw.panos",
-        "ingested": "2024-02-14T21:29:24Z",
+        "ingested": "2023-09-26T16:43:58Z",
         "kind": "alert",
         "original": "<14>Nov 30 16:09:08 PA-220 1,2012/10/30 09:46:12,01606001116,THREAT,url,1,2012/04/10 04:39:56,192.168.0.2,175.16.199.1,0.0.0.0,0.0.0.0,rule1,crusher,,web-browsing,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 04:39:58,25149,1,59309,80,0,0,0x208000,tcp,alert,\"lorexx.cn/loader.exe\",(9999),not-resolved,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html",
         "outcome": "success",
@@ -103,7 +103,7 @@ An example event for `panos` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.21.0.4:45110"
+            "address": "192.168.80.7:47488"
         },
         "syslog": {
             "facility": {
@@ -205,6 +205,7 @@ An example event for `panos` looks as following:
         "name": "crusher"
     }
 }
+
 ```
 
 **Exported fields**

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -654,7 +654,7 @@ An example event for `panos` looks as following:
 | server.port | Port of the server. | long |
 | server.user.name | Short name or login of the user. | keyword |
 | server.user.name.text | Multi-field of `server.user.name`. | match_only_text |
-| session.start_time |  | date |
+| session.start_time | Time of session start. | date |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |

--- a/packages/panw/docs/README.md
+++ b/packages/panw/docs/README.md
@@ -654,6 +654,7 @@ An example event for `panos` looks as following:
 | server.port | Port of the server. | long |
 | server.user.name | Short name or login of the user. | keyword |
 | server.user.name.text | Multi-field of `server.user.name`. | match_only_text |
+| session.start_time |  | date |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.21.2"
+version: "3.22.0"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
## Proposed commit message

Add session.start_time for ML jobs

Addresses SDH: https://github.com/elastic/sdh-beats/issues/4367

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/4367

