### PR TITLE
Check whether or not jenkins folder exists in backport branches

### DIFF
--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -114,7 +114,9 @@ updateBackportBranchContents() {
   else
     echo "Commiting and pushing..."
     git add $BUILDKITE_FOLDER_PATH
-    git add $JENKINS_FOLDER_PATH
+    if [ -d "${JENKINS_FOLDER_PATH}" ]; then
+      git add $JENKINS_FOLDER_PATH
+    fi
     git add $PACKAGES_FOLDER_PATH/
     git commit -m "Add $BUILDKITE_FOLDER_PATH and $JENKINS_FOLDER_PATH to backport branch: $BACKPORT_BRANCH_NAME from the $SOURCE_BRANCH branch"
     git push origin $BACKPORT_BRANCH_NAME

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -184,4 +184,7 @@ MSG="The backport branch: **$BACKPORT_BRANCH_NAME** has been created."
 echo "Adding CI files into the branch ${BACKPORT_BRANCH_NAME}"
 updateBackportBranchContents
 
+if [ "${DRY_RUN}" == "true" ]; then
+  MSG="[DRY_RUN] ${MSG}."
+fi
 buildkite-agent annotate "$MSG" --style "success"

--- a/.buildkite/scripts/backport_branch.sh
+++ b/.buildkite/scripts/backport_branch.sh
@@ -118,6 +118,7 @@ updateBackportBranchContents() {
       git add $JENKINS_FOLDER_PATH
     fi
     git add $PACKAGES_FOLDER_PATH/
+    git status
     git commit -m "Add $BUILDKITE_FOLDER_PATH and $JENKINS_FOLDER_PATH to backport branch: $BACKPORT_BRANCH_NAME from the $SOURCE_BRANCH branch"
     git push origin $BACKPORT_BRANCH_NAME
   fi


### PR DESCRIPTION
## Proposed commit message

Do not run `git add` command if the `.ci` folder does not exist (Jenkins folder)
