### PR TITLE
Fix Exchange Server Dashboard references

### DIFF
--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix missing Dashboard references
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9197
 - version: "0.1.0"
   changes:
     - description: Initial release of the package

--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix missing Dashboard references
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9197
+      link: https://github.com/elastic/integrations/pull/9325
 - version: "0.1.0"
   changes:
     - description: Initial release of the package

--- a/packages/microsoft_exchange_server/kibana/dashboard/microsoft_exchange_server-2b868ef0-c041-11ee-a682-0f218cc418af.json
+++ b/packages/microsoft_exchange_server/kibana/dashboard/microsoft_exchange_server-2b868ef0-c041-11ee-a682-0f218cc418af.json
@@ -639,9 +639,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-08T09:17:13.417Z",
+    "created_at": "2024-03-11T10:14:48.072Z",
     "id": "microsoft_exchange_server-2b868ef0-c041-11ee-a682-0f218cc418af",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logs-*",

--- a/packages/microsoft_exchange_server/kibana/dashboard/microsoft_exchange_server-8e9d55c5-637a-4fd8-b53b-9501e98a8e88.json
+++ b/packages/microsoft_exchange_server/kibana/dashboard/microsoft_exchange_server-8e9d55c5-637a-4fd8-b53b-9501e98a8e88.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"3b96aa56-e784-4ba5-9e3c-c7a260f817aa\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"3b96aa56-e784-4ba5-9e3c-c7a260f817aa\",\"fieldName\":\"microsoft.exchange.anchormailbox\",\"title\":\"Anchormailbox\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}},\"ecdd0ef4-0779-48f2-a283-cda224f888ff\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"ecdd0ef4-0779-48f2-a283-cda224f888ff\",\"fieldName\":\"microsoft.exchange.authenticateduser\",\"title\":\"Authenticated user\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}},\"60ed44b4-dae1-48de-801b-f4ef52c7b52d\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"60ed44b4-dae1-48de-801b-f4ef52c7b52d\",\"fieldName\":\"microsoft.exchange.urlhost\",\"title\":\"URL Host\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"a5fe2192-b77c-4f16-888e-4e59fe064c78\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"a5fe2192-b77c-4f16-888e-4e59fe064c78\",\"fieldName\":\"microsoft.exchange.anchormailbox\",\"title\":\"Anchormailbox\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}},\"7c8291ec-dc6d-4fa0-8d67-bb53efdf6c57\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"7c8291ec-dc6d-4fa0-8d67-bb53efdf6c57\",\"fieldName\":\"microsoft.exchange.authenticateduser\",\"title\":\"Authenticated user\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}},\"f542c63c-4265-4ebc-a9d6-7278f4d3976a\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"f542c63c-4265-4ebc-a9d6-7278f4d3976a\",\"fieldName\":\"microsoft.exchange.urlhost\",\"title\":\"URL Host\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"wildcard\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -142,14 +142,13 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "f045c6e1-ff4e-4d5f-86b5-6eb6be955767",
+                    "i": "d2e19276-b24c-4239-ab0f-3b9c328fb252",
                     "w": 8,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "f045c6e1-ff4e-4d5f-86b5-6eb6be955767",
-                "type": "lens",
-                "version": "8.10.4"
+                "panelIndex": "d2e19276-b24c-4239-ab0f-3b9c328fb252",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -160,17 +159,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "9276c7a4-c750-4092-81d5-ea02cccadc91",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "d64931ec-87ab-4503-9c67-dbb397048ac8": {
                                             "columnOrder": [
@@ -193,10 +188,11 @@
                                                         }
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "microsoft.exchange.requestbytes"
+                                                    "sourceField": "http.request.bytes"
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -252,14 +248,13 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "b4f4da92-d6f3-49d3-a5cd-14421ddc25bb",
+                    "i": "8a0f3277-f4af-40f5-9526-0b8be36b2daf",
                     "w": 8,
                     "x": 8,
                     "y": 0
                 },
-                "panelIndex": "b4f4da92-d6f3-49d3-a5cd-14421ddc25bb",
-                "type": "lens",
-                "version": "8.10.4"
+                "panelIndex": "8a0f3277-f4af-40f5-9526-0b8be36b2daf",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -270,17 +265,13 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
                                 "type": "index-pattern"
