### PR TITLE
Disable secrets for packages with older stack versions due to errors.

### DIFF
--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.1.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.1.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/activemq/changelog.yml
+++ b/packages/activemq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.1.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/activemq/manifest.yml
+++ b/packages/activemq/manifest.yml
@@ -1,6 +1,6 @@
 name: activemq
 title: ActiveMQ
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs and metrics from ActiveMQ instances with Elastic Agent.
 type: integration
 icons:
@@ -79,7 +79,7 @@ policy_templates:
             multi: false
             required: true
             show_user: true
-            secret: true
+            secret: false
             description: Password for authentication of ActiveMQ instance.
             default: admin
           - name: ssl

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.3.0"
+version: "1.3.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration
@@ -33,7 +33,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 0.2.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/azure_app_service/changelog.yml
+++ b/packages/azure_app_service/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 0.2.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/azure_app_service/manifest.yml
+++ b/packages/azure_app_service/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_app_service
 title: "Azure App Service"
-version: "0.2.0"
+version: "0.2.1"
 source:
   license: "Elastic-2.0"
 description: "Collect logs and metrics from Azure App Service with Elastic Agent."
@@ -33,7 +33,7 @@ vars:
   - name: connection_string
     type: password
     title: Connection String
-    secret: true
+    secret: false
     multi: false
     required: true
     show_user: true
@@ -50,7 +50,7 @@ vars:
   - name: storage_account_key
     type: password
     title: Storage Account Key
-    secret: true
+    secret: false
     multi: false
     required: true
     show_user: true

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.4.2
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.4.1
   changes:
     - description: Add documentation for assigning roles for department and billing account scopes.

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.4.1
   changes:
     - description: Add documentation for assigning roles for department and billing account scopes.

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.4.1"
+version: "1.4.2"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:
@@ -33,7 +33,7 @@ vars:
   - name: client_secret
     type: password
     title: Client Secret
-    secret: true
+    secret: false
     description: The secret key of the App Registration.
     multi: false
     required: true

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 0.3.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.3.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 0.3.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/azure_functions/data_stream/functionapplogs/manifest.yml
+++ b/packages/azure_functions/data_stream/functionapplogs/manifest.yml
@@ -25,7 +25,7 @@ streams:
       - name: connection_string
         type: password
         title: Connection String
-        secret: true
+        secret: false
         multi: false
         required: true
         show_user: true
@@ -42,7 +42,7 @@ streams:
       - name: storage_account_key
         type: password
         title: Storage Account Key
-        secret: true
+        secret: false
         multi: false
         required: true
         show_user: true

--- a/packages/azure_functions/data_stream/metrics/manifest.yml
+++ b/packages/azure_functions/data_stream/metrics/manifest.yml
@@ -16,7 +16,7 @@ streams:
       - name: client_secret
         type: password
         title: Client Secret
-        secret: true
+        secret: false
         multi: false
         required: true
         show_user: true

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.3.0"
+version: "0.3.1"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"

--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.11.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.11.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/cassandra/changelog.yml
+++ b/packages/cassandra/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.11.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/cassandra/manifest.yml
+++ b/packages/cassandra/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cassandra
 title: Cassandra
-version: "1.11.0"
+version: "1.11.1"
 description: This Elastic integration collects logs and metrics from cassandra.
 type: integration
 categories:
@@ -61,7 +61,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false

--- a/packages/ceph/changelog.yml
+++ b/packages/ceph/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/ceph/changelog.yml
+++ b/packages/ceph/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/ceph/manifest.yml
+++ b/packages/ceph/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ceph
 title: Ceph
-version: "1.3.0"
+version: "1.3.1"
 description: This Elastic integration collects metrics from Ceph instance.
 type: integration
 categories:
@@ -63,7 +63,7 @@ policy_templates:
           - name: api_secret
             type: password
             title: API Secret Key
-            secret: true
+            secret: false
             show_user: true
             required: true
             default: 52dffd92-a103-4a10-bfce-5b60f48f764e

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.3.0"
+version: "1.3.1"
 description: This Elastic integration collects metrics from Citrix ADC product.
 type: integration
 categories:
@@ -76,7 +76,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             show_user: true
             required: false
             default: nsroot

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.8.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/cockroachdb/changelog.yml
+++ b/packages/cockroachdb/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.8.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.8.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/cockroachdb/data_stream/status/manifest.yml
+++ b/packages/cockroachdb/data_stream/status/manifest.yml
@@ -54,7 +54,7 @@ streams:
       - name: password
         type: password
         title: Password
-        secret: true
+        secret: false
         multi: false
         required: false
         show_user: true

--- a/packages/cockroachdb/manifest.yml
+++ b/packages/cockroachdb/manifest.yml
@@ -1,6 +1,6 @@
 name: cockroachdb
 title: CockroachDB Metrics
