### PR TITLE
apm: update package version 8.13.1-preview

### DIFF
--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,6 +1,6 @@
-- version: 8.14.0-preview-1705349441
+- version: 8.13.1-preview-1708411360
   changes:
-    - description: placeholder
+    - description: Remove version check
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9185
 - version: 8.13.0

--- a/packages/apm/changelog.yml
+++ b/packages/apm/changelog.yml
@@ -1,4 +1,9 @@
-- version: 8.13.0-preview-1705349441
+- version: 8.14.0-preview-1705349441
+  changes:
+    - description: placeholder
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9185
+- version: 8.13.0
   changes:
     - description: Add a new field transaction.profiler_stack_trace_ids to traces-apm
       type: enhancement

--- a/packages/apm/data_stream/app_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/app_logs/elasticsearch/ingest_pipeline/default.yml
@@ -6,21 +6,6 @@ processors:
       ignore_failure: true
       ignore_missing: true
       target_field: process.parent.pid
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/app_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/app_logs/elasticsearch/ingest_pipeline/default.yml
@@ -14,7 +14,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM application metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM error events.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM internal metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM RUM trace events.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_destination_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service destination metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_destination_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_destination_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service destination metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_destination_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_destination_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service destination metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_destination_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_destination_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_summary_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_summary_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service summary metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_summary_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_summary_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service summary metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_summary_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_summary_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_summary_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service summary metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/service_transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/service_transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/service_transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM service transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM trace events.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_10m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_1m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/data_stream/transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -9,7 +9,7 @@ processors:
         - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
   - fail:
       if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.13.0). The APM integration must be upgraded.
+      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
   - remove:
       field:
         - observer.version_major

--- a/packages/apm/data_stream/transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apm/data_stream/transaction_60m_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,6 @@
 ---
 description: Pipeline for ingesting APM transaction metrics.
 processors:
-  - grok:
-      field: observer.version
-      pattern_definitions:
-        DIGITS: (?:[0-9]+)
-      patterns:
-        - '%{DIGITS:observer.version_major:int}.%{DIGITS:observer.version_minor:int}.%{DIGITS:observer.version_patch:int}(?:[-+].*)?'
-  - fail:
-      if: ctx.observer.version_major > 8 || (ctx.observer.version_major == 8 && ctx.observer.version_minor > 13)
-      message: Document produced by APM Server v{{{observer.version}}}, which is newer than the installed APM integration (v8.14.0). The APM integration must be upgraded.
-  - remove:
-      field:
-        - observer.version_major
-        - observer.version_minor
-        - observer.version_patch
-      ignore_missing: true
   - remove:
       field:
         - observer.id

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.0
 name: apm
 title: Elastic APM
-version: 8.14.0-preview-1705349441
+version: 8.13.1-preview-1708411360
 description: Monitor, detect, and diagnose complex application performance issues.
 type: integration
 categories: ["elastic_stack", "monitoring"]
@@ -10,7 +10,7 @@ conditions:
     capabilities:
       - apm
   kibana:
-    version: ^8.14.0
+    version: ^8.13.0
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo

--- a/packages/apm/manifest.yml
+++ b/packages/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.0
 name: apm
 title: Elastic APM
-version: 8.13.0-preview-1705349441
+version: 8.14.0-preview-1705349441
 description: Monitor, detect, and diagnose complex application performance issues.
 type: integration
 categories: ["elastic_stack", "monitoring"]
@@ -10,7 +10,7 @@ conditions:
     capabilities:
       - apm
   kibana:
-    version: ^8.13.0
+    version: ^8.14.0
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
~Update apm version and min required Kibana version to 8.14.0.~
* Bump version to `8.13.1-preview-<timestamp>`, but leave min required Kibana version at `8.13.0`. This is necessary to avoid CI failures and be able to bundle this apm version with the latest Kibana snapshot. 
* Remove grok processor for `observer.version_xx` and the actual version check in the pipeline. 