-                            },
-                            {
-                                "id": "logs-*",
-                                "name": "9048201a-d0d3-42b8-bd95-4a8caaed9cef",
-                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "d64931ec-87ab-4503-9c67-dbb397048ac8": {
                                             "columnOrder": [
@@ -303,10 +294,11 @@
                                                         }
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "microsoft.exchange.responsebytes"
+                                                    "sourceField": "http.response.bytes"
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -362,14 +354,13 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "734077b2-55d3-4827-8d61-555ccca7a87d",
+                    "i": "8cd05d59-543a-4b41-9bdd-49b7b8e2cd31",
                     "w": 8,
                     "x": 16,
                     "y": 0
                 },
-                "panelIndex": "734077b2-55d3-4827-8d61-555ccca7a87d",
-                "type": "lens",
-                "version": "8.10.4"
+                "panelIndex": "8cd05d59-543a-4b41-9bdd-49b7b8e2cd31",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -465,15 +456,14 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "7ef48143-1bb4-418e-9b66-4484816bcf56",
+                    "i": "3fdd01ea-f1a6-4aef-9f4c-ceb6d2c787ba",
                     "w": 8,
                     "x": 24,
                     "y": 0
                 },
-                "panelIndex": "7ef48143-1bb4-418e-9b66-4484816bcf56",
+                "panelIndex": "3fdd01ea-f1a6-4aef-9f4c-ceb6d2c787ba",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -569,15 +559,14 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "4d3d518a-c20e-4ccc-8904-e5cf35f60eb2",
+                    "i": "fdf2a0a3-389d-4f7c-9684-5b8d1ed89c91",
                     "w": 8,
                     "x": 32,
                     "y": 0
                 },
-                "panelIndex": "4d3d518a-c20e-4ccc-8904-e5cf35f60eb2",
+                "panelIndex": "fdf2a0a3-389d-4f7c-9684-5b8d1ed89c91",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -673,15 +662,14 @@
                 },
                 "gridData": {
                     "h": 6,
-                    "i": "dbc72b95-0aa9-4962-83ae-69c119bb819e",
+                    "i": "2997a185-6ea5-4e41-bd70-f5a46bd4e127",
                     "w": 8,
                     "x": 40,
                     "y": 0
                 },
-                "panelIndex": "dbc72b95-0aa9-4962-83ae-69c119bb819e",
+                "panelIndex": "2997a185-6ea5-4e41-bd70-f5a46bd4e127",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -859,14 +847,13 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "2686237c-5a6c-45c0-854f-cd2e109c4689",
+                    "i": "b489c5cc-9794-46a7-9fe1-a5370fc7d4b3",
                     "w": 48,
                     "x": 0,
                     "y": 6
                 },
-                "panelIndex": "2686237c-5a6c-45c0-854f-cd2e109c4689",
-                "type": "lens",
-                "version": "8.10.4"
+                "panelIndex": "b489c5cc-9794-46a7-9fe1-a5370fc7d4b3",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1033,15 +1020,14 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "f977ebfe-fe73-45a6-a1ea-c06e482cda4c",
+                    "i": "0720a83e-43d7-4993-8072-26be8aa3feb6",
                     "w": 16,
                     "x": 0,
                     "y": 15
                 },
-                "panelIndex": "f977ebfe-fe73-45a6-a1ea-c06e482cda4c",
+                "panelIndex": "0720a83e-43d7-4993-8072-26be8aa3feb6",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1209,15 +1195,14 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "7361b95a-a28a-4de4-89f8-f6f4231258ae",
+                    "i": "70ef3233-def0-42d0-9b35-2e48221fcd16",
                     "w": 16,
                     "x": 16,
                     "y": 15
                 },
-                "panelIndex": "7361b95a-a28a-4de4-89f8-f6f4231258ae",
+                "panelIndex": "70ef3233-def0-42d0-9b35-2e48221fcd16",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1352,15 +1337,14 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "cdc6c5e6-e8b9-40fe-9c4c-204074620499",
+                    "i": "4f7e8e5e-8dc8-4fe7-98b1-16ce0cc6cbcb",
                     "w": 16,
                     "x": 32,
                     "y": 15
                 },
-                "panelIndex": "cdc6c5e6-e8b9-40fe-9c4c-204074620499",
+                "panelIndex": "4f7e8e5e-8dc8-4fe7-98b1-16ce0cc6cbcb",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.4"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1368,15 +1352,14 @@
                 },
                 "gridData": {
                     "h": 27,
-                    "i": "0eb79219-ddd9-4ae4-8278-9b12e3e7668b",
+                    "i": "f2260518-d4c1-4b3b-a602-c18c06fc1562",
                     "w": 48,
                     "x": 0,
                     "y": 30
                 },
