### PR TITLE
[ti_crowdstrike] Add ilm policy to intel data stream

### DIFF
--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.2"
+  changes:
+    - description: Add ilm policy to intel data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9274
 - version: "0.5.1"
   changes:
     - description: Add the mapping of hash sha1 type indicator.

--- a/packages/ti_crowdstrike/data_stream/intel/manifest.yml
+++ b/packages/ti_crowdstrike/data_stream/intel/manifest.yml
@@ -1,5 +1,6 @@
 title: Collect Intel logs from CrowdStrike Falcon Intelligence.
 type: logs
+ilm_policy: logs-ti_crowdstrike.intel-default_policy
 streams:
   - input: cel
     title: Intel logs

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: 0.5.1
+version: 0.5.2
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The `ilm_policy` is not defined for intel data_stream. This helps user saves space.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