-version: "1.8.0"
+version: "1.8.1"
 description: Collect metrics from CockroachDB servers with Elastic Agent.
 type: integration
 icons:

--- a/packages/golang/changelog.yml
+++ b/packages/golang/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/golang/changelog.yml
+++ b/packages/golang/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.3.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/golang/manifest.yml
+++ b/packages/golang/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: golang
 title: Golang
-version: "1.3.0"
+version: "1.3.1"
 description: This Elastic integration collects metrics from Golang applications.
 type: integration
 categories:
@@ -64,7 +64,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             show_user: false
             required: false
             description: Enter password of Golang application.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.12.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/kafka/changelog.yml
+++ b/packages/kafka/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.12.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/kafka/data_stream/consumergroup/manifest.yml
+++ b/packages/kafka/data_stream/consumergroup/manifest.yml
@@ -15,7 +15,7 @@ streams:
         title: SASL username
       - name: password
         type: password
-        secret: true
+        secret: false
         title: SASL password
       - name: mechanism
         type: text

--- a/packages/kafka/data_stream/partition/manifest.yml
+++ b/packages/kafka/data_stream/partition/manifest.yml
@@ -16,7 +16,7 @@ streams:
       - name: password
         type: password
         title: SASL password
-        secret: true
+        secret: false
       - name: mechanism
         type: text
         title: SASL mechanism

--- a/packages/kafka/manifest.yml
+++ b/packages/kafka/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: kafka
 title: Kafka
-version: "1.12.0"
+version: "1.12.1"
 description: Collect logs and metrics from Kafka servers with Elastic Agent.
 type: integration
 categories:
@@ -68,7 +68,7 @@ policy_templates:
           - name: ssl.key_passphrase
             type: password
             title: SSL Key Passphrase
-            secret: true
+            secret: false
             show_user: true
           - name: ssl.verification_mode
             type: text

--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.5.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/kafka_log/changelog.yml
+++ b/packages/kafka_log/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.5.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.5.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/kafka_log/data_stream/generic/manifest.yml
+++ b/packages/kafka_log/data_stream/generic/manifest.yml
@@ -85,7 +85,7 @@ streams:
       - name: password
         type: password
         title: Password
-        secret: true
+        secret: false
         description: Password used for SASL authentication.
         required: false
         show_user: true
@@ -118,7 +118,7 @@ streams:
       - name: kerberos_password
         type: password
         title: Kerberos Password
-        secret: true
+        secret: false
         description: If you configured password for Auth Type, you have to provide a password for the selected principal.
         required: false
         show_user: false

--- a/packages/kafka_log/manifest.yml
+++ b/packages/kafka_log/manifest.yml
@@ -3,7 +3,7 @@ name: kafka_log
 title: Custom Kafka Logs
 description: Collect data from kafka topic with Elastic Agent.
 type: integration
-version: "1.5.0"
+version: "1.5.1"
 conditions:
   kibana:
     version: "^7.16.0 || ^8.0.0"

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.18.1
   changes:
     - description: Add missing dimension to the performance datastream.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.18.2
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.18.1
   changes:
     - description: Add missing dimension to the performance datastream.

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.18.1"
+version: "1.18.2"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:
@@ -53,7 +53,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             default: test
 owner:
   github: elastic/obs-infraobs-integrations

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.19.0"
   changes:
     - description: Add support for tags in stub status metrics

--- a/packages/nginx/changelog.yml
+++ b/packages/nginx/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.19.0"
   changes:
     - description: Add support for tags in stub status metrics

--- a/packages/nginx/manifest.yml
+++ b/packages/nginx/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: nginx
 title: Nginx
-version: "1.19.0"
+version: "1.19.1"
 description: Collect logs and metrics from Nginx HTTP servers with Elastic Agent.
 type: integration
 categories:
@@ -65,12 +65,12 @@ policy_templates:
             type: password
             title: Splunk REST API Password
             show_user: true
-            secret: true
+            secret: false
             required: false
           - name: token
             type: password
             title: Splunk Authorization Token
-            secret: true
+            secret: false
             description: |
               Bearer Token or Session Key, e.g. "Bearer eyJFd3e46..."
               or "Splunk 192fd3e...".  Cannot be used with username

--- a/packages/oracle_weblogic/changelog.yml
+++ b/packages/oracle_weblogic/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.4.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/oracle_weblogic/changelog.yml
+++ b/packages/oracle_weblogic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.4.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.4.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/oracle_weblogic/manifest.yml
+++ b/packages/oracle_weblogic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: oracle_weblogic
 title: Oracle WebLogic
-version: "1.4.0"
+version: "1.4.1"
 description: Collect logs and metrics from Oracle WebLogic with Elastic Agent.
 type: integration
 categories:
