### PR TITLE
[cisco_ios] Remove erroneous period from repeated messages grok

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove erroneous period from repeated messages grok
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9001
+      link: https://github.com/elastic/integrations/pull/9228
 - version: "1.25.0"
   changes:
     - description: Add support for repeated messages logs

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Remove erroneous period from repeated messages grok
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9001
 - version: "1.25.0"
   changes:
     - description: Add support for repeated messages logs

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
@@ -7,4 +7,4 @@
 <191>2637087: rt401-rk30409: Aug 18 07:15:04.461 CEST: NTP Core (NOTICE): Clock is synchronized.
 <190>3352436: 3352457: Aug 12 2023 12:14:24.412 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807766185951588 %FW-6-SESS_AUDIT_TRAIL: (target:class) (ZP_PROCESS_TO_CORPORATE:CM_PROCESS_TO_CORPORATE):Stop dns session: initiator (10.50.14.44:33207) sent 48 bytes -- responder (10.120.42.6:53) sent 40 bytes, from GigabitEthernet10/0/2.6
 <190>3352460: 3352481: Aug 12 2023 12:15:33.963 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807835737559120 %FW-6-DROP_PKT: Dropping tcp pkt from GigabitEthernet1/0/2.6 10.50.14.44:53836 => 89.160.20.128:80(target:class)-(ZP_PROCESS_TO_CORPORATE:class-default) due to Policy drop:classify result with ip ident 13017 tcp flag 0x2, seq 4266642156, ack 0
-<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times.
+<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -455,7 +455,7 @@
                 "category": [
                     "network"
                 ],
-                "original": "<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times.",
+                "original": "<191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times",
                 "provider": "firewall",
                 "timezone": "UTC",
                 "type": [
@@ -468,7 +468,7 @@
                     "priority": 191
                 }
             },
-            "message": "last message repeated 66 times.",
+            "message": "last message repeated 66 times",
             "observer": {
                 "product": "IOS",
                 "type": "firewall",

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -39,7 +39,7 @@ processors:
         - '%{DATA:_temp_.header} %{REPEATED_MESSAGE:repeated_message}'
       pattern_definitions:
         NTP_MESSAGE: 'NTP %{GREEDYDATA}'
-        REPEATED_MESSAGE: 'last message repeated %{INT} times.'
+        REPEATED_MESSAGE: 'last message repeated %{INT} times'
       tag: dissect_header
   - grok:
       field: _temp_.header

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: cisco_ios
 title: Cisco IOS
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- During initial development, a period at the end of the repeated messages grok was added by mistake
- The period has been removed and tests updated

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_ios
elastic-package test
```

## Related issues

- Relates #8989 
