### PR TITLE
[D4C] Update subscription tier in manifest.yml

### DIFF
--- a/packages/cloud_defend/changelog.yml
+++ b/packages/cloud_defend/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.4"
+  changes:
+    - description: Fix integration subscription tier
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9416
 - version: "1.2.3"
   changes:
     - description: Changed owners

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -14,6 +14,7 @@ conditions:
   kibana:
     version: ^8.11.0
   elastic:
+    subscription: enterprise
     capabilities:
       - security
 screenshots:

--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_defend
 title: "Defend for Containers"
-version: 1.2.3
+version: 1.2.4
 source:
   license: "Elastic-2.0"
 description: "Elastic Defend for Containers (BETA) provides cloud-native runtime protections for containerized environments."


### PR DESCRIPTION
## What does this PR do?

D4C [doc](https://docs.elastic.co/integrations/cloud_defend) update to reflect correct subscription tier.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).