### PR TITLE
[jamf_compliance_reporter] Clean up null handling, other checks, scripting

### DIFF
--- a/packages/jamf_compliance_reporter/changelog.yml
+++ b/packages/jamf_compliance_reporter/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.2"
+  changes:
+    - description: Clean up null handling, other checks and scripting
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9179
 - version: "1.11.1"
   changes:
     - description: Changed owners

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -18,7 +18,7 @@ processors:
       if: ctx.json?.header?.event_name == 'APP_METRICS'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_audit" }}'
-      if: ctx.json?.header?.event_name != null && ctx.json?.header?.event_name.startsWith('AUE_')
+      if: ctx.json?.header?.event_name?.startsWith('AUE_') == true
   - pipeline:
       name: '{{ IngestPipeline "pipeline_event" }}'
       if: "['AUDIO_VIDEO_DEVICE_EVENT','AUDIT_CLASS_VERIFICATION_EVENT','COMPLIANCE_REPORTER_TAMPER_EVENT','FILE_EVENT','GATEKEEPER_INFO_EVENT','GATEKEEPER_MANUAL_OVERRIDES','GATEKEEPER_QUARANTINE_LOG','HARDWARE_EVENT','LICENSE_INFO_EVENT','PREFERENCE_LIST_EVENT','PRINT_EVENT_INFORMATION','PROHIBITED_APP_BLOCKED','SIGNAL_EVENT','UNIFIED_LOG_EVENT','XPROTECT_DEFINITIONS_VERSION_INFO','XPROTECT_EVENT_LOG'].contains(ctx.json?.header?.event_name)"

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
@@ -136,7 +136,7 @@ processors:
       if: ctx.json?.app_metric_info?.cpu_percentage != null
       source: |
         ctx.host.cpu = new HashMap();
-        ctx.host.cpu.usage = Math.round(ctx.json?.app_metric_info?.cpu_percentage *10) / 1000.0;
+        ctx.host.cpu.usage = Math.round(ctx.json.app_metric_info.cpu_percentage *10) / 1000.0;
 on_failure:
   - set:
       field: event.kind

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_app_metrics.yml
@@ -136,7 +136,7 @@ processors:
       if: ctx.json?.app_metric_info?.cpu_percentage != null
       source: |
         ctx.host.cpu = new HashMap();
-        ctx.host.cpu.usage = Math.round(ctx.json.app_metric_info.cpu_percentage *10) / 1000.0;
+        ctx.host.cpu.usage = Math.round(ctx.json.app_metric_info.cpu_percentage * 10) / 1000.0;
 on_failure:
   - set:
       field: event.kind

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_audit.yml
@@ -34,12 +34,15 @@ processors:
       ignore_missing: true
   - script:
       lang: painless
-      if: ctx.json?.header?.time_seconds_epoch != 0
+      if: ctx.json?.header?.time_seconds_epoch != null && ctx.json.header.time_seconds_epoch != 0
       source: |
-        ctx.json.time_milliseconds = (long)ctx.json?.header?.time_seconds_epoch * 1000 + (long)ctx.json?.header?.time_milliseconds_offset;
+        ctx.json.time_milliseconds = (long)ctx.json.header.time_seconds_epoch * 1000;
+        if (ctx.json?.header?.time_milliseconds_offset != null && ctx.json.header.time_milliseconds_offset != 0) {
+          ctx.json.time_milliseconds = ctx.json.time_milliseconds + (long)ctx.json.header.time_milliseconds_offset;
+        }
   - date:
       field: json.time_milliseconds
-      if: ctx.json?.time_milliseconds != 0
+      if: ctx.json?.time_milliseconds != null && ctx.json.time_milliseconds != 0
       formats:
         - UNIX_MS
       on_failure:
