### PR TITLE
Replace dots in branch names by dash in Terraform labels

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -44,7 +44,7 @@ export REPO="${REPO_NAME}"
 
 # From Jenkins
 # BRANCH_NAME_LOWER_CASE = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
-BRANCH_NAME_LOWER_CASE=$(echo "$BUILDKITE_BRANCH" | tr '[:upper:]' '[:lower:]' | tr '_/\: ' '-')
+BRANCH_NAME_LOWER_CASE=$(echo "$BUILDKITE_BRANCH" | tr '[:upper:]' '[:lower:]' | tr '_/\:. ' '-')
 export BRANCH_NAME_LOWER_CASE
 export BUILD_ID="${BUILDKITE_BUILD_ID}"
 # get current timestamp in milliseconds


### PR DESCRIPTION
## Proposed commit message

This PR adds the dot character as a new one to be replaced by a dash in the labels used by terraform.

Error when trying to use dots in GCP resources:
```
Error: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.labels': ''. Label value 'elastic-dependabot-go-modules-helm.sh-helm-v3-3.14.1' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid
```

Example:

```
 $ BUILDKITE_BRANCH="elastic:dependabot/go_modules/helm.sh/helm/v3-3.14.1"
 $ echo "$BUILDKITE_BRANCH" | tr '[:upper:]' '[:lower:]' | tr '_/\:. ' '-'
elastic-dependabot-go-modules-helm-sh-helm-v3-3-14-1
```
