### PR TITLE
[MongoDB] Update the Kibana version condition for the fix of disk space exhaustion.

### DIFF
--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,8 +1,8 @@
 - version: 1.13.2
   changes:
-    - description: Update the Kibana version condition for disk space exhaustion.
+    - description: Update the Kibana version condition for the fix of disk space exhaustion.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9221
 - version: 1.13.1
   changes:
     - description: Update the Kibana version condition for multihost fix support and add MongoDB `hosts` field examples to the documentation.

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,6 +1,6 @@
 - version: 1.13.2
   changes:
-    - description: Update the Kibana version condition for the fix of disk space exhaustion.
+    - description: Update the Kibana version to fix the disk space exhaustion.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9221
 - version: 1.13.1

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.13.2
+  changes:
+    - description: Update the Kibana version condition for disk space exhaustion.
+      type: bugfix
+      link: tba
 - version: 1.13.1
   changes:
     - description: Update the Kibana version condition for multihost fix support and add MongoDB `hosts` field examples to the documentation.

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.13.1"
+version: "1.13.2"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:
@@ -14,7 +14,7 @@ icons:
 format_version: "3.0.2"
 conditions:
   kibana:
-    version: "^8.9.0"
+    version: "^8.12.2"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
## Proposed commit message

This PR updates the Kibana version condition for MongoDB integration to address the fix for MongoDB disk space exhaustion.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues


- Closes #9220 
