### PR TITLE
[Buildkite] Avoid fail job if no XML files are downloaded in sonarqube step

### DIFF
--- a/.buildkite/scripts/run_sonar_scanner.sh
+++ b/.buildkite/scripts/run_sonar_scanner.sh
@@ -5,9 +5,10 @@ run_sonar_scanner() {
     local message=""
     echo "--- Download coverage reports and merge them"
     if ! buildkite-agent artifact download build/test-coverage/coverage-*.xml . ; then
-        echo "--- :boom: Could not download XML artifacts. Skip coverage."
+        message="Could not download XML artifacts. Skip coverage."
+        echo "--- :boom: ${message}"
         buildkite-agent annotate \
-            "${message}" \
+            "[Code inspection] ${message}" \
             --context "ctx-sonarqube-no-files" \
             --style "warning"
         exit 0

--- a/.buildkite/scripts/run_sonar_scanner.sh
+++ b/.buildkite/scripts/run_sonar_scanner.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 
 run_sonar_scanner() {
+    local message=""
     echo "--- Download coverage reports and merge them"
-    buildkite-agent artifact download build/test-coverage/coverage-*.xml .
+    if ! buildkite-agent artifact download build/test-coverage/coverage-*.xml . ; then
+        message="Error downloading XML files for coverage. Skip coverage."
+        buildkite-agent annotate \
+            "${message}" \
+            --context "ctx-sonarqube-no-files" \
+            --style "warning"
+        exit 0
+    fi
 
     echo "Merge all coverage reports"
     .buildkite/scripts/merge_xml.sh

--- a/.buildkite/scripts/run_sonar_scanner.sh
+++ b/.buildkite/scripts/run_sonar_scanner.sh
@@ -5,7 +5,7 @@ run_sonar_scanner() {
     local message=""
     echo "--- Download coverage reports and merge them"
     if ! buildkite-agent artifact download build/test-coverage/coverage-*.xml . ; then
-        message="Error downloading XML files for coverage. Skip coverage."
+        echo "--- :boom: Could not download XML artifacts. Skip coverage."
         buildkite-agent annotate \
             "${message}" \
             --context "ctx-sonarqube-no-files" \

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -31,40 +31,40 @@ echo "[DEBUG] Checking with commits: from: '${from}' to: '${to}'"
 
 packages_to_test=0
 
-# for package in ${PACKAGE_LIST}; do
-#     # check if needed to create an step for this package
-#     pushd "packages/${package}" > /dev/null
-#     skip_package="false"
-#     if ! reason=$(is_pr_affected "${package}" "${from}" "${to}") ; then
-#         skip_package="true"
-#     fi
-#     echoerr "${reason}"
-#     popd > /dev/null
-# 
-#     if [[ "$skip_package" == "true" ]] ; then
-#         continue
-#     fi
-# 
-#     packages_to_test=$((packages_to_test+1))
-#     cat << EOF >> ${PIPELINE_FILE}
-#     - label: "Check integrations ${package}"
-#       key: "test-integrations-${package}"
-#       command: ".buildkite/scripts/test_one_package.sh ${package} ${from} ${to}"
-#       agents:
-#         provider: gcp
-#       env:
-#         STACK_VERSION: "${STACK_VERSION}"
-#         FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
-#         SERVERLESS: "false"
-#         UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
-#       artifact_paths:
-#         - build/test-results/*.xml
-#         - build/test-coverage/*.xml
-#         - build/benchmark-results/*.json
-#         - build/elastic-stack-dump/*/logs/*.log
-#         - build/elastic-stack-dump/*/logs/fleet-server-internal/**/*
-# EOF
-# done
+for package in ${PACKAGE_LIST}; do
+    # check if needed to create an step for this package
+    pushd "packages/${package}" > /dev/null
+    skip_package="false"
+    if ! reason=$(is_pr_affected "${package}" "${from}" "${to}") ; then
+        skip_package="true"
+    fi
+    echoerr "${reason}"
+    popd > /dev/null
+
+    if [[ "$skip_package" == "true" ]] ; then
+        continue
+    fi
+
+    packages_to_test=$((packages_to_test+1))
+    cat << EOF >> ${PIPELINE_FILE}
+    - label: "Check integrations ${package}"
+      key: "test-integrations-${package}"
+      command: ".buildkite/scripts/test_one_package.sh ${package} ${from} ${to}"
+      agents:
+        provider: gcp
+      env:
+        STACK_VERSION: "${STACK_VERSION}"
+        FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
+        SERVERLESS: "false"
+        UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
+      artifact_paths:
+        - build/test-results/*.xml
+        - build/test-coverage/*.xml
+        - build/benchmark-results/*.json
+        - build/elastic-stack-dump/*/logs/*.log
+        - build/elastic-stack-dump/*/logs/fleet-server-internal/**/*
+EOF
+done
 
 if [ ${packages_to_test} -eq 0 ]; then
     buildkite-agent annotate "No packages to be tested" --context "ctx-no-packages" --style "warning"

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -31,40 +31,40 @@ echo "[DEBUG] Checking with commits: from: '${from}' to: '${to}'"
 
 packages_to_test=0
 
-for package in ${PACKAGE_LIST}; do
-    # check if needed to create an step for this package
-    pushd "packages/${package}" > /dev/null
-    skip_package="false"
-    if ! reason=$(is_pr_affected "${package}" "${from}" "${to}") ; then
-        skip_package="true"
-    fi
-    echoerr "${reason}"
-    popd > /dev/null
-
-    if [[ "$skip_package" == "true" ]] ; then
-        continue
-    fi
-
-    packages_to_test=$((packages_to_test+1))
-    cat << EOF >> ${PIPELINE_FILE}
-    - label: "Check integrations ${package}"
-      key: "test-integrations-${package}"
-      command: ".buildkite/scripts/test_one_package.sh ${package} ${from} ${to}"
-      agents:
-        provider: gcp
-      env:
-        STACK_VERSION: "${STACK_VERSION}"
-        FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
-        SERVERLESS: "false"
-        UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
-      artifact_paths:
-        - build/test-results/*.xml
-        - build/test-coverage/*.xml
-        - build/benchmark-results/*.json
-        - build/elastic-stack-dump/*/logs/*.log
-        - build/elastic-stack-dump/*/logs/fleet-server-internal/**/*
-EOF
-done
+# for package in ${PACKAGE_LIST}; do
+#     # check if needed to create an step for this package
+#     pushd "packages/${package}" > /dev/null
+#     skip_package="false"
+#     if ! reason=$(is_pr_affected "${package}" "${from}" "${to}") ; then
+#         skip_package="true"
+#     fi
+#     echoerr "${reason}"
+#     popd > /dev/null
+# 
+#     if [[ "$skip_package" == "true" ]] ; then
+#         continue
+#     fi
+# 
+#     packages_to_test=$((packages_to_test+1))
+#     cat << EOF >> ${PIPELINE_FILE}
+#     - label: "Check integrations ${package}"
+#       key: "test-integrations-${package}"
+#       command: ".buildkite/scripts/test_one_package.sh ${package} ${from} ${to}"
+#       agents:
+#         provider: gcp
+#       env:
+#         STACK_VERSION: "${STACK_VERSION}"
+#         FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
+#         SERVERLESS: "false"
+#         UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
+#       artifact_paths:
+#         - build/test-results/*.xml
+#         - build/test-coverage/*.xml
+#         - build/benchmark-results/*.json
+#         - build/elastic-stack-dump/*/logs/*.log
+#         - build/elastic-stack-dump/*/logs/fleet-server-internal/**/*
+# EOF
+# done
 
 if [ ${packages_to_test} -eq 0 ]; then
     buildkite-agent annotate "No packages to be tested" --context "ctx-no-packages" --style "warning"


### PR DESCRIPTION
## Proposed commit message

Avoid fail job if no XML files are downloaded in sonarqube step, following the same strategy as in JUnit plugin: https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin/blob/524ac3323eeab88cb74a1eb63e17134b4d1bf3d9/hooks/command#L37-L40

Example failing build:
https://buildkite.com/elastic/integrations/builds/9406#_
> Download coverage reports and merge them
2024-03-07 10:34:26 INFO   Searching for artifacts: "build/test-coverage/coverage-*.xml"
fatal: failed to download artifacts: No artifacts found for downloading
🚨 Error: The command exited with status 1

Example build with this change and no test packages:
https://buildkite.com/elastic/integrations/builds/9419

![buildkite annotations](https://github.com/elastic/integrations/assets/5330827/95f6f785-c190-42ac-9ff1-5cb82ea306d7)


> Download coverage reports and merge them
💥 Could not download XML artifacts. Skip coverage.


Relates #9297

