### PR TITLE
[ti_crowdstrike] Add Support of Deep Pagination in Intel Data Stream

### DIFF
--- a/packages/ti_crowdstrike/_dev/deploy/docker/files/config.yml
+++ b/packages/ti_crowdstrike/_dev/deploy/docker/files/config.yml
@@ -21,6 +21,8 @@ rules:
         headers:
           Content-Type:
             - application/json
+          Next-Page:
+            - /abc?_marker=123
         body: |-
           {
               "meta": {
@@ -123,7 +125,7 @@ rules:
       Authorization:
         - 'Bearer xxxx'
     query_params:
-      offset: 1
+      _marker: 123
       limit: 1
     responses:
       - status_code: 200

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.4.0"
+  changes:
+    - description: Adding support of Deep Pagination in Intel Data Stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.1"
   changes:
     - description: Adding null checks to processors.

--- a/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
@@ -27,40 +27,31 @@ auth.oauth2:
 state:
   initial_interval: {{initial_interval}}
   want_more: false
-  offset: 0
   batch_size: {{batch_size}}
 redact:
   fields: ~
 program: |
   (
     !state.want_more ?
-      request("GET", state.url + "/intel/combined/indicators/v1?offset=0&limit=" + string(state.batch_size) + '&filter=last_updated:>"' + (
+      request("GET", state.url + "/intel/combined/indicators/v1?offset=0&sort=_marker.asc&limit=" + string(state.batch_size) + '&filter=_marker:>"' + (
         has(state.cursor) && has(state.cursor.last_timestamp) && state.cursor.last_timestamp != null ?
           state.cursor.last_timestamp + '"'
         :
-          (now - duration(state.initial_interval)).format(time_layout.RFC3339) + '"'
+          string(int(now - duration(state.initial_interval))) + '"'
       ))
     :
-      request("GET", state.url + "/intel/combined/indicators/v1?offset=" + string(state.offset) + "&limit=" + string(state.batch_size) + '&filter=last_updated:>"' + (
-        has(state.cursor) && has(state.cursor.first_timestamp) && state.cursor.first_timestamp != null ?
-          state.cursor.first_timestamp + '"'
-        :
-          '"'
-      ))
-  ).do_request().as(resp, 
+      request("GET", state.url + string(state.next_url[0]))
+  ).do_request().as(resp,
     resp.StatusCode == 200 ?
       bytes(resp.Body).decode_json().as(body, {
         "events": body.resources.map(e, {
           "message": e.encode_json(),
         }),
-        "want_more": has(body.meta.pagination) && (int(state.offset) + body.resources.size()) < body.meta.pagination.total,
-        "offset": has(body.meta.pagination) && ((int(state.offset) + body.resources.size()) < body.meta.pagination.total) ?
-          int(state.offset) + int(body.resources.size())
-        :
-          0,
+        "want_more": resp.as(resp, "Next-Page" in resp.Header),
         "url": state.url,
         "batch_size": state.batch_size,
         "initial_interval": state.initial_interval,
+        "next_url": resp.as(resp, "Next-Page" in resp.Header) ? resp.Header["Next-Page"] : "",
         "cursor": {
           "last_timestamp": (
             has(body.resources) && body.resources.size() > 0 ?
@@ -78,17 +69,6 @@ program: |
                   null
               )
           ),
-          "first_timestamp": (
-            has(state.cursor) && has(state.cursor.first_timestamp) && state.cursor.first_timestamp != null ?
-              (
-                state.want_more ?
-                  state.cursor.first_timestamp
-                :
-                  state.cursor.last_timestamp
-              )
-            :
-              (now - duration(state.initial_interval)).format(time_layout.RFC3339)
-          ),
         },
       })
     :
@@ -105,7 +85,6 @@ program: |
         "batch_size": state.batch_size,
         "initial_interval": state.initial_interval,
       }
-
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/ti_crowdstrike/data_stream/intel/sample_event.json
+++ b/packages/ti_crowdstrike/data_stream/intel/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2023-11-21T06:16:01.000Z",
     "agent": {
-        "ephemeral_id": "b21c4b34-fd7e-4d94-8a0c-9197ae0af332",
-        "id": "436e2e4c-333b-45e1-8138-f548a20e88a8",
+        "ephemeral_id": "01671c0a-f3d2-4b9e-a820-7bcb5834d33e",
+        "id": "30c4e0f3-2beb-42a8-9111-37a38b4d2145",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.11.0"
@@ -16,7 +16,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "436e2e4c-333b-45e1-8138-f548a20e88a8",
+        "id": "30c4e0f3-2beb-42a8-9111-37a38b4d2145",
         "snapshot": false,
         "version": "8.11.0"
     },
@@ -27,7 +27,7 @@
         ],
         "dataset": "ti_crowdstrike.intel",
         "id": "hash_sha256_c98e1a7f563824cd448b47613743dcd1c853742b78f42b000192b83d",
-        "ingested": "2024-01-30T12:30:43Z",
+        "ingested": "2024-02-20T09:43:15Z",
         "kind": "enrichment",
         "original": "{\"_marker\":\"17005473618d17ae6353d123235e4158c5c81f25f0\",\"actors\":[\"SALTYSPIDER\"],\"deleted\":false,\"domain_types\":[\"abc.com\"],\"id\":\"hash_sha256_c98e1a7f563824cd448b47613743dcd1c853742b78f42b000192b83d\",\"indicator\":\"c98e192bf71a7f97563824cd448b47613743dcd1c853742b78f42b000192b83d\",\"ip_address_types\":[\"81.2.69.192\"],\"kill_chains\":[\"Installation\",\"C2\"],\"labels\":[{\"created_on\":1700547356,\"last_valid_on\":1700547360,\"name\":\"MaliciousConfidence/High\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"Malware/Mofksys\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/Commodity\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/CredentialHarvesting\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/InformationStealer\"}],\"last_updated\":1700547361,\"malicious_confidence\":\"high\",\"malware_families\":[\"Mofksys\"],\"published_date\":1700547356,\"relations\":[{\"created_date\":1700547339,\"id\":\"domain.com.yy\",\"indicator\":\"domain.ds\",\"last_valid_date\":1700547339,\"type\":\"domain\"},{\"created_date\":1700547339,\"id\":\"domain.xx.yy\",\"indicator\":\"domain.xx.fd\",\"last_valid_date\":1700547339,\"type\":\"domain\"}],\"reports\":[\"reports\"],\"targets\":[\"abc\"],\"threat_types\":[\"Commodity\",\"CredentialHarvesting\",\"InformationStealer\"],\"type\":\"hash_sha256\",\"vulnerabilities\":[\"vuln\"]}",
         "type": [
@@ -45,6 +45,9 @@
     "related": {
         "hash": [
             "c98e192bf71a7f97563824cd448b47613743dcd1c853742b78f42b000192b83d"
+        ],
+        "ip": [
+            "81.2.69.192"
         ]
     },
     "tags": [

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -93,8 +93,8 @@ An example event for `intel` looks as following:
 {
     "@timestamp": "2023-11-21T06:16:01.000Z",
     "agent": {
-        "ephemeral_id": "b21c4b34-fd7e-4d94-8a0c-9197ae0af332",
-        "id": "436e2e4c-333b-45e1-8138-f548a20e88a8",
+        "ephemeral_id": "01671c0a-f3d2-4b9e-a820-7bcb5834d33e",
+        "id": "30c4e0f3-2beb-42a8-9111-37a38b4d2145",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.11.0"
@@ -108,7 +108,7 @@ An example event for `intel` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "436e2e4c-333b-45e1-8138-f548a20e88a8",
+        "id": "30c4e0f3-2beb-42a8-9111-37a38b4d2145",
         "snapshot": false,
         "version": "8.11.0"
     },
@@ -119,7 +119,7 @@ An example event for `intel` looks as following:
         ],
         "dataset": "ti_crowdstrike.intel",
         "id": "hash_sha256_c98e1a7f563824cd448b47613743dcd1c853742b78f42b000192b83d",
-        "ingested": "2024-01-30T12:30:43Z",
+        "ingested": "2024-02-20T09:43:15Z",
         "kind": "enrichment",
         "original": "{\"_marker\":\"17005473618d17ae6353d123235e4158c5c81f25f0\",\"actors\":[\"SALTYSPIDER\"],\"deleted\":false,\"domain_types\":[\"abc.com\"],\"id\":\"hash_sha256_c98e1a7f563824cd448b47613743dcd1c853742b78f42b000192b83d\",\"indicator\":\"c98e192bf71a7f97563824cd448b47613743dcd1c853742b78f42b000192b83d\",\"ip_address_types\":[\"81.2.69.192\"],\"kill_chains\":[\"Installation\",\"C2\"],\"labels\":[{\"created_on\":1700547356,\"last_valid_on\":1700547360,\"name\":\"MaliciousConfidence/High\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"Malware/Mofksys\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/Commodity\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/CredentialHarvesting\"},{\"created_on\":1700547359,\"last_valid_on\":1700547359,\"name\":\"ThreatType/InformationStealer\"}],\"last_updated\":1700547361,\"malicious_confidence\":\"high\",\"malware_families\":[\"Mofksys\"],\"published_date\":1700547356,\"relations\":[{\"created_date\":1700547339,\"id\":\"domain.com.yy\",\"indicator\":\"domain.ds\",\"last_valid_date\":1700547339,\"type\":\"domain\"},{\"created_date\":1700547339,\"id\":\"domain.xx.yy\",\"indicator\":\"domain.xx.fd\",\"last_valid_date\":1700547339,\"type\":\"domain\"}],\"reports\":[\"reports\"],\"targets\":[\"abc\"],\"threat_types\":[\"Commodity\",\"CredentialHarvesting\",\"InformationStealer\"],\"type\":\"hash_sha256\",\"vulnerabilities\":[\"vuln\"]}",
         "type": [
@@ -137,6 +137,9 @@ An example event for `intel` looks as following:
     "related": {
         "hash": [
             "c98e192bf71a7f97563824cd448b47613743dcd1c853742b78f42b000192b83d"
+        ],
+        "ip": [
+            "81.2.69.192"
         ]
     },
     "tags": [

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: 0.3.1
+version: 0.4.0
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Enhancement

## What does this PR do?
**Add Support of Deep Pagination in Intel Data Stream**
Currently, the CrowdStrike Intel API limits the pagination to fetch the data upto 50,000 records only. If the sum of the offset and limit exceeds the value of 50000 then the API throws an error.
Using Deep Pagination, we can fetch all the data through the Intel Data Stream. Hence, Modified the data collection logic to perform pagination through the `_marker` in the filter instead of the `offset` and `last_udpated` to overcome the limit of Intel API.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

### All changes
- [x] Change follows the [contributing guidelines](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md)
- [x] Supported versions of the monitoring target are documented
- [x] Supported operating systems are documented (if applicable)
- [x] Integration or [System tests](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md) exist
- [x] Documentation exists
- [x] Fields follow [ECS](https://github.com/elastic/ecs) and [naming conventions](https://www.elastic.co/guide/en/beats/devguide/master/event-conventions.html)
- [x] At least a manual test with ES / Kibana / Agent has been performed.
- [x] Required Kibana version set to: ^8.11.0

## How to test this PR locally
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/ti_crowdstrike directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/9199

## Automated Test
[test-ti_crowdstrike.log](https://github.com/elastic/integrations/files/14343230/test-ti_crowdstrike.log)


