### PR TITLE
[windows] Map host.os.type explicitly for all data streams.

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.44.4"
+  changes:
+    - description: Map host.os.type explicitly for all data streams.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9367
 - version: "1.44.3"
   changes:
     - description: Add filters for visualizations to ensure only AppLocker events are displayed

--- a/packages/windows/data_stream/applocker_exe_and_dll/fields/agent.yml
+++ b/packages/windows/data_stream/applocker_exe_and_dll/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/applocker_msi_and_script/fields/agent.yml
+++ b/packages/windows/data_stream/applocker_msi_and_script/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/applocker_packaged_app_deployment/fields/agent.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_deployment/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/applocker_packaged_app_execution/fields/agent.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_execution/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/forwarded/fields/agent.yml
+++ b/packages/windows/data_stream/forwarded/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/perfmon/fields/agent.yml
+++ b/packages/windows/data_stream/perfmon/fields/agent.yml
@@ -56,6 +56,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/powershell/fields/agent.yml
+++ b/packages/windows/data_stream/powershell/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/powershell_operational/fields/agent.yml
+++ b/packages/windows/data_stream/powershell_operational/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/service/fields/agent.yml
+++ b/packages/windows/data_stream/service/fields/agent.yml
@@ -63,6 +63,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/data_stream/sysmon_operational/fields/agent.yml
+++ b/packages/windows/data_stream/sysmon_operational/fields/agent.yml
@@ -54,6 +54,8 @@
       external: ecs
     - name: os.platform
       external: ecs
+    - name: os.type
+      external: ecs
     - name: os.version
       external: ecs
     - name: type

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -274,6 +274,7 @@ An example event for `applocker_exe_and_dll` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -653,6 +654,7 @@ An example event for `applocker_msi_and_script` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -1025,6 +1027,7 @@ An example event for `applocker_packaged_app_deployment` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -1398,6 +1401,7 @@ An example event for `applocker_packaged_app_execution` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -1746,6 +1750,7 @@ An example event for `powershell` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -2082,6 +2087,7 @@ An example event for `powershell_operational` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -2505,6 +2511,7 @@ An example event for `sysmon_operational` looks as following:
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | input.type | Type of Filebeat input. | keyword |
@@ -2778,6 +2785,7 @@ The Windows `service` data stream provides service details.
 | host.os.name | Operating system name, without the version. | keyword |  |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |  |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
 | windows.service.display_name | The display name of the service. | keyword |  |
@@ -2834,6 +2842,7 @@ The Windows `perfmon` data stream provides performance counter values.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.name.text | Multi-field of `host.os.name`. | match_only_text |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
+| host.os.type | Use the `os.type` field to categorize the operating system into one of the broad commercial families. One of these following values should be used (lowercase): linux, macos, unix, windows. If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition. | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
 | windows.perfmon.instance | Instance value. | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.44.3
+version: 1.44.4
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adds explicit mapping for `host.os.type`.

Newer versions of the stack will add the ECS templates automatically, but since this integrations is supported since 8.8 this will fix any potential error in mappings for this field.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

