### PR TITLE
[Prometheus] SSL Certificate Authorities for remote_write

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.1"
+  changes:
+    - description: Add Certificate Authorities for Remote Write
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9264
 - version: "1.14.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/prometheus/data_stream/remote_write/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/remote_write/agent/stream/stream.yml.hbs
@@ -4,6 +4,7 @@ port: {{port}}
 ssl.enabled: {{ssl.enabled}}
 ssl.certificate: {{ssl.certificate}}
 ssl.key: {{ssl.key}}
+ssl.certificate_authorities: {{ssl.certificate_authorities}}
 rate_counters: {{rate_counters}}
 use_types: {{use_types}}
 types_patterns.exclude:

--- a/packages/prometheus/data_stream/remote_write/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/remote_write/agent/stream/stream.yml.hbs
@@ -4,7 +4,12 @@ port: {{port}}
 ssl.enabled: {{ssl.enabled}}
 ssl.certificate: {{ssl.certificate}}
 ssl.key: {{ssl.key}}
-ssl.certificate_authorities: {{ssl.certificate_authorities}}
+{{#if ssl.certificate_authorities}}
+ssl.certificate_authorities:
+{{#each ssl.certificate_authorities}}
+  - {{this}}
+{{/each}}
+{{/if}}
 rate_counters: {{rate_counters}}
 use_types: {{use_types}}
 types_patterns.exclude:

--- a/packages/prometheus/data_stream/remote_write/manifest.yml
+++ b/packages/prometheus/data_stream/remote_write/manifest.yml
@@ -40,6 +40,13 @@ streams:
         required: false
         show_user: false
         default: /etc/pki/server/cert.key
+      - name: ssl.certificate_authorities
+        type: text
+        title: SSL Certificate Authorities
+        multi: false
+        required: false
+        show_user: false
+        default: /etc/pki/server/certificate_authorities.key
       - name: rate_counters
         type: bool
         title: Rate Counters

--- a/packages/prometheus/data_stream/remote_write/manifest.yml
+++ b/packages/prometheus/data_stream/remote_write/manifest.yml
@@ -46,7 +46,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: /etc/pki/server/certificate_authorities.key
+        default: /etc/pki/server/certificate_authorities.pem
       - name: rate_counters
         type: bool
         title: Rate Counters

--- a/packages/prometheus/data_stream/remote_write/manifest.yml
+++ b/packages/prometheus/data_stream/remote_write/manifest.yml
@@ -43,10 +43,9 @@ streams:
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
-        multi: false
+        multi: true
         required: false
         show_user: false
-        default: /etc/pki/server/certificate_authorities.pem
       - name: rate_counters
         type: bool
         title: Rate Counters

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.14.0
+version: 1.14.1
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

Add option to provide a CA in SSL Settings of Prometheus.
This allows to allow providing the root CA for Prometheus HTTPS/TLS to implement mTLS.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.

## Author's Checklist

- [ ] Test this locally
- [ ] Check for inconsistencies
- [ ] Add docs