@@ -54,7 +54,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.18.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/postgresql/changelog.yml
+++ b/packages/postgresql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.18.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/postgresql/manifest.yml
+++ b/packages/postgresql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: postgresql
 title: PostgreSQL
-version: "1.18.0"
+version: "1.18.1"
 description: Collect logs and metrics from PostgreSQL servers with Elastic Agent.
 type: integration
 categories:
@@ -56,7 +56,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.2"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.14.1"
   changes:
     - description: Add Certificate Authorities for Remote Write

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.14.1"
   changes:
     - description: Add Certificate Authorities for Remote Write

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -94,13 +94,12 @@ streams:
         default: user
       - name: password
         type: password
-        secret: true
+        secret: false
         title: 'HTTP config options: Password'
         description: The password to use for basic authentication.
         multi: false
         required: false
         show_user: false
-        default: secret
       - name: connect_timeout
         type: text
         title: 'HTTP config options: connect_timeout'

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.14.1
+version: 1.14.2
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 0.3.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/prometheus_input/changelog.yml
+++ b/packages/prometheus_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.3.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 0.3.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/prometheus_input/manifest.yml
+++ b/packages/prometheus_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: prometheus_input
 title: "Prometheus Input"
-version: "0.3.0"
+version: "0.3.1"
 description: "Collects metrics from Prometheus exporter."
 type: input
 categories:
@@ -84,7 +84,7 @@ policy_templates:
       - name: password
         type: password
         title: Password
-        secret: true
+        secret: false
         multi: false
         required: false
         show_user: true

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.12.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/rabbitmq/changelog.yml
+++ b/packages/rabbitmq/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.12.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.12.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/rabbitmq/manifest.yml
+++ b/packages/rabbitmq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: rabbitmq
 title: RabbitMQ Logs and Metrics
-version: "1.12.0"
+version: "1.12.1"
 description: Collect and parse logs from RabbitMQ servers with Elastic Agent.
 type: integration
 categories:
@@ -60,7 +60,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.13.1"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "0.13.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/salesforce/changelog.yml
+++ b/packages/salesforce/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "0.13.0"
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/salesforce/manifest.yml
+++ b/packages/salesforce/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: salesforce
 title: Salesforce
-version: "0.13.0"
+version: "0.13.1"
 description: Collect logs from Salesforce with Elastic Agent.
 type: integration
 categories:
@@ -53,7 +53,7 @@ vars:
     title: Client Secret
     description: OAuth 2.0 client secret.
     required: true
-    secret: true
+    secret: false
     show_user: true
     default: client_secret
   - name: username
@@ -66,7 +66,7 @@ vars:
   - name: password
     type: password
     title: Password
-    secret: true
+    secret: false
     description: The password used as part of the authentication flow.
     required: true
     show_user: true

--- a/packages/spring_boot/changelog.yml
+++ b/packages/spring_boot/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.2"
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: "1.3.1"
   changes:
     - description: Update README to follow documentation guidelines.

--- a/packages/spring_boot/changelog.yml
+++ b/packages/spring_boot/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: "1.3.1"
   changes:
     - description: Update README to follow documentation guidelines.

--- a/packages/spring_boot/manifest.yml
+++ b/packages/spring_boot/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: spring_boot
 title: Spring Boot
-version: "1.3.1"
+version: "1.3.2"
 description: This Elastic integration collects logs and metrics from Spring Boot integration.
 type: integration
 categories:
@@ -88,7 +88,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable secrets for older stack versions due to errors.
       type: bugfix
-      link: tba
+      link: https://github.com/elastic/integrations/pull/9279
 - version: 1.2.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/websphere_application_server/changelog.yml
+++ b/packages/websphere_application_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.2.1
+  changes:
+    - description: Disable secrets for older stack versions due to errors.
+      type: bugfix
+      link: tba
 - version: 1.2.0
   changes:
     - description: Enable 'secret' for the sensitive fields, supported from 8.12.

--- a/packages/websphere_application_server/manifest.yml
+++ b/packages/websphere_application_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: websphere_application_server
 title: WebSphere Application Server
-version: "1.2.0"
+version: "1.2.1"
 description: Collects metrics from IBM WebSphere Application Server with Elastic Agent.
 type: integration
 categories:
@@ -65,7 +65,7 @@ policy_templates:
           - name: password
             type: password
             title: Password
-            secret: true
+            secret: false
             multi: false
             required: false
             show_user: false


### PR DESCRIPTION
## Proposed commit message

This PR disables the secrets for packages on versions below 8.10.0 due to errors. More details in comment section [here](https://github.com/elastic/obs-infraobs-team/issues/1305).

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## Related issues

- Relates [#1305](https://github.com/elastic/obs-infraobs-team/issues/1305)

