### PR TITLE
Use docker.elastic.co/observability/stream:v0.15.0

### DIFF
--- a/packages/1password/_dev/deploy/docker/docker-compose.yml
+++ b/packages/1password/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   1password_eventsapi_mock:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: 1password_eventsapi_mock
     ports:
       - 8080

--- a/packages/airflow/_dev/deploy/docker/docker-compose.yml
+++ b/packages/airflow/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   airflow:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8125 -p=udp /sample_logs/test-airflow.log

--- a/packages/arista_ngfw/_dev/deploy/docker/docker-compose.yml
+++ b/packages/arista_ngfw/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "2.3"
 services:
   arista-ngfw-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   arista-ngfw-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/atlassian_bitbucket/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_bitbucket/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   bitbucket-api:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_confluence/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   confluence-api:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
+++ b/packages/atlassian_jira/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   jira-api:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/auth0/_dev/deploy/docker/docker-compose.yml
+++ b/packages/auth0/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   auth0-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/auth0-ndjson.log
   auth0-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/aws/data_stream/guardduty/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/guardduty/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   guardduty:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: guardduty.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/aws/data_stream/inspector/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/inspector/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   inspector:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: inspector2.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/aws/data_stream/securityhub_findings/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/securityhub_findings/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   securityhub:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: securityhub.xxxx.amazonaws.cn
     ports:
       - 443

--- a/packages/aws/data_stream/securityhub_insights/_dev/deploy/docker/docker-compose.yml
+++ b/packages/aws/data_stream/securityhub_insights/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   securityhub:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: securityhub.xxxx.amazonaws.com
     ports:
       - 443

--- a/packages/azure_blob_storage/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_blob_storage/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "10000/tcp"
   azure-blob-storage:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/barracuda/_dev/deploy/docker/docker-compose.yml
+++ b/packages/barracuda/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "2.3"
 services:
   barracuda-waf-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9581 -p=tls --insecure /sample_logs/barracuda.log
   barracuda-waf-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9580 -p=tcp /sample_logs/barracuda.log
   barracuda-waf-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9580 -p=udp /sample_logs/barracuda.log

--- a/packages/barracuda_cloudgen_firewall/_dev/deploy/docker/docker-compose.yml
+++ b/packages/barracuda_cloudgen_firewall/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   barracuda-cloudgen-lumberjack:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bitdefender/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   bitdefender-push-notification-http:
-    image: docker.elastic.co/observability/stream:v0.9.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/qradar_format.log
   bitdefender-push-notification-https:
-    image: docker.elastic.co/observability/stream:v0.9.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -20,7 +20,7 @@ services:
       - STREAM_INSECURE=true
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/qradar_format.log
   bitdefender-gravityzone-api-mock:
-    image: docker.elastic.co/observability/stream:v0.9.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: bitdefender_gravityzone_api_mock
     ports:
       - 8585

--- a/packages/bitwarden/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bitwarden/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   bitwarden:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: bitwarden
     ports:
       - 8090

--- a/packages/box_events/_dev/deploy/docker/docker-compose.yml
+++ b/packages/box_events/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   box-http:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/carbon_black_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/carbon_black_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   carbon_black_cloud:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: carbon_black_cloud
     ports:
       - 8080

--- a/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/carbonblack_edr/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   carbonblack_edr-http:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -15,7 +15,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -23,7 +23,7 @@ services:
       - STREAM_ADDR=elastic-agent:9081
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/cb_edr.ndjson.log
   carbonblack_edr-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/cef/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cef/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cef-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cef.log
   cef-log-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/cef.log

--- a/packages/cel/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cel/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cel:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ceph/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ceph/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ceph:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/checkpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/checkpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   checkpoint-firewall-tls:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/test-checkpoint.log
   checkpoint-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/test-checkpoint.log
   checkpoint-firewall-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test-checkpoint.log

--- a/packages/cisa_kevs/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisa_kevs/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cisakev:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/cisco_aironet/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_aironet/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-aironet-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9009 -p=tcp /sample_logs/cisco-aironet.log
   cisco-aironet-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9009 -p=udp /sample_logs/cisco-aironet.log

--- a/packages/cisco_asa/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_asa/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-asa-tls:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/cisco-asa.log
   cisco-asa-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cisco-asa.log
   cisco-asa-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/cisco-asa.log

--- a/packages/cisco_duo/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_duo/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cisco_duo:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: cisco_duo
     ports:
       - 8080