-                "panelIndex": "0eb79219-ddd9-4ae4-8278-9b12e3e7668b",
-                "panelRefName": "panel_0eb79219-ddd9-4ae4-8278-9b12e3e7668b",
-                "type": "search",
-                "version": "8.10.4"
+                "panelIndex": "f2260518-d4c1-4b3b-a602-c18c06fc1562",
+                "panelRefName": "panel_f2260518-d4c1-4b3b-a602-c18c06fc1562",
+                "type": "search"
             }
         ],
         "timeRestore": false,
@@ -1384,8 +1367,8 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-08T09:17:13.417Z",
-    "id": "microsoft_exchange_server-e52391d0-c034-11ee-a682-0f218cc418af",
+    "created_at": "2024-03-11T10:15:01.086Z",
+    "id": "microsoft_exchange_server-8e9d55c5-637a-4fd8-b53b-9501e98a8e88",
     "managed": true,
     "references": [
         {
@@ -1395,122 +1378,112 @@
         },
         {
             "id": "logs-*",
-            "name": "f045c6e1-ff4e-4d5f-86b5-6eb6be955767:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "d2e19276-b24c-4239-ab0f-3b9c328fb252:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f045c6e1-ff4e-4d5f-86b5-6eb6be955767:e6c91c87-ff12-4e3b-9ce7-b54ed4facc16",
+            "name": "d2e19276-b24c-4239-ab0f-3b9c328fb252:e6c91c87-ff12-4e3b-9ce7-b54ed4facc16",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "b4f4da92-d6f3-49d3-a5cd-14421ddc25bb:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "8a0f3277-f4af-40f5-9526-0b8be36b2daf:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "b4f4da92-d6f3-49d3-a5cd-14421ddc25bb:9276c7a4-c750-4092-81d5-ea02cccadc91",
+            "name": "8cd05d59-543a-4b41-9bdd-49b7b8e2cd31:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "734077b2-55d3-4827-8d61-555ccca7a87d:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "3fdd01ea-f1a6-4aef-9f4c-ceb6d2c787ba:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "734077b2-55d3-4827-8d61-555ccca7a87d:9048201a-d0d3-42b8-bd95-4a8caaed9cef",
+            "name": "3fdd01ea-f1a6-4aef-9f4c-ceb6d2c787ba:db318c6d-c8a9-4f58-89ce-3cafe82ddb9d",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "7ef48143-1bb4-418e-9b66-4484816bcf56:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "fdf2a0a3-389d-4f7c-9684-5b8d1ed89c91:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "7ef48143-1bb4-418e-9b66-4484816bcf56:db318c6d-c8a9-4f58-89ce-3cafe82ddb9d",
+            "name": "fdf2a0a3-389d-4f7c-9684-5b8d1ed89c91:7eefe26a-cbbb-424b-a989-b3be44ac08ed",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "4d3d518a-c20e-4ccc-8904-e5cf35f60eb2:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "2997a185-6ea5-4e41-bd70-f5a46bd4e127:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "4d3d518a-c20e-4ccc-8904-e5cf35f60eb2:7eefe26a-cbbb-424b-a989-b3be44ac08ed",
+            "name": "2997a185-6ea5-4e41-bd70-f5a46bd4e127:b3936adc-f4db-45b1-845e-a13a7c890d2c",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "dbc72b95-0aa9-4962-83ae-69c119bb819e:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "b489c5cc-9794-46a7-9fe1-a5370fc7d4b3:indexpattern-datasource-layer-f50b399c-7fd8-43f7-8464-fcf7127eb0c4",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "dbc72b95-0aa9-4962-83ae-69c119bb819e:b3936adc-f4db-45b1-845e-a13a7c890d2c",
+            "name": "b489c5cc-9794-46a7-9fe1-a5370fc7d4b3:46fa66b7-9fa0-45f5-8e0b-c9ef86b8acc3",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "2686237c-5a6c-45c0-854f-cd2e109c4689:indexpattern-datasource-layer-f50b399c-7fd8-43f7-8464-fcf7127eb0c4",
+            "name": "0720a83e-43d7-4993-8072-26be8aa3feb6:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "2686237c-5a6c-45c0-854f-cd2e109c4689:46fa66b7-9fa0-45f5-8e0b-c9ef86b8acc3",
+            "name": "0720a83e-43d7-4993-8072-26be8aa3feb6:2f74c5df-c534-4145-a74f-8489c346879e",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f977ebfe-fe73-45a6-a1ea-c06e482cda4c:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "70ef3233-def0-42d0-9b35-2e48221fcd16:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f977ebfe-fe73-45a6-a1ea-c06e482cda4c:2f74c5df-c534-4145-a74f-8489c346879e",
+            "name": "70ef3233-def0-42d0-9b35-2e48221fcd16:af78ff4d-82f1-410b-8478-0732fffc9e5b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "7361b95a-a28a-4de4-89f8-f6f4231258ae:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
+            "name": "4f7e8e5e-8dc8-4fe7-98b1-16ce0cc6cbcb:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "7361b95a-a28a-4de4-89f8-f6f4231258ae:af78ff4d-82f1-410b-8478-0732fffc9e5b",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "cdc6c5e6-e8b9-40fe-9c4c-204074620499:indexpattern-datasource-layer-d64931ec-87ab-4503-9c67-dbb397048ac8",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "cdc6c5e6-e8b9-40fe-9c4c-204074620499:c9c5c37e-da56-4106-b488-560a5da4a1f8",
+            "name": "4f7e8e5e-8dc8-4fe7-98b1-16ce0cc6cbcb:c9c5c37e-da56-4106-b488-560a5da4a1f8",
             "type": "index-pattern"
         },
         {
             "id": "microsoft_exchange_server-75b14bd0-c034-11ee-a682-0f218cc418af",
-            "name": "0eb79219-ddd9-4ae4-8278-9b12e3e7668b:panel_0eb79219-ddd9-4ae4-8278-9b12e3e7668b",
+            "name": "f2260518-d4c1-4b3b-a602-c18c06fc1562:panel_f2260518-d4c1-4b3b-a602-c18c06fc1562",
             "type": "search"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_3b96aa56-e784-4ba5-9e3c-c7a260f817aa:optionsListDataView",
+            "name": "controlGroup_a5fe2192-b77c-4f16-888e-4e59fe064c78:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_ecdd0ef4-0779-48f2-a283-cda224f888ff:optionsListDataView",
+            "name": "controlGroup_7c8291ec-dc6d-4fa0-8d67-bb53efdf6c57:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_60ed44b4-dae1-48de-801b-f4ef52c7b52d:optionsListDataView",
+            "name": "controlGroup_f542c63c-4265-4ebc-a9d6-7278f4d3976a:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/microsoft_exchange_server/kibana/search/microsoft_exchange_server-75b14bd0-c034-11ee-a682-0f218cc418af.json
+++ b/packages/microsoft_exchange_server/kibana/search/microsoft_exchange_server-75b14bd0-c034-11ee-a682-0f218cc418af.json
@@ -2,10 +2,10 @@
     "attributes": {
         "columns": [
             "http.request.bytes",
+            "http.response.bytes",
             "http.response.status_code",
             "microsoft.exchange.anchormailbox",
             "microsoft.exchange.authenticateduser",
-            "microsoft.exchange.requestbytes",
             "microsoft.exchange.urlhost",
             "microsoft.exchange.totalrequesttime"
         ],
@@ -57,7 +57,7 @@
         "viewMode": "documents"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-08T09:17:13.417Z",
+    "created_at": "2024-03-11T10:14:48.072Z",
     "id": "microsoft_exchange_server-75b14bd0-c034-11ee-a682-0f218cc418af",
     "managed": true,
     "references": [

--- a/packages/microsoft_exchange_server/kibana/search/microsoft_exchange_server-ee0a5030-c03f-11ee-a682-0f218cc418af.json
+++ b/packages/microsoft_exchange_server/kibana/search/microsoft_exchange_server-ee0a5030-c03f-11ee-a682-0f218cc418af.json
@@ -4,7 +4,7 @@
             "email.direction",
             "email.from.address",
             "email.to.address",
-            "microsoft.exchange.messagesubject",
+            "email.subject",
             "email.message_id",
             "network.bytes"
         ],
@@ -56,7 +56,7 @@
         "usesAdHocDataView": false
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-08T09:17:13.417Z",
+    "created_at": "2024-03-11T10:14:48.072Z",
     "id": "microsoft_exchange_server-ee0a5030-c03f-11ee-a682-0f218cc418af",
     "managed": true,
     "references": [

--- a/packages/microsoft_exchange_server/manifest.yml
+++ b/packages/microsoft_exchange_server/manifest.yml
@@ -1,10 +1,10 @@
 format_version: 3.0.3
 name: microsoft_exchange_server
 title: "Microsoft Exchange Server"
-version: 0.1.0
+version: 0.1.1
 source:
   license: "Elastic-2.0"
-description: Collect logs from Microsoft Exchange Server with Elastic Agent. 
+description: Collect logs from Microsoft Exchange Server with Elastic Agent.
 type: integration
 categories:
   - security


### PR DESCRIPTION
Due to removal of the duplicated field in PR #9197 the dashboard adjustments to use only the ECS field was missing