### PR TITLE
Add error.message mapping for system.syslog

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.54.1"
+  changes:
+    - description: Add error.message mapping for system.syslog
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9304
 - version: "1.54.0"
   changes:
     - description: Enable 'secret' for the sensitive fields.

--- a/packages/system/data_stream/syslog/fields/ecs.yml
+++ b/packages/system/data_stream/syslog/fields/ecs.yml
@@ -1,6 +1,8 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.message  
+- external: ecs
   name: event.action
 - external: ecs
   name: event.category


### PR DESCRIPTION

- Bug

The error.message mapping did not exist for system.syslog 

Added error.message mapping to ecs.yml for system.syslog

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