--- a/packages/cisco_ftd/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ftd/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-ftd-tls:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/cisco-ftd.log
   cisco-ftd-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/cisco-ftd.log
   cisco-ftd-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/cisco-ftd.log

--- a/packages/cisco_ios/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ios/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-ios-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/*.log
   cisco-ios-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   cisco-ios-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_meraki/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   meraki-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:8686/meraki/events
     command: log --start-signal=SIGHUP --delay=5s /sample_events/meraki-mx-ndjson.log
   meraki-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_events:/sample_events:ro
     environment:
@@ -24,12 +24,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco_meraki-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=udp /sample_logs/cisco-meraki.log
   cisco_meraki-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8685 -p=tcp /sample_logs/cisco-meraki.log

--- a/packages/cisco_nexus/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_nexus/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco-nexus-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=udp /sample_logs/test-nexus.log
   cisco-nexus-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=tcp /sample_logs/test-nexus.log
   cisco-nexus-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9506 -p=tls --insecure /sample_logs/test-nexus.log

--- a/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_secure_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cisco_secure_endpoint:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/citrix_adc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/citrix_adc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   citrix_adc:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: citrix_adc
     ports:
       - 8080

--- a/packages/citrix_waf/_dev/deploy/docker/docker-compose.yml
+++ b/packages/citrix_waf/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   citrix-waf-tls:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9561 -p=tls --insecure /sample_logs/citrix-waf.log
   citrix-waf-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=tcp /sample_logs/citrix-waf.log
   citrix-waf-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9560 -p=udp /sample_logs/citrix-waf.log

--- a/packages/cloudflare/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cloudflare/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cloudflare:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cloudflare_logpush/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   cloudflare-logpush-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/audit
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   cloudflare-logpush-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -17,7 +17,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns.log
   cloudflare-logpush-firewall-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -25,7 +25,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/firewall_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall_event.log
   cloudflare-logpush-http-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -33,7 +33,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/http_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/http_request.log
   cloudflare-logpush-nel-report-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -41,7 +41,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/nel_report
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/nel_report.log
   cloudflare-logpush-network-analytics-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -49,7 +49,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_analytics
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_analytics.log
   cloudflare-logpush-spectrum-event-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -57,7 +57,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/spectrum_event
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/spectrum_event.log
   cloudflare-logpush-gateway-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -65,7 +65,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_dns
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_dns.log
   cloudflare-logpush-gateway-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -73,7 +73,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_http.log
   cloudflare-logpush-gateway-network-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -81,7 +81,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/gateway_network
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/gateway_network.log
   cloudflare-logpush-network-session-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -89,7 +89,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/network_session
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/network_session.log
   cloudflare-logpush-casb-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -97,7 +97,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/casb
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/casb.log
   cloudflare-logpush-access-request-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -105,7 +105,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/access_request
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/access_request.log
   cloudflare-logpush-device-posture-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -113,7 +113,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/device_posture
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/device_posture.log
   cloudflare-logpush-workers-trace-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -121,7 +121,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/workers_trace
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/workers_trace.log
   cloudflare-logpush-magic-ids-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -129,7 +129,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/magic_ids
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/magic_ids.log
   cloudflare-logpush-sinkhole-http-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -137,7 +137,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9560/cloudflare_logpush/sinkhole_http
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/sinkhole_http.log
   cloudflare-logpush-dns-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
+++ b/packages/crowdstrike/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   crowdstrike-alert:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: crowdstrike-alert
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/config-alert.yml
   crowdstrike-host:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: crowdstrike-host
     ports:
       - 8090

--- a/packages/cyberark_pta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cyberark_pta/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "2.3"
 services:
   cyberark-pta-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log
   cyberark-pta-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log

--- a/packages/darktrace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/darktrace/_dev/deploy/docker/docker-compose.yml
@@ -1,52 +1,52 @@
 version: '2.3'
 services:
   darktrace-ai_analyst_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tls --insecure /sample_logs/ai_analyst_alert.log
   darktrace-ai_analyst_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tcp /sample_logs/ai_analyst_alert.log
   darktrace-ai_analyst_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9574 -p=udp /sample_logs/ai_analyst_alert.log
   darktrace-model_breach_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9572 -p=tls --insecure /sample_logs/model_breach_alert.log
   darktrace-model_breach_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9572 -p=tcp /sample_logs/model_breach_alert.log
   darktrace-model_breach_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9575 -p=udp /sample_logs/model_breach_alert.log
   darktrace-system_status_alert-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9573 -p=tls --insecure /sample_logs/system_status_alert.log
   darktrace-system_status_alert-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9573 -p=tcp /sample_logs/system_status_alert.log
   darktrace-system_status_alert-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9576 -p=udp /sample_logs/system_status_alert.log
   darktrace:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: darktrace
     ports:
       - 8080

--- a/packages/entityanalytics_entra_id/_dev/deploy/docker/docker-compose.yml
+++ b/packages/entityanalytics_entra_id/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   entra_id:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/entityanalytics_okta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/entityanalytics_okta/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   entityanalytics_okta:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: trial-xxxxxxx-admin.okta.com
     ports:
       - 443

--- a/packages/eset_protect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/eset_protect/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3.7'
 services:
   eset_protect-event-tls:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9589 -p=tls --insecure /sample_logs/event.log
   eset_protect-detection:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: xx.incident-management.eset.systems
     ports:
       - 443
@@ -21,7 +21,7 @@ services:
       - --tls-cert=/files/detection-certificate.crt
       - --tls-key=/files/detection-private.key
   eset_protect-device_task:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: xx.automation.eset.systems
     ports:
       - 443
@@ -36,7 +36,7 @@ services:
       - --tls-cert=/files/device_task-certificate.crt
       - --tls-key=/files/device_task-private.key
   eset_protect-oauth:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: xx.business-account.iam.eset.systems
     networks:
       - elastic-package-stack_default

--- a/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
+++ b/packages/f5_bigip/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   f5-bigip-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/forgerock/_dev/deploy/docker/docker-compose.yml
+++ b/packages/forgerock/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   forgerock:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/fortinet_forticlient/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_forticlient/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-clientendpoint-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-clientendpoint.log
   fortinet-clientendpoint-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-clientendpoint.log

--- a/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortiedr/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-edr-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-edr.log
   fortinet-edr-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-edr.log

--- a/packages/fortinet_fortigate/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortigate/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-firewall-tls:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/fortinet-firewall.log
   fortinet-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/fortinet-firewall.log
   fortinet-firewall-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/fortinet-firewall.log

--- a/packages/fortinet_fortimail/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortimail/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-fortimail-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=tcp /sample_logs/fortinet-fortimail.log
   fortinet-fortimail-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=tls --insecure /sample_logs/fortinet-fortimail.log
   fortinet-fortimail-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9024 -p=udp /sample_logs/fortinet-fortimail.log

--- a/packages/fortinet_fortimanager/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fortinet_fortimanager/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fortinet-fortimanager-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=tcp /sample_logs/fortinet-fortimanager.log
   fortinet-fortimanager-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=tls --insecure /sample_logs/fortinet-fortimanager.log
   fortinet-fortimanager-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9022 -p=udp /sample_logs/fortinet-fortimanager.log

--- a/packages/gcp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gcp/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-audit:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -20,7 +20,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-dns:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -34,7 +34,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-firewall:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -48,7 +48,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-vpcflow:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:
@@ -62,7 +62,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-load-balancer:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/gcp_pubsub/_dev/deploy/docker/docker-compose.yml
+++ b/packages/gcp_pubsub/_dev/deploy/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-generic:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/github/_dev/deploy/docker/docker-compose.yml
+++ b/packages/github/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   github:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/google_scc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/google_scc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   google_scc:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: google_scc
     ports:
       - 8090
@@ -19,7 +19,7 @@ services:
     ports:
       - "8681/tcp"
   gcppubsub-audit:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./files:/files:ro
     command:
@@ -33,7 +33,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-asset:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./files:/files:ro
     command:
@@ -47,7 +47,7 @@ services:
     depends_on:
       - gcppubsub-emulator
   gcppubsub-finding:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./files:/files:ro
     command:

--- a/packages/google_workspace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/google_workspace/_dev/deploy/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         awk -v var="$$(sed -E ':a;N;$$!ba;s/\r{0,1}\n/\\\\n/g' pkcs8.key)" '{sub(/the-key/,var)}1' /credentials.json > /config/credentials.json;
         sleep 1000
   google_workspace:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: google_workspace
     ports:
       - 8080

--- a/packages/hashicorp_vault/_dev/deploy/docker/docker-compose.yml
+++ b/packages/hashicorp_vault/_dev/deploy/docker/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     depends_on:
       - hashicorp_vault
   hashicorp_vault-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9007 -p=tcp /sample_logs/audit.ndjson

--- a/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/http_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   test-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/httpjson/_dev/deploy/docker/docker-compose.yml
+++ b/packages/httpjson/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   httpjson:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/imperva/_dev/deploy/docker/docker-compose.yml
+++ b/packages/imperva/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   imperva-securesphere-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=udp /sample_logs/test-imperva-securesphere.log
   imperva-securesphere-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=tcp /sample_logs/test-imperva-securesphere.log
   imperva-securesphere-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9507 -p=tls --insecure /sample_logs/test-imperva-securesphere.log

--- a/packages/infoblox_bloxone_ddi/_dev/deploy/docker/docker-compose.yml
+++ b/packages/infoblox_bloxone_ddi/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   infoblox-bloxone-ddi:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: infoblox-bloxone-ddi
     ports:
       - 8080

--- a/packages/iptables/_dev/deploy/docker/docker-compose.yml
+++ b/packages/iptables/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   iptables-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/iptables-syslog.log

--- a/packages/jumpcloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jumpcloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   jumpcloud:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: jumpcloud
     ports:
       - 8090

--- a/packages/juniper_junos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_junos/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-junos-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-junos.log
   juniper-junos-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-junos.log

--- a/packages/juniper_netscreen/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_netscreen/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-netscreen-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-netscreen.log
   juniper-netscreen-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-netscreen.log

--- a/packages/juniper_srx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/juniper_srx/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   juniper-srx-tls:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/juniper-srx.log
   juniper-srx-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/juniper-srx.log
   juniper-srx-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/juniper-srx.log

--- a/packages/kafka_log/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kafka_log/_dev/deploy/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - 9094
   kafka-generic:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command:

--- a/packages/lastpass/_dev/deploy/docker/docker-compose.yml
+++ b/packages/lastpass/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   lastpass:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: lastpass
     ports:
       - 8090

--- a/packages/lumos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/lumos/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   lumos:
-    image: docker.elastic.co/observability/stream:v0.11.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: lumos
     ports:
       - 8080

--- a/packages/m365_defender/_dev/deploy/docker/docker-compose.yml
+++ b/packages/m365_defender/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   m365-defender-log-http:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -14,7 +14,7 @@ services:
       - --addr=:8080
       - --config=/config.yml
   m365-defender-incident-http:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -27,7 +27,7 @@ services:
       - --addr=:8080
       - --config=/config.yml
   m365-defender-alert-http:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/microsoft_defender_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/microsoft_defender_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   microsoft-defender-mock:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/docker-compose.yml
+++ b/packages/microsoft_exchange_online_message_trace/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   exchange_online:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: exchange_online
     ports:
       - 8080

--- a/packages/mimecast/_dev/deploy/docker/docker-compose.yml
+++ b/packages/mimecast/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   mimecast:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/nagios_xi/_dev/deploy/docker/docker-compose.yml
+++ b/packages/nagios_xi/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   nagios_xi:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: nagios_xi
     ports:
       - 8080

--- a/packages/netflow/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netflow/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   netflow-log-netflow:
-    image: akroh/stream:v0.0.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: pcap --start-signal=SIGHUP --delay=5s --addr elastic-agent:2055 -p=udp /sample_logs/ipfix_cisco.pcap

--- a/packages/o365/_dev/deploy/docker/docker-compose.yml
+++ b/packages/o365/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   o365-cel:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     environment:

--- a/packages/okta/_dev/deploy/docker/docker-compose.yml
+++ b/packages/okta/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   okta:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config.yml
   okta-oauth2:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/panw/_dev/deploy/docker/docker-compose.yml
+++ b/packages/panw/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   panw-panos-tls:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/*.log
   panw-panos-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/*.log
   panw-panos-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./syslog_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/*.log

--- a/packages/panw_cortex_xdr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/panw_cortex_xdr/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   panw-cortex-xdr-mock:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ping_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ping_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ping-one-audit-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,7 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9577/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/audit.log
   ping_one:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: ping_one
     ports:
       - 8080

--- a/packages/prisma_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/prisma_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,37 +1,37 @@
 version: '2.3'
 services:
   prisma_cloud-host-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9508 -p=tcp /sample_logs/host.log
   prisma_cloud-host-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9509 -p=udp /sample_logs/host.log
   prisma_cloud-host_profile-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9510 -p=tcp /sample_logs/host_profile.log
   prisma_cloud-host_profile-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9511 -p=udp /sample_logs/host_profile.log
   prisma_cloud-incident_audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9512 -p=tcp /sample_logs/incident_audit.log
   prisma_cloud-incident_audit-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9513 -p=udp /sample_logs/incident_audit.log
   prisma_cloud:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: prisma_cloud
     ports:
       - 8090

--- a/packages/proofpoint_tap/_dev/deploy/docker/docker-compose.yml
+++ b/packages/proofpoint_tap/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   proofpoint_tap:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: proofpoint_tap
     ports:
       - 8080

--- a/packages/pulse_connect_secure/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pulse_connect_secure/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   pulse_connect_secure-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/test-syslog.log
   pulse_connect_secure-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test-syslog.log
   pulse_connect_secure-log-tls:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test-syslog.log

--- a/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml
+++ b/packages/qualys_vmdr/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   qualys_vmdr:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: qualys_vmdr
     ports:
       - 8090

--- a/packages/radware/_dev/deploy/docker/docker-compose.yml
+++ b/packages/radware/_dev/deploy/docker/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   radware-defensepro-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=udp /sample_logs/radware-defensepro-*.log
   radware-defensepro-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash

--- a/packages/rapid7_insightvm/_dev/deploy/docker/docker-compose.yml
+++ b/packages/rapid7_insightvm/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   rapid7_insightvm:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: rapid7_insightvm
     ports:
       - 8080

--- a/packages/salesforce/_dev/deploy/docker/docker-compose.yml
+++ b/packages/salesforce/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   salesforce:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: salesforce
     ports:
       - 8010

--- a/packages/sentinel_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sentinel_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   sentinel_one:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: sentinel_one
     ports:
       - 8080

--- a/packages/slack/_dev/deploy/docker/docker-compose.yml
+++ b/packages/slack/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   slack:
-    image: docker.elastic.co/observability/stream:v0.11.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/snort/_dev/deploy/docker/docker-compose.yml
+++ b/packages/snort/_dev/deploy/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.log /var/log/"
   snort-log-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/test-syslog.log

--- a/packages/snyk/_dev/deploy/docker/docker-compose.yml
+++ b/packages/snyk/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   snyk:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/sophos_central/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sophos_central/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   sophos_central:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: sophos_central
     ports:
       - 8080

--- a/packages/statsd_input/_dev/deploy/docker/docker-compose.yml
+++ b/packages/statsd_input/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   statsd_input:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:8125 -p=udp /sample_logs/test-statsd.log

--- a/packages/symantec_edr_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/symantec_edr_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   symantec_edr_cloud-incident:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: symantec_edr_cloud-incident
     ports:
       - 8090

--- a/packages/symantec_endpoint/_dev/deploy/docker/docker-compose.yml
+++ b/packages/symantec_endpoint/_dev/deploy/docker/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   symantec_endpoint-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/symantec_endpoint.log
   symantec_endpoint-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.2
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/symantec_endpoint.log

--- a/packages/tcp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tcp/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   test-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/test-tcp.log
   test-tls:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=tls --insecure /sample_logs/test-tcp.log
   test-syslog:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9517 -p=tcp /sample_logs/test-tcp.log

--- a/packages/tenable_io/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tenable_io/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   tenable_io:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: tenable_io
     ports:
       - 8080

--- a/packages/tenable_sc/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tenable_sc/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   tenable_sc:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: tenable_sc
     ports:
       - 8080

--- a/packages/ti_abusech/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_abusech/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   abusech:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config.yml
   abusech-threatfox:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8081
     volumes:

--- a/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_anomali/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   limo-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config.yml
   threatstream-webhook-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -21,7 +21,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9080/
     command: log --webhook-content-type application/x-ndjson --start-signal=SIGHUP --delay=5s /sample_logs/test-threatstream-ndjson.log
   threatstream-webhook-https:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/ti_cif3/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_cif3/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cif3:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_crowdstrike/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_crowdstrike/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ti_crowdstrike:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: ti_crowdstrike
     ports:
       - 8090

--- a/packages/ti_cybersixgill/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_cybersixgill/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   cybersixgill-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_eclecticiq/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_eclecticiq/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   eiqtip:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     environment:

--- a/packages/ti_eset/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_eset/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   eti:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_maltiverse/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_maltiverse/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   maltiverse:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     environment:

--- a/packages/ti_mandiant_advantage/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_mandiant_advantage/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   ti_mandiant_advantage:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_misp/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   misp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_opencti/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_opencti/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   opencti_stub:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_otx/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   otx:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     environment:

--- a/packages/ti_rapid7_threat_command/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_rapid7_threat_command/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   ti_rapid7_threat_command:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: ti_rapid7_threat_command
     ports:
       - 8080

--- a/packages/ti_recordedfuture/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_recordedfuture/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   recordedfuture-api-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:
@@ -13,7 +13,7 @@ services:
       - --addr=:8080
       - --config=/files/config-api.yml
   recordedfuture-csv-download-http:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/ti_threatconnect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_threatconnect/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   threatconnect-indicator:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: threatconnect-indicator
     ports:
       - 8090

--- a/packages/ti_threatq/_dev/deploy/docker/docker-compose.yml
+++ b/packages/ti_threatq/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   threatq:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/tines/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tines/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 services:
   tines_api_mock:
-    image: docker.elastic.co/observability/stream:v0.9.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: tines_api_mock
     ports:
       - 8080

--- a/packages/trellix_epo_cloud/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trellix_epo_cloud/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   trellix_epo_cloud:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: trellix_epo_cloud
     ports:
       - 8090

--- a/packages/trend_micro_vision_one/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trend_micro_vision_one/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   trend_micro_vision_one:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: trend_micro_vision_one
     ports:
       - 8080

--- a/packages/trendmicro/_dev/deploy/docker/docker-compose.yml
+++ b/packages/trendmicro/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   trendmicro-tls:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tls --insecure /sample_logs/trendmicro.log
   trendmicro-tcp:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=tcp /sample_logs/trendmicro.log
   trendmicro-udp:
-    image: docker.elastic.co/observability/stream:v0.13.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/trendmicro.log

--- a/packages/udp/_dev/deploy/docker/docker-compose.yml
+++ b/packages/udp/_dev/deploy/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2.3'
 services:
   test-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=udp /sample_logs/test-udp.log
   test-syslog:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9516 -p=udp /sample_logs/test-udp.log

--- a/packages/vectra_detect/_dev/deploy/docker/docker-compose.yml
+++ b/packages/vectra_detect/_dev/deploy/docker/docker-compose.yml
@@ -1,17 +1,17 @@
 version: '2.3'
 services:
   vectra_detect-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tcp /sample_logs/vectra_detect.log
   vectra_detect-tls:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tls --insecure /sample_logs/vectra_detect.log
   vectra_detect-udp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=udp /sample_logs/vectra_detect.log

--- a/packages/vsphere/_dev/deploy/docker/docker-compose.yml
+++ b/packages/vsphere/_dev/deploy/docker/docker-compose.yml
@@ -9,12 +9,12 @@ services:
     ports:
       - 8989
   vsphere-log-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/syslog.log
   vsphere-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9515 -p=tcp /sample_logs/syslog.log

--- a/packages/windows/_dev/deploy/docker/docker-compose.yml
+++ b/packages/windows/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   splunk-mock:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/wiz/_dev/deploy/docker/docker-compose.yml
+++ b/packages/wiz/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   wiz-audit:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: wiz-audit
     ports:
       - 8090
@@ -14,7 +14,7 @@ services:
       - --addr=:8090
       - --config=/files/config-audit.yml
   wiz-issue:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: wiz-issue
     ports:
       - 8090
@@ -27,7 +27,7 @@ services:
       - --addr=:8090
       - --config=/files/config-issue.yml
   wiz-vulnerability:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     hostname: wiz-vulnerability
     ports:
       - 8090

--- a/packages/zeek/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zeek/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   splunk-mock:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/zerofox/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zerofox/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zerofox-http:
-    image: docker.elastic.co/observability/stream:v0.5.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/zeronetworks/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zeronetworks/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zeronetworks:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     ports:
       - 8080
     volumes:

--- a/packages/zoom/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zoom/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   zoom-webhook-http:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -10,7 +10,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Authorization=abc123
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/account-ndjson.log
   zoom-webhook-https:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:


### PR DESCRIPTION
## Proposed commit message

Use [elastic/stream:v0.15.0](https://github.com/elastic/stream/releases/tag/v0.15.0) across all system tests. This will help reduce data transfer costs because the latest image is smaller (based on alpine) and the image cache will be more effective because most tests will rely on the same elastic/stream image.

The latest release also provides a multi-arch image for amd64 and arm64 so it can run natively (without emulation), which good for developers running Apple ARM chips.

There's no requirement that all tests be on the same image version, but I might sync them occasionally. There is no version or changelog entry because this is not a user-facing change (affects tests only).

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
