### PR TITLE
[MongoDB] Update the Kibana version condition for multi-host fix and documentation

### DIFF
--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -23,7 +23,7 @@ When utilizing the parameter `directConnection=true` in the connection URI, all 
 
 Example with replica set specified:
 
-- Replica set with specified username and password: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
+- `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
 
 The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
 

--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -2,6 +2,31 @@
 
 This integration is used to fetch logs and metrics from [MongoDB](https://www.mongodb.com/).
 
+## Configuration Notes
+
+When configuring the `hosts` option, MongoDB URLs should adhere to the following formats:
+
+- Simple: `[mongodb://][user:pass@]host[:port][?options]`
+- Complex: `mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]`
+
+Examples of URLs can vary from simple to complex:
+
+- Basic: `localhost`
+- Complex: `mongodb://myuser:mypass@localhost:40001", "otherhost:40001`
+
+Additional supported URL examples include:
+
+- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023`
+- Direct connection: `mongodb://localhost:27017/?directConnection=true`
+
+When utilizing the parameter `directConnection=true` in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI, as it won't be automatically added.
+
+Example with replica set specified:
+
+- Replica set with specified username and password: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
+
+The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
+
 ## Compatibility
 
 The `log` dataset is tested with logs from versions v3.2.11 and v4.4.4 in

--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -4,28 +4,24 @@ This integration is used to fetch logs and metrics from [MongoDB](https://www.mo
 
 ## Configuration Notes
 
-When configuring the `hosts` option, MongoDB URLs should adhere to the following formats:
+When configuring the `hosts` option, MongoDB URIs must adhere to the following formats:
 
-- Simple: `[mongodb://][user:pass@]host[:port][?options]`
+- Simple: `mongodb://[user:pass@]host[:port][?options]`
 - Complex: `mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]`
 
-Examples of URLs can vary from simple to complex:
+Examples of URIs can vary from simple to complex:
 
-- Basic: `localhost`
+- Simple: `localhost`
 - Complex: `mongodb://myuser:mypass@localhost:40001", "otherhost:40001`
 
-Additional supported URL examples include:
+Additional supported URI examples include:
 
-- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023`
+- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
 - Direct connection: `mongodb://localhost:27017/?directConnection=true`
 
-When utilizing the parameter `directConnection=true` in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI, as it won't be automatically added.
+When using the `directConnection=true` parameter in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI as it won't be automatically added.
 
-Example with replica set specified:
-
-- `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
-
-The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
+The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
 ## Compatibility
 

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.13.1
+  changes:
+    - description: Update the Kibana version condition for multihost fix support and add MongoDB `hosts` field examples to the documentation.
+      type: bugfix
+      link: tba
 - version: 1.13.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update the Kibana version condition for multihost fix support and add MongoDB `hosts` field examples to the documentation.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9189
 - version: 1.13.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -23,7 +23,7 @@ When utilizing the parameter `directConnection=true` in the connection URI, all 
 
 Example with replica set specified:
 
-- Replica set with specified username and password: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
+- `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
 
 The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
 

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -2,6 +2,31 @@
 
 This integration is used to fetch logs and metrics from [MongoDB](https://www.mongodb.com/).
 
+## Configuration Notes
+
+When configuring the `hosts` option, MongoDB URLs should adhere to the following formats:
+
+- Simple: `[mongodb://][user:pass@]host[:port][?options]`
+- Complex: `mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]`
+
+Examples of URLs can vary from simple to complex:
+
+- Basic: `localhost`
+- Complex: `mongodb://myuser:mypass@localhost:40001", "otherhost:40001`
+
+Additional supported URL examples include:
+
+- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023`
+- Direct connection: `mongodb://localhost:27017/?directConnection=true`
+
+When utilizing the parameter `directConnection=true` in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI, as it won't be automatically added.
+
+Example with replica set specified:
+
+- Replica set with specified username and password: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
+
+The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
+
 ## Compatibility
 
 The `log` dataset is tested with logs from versions v3.2.11 and v4.4.4 in

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -4,28 +4,24 @@ This integration is used to fetch logs and metrics from [MongoDB](https://www.mo
 
 ## Configuration Notes
 
-When configuring the `hosts` option, MongoDB URLs should adhere to the following formats:
+When configuring the `hosts` option, MongoDB URIs must adhere to the following formats:
 
-- Simple: `[mongodb://][user:pass@]host[:port][?options]`
+- Simple: `mongodb://[user:pass@]host[:port][?options]`
 - Complex: `mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]`
 
-Examples of URLs can vary from simple to complex:
+Examples of URIs can vary from simple to complex:
 
-- Basic: `localhost`
+- Simple: `localhost`
 - Complex: `mongodb://myuser:mypass@localhost:40001", "otherhost:40001`
 
-Additional supported URL examples include:
+Additional supported URI examples include:
 
-- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023`
+- Replica set: `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
 - Direct connection: `mongodb://localhost:27017/?directConnection=true`
 
-When utilizing the parameter `directConnection=true` in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI, as it won't be automatically added.
+When using the `directConnection=true` parameter in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI as it won't be automatically added.
 
-Example with replica set specified:
-
-- `mongodb://localhost:27017,localhost:27022,localhost:27023/?replicaSet=dbrs`
-
-The username and password can either be included in the URL or set using the respective configuration options. If included in the URL, the credentials take precedence over the username and password configuration options.
+The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
 ## Compatibility
 

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.13.0"
+version: "1.13.1"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:
@@ -14,7 +14,7 @@ icons:
 format_version: "3.0.2"
 conditions:
   kibana:
-    version: "^8.8.0"
+    version: "^8.9.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

This PR updates the Kibana version condition for mongodb multihost fix support which is available from version 8.9.0 and it also adds configuration examples for MongoDB `hosts` field to the documentation.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #9162 


## Screenshots

<img width="1717" alt="image" src="https://github.com/elastic/integrations/assets/102972658/9c39b15f-5d7e-4eba-9161-20ac03d977b8">



