### PR TITLE
[trendmicro] Add ECS Categorization for Anti-malware Events

### DIFF
--- a/packages/trendmicro/changelog.yml
+++ b/packages/trendmicro/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.2.0"
+  changes:
+    - description: Add ECS categorizations for anti-malware events.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.1.0"
   changes:
     - description: Use CEF name as `event.action` if no action is specified.

--- a/packages/trendmicro/changelog.yml
+++ b/packages/trendmicro/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add ECS categorizations for anti-malware events.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9407
 - version: "2.1.0"
   changes:
     - description: Use CEF name as `event.action` if no action is specified.

--- a/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json
+++ b/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json
@@ -183,6 +183,74 @@
                 "port": 65535,
                 "mac": "11-AA-00-00-AA-00"
             }
+        },
+        {
+            "@timestamp": "2024-01-22T10:19:47.482Z",
+            "event": {
+                "code": "4000000",
+                "severity": 6,
+                "action": "Reset",
+                "original": "<190>Jan 19 13:36:47 2K19-va CEF:0|Trend Micro|Deep Security Agent|20.0.1.690|1001251|Disallow Web Proxy Autodiscovery Protocol|6|cn1=4 cn1Label=Host ID dvchost=2K19-va.test.local TrendMicroDsTenant=814726098539 TrendMicroDsTenantId=16005 dmac=11-AA-00-00-AA-00 smac=00-BB-00-00-BB-00 TrendMicroDsFrameType=IP src=216.160.83.56 dst=81.2.69.144 in=150 proto=UDP spt=53 dpt=65535 cnt=1 act=Reset cn3=16 cn3Label=DPI Packet Position cs5=16 cs5Label=DPI Stream Position cs1=CVE-2007-5355 cs1Label=DPI Note cs6=8 cs6Label=DPI Flags TrendMicroDsPacketData=PUaBgwABAAAAAQAABHdwYWQEdGVzdAVsb2NhbAAAAQABAAAGAAEAAVF5AEABYQxyb290LXNlcnZlcnMDbmV0AAVuc3RsZAx2ZXJpc2lnbi1ncnMDY29tAHij+HwAAAcIAAADhAAJOoAAAVGA"
+            },
+            "source": {
+                "port": 53,
+                "mac": "00-BB-00-00-BB-00",
+                "ip": "216.160.83.56",
+                "bytes": 150
+            },
+            "message": "Disallow Web Proxy Autodiscovery Protocol",
+            "cef": {
+                "name": "Disallow Web Proxy Autodiscovery Protocol",
+                "severity": "6",
+                "extensions": {
+                    "deviceCustomString6": "8",
+                    "sourceMacAddress": "00-BB-00-00-BB-00",
+                    "deviceCustomString1Label": "DPI Note",
+                    "destinationPort": 65535,
+                    "deviceCustomString5Label": "DPI Stream Position",
+                    "deviceCustomNumber3": 16,
+                    "transportProtocol": "UDP",
+                    "sourcePort": 53,
+                    "deviceCustomNumber1": 4,
+                    "TrendMicroDsFrameType": "IP",
+                    "destinationMacAddress": "11-AA-00-00-AA-00",
+                    "TrendMicroDsTenant": "814726098539",
+                    "TrendMicroDsPacketData": "PUaBgwAAAAAQAABHdwYWQEdGVzdAVsb2NhbAAAAQABAAAGAAEAAVF5AEABYQxyb290LXNlcnZlcnMDbmV0AAVuc3RsZAx2ZXJpc2lnbi1ncnMDY29tAHij+HwAAAcIAAADhAAJOoAAAVGA",
+                    "deviceAction": "Reset",
+                    "destinationAddress": "81.2.69.144",
+                    "deviceCustomString1": "CVE-2007-5355",
+                    "sourceAddress": "216.160.83.56",
+                    "deviceCustomString6Label": "DPI Flags",
+                    "deviceHostName": "2K19-va.test.local",
+                    "deviceCustomString5": "16",
+                    "deviceCustomNumber1Label": "Host ID",
+                    "deviceCustomNumber3Label": "DPI Packet Position",
+                    "baseEventCount": 1,
+                    "bytesIn": 150,
+                    "TrendMicroDsTenantId": "16005"
+                },
+                "version": "0",
+                "device": {
+                    "vendor": "Trend Micro",
+                    "product": "Deep Security Agent",
+                    "version": "20.0.1.690",
+                    "event_class_id": "4000001"
+                }
+            },
+            "network": {
+                "transport": "udp"
+            },
+            "observer": {
+                "product": "Deep Security Agent",
+                "version": "20.0.1.690",
+                "hostname": "2K19-va.test.local",
+                "vendor": "Trend Micro"
+            },
+            "destination": {
+                "ip": "81.2.69.144",
+                "port": 65535,
+                "mac": "11-AA-00-00-AA-00"
+            }
         }
     ]
 }

