### PR TITLE
Fix event.outcome condition for redirection status codes(3xx)

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.3"
+  changes:
+    - description: "Fix event.outcome for redirection status_codes 3xx"
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.3.2"
   changes:
     - description: "Fix non-matching grok patterns in access log pipeline for 302 errors"

--- a/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
+++ b/packages/apache_tomcat/data_stream/access/_dev/test/pipeline/test-access.log-expected.json
@@ -113,6 +113,7 @@
                 "kind": "event",
                 "module": "apache_tomcat",
                 "original": "81.2.69.144 - admin [02/Mar/2023:18:58:17 +0530] \"POST /host-manager/images/asf-logo.svg HTTP/1.1\" 302 - 81.2.69.145 + 400 \"http://localhost:8080/host-manager/html\" \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36\" X-Forwarded-For=\"127.0.0.1, 127.0.0.2\"",
+                "outcome": "success",
                 "type": [
                     "access"
                 ]

--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -97,11 +97,11 @@ processors:
   - set:
       field: event.outcome
       value: success
-      if: ctx.http?.response?.status_code != null && ctx.http.response.status_code >= 200 && ctx.http.response.status_code < 300
+      if: ctx.http?.response?.status_code != null && ctx.http.response.status_code < 400
   - set:
       field: event.outcome
       value: failure
-      if: ctx.http?.response?.status_code != null && ctx.http.response.status_code >= 400 && ctx.http.response.status_code < 600
+      if: ctx.http?.response?.status_code != null && ctx.http.response.status_code >= 400
   - remove:
       if: ctx.destination?.bytes == '-'
       field: destination.bytes

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.3.2"
+version: "1.3.3"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION

- Bug

## Proposed commit message

This PR fixes the ingest processor fails to process the `event.outcome ` for the http 3xx status_code. Considering the status_code `<400` as success.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

Perform pipeline test and verify the `event.outcome` is getting generated and logged for the 3xx status_codes.
