### PR TITLE
[AWS] Improve latency description in integration setup

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.13.1"
+  changes:
+    - description: Update latency parameter description
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9355
 - version: "2.13.0"
   changes:
     - description: Add Amazon MSK integration

--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update latency parameter description
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9355
+      link: https://github.com/elastic/integrations/pull/9346
 - version: "2.13.0"
   changes:
     - description: Add Amazon MSK integration

--- a/packages/aws/data_stream/apigateway_metrics/manifest.yml
+++ b/packages/aws/data_stream/apigateway_metrics/manifest.yml
@@ -25,7 +25,7 @@ streams:
         required: false
         show_user: true
       - name: latency
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `5m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
         type: text
         title: Latency
         multi: false

--- a/packages/aws/data_stream/ebs/manifest.yml
+++ b/packages/aws/data_stream/ebs/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/ec2_metrics/manifest.yml
+++ b/packages/aws/data_stream/ec2_metrics/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/ecs_metrics/manifest.yml
+++ b/packages/aws/data_stream/ecs_metrics/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/elb_metrics/manifest.yml
+++ b/packages/aws/data_stream/elb_metrics/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/emr_metrics/manifest.yml
+++ b/packages/aws/data_stream/emr_metrics/manifest.yml
@@ -31,7 +31,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/firewall_metrics/manifest.yml
+++ b/packages/aws/data_stream/firewall_metrics/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/kafka_metrics/manifest.yml
+++ b/packages/aws/data_stream/kafka_metrics/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/kinesis/manifest.yml
+++ b/packages/aws/data_stream/kinesis/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/lambda/manifest.yml
+++ b/packages/aws/data_stream/lambda/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/natgateway/manifest.yml
+++ b/packages/aws/data_stream/natgateway/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/rds/manifest.yml
+++ b/packages/aws/data_stream/rds/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/redshift/manifest.yml
+++ b/packages/aws/data_stream/redshift/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/s3_daily_storage/manifest.yml
+++ b/packages/aws/data_stream/s3_daily_storage/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/s3_request/manifest.yml
+++ b/packages/aws/data_stream/s3_request/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/s3_storage_lens/manifest.yml
+++ b/packages/aws/data_stream/s3_storage_lens/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/sns/manifest.yml
+++ b/packages/aws/data_stream/sns/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/data_stream/sqs/manifest.yml
+++ b/packages/aws/data_stream/sqs/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/transitgateway/manifest.yml
+++ b/packages/aws/data_stream/transitgateway/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/usage/manifest.yml
+++ b/packages/aws/data_stream/usage/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: include_linked_accounts
         type: bool
         title: Include Linked Accounts

--- a/packages/aws/data_stream/vpn/manifest.yml
+++ b/packages/aws/data_stream/vpn/manifest.yml
@@ -30,7 +30,7 @@ streams:
         multi: false
         required: false
         show_user: false
-        description: To address latency issues between certain AWS services and CloudWatch, specify a latency parameter to adjust the collection start time and end time in Metricbeat such as `15m`.
+        description: The 'latency' parameter adjusts the Metricbeat collection start and end times. AWS CloudWatch might experience delay in processing metrics for some services causing data points to be missed during the integration collection period. To mitigate this potential issue, specify a latency parameter such as `15m`.
       - name: tags_filter
         type: yaml
         title: Tags Filter

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.13.0
+version: 2.13.1
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Improve the description of `latency` parameter in integration setup for integrations using the `cloudwatch` metricset.

The current description is lacking, especially in warning the user that data points might be missing due to delay in processing metrics in AWS CloudWatch.

In our official [aws module docs](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-aws.html), the description of latency is more verbose.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally
- run `elastic-package stack up`
- inspect the integrations setup pages with updated descriptions

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #9335

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->


<img width="515" alt="latency parameter" src="https://github.com/elastic/integrations/assets/59661554/b9c8f04b-36e6-46e5-baff-3d7f995bf61c">