### PR TITLE
Set sensitive values as secret in services integrations

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive value as secret in cel input.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "1.31.0"
   changes:
     - description: Add support for Alert and Host API endpoints.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.0"
+  changes:
+    - description: Set sensitive value as secret in cel input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.31.0"
   changes:
     - description: Add support for Alert and Host API endpoints.

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -71,6 +71,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
+            secret: true
           - name: url
             type: text
             title: URL

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.31.0"
+version: "1.32.0"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.0"

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.1"
   changes:
     - description: Changed owners

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "0.1.1"
   changes:
     - description: Changed owners

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.1
+format_version: 3.0.3
 name: eset_protect
 title: ESET PROTECT
-version: 0.1.1
+version: 0.2.0
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:
@@ -61,6 +61,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
+            secret: true
           - name: enable_request_tracer
             type: bool
             title: Enable request tracing

--- a/packages/forcepoint_web/changelog.yml
+++ b/packages/forcepoint_web/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Upgrade to package spec 3.0.3.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "1.7.2"
   changes:
     - description: Changed owners

--- a/packages/forcepoint_web/changelog.yml
+++ b/packages/forcepoint_web/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.0"
+  changes:
+    - description: Upgrade to package spec 3.0.3.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.7.2"
   changes:
     - description: Changed owners

--- a/packages/forcepoint_web/data_stream/logs/manifest.yml
+++ b/packages/forcepoint_web/data_stream/logs/manifest.yml
@@ -21,6 +21,7 @@ streams:
         required: true
         show_user: true
         default: '\"%{date}\",\"%{time}\",\"%{user}\",\"%{workstation}\",\"%{category}\",\"%{action}\",\"%{risk_class}\",\"%{policy_name}\",\"%{url}\",\"%{connection_ip}\",\"%{destination_ip}\",\"%{source_ip}\",\"%{threat_type}\",\"%{threat_name}\",\"%{user_agent_string}\",\"%{http_status_code}\",\"%{http_request_method}\"'
+        secret: false
       - name: tags
         type: text
         title: Tags

--- a/packages/forcepoint_web/manifest.yml
+++ b/packages/forcepoint_web/manifest.yml
@@ -1,7 +1,7 @@
-format_version: "3.0.0"
+format_version: "3.0.3"
 name: forcepoint_web
 title: "Forcepoint Web Security"
-version: "1.7.2"
+version: "1.8.0"
 source:
   license: "Elastic-2.0"
 description: "Forcepoint Web Security"

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "0.2.0"
   changes:
     - description: Added Attack Map, Events Over Time, Unique IP and domain visualizations.

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,7 +1,12 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
-    - description: Added Attack Map, Events Over Time, Unique IP and domain visualizations. 
+    - description: Added Attack Map, Events Over Time, Unique IP and domain visualizations.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9210
 - version: "0.1.0"

--- a/packages/imperva_cloud_waf/data_stream/event/manifest.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/manifest.yml
@@ -14,6 +14,7 @@ streams:
         multi: false
         required: true
         show_user: true
+        secret: true
       - name: api_key
         type: password
         title: API Key
@@ -21,6 +22,7 @@ streams:
         multi: false
         required: true
         show_user: true
+        secret: true
       - name: url
         type: text
         title: URL
@@ -139,6 +141,7 @@ streams:
         required: false
         show_user: true
         description: First part of access key.
+        secret: true
       - name: secret_access_key
         type: password
         title: Secret Access Key
@@ -146,6 +149,7 @@ streams:
         required: false
         show_user: true
         description: Second part of access key.
+        secret: true
       - name: session_token
         type: text
         title: Session Token
@@ -153,6 +157,7 @@ streams:
         required: false
         show_user: true
         description: Required when using temporary security credentials.
+        secret: false
       - name: bucket_arn
         type: text
         title: "[S3] Bucket ARN"

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,14 +1,14 @@
-format_version: 3.0.1
+format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: 0.2.0
+version: 0.3.0
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:
   - security
 conditions:
   kibana:
-    version: ^8.10.1
+    version: ^8.12.0
   elastic:
     subscription: basic
 screenshots:

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.4.1"
   changes:
     - description: Typecast the cursor value to string and update Readme.

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "0.4.1"
   changes:
     - description: Typecast the cursor value to string and update Readme.

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.0
+format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: 0.4.1
+version: 0.5.0
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: ^8.11.0
+    version: ^8.12.0
   elastic:
     subscription: basic
 screenshots:
@@ -49,6 +49,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
+            secret: true
           - name: url
             type: text
             title: URL

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "0.2.0"
   changes:
     - description: Enable SSL configuration for requests

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Set sensitive values as secret, upgrade to package spec 3.0.3.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Enable SSL configuration for requests

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.0
+format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: 0.2.0
+version: 0.3.0
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: ^8.8.2
+    version: ^8.12.0
   elastic:
     subscription: basic
 icons:
@@ -33,10 +33,11 @@ policy_templates:
             show_user: true
             required: true
           - name: token
-            type: text
+            type: password
             title: API token
             show_user: true
             required: true
+            secret: true
           - name: ssl
             type: yaml
             title: SSL Configuration
@@ -72,7 +73,6 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-
 owner:
   github: elastic/security-service-integrations
   type: partner

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3, and add missing mapping.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9238
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.0"
+  changes:
+    - description: Set sensitive values as secret, upgrade to package spec 3.0.3, and add missing mapping.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/ti_threatconnect/data_stream/indicator/fields/fields.yml
+++ b/packages/ti_threatconnect/data_stream/indicator/fields/fields.yml
@@ -541,6 +541,9 @@
                 - name: owner
                   type: keyword
                   description: The entity or system that owns or manages the security label.
+                - name: source
+                  type: keyword
+                  description: The source of the security label.
         - name: sha1
           type: keyword
           description: The SHA1 hash associated with the File Indicator.

--- a/packages/ti_threatconnect/docs/README.md
+++ b/packages/ti_threatconnect/docs/README.md
@@ -512,6 +512,7 @@ An example event for `indicator` looks as following:
 | threat_connect.indicator.security_labels.data.id | Unique identifier for the security label. | keyword |
 | threat_connect.indicator.security_labels.data.name | Actual name or label of the security classification. | keyword |
 | threat_connect.indicator.security_labels.data.owner | The entity or system that owns or manages the security label. | keyword |
+| threat_connect.indicator.security_labels.data.source | The source of the security label. | keyword |
 | threat_connect.indicator.sha1 | The SHA1 hash associated with the File Indicator. | keyword |
 | threat_connect.indicator.sha256 | The SHA256 hash associated with the File Indicator. | keyword |
 | threat_connect.indicator.size | The size of the file associated with the File Indicator. | keyword |

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -1,7 +1,7 @@
-format_version: 3.0.0
+format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: 0.1.0
+version: 0.2.0
 description: Collect logs from ThreatConnect with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: ^8.11.0
+    version: ^8.12.0
   elastic:
     subscription: basic
 screenshots:
@@ -52,6 +52,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
+            secret: true
           - name: proxy_url
             type: text
             title: Proxy URL


### PR DESCRIPTION
## Proposed commit message

- Set sensitive values in several services integrations as secret
- Marked non-sensitive values as not a secret
- Upgraded pkg-spec to 3.0.3 where possible, gaining secrets validation from 3.0.2

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates elastic/security-team#7388
