### PR TITLE
[Logstash] Add docs link to monitoring with agent topic in LSR

### DIFF
--- a/packages/logstash/_dev/build/docs/README.md
+++ b/packages/logstash/_dev/build/docs/README.md
@@ -1,6 +1,8 @@
 # Logstash
 
-The `logstash` package collects metrics and logs of Logstash.
+The `logstash` package collects metrics and logs related to Logstash.
+
+You can find additional information about monitoring Logstash with the Logstash integration in the **Logstash Reference**: [Monitoring Logstash with Elastic Agent](https://www.elastic.co/guide/en/logstash/current/monitoring-with-ea.html). 
 
 ## Compatibility
 


### PR DESCRIPTION
Add link from Logstash integration docs to "Monitoring Logstash with Agent" topic in the Logstash Reference (LSR) for additional context. 

cc:/ @robbavey 
cc:/ @kaisecheng, following up on your suggestion. Thank you! 