### PR TITLE
Update ownership for azure missing data streams (application_gateway, firewall_logs)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,8 @@
 /packages/azure/data_stream/provisioning @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/signinlogs @elastic/obs-infraobs-integrations
 /packages/azure/data_stream/springcloudlogs @elastic/obs-infraobs-integrations
+/packages/azure/data_stream/application_gateway @elastic/security-service-integrations
+/packages/azure/data_stream/firewall_logs @elastic/security-service-integrations
 /packages/azure_app_service @elastic/obs-infraobs-integrations
 /packages/azure_app_service/data_stream/app_service_logs @elastic/obs-infraobs-integrations
 /packages/azure_application_insights @elastic/obs-infraobs-integrations


### PR DESCRIPTION

Update ownership for azure missing data streams (application_gateway, firewall_logs) to security service integrations team 
