### PR TITLE
Add elastic-package prefix to tf resources

### DIFF
--- a/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
+++ b/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
@@ -39,7 +39,7 @@ resource "aws_sqs_queue" "crowdstrike_queue" {
 # IAM Policy for EventBridge Scheduler
 resource "aws_iam_policy" "sqs_access_policy" {
   count       = var.eventbridge_role_arn == null ? 1 : 0
-  name        = "sqs-access-policy-${var.TEST_RUN_ID}"
+  name        = "elastic-package-sqs-access-policy-${var.TEST_RUN_ID}"
   description = "Policy for EventBridge Scheduler to send messages to SQS"
 
   policy = jsonencode({
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "sqs_access_policy" {
 # IAM Role for EventBridge Scheduler
 resource "aws_iam_role" "eventbridge_scheduler_iam_role" {
   count               = var.eventbridge_role_arn == null ? 1 : 0
-  name_prefix         = "eb-scheduler-role-${var.TEST_RUN_ID}-"
+  name_prefix         = "elastic-package-eb-scheduler-role-${var.TEST_RUN_ID}-"
   managed_policy_arns = [aws_iam_policy.sqs_access_policy.0.arn]
   path                = "/"
   assume_role_policy  = <<EOF
@@ -83,7 +83,7 @@ EOF
 // uses a custom notification format that is different than the AWS S3 event
 // notification format.
 resource "aws_scheduler_schedule" "eventbridge_scheduler_every1minute" {
-  name       = "eventbridge_scheduler_crowdstrike_fdr_sqs-${var.TEST_RUN_ID}"
+  name       = "elastic-package-eventbridge_scheduler_crowdstrike_fdr_sqs-${var.TEST_RUN_ID}"
   group_name = "default"
 
   flexible_time_window {

--- a/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
+++ b/packages/crowdstrike/data_stream/fdr/_dev/deploy/tf/main.tf
@@ -39,7 +39,7 @@ resource "aws_sqs_queue" "crowdstrike_queue" {
 # IAM Policy for EventBridge Scheduler
 resource "aws_iam_policy" "sqs_access_policy" {
   count       = var.eventbridge_role_arn == null ? 1 : 0
-  name        = "elastic-package-sqs-access-policy-${var.TEST_RUN_ID}"
+  name        = "ep-sqs-access-policy-${var.TEST_RUN_ID}"
   description = "Policy for EventBridge Scheduler to send messages to SQS"
 
   policy = jsonencode({
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "sqs_access_policy" {
 # IAM Role for EventBridge Scheduler
 resource "aws_iam_role" "eventbridge_scheduler_iam_role" {
   count               = var.eventbridge_role_arn == null ? 1 : 0
-  name_prefix         = "elastic-package-eb-scheduler-role-${var.TEST_RUN_ID}-"
+  name_prefix         = "ep-eb-scheduler-role-${var.TEST_RUN_ID}-"
   managed_policy_arns = [aws_iam_policy.sqs_access_policy.0.arn]
   path                = "/"
   assume_role_policy  = <<EOF
@@ -83,7 +83,7 @@ EOF
 // uses a custom notification format that is different than the AWS S3 event
 // notification format.
 resource "aws_scheduler_schedule" "eventbridge_scheduler_every1minute" {
-  name       = "elastic-package-eventbridge_scheduler_crowdstrike_fdr_sqs-${var.TEST_RUN_ID}"
+  name       = "ep-eventbridge_scheduler_crowdstrike_fdr_sqs-${var.TEST_RUN_ID}"
   group_name = "default"
 
   flexible_time_window {


### PR DESCRIPTION
## Proposed commit message

Add `ep-` (elastic-package) prefix in the resources to help filter them in case it is needed.

It cannot be used `elastic-package` as in other packages since it would result in a string larger than it is expected. For instance:
> Error: expected length of name_prefix to be in the range (1 - 38), got elastic-package-eb-scheduler-role-84580-