@@ -281,82 +284,82 @@ processors:
       value: authentication
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_accept" }}'
-      if: ctx.event?.action == 'aue_accept'
+      if: ctx.event.action == 'aue_accept'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_auth" }}'
-      if: '["aue_auth_user", "aue_ssauthorize", "aue_ssauthmech"].contains(ctx.event?.action)'
+      if: '["aue_auth_user", "aue_ssauthorize", "aue_ssauthmech"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_bind_and_aue_connect" }}'
-      if: '["aue_bind", "aue_connect"].contains(ctx.event?.action)'
+      if: '["aue_bind", "aue_connect"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_chdir" }}'
-      if: ctx.event?.action == 'aue_chdir'
+      if: ctx.event.action == 'aue_chdir'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_chroot" }}'
-      if: ctx.event?.action == 'aue_chroot'
+      if: ctx.event.action == 'aue_chroot'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_execve" }}'
-      if: ctx.event?.action == 'aue_execve'
+      if: ctx.event.action == 'aue_execve'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_exit" }}'
-      if: ctx.event?.action == 'aue_exit'
+      if: ctx.event.action == 'aue_exit'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_kill" }}'
-      if: ctx.event?.action == 'aue_kill'
+      if: ctx.event.action == 'aue_kill'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_mount" }}'
-      if: ctx.event?.action == 'aue_mount'
+      if: ctx.event.action == 'aue_mount'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_posix_spawn" }}'
-      if: ctx.event?.action == 'aue_posix_spawn'
+      if: ctx.event.action == 'aue_posix_spawn'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_remove_from_group_and_aue_mac_set_proc" }}'
-      if: '["aue_remove_from_group", "aue_mac_set_proc"].contains(ctx.event?.action)'
+      if: '["aue_remove_from_group", "aue_mac_set_proc"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_session" }}'
-      if: '["aue_session_end", "aue_session_update", "aue_session_close", "aue_session_start"].contains(ctx.event?.action)'
+      if: '["aue_session_end", "aue_session_update", "aue_session_close", "aue_session_start"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_arguments" }}'
-      if: '["aue_setsockopt", "aue_shutdown"].contains(ctx.event?.action)'
+      if: '["aue_setsockopt", "aue_shutdown"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_ssauthint" }}'
-      if: ctx.event?.action == 'aue_ssauthint'
+      if: ctx.event.action == 'aue_ssauthint'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_tasknameforpid" }}'
-      if: ctx.event?.action == 'aue_tasknameforpid'
+      if: ctx.event.action == 'aue_tasknameforpid'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_unmount" }}'
-      if: ctx.event?.action == 'aue_unmount'
+      if: ctx.event.action == 'aue_unmount'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_fork" }}'
-      if: ctx.event?.action == 'aue_fork'
+      if: ctx.event.action == 'aue_fork'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'
-      if: '["aue_getauid", "aue_lw_login", "aue_settimeofday"].contains(ctx.event?.action)'
+      if: '["aue_getauid", "aue_lw_login", "aue_settimeofday"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_listen" }}'
-      if: ctx.event?.action == 'aue_listen'
+      if: ctx.event.action == 'aue_listen'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_logout" }}'
-      if: ctx.event?.action == 'aue_logout'
+      if: ctx.event.action == 'aue_logout'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_pidfortask" }}'
-      if: ctx.event?.action == 'aue_pidfortask'
+      if: ctx.event.action == 'aue_pidfortask'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_ptrace" }}'
-      if: ctx.event?.action == 'aue_ptrace'
+      if: ctx.event.action == 'aue_ptrace'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_setpriority" }}'
-      if: ctx.event?.action == 'aue_setpriority'
+      if: ctx.event.action == 'aue_setpriority'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_socketpair" }}'
-      if: ctx.event?.action == 'aue_socketpair'
+      if: ctx.event.action == 'aue_socketpair'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_taskforpid" }}'
-      if: ctx.event?.action == 'aue_taskforpid'
+      if: ctx.event.action == 'aue_taskforpid'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_aue_wait4" }}'
-      if: ctx.event?.action == 'aue_wait4'
+      if: ctx.event.action == 'aue_wait4'
 on_failure:
   - set:
       field: event.kind

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chdir.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chdir.yml
@@ -65,8 +65,9 @@ processors:
   - script:
       description: Convert Decimal into Octal.
       lang: painless
+      if: ctx.json?.file_access_mode != null
       source: |
-        int temp = (int)ctx.json?.file_access_mode;
+        int temp = (int)ctx.json.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
 on_failure:
   - set:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chroot.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_chroot.yml
@@ -67,8 +67,9 @@ processors:
   - script:
       description: Convert Decimal into Octal.
       lang: painless
+      if: ctx.json?.file_access_mode != null
       source: |
-        int temp = (int)ctx.json?.file_access_mode;
+        int temp = (int)ctx.json.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
 on_failure:
   - set:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_execve.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_execve.yml
@@ -134,14 +134,17 @@ processors:
       source: |
         def args_list = new ArrayList();
         ctx.process.args = args_list;
