### PR TITLE
[Cloud Security Posture] Label keys as secrets

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.9.x - 8.14.x
 # 1.8.x - 8.13.x
 # 1.7.x - 8.12.x
 # 1.6.x - 8.11.x
@@ -7,6 +8,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.9.0-preview01"
+  changes:
+    - description: Convert fields to secrets
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9331
 - version: "1.8.0"
   changes:
     - description: Bump up version

--- a/packages/cloud_security_posture/data_stream/findings/manifest.yml
+++ b/packages/cloud_security_posture/data_stream/findings/manifest.yml
@@ -31,7 +31,7 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true
       - name: session_token
         type: text
         title: Session Token
@@ -81,7 +81,7 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true
       - name: session_token
         type: text
         title: Session Token
@@ -161,6 +161,7 @@ streams:
         multi: false
         required: false
         show_user: true
+        secret: true
   - input: cloudbeat/cis_azure
     title: CIS Azure Benchmark
     description: CIS Benchmark for Microsoft Azure Foundations
@@ -197,7 +198,7 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true
       - name: azure.credentials.client_username
         type: text
         title: Client Username
@@ -210,7 +211,7 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true
       - name: azure.credentials.client_certificate_path
         type: text
         title: Client Certificate Path
@@ -223,4 +224,4 @@ streams:
         multi: false
         required: false
         show_user: true
-        secret: false
+        secret: true

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.8.0"
+version: "1.9.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -11,7 +11,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^8.13.0"
+    version: "^8.14.0"
   elastic:
     subscription: basic
     capabilities:


### PR DESCRIPTION
Label secret keys in Cloud Security Posture Integration.

Labeled fields:
- secret_access_key
- secret_access_key
- gcp.credentials.json
- azure.credentials.client_secret
- azure.credentials.client_password
- azure.credentials.client_certificate_password

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Test create integration
![image](https://github.com/elastic/integrations/assets/5350001/d3656297-bcc7-4054-884a-ba46887ac094)
- [x] Test update integration secret
![image](https://github.com/elastic/integrations/assets/5350001/2c8f9123-3be0-4a92-97b1-1401a7e2b01c)
- [x] Test upgrade integration integration
![image](https://github.com/elastic/integrations/assets/5350001/f1ef373a-975b-440a-8589-3988ef8f2be4)
- [x] Test remove `secret` label and write a plain value
![image](https://github.com/elastic/integrations/assets/5350001/ab5028c7-90cd-4603-a498-e63dfea52f42)

## How to test this PR locally

- Pull integrations branch, `cd` to the root integrations folder
- Start elastic stack
  -  `elastic-package stack up -v --version 8.14.0-SNAPSHOT`
- Build `cloud_security_posture
  - `cd packages/cloud_security_posture`
  - `elastic-package build`
- Bring `package-registry` up
  - `elastic-package stack up -d -v --version 8.14.0-SNAPSHOT --services package-registry`
- Bring `fleet-server` up
  - `elastic-package stack up -d -v --version 8.14.0-SNAPSHOT --services fleet-server`
- In your browser, open Integrations page inside local Kibana instance
- Enable `Display beta integrations`
- Search for CSPM
- Install, Update, Upgrade (play as much as you can with unconventional flows) with the integration(s)

## Related issues
- Solves https://github.com/elastic/security-team/issues/7380
- Brings the bug described in https://github.com/elastic/kibana/issues/172071 to light. We need to fix this before 8.14 release