--- a/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json-expected.json
+++ b/packages/trendmicro/data_stream/deep_security/_dev/test/pipeline/test-trendmicro.json-expected.json
@@ -345,6 +345,148 @@
                     "version": "0"
                 }
             }
+        },
+        {
+            "@timestamp": "2024-01-19T13:36:47.000Z",
+            "destination": {
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "mac": "11-AA-00-00-AA-00",
+                "port": 65535
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "reset",
+                "category": [
+                    "malware"
+                ],
+                "code": "4000001",
+                "kind": "alert",
+                "original": "<190>Jan 19 13:36:47 2K19-va CEF:0|Trend Micro|Deep Security Agent|20.0.1.690|1001251|Disallow Web Proxy Autodiscovery Protocol|6|cn1=4 cn1Label=Host ID dvchost=2K19-va.test.local TrendMicroDsTenant=814726098539 TrendMicroDsTenantId=16005 dmac=11-AA-00-00-AA-00 smac=00-BB-00-00-BB-00 TrendMicroDsFrameType=IP src=216.160.83.56 dst=81.2.69.144 in=150 proto=UDP spt=53 dpt=65535 cnt=1 act=Reset cn3=16 cn3Label=DPI Packet Position cs5=16 cs5Label=DPI Stream Position cs1=CVE-2007-5355 cs1Label=DPI Note cs6=8 cs6Label=DPI Flags TrendMicroDsPacketData=PUaBgwABAAAAAQAABHdwYWQEdGVzdAVsb2NhbAAAAQABAAAGAAEAAVF5AEABYQxyb290LXNlcnZlcnMDbmV0AAVuc3RsZAx2ZXJpc2lnbi1ncnMDY29tAHij+HwAAAcIAAADhAAJOoAAAVGA",
+                "severity": 6,
+                "type": [
+                    "info"
+                ]
+            },
+            "host": {
+                "id": "4"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 190
+                }
+            },
+            "message": "Disallow Web Proxy Autodiscovery Protocol",
+            "network": {
+                "community_id": "1:TJGLD3dNqhqQdTNdSwivLmyc8vs=",
+                "transport": "udp"
+            },
+            "observer": {
+                "hostname": "2K19-va.test.local",
+                "product": "Deep Security Agent",
+                "vendor": "Trend Micro",
+                "version": "20.0.1.690"
+            },
+            "related": {
+                "hosts": [
+                    "4"
+                ],
+                "ip": [
+                    "81.2.69.144",
+                    "216.160.83.56"
+                ]
+            },
+            "source": {
+                "bytes": 150,
+                "geo": {
+                    "city_name": "Milton",
+                    "continent_name": "North America",
+                    "country_iso_code": "US",
+                    "country_name": "United States",
+                    "location": {
+                        "lat": 47.2513,
+                        "lon": -122.3149
+                    },
+                    "region_iso_code": "US-WA",
+                    "region_name": "Washington"
+                },
+                "ip": "216.160.83.56",
+                "mac": "00-BB-00-00-BB-00",
+                "port": 53
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ],
+            "trendmicro": {
+                "deep_security": {
+                    "action": "Reset",
+                    "base_event_count": 1,
+                    "bytes_in": 150,
+                    "destination": {
+                        "address": "81.2.69.144",
+                        "mac_address": "11-AA-00-00-AA-00",
+                        "port": 65535
+                    },
+                    "device": {
+                        "custom_number1": {
+                            "label": "Host ID",
+                            "value": "4"
+                        },
+                        "custom_number3": {
+                            "label": "DPI Packet Position",
+                            "value": 16
+                        },
+                        "custom_string1": {
+                            "label": "DPI Note",
+                            "value": "CVE-2007-5355"
+                        },
+                        "custom_string5": {
+                            "label": "DPI Stream Position",
+                            "value": "16"
+                        },
+                        "custom_string6": {
+                            "label": "DPI Flags",
+                            "value": "8"
+                        },
+                        "product": "Deep Security Agent",
+                        "vendor": "Trend Micro",
+                        "version": "20.0.1.690"
+                    },
+                    "deviceHostName": "2K19-va.test.local",
+                    "event_category": "anti-malware-event",
+                    "event_class_id": "4000001",
+                    "name": "Disallow Web Proxy Autodiscovery Protocol",
+                    "severity": 6,
+                    "signature_id": 4000001,
+                    "source": {
+                        "address": "216.160.83.56",
+                        "mac_address": "00-BB-00-00-BB-00",
+                        "port": 53
+                    },
+                    "transport_protocol": "UDP",
+                    "trendmicro": {
+                        "ds_frame_type": "IP",
+                        "ds_packet_data": "PUaBgwAAAAAQAABHdwYWQEdGVzdAVsb2NhbAAAAQABAAAGAAEAAVF5AEABYQxyb290LXNlcnZlcnMDbmV0AAVuc3RsZAx2ZXJpc2lnbi1ncnMDY29tAHij+HwAAAcIAAADhAAJOoAAAVGA",
+                        "ds_tenant": "814726098539",
+                        "ds_tenant_id": "16005"
+                    },
+                    "version": "0"
+                }
+            }
         }
     ]
 }

--- a/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
+++ b/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
@@ -20,7 +20,7 @@ processors:
       on_failure:
         - append:
             field: error.message
-            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 on_failure:
   - append:
       field: error.message

--- a/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
+++ b/packages/trendmicro/data_stream/deep_security/elasticsearch/ingest_pipeline/malware-event.yml
@@ -5,6 +5,22 @@ processors:
       field: trendmicro.deep_security.event_category
       tag: set_deep_security_event_category
       value: anti-malware-event
+  - script:
+      lang: painless
+      tag: script_to_set_ecs_categorization_in_malware_pipeline
+      description: Script to set ECS categorizations.
+      if: ctx.trendmicro?.deep_security?.signature_id != null
+      source: >-
+        def signatureIds = [4000000L, 4000001L, 4000002L, 4000003L, 4000010L, 4000011L, 4000012L, 4000013L, 4000020L, 4000030L];
+        if (signatureIds.contains(ctx.trendmicro.deep_security.signature_id)) {
+          ctx.event.category = ["malware"];
+          ctx.event.kind = "alert";
+          ctx.event.type = ["info"];
+        }
+      on_failure:
+        - append:
+            field: error.message
+            value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag fail-{{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
 on_failure:
   - append:
       field: error.message

--- a/packages/trendmicro/data_stream/deep_security/sample_event.json
+++ b/packages/trendmicro/data_stream/deep_security/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2020-09-21T07:21:11.000Z",
     "agent": {
-        "ephemeral_id": "28288d1c-681d-44d2-814c-bbd501a8aedb",
-        "id": "2e2f0b52-c190-4fb3-b530-9ea2bb568091",
+        "ephemeral_id": "2ea89e49-a391-4415-a8c4-c0ad743e691b",
+        "id": "e87ecfdf-7336-4275-96c5-a4ab24a8facc",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.11.0"
@@ -16,7 +16,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "2e2f0b52-c190-4fb3-b530-9ea2bb568091",
+        "id": "e87ecfdf-7336-4275-96c5-a4ab24a8facc",
         "snapshot": false,
         "version": "8.11.0"
     },
@@ -27,7 +27,7 @@
         ],
         "code": "5000000",
         "dataset": "trendmicro.deep_security",
-        "ingested": "2024-02-21T05:54:09Z",
+        "ingested": "2024-03-20T09:48:02Z",
         "kind": "event",
         "original": "194 <86>2020-09-21T13:51:11+06:30 DeepSec Logs CEF:0|Trend Micro|Deep Security Agent|10.2.229|5000000|WebReputation|5|cn1=1 cn1Label=Host ID dvchost=hostname request=example.com msg=Blocked By Admin",
         "severity": 5,
@@ -44,7 +44,7 @@
     },
     "log": {
         "source": {
-            "address": "192.168.32.7:58355"
+            "address": "192.168.224.7:54066"
         },
         "syslog": {
             "priority": 86

--- a/packages/trendmicro/docs/README.md
+++ b/packages/trendmicro/docs/README.md
@@ -59,8 +59,8 @@ An example event for `deep_security` looks as following:
 {
     "@timestamp": "2020-09-21T07:21:11.000Z",
     "agent": {
-        "ephemeral_id": "28288d1c-681d-44d2-814c-bbd501a8aedb",
-        "id": "2e2f0b52-c190-4fb3-b530-9ea2bb568091",
+        "ephemeral_id": "2ea89e49-a391-4415-a8c4-c0ad743e691b",
+        "id": "e87ecfdf-7336-4275-96c5-a4ab24a8facc",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.11.0"
@@ -74,7 +74,7 @@ An example event for `deep_security` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "2e2f0b52-c190-4fb3-b530-9ea2bb568091",
+        "id": "e87ecfdf-7336-4275-96c5-a4ab24a8facc",
         "snapshot": false,
         "version": "8.11.0"
     },
@@ -85,7 +85,7 @@ An example event for `deep_security` looks as following:
         ],
         "code": "5000000",
         "dataset": "trendmicro.deep_security",
-        "ingested": "2024-02-21T05:54:09Z",
+        "ingested": "2024-03-20T09:48:02Z",
         "kind": "event",
         "original": "194 <86>2020-09-21T13:51:11+06:30 DeepSec Logs CEF:0|Trend Micro|Deep Security Agent|10.2.229|5000000|WebReputation|5|cn1=1 cn1Label=Host ID dvchost=hostname request=example.com msg=Blocked By Admin",
         "severity": 5,
@@ -102,7 +102,7 @@ An example event for `deep_security` looks as following:
     },
     "log": {
         "source": {
-            "address": "192.168.32.7:58355"
+            "address": "192.168.224.7:54066"
         },
         "syslog": {
             "priority": 86

--- a/packages/trendmicro/manifest.yml
+++ b/packages/trendmicro/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: trendmicro
 title: Trend Micro Deep Security
-version: "2.1.0"
+version: "2.2.0"
 description: Collect logs from Trend Micro Deep Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Enhancement

## What does this PR do?
**Add ECS categorizations for anti-malware events.**

Based on guidance from Trend Micro, we have categorized the below-mentioned event id's as malware alerts (i.e. `event.category : malware`, `event.type: info`, `event.kind: alert`)
IDs = [4000000, 4000001, 4000002, 4000003, 4000010, 4000011, 4000012, 4000013, 4000020, 4000030]



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

### All changes
- [x] Change follows the [contributing guidelines](https://github.com/elastic/integrations/blob/master/CONTRIBUTING.md)
- [x] Supported versions of the monitoring target are documented
- [x] Supported operating systems are documented (if applicable)
- [x] Integration or [System tests](https://github.com/elastic/elastic-package/blob/master/docs/howto/system_testing.md) exist
- [x] Documentation exists
- [x] Fields follow [ECS](https://github.com/elastic/ecs) and [naming conventions](https://www.elastic.co/guide/en/beats/devguide/master/event-conventions.html)
- [x] At least a manual test with ES / Kibana / Agent has been performed.
- [x] Required Kibana version set to: ^8.11.0

## How to test this PR locally
Clone integrations repo.
Install the elastic package locally.
Start the elastic stack using the elastic package.
Move to integrations/packages/trendmicro directory.
Run the following command to run tests.
`elastic-package test -v`

## Related issues

- Closes https://github.com/elastic/integrations/issues/9250

## Automated Test
[test-trend-micro_2.2.0.log](https://github.com/elastic/integrations/files/14692383/test-trend-micro_2.2.0.log)