-        for (Map.Entry m : ctx.json?.args.entrySet()) {
-          ctx.process?.args.add(m.getValue());
+        if (ctx.json?.args != null) {
+          for (Map.Entry m : ctx.json.args.entrySet()) {
+            ctx.process.args.add(m.getValue());
+          }
         }
   - script:
       description: Convert Decimal into Octal.
       lang: painless
+      if: ctx.json?.file_access_mode != null
       source: |
-        int temp = (int)ctx.json?.file_access_mode;
+        int temp = (int)ctx.json.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
 on_failure:
   - set:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_mount.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_mount.yml
@@ -77,6 +77,7 @@ processors:
   - script:
       description: Convert Decimal into Octal.
       lang: painless
+      if: ctx.json?.file_access_mode != null
       source: |
         int temp = (int)ctx.json?.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_posix_spawn.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_posix_spawn.yml
@@ -40,8 +40,10 @@ processors:
       source: |
         def args_list = new ArrayList();
         ctx.process.args = args_list;
-        for (Map.Entry m : ctx.json?.args.entrySet()) {
-          ctx.process?.args.add(m.getValue());
+        if (ctx.json?.args != null) {
+          for (Map.Entry m : ctx.json.args.entrySet()) {
+            ctx.process.args.add(m.getValue());
+          }
         }
   - pipeline:
       name: '{{ IngestPipeline "pipeline_identity_object" }}'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_unmount.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_aue_unmount.yml
@@ -67,8 +67,9 @@ processors:
   - script:
       description: Convert Decimal into Octal.
       lang: painless
+      if: ctx.json?.file_access_mode != null
       source: |
-        int temp = (int)ctx.json?.file_access_mode;
+        int temp = (int)ctx.json.file_access_mode;
         ctx.jamf_compliance_reporter.log.attributes.file.access_mode = Integer.toOctalString(temp);
 on_failure:
   - set:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
@@ -78,6 +78,7 @@ processors:
       field: json.host_info.serial_number
       target_field: host.id
       ignore_missing: true
+  # NOTE: ctx.event is initialized by an earlier processor
   - pipeline:
       name: '{{ IngestPipeline "pipeline_audio_video_device_event" }}'
       if: ctx.event.action == 'audio_video_device_event'

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_event.yml
@@ -80,49 +80,49 @@ processors:
       ignore_missing: true
   - pipeline:
       name: '{{ IngestPipeline "pipeline_audio_video_device_event" }}'
-      if: ctx.event?.action == 'audio_video_device_event'
+      if: ctx.event.action == 'audio_video_device_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_audit_class_verification_event" }}'
-      if: ctx.event?.action == 'audit_class_verification_event'
+      if: ctx.event.action == 'audit_class_verification_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_compliance_reporter_tamper_event_and_file_event_info" }}'
-      if: '["compliance_reporter_tamper_event", "file_event"].contains(ctx.event?.action)'
+      if: '["compliance_reporter_tamper_event", "file_event"].contains(ctx.event.action)'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_gatekeeper_info_event" }}'
-      if: ctx.event?.action == 'gatekeeper_info_event'
+      if: ctx.event.action == 'gatekeeper_info_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_gatekeeper_manual_overrides" }}'
-      if: ctx.event?.action == 'gatekeeper_manual_overrides'
+      if: ctx.event.action == 'gatekeeper_manual_overrides'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_gatekeeper_quarantine_log" }}'
-      if: ctx.event?.action == 'gatekeeper_quarantine_log'
+      if: ctx.event.action == 'gatekeeper_quarantine_log'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_hardware_event" }}'
-      if: ctx.event?.action == 'hardware_event'
+      if: ctx.event.action == 'hardware_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_license_info_event" }}'
-      if: ctx.event?.action == 'license_info_event'
+      if: ctx.event.action == 'license_info_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_preference_list_event" }}'
-      if: ctx.event?.action == 'preference_list_event'
+      if: ctx.event.action == 'preference_list_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_print_event_information" }}'
-      if: ctx.event?.action == 'print_event_information'
+      if: ctx.event.action == 'print_event_information'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_prohibited_app_blocked" }}'
-      if: ctx.event?.action == 'prohibited_app_blocked'
+      if: ctx.event.action == 'prohibited_app_blocked'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_signal_event" }}'
-      if: ctx.event?.action == 'signal_event'
+      if: ctx.event.action == 'signal_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_unified_log_event" }}'
-      if: ctx.event?.action == 'unified_log_event'
+      if: ctx.event.action == 'unified_log_event'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_xprotect_definitions_version_info" }}'
-      if: ctx.event?.action == 'xprotect_definitions_version_info'
+      if: ctx.event.action == 'xprotect_definitions_version_info'
   - pipeline:
       name: '{{ IngestPipeline "pipeline_xprotect_event_log" }}'
-      if: ctx.event?.action == 'xprotect_event_log'
+      if: ctx.event.action == 'xprotect_event_log'
 on_failure:
   - set:
       field: event.kind

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_license_info_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_license_info_event.yml
@@ -14,7 +14,7 @@ processors:
   - date:
       field: json.ComplianceReporter_license_info.expiration_date
       target_field: jamf_compliance_reporter.log.compliancereporter_license_info.expiration_date
-      if: ctx.json?.compliancereporter_license_info?.expiration_date != 0
+      if: ctx.json?.ComplianceReporter_license_info?.expiration_date != null && ctx.json.ComplianceReporter_license_info.expiration_date != 0
       formats:
         - dd/MM/yyyy
       on_failure:
@@ -28,7 +28,7 @@ processors:
   - date:
       field: json.ComplianceReporter_license_info.time_seconds_epoch
       target_field: jamf_compliance_reporter.log.compliancereporter_license_info.time
-      if: ctx.json?.compliancereporter_license_info?.time_seconds_epoch != '0'
+      if: ctx.json?.ComplianceReporter_license_info?.time_seconds_epoch != null && ctx.json.ComplianceReporter_license_info.time_seconds_epoch != '0'
       formats:
         - UNIX
       on_failure:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_print_event_information.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_print_event_information.yml
@@ -4,7 +4,7 @@ processors:
   - date:
       field: json.event_attributes.job_completed_time
       target_field: jamf_compliance_reporter.log.event_attributes.job.completed_time
-      if: ctx.json?.event_attributes?.job_completed_time != 0
+      if: ctx.json?.event_attributes?.job_completed_time != null && ctx.json.event_attributes.job_completed_time != 0
       formats:
         - UNIX
       on_failure:
@@ -14,7 +14,7 @@ processors:
   - date:
       field: json.event_attributes.job_creation_time
       target_field: jamf_compliance_reporter.log.event_attributes.job.creation_time
-      if: ctx.json?.event_attributes?.job_creation_time != 0
+      if: ctx.json?.event_attributes?.job_creation_time != null && ctx.json.event_attributes.job_creation_time != 0
       formats:
         - UNIX
       on_failure:
@@ -38,7 +38,7 @@ processors:
   - date:
       field: json.event_attributes.job_processing_time
       target_field: jamf_compliance_reporter.log.event_attributes.job.processing_time
-      if: ctx.json?.event_attributes?.job_processing_time != 0
+      if: ctx.json?.event_attributes?.job_processing_time != null && ctx.json.event_attributes.job_processing_time != 0
       formats:
         - UNIX
       on_failure:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_prohibited_app_blocked.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_prohibited_app_blocked.yml
@@ -263,8 +263,10 @@ processors:
       source: |
         def args_list = new ArrayList();
         ctx.process.args = args_list;
-        for (Map.Entry m : ctx.json?.args.entrySet()) {
-          ctx.process?.args.add(m.getValue());
+        if (ctx.json?.args != null) {
+          for (Map.Entry m : ctx.json.args.entrySet()) {
+            ctx.process.args.add(m.getValue());
+          }
         }
 on_failure:
   - set:

--- a/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_unified_log_event.yml
+++ b/packages/jamf_compliance_reporter/data_stream/log/elasticsearch/ingest_pipeline/pipeline_unified_log_event.yml
@@ -126,7 +126,7 @@ processors:
   - date:
       field: json.event_attributes.timestamp
       target_field: jamf_compliance_reporter.log.event_attributes.timestamp
-      if: ctx.json?.event_attributes?.timestamp != 0
+      if: ctx.json?.event_attributes?.timestamp != null && ctx.json.event_attributes.timestamp != 0
       formats:
         - yyyy-MM-dd HH:mm:ss.SSSSSSZ
       on_failure:

--- a/packages/jamf_compliance_reporter/manifest.yml
+++ b/packages/jamf_compliance_reporter/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: jamf_compliance_reporter
 title: Jamf Compliance Reporter
-version: "1.11.1"
+version: "1.11.2"
 description: Collect logs from Jamf Compliance Reporter with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[jamf_compliance_reporter] Clean up null handling, other checks, scripting (#)

- Combine 'not null and is/not value' checks.
- Remove redundant null-safe operator.
- Add 'not null' check to 'not value' checks.
- Correct date conversion conditions to check source values.
- Add 'not null' check before .entrySet().
- Avoid trying to cast null to long/int.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #8646