### PR TITLE
[Cloud Security] Fix cluster_id missing error in the Ingest Pipeline

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -8,6 +8,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.9.0-preview02"
+  changes:
+    - description: Fix cluster_id missing error in the Ingest Pipeline
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9434
 - version: "1.9.0-preview01"
   changes:
     - description: Convert fields to secrets

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,7 +10,7 @@
 # 1.2.x - 8.7.x
 - version: "1.9.0-preview02"
   changes:
-    - description: Fix cluster_id missing error in the Ingest Pipeline
+    - description: Fix cluster_id missing error in the Ingest Pipeline, Remove cloud.account.name null fields
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9434
 - version: "1.9.0-preview01"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,7 +10,7 @@
 # 1.2.x - 8.7.x
 - version: "1.9.0-preview02"
   changes:
-    - description: Fix cluster_id missing error in the Ingest Pipeline, Remove cloud.account.name null fields
+    - description: Fix cluster_id missing error in the Ingest Pipeline
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9434
 - version: "1.9.0-preview01"

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,7 @@ processors:
     field: orchestrator.cluster.id
     copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
-    if: ctx.orchestrator?.cluster?.id == null
+    if: ctx.cluster_id != null && ctx.orchestrator?.cluster?.id == null
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,8 @@ processors:
     field: orchestrator.cluster.id
     copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
-    if: ctx.cluster_id != null && ctx.orchestrator?.cluster?.id == null
+    ignore_empty_value: true
+    if: ctx.orchestrator?.cluster?.id == null
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -14,6 +14,11 @@ processors:
     copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
     if: ctx.cluster_id != null && ctx.orchestrator?.cluster?.id == null
+- remove:
+    field: cloud.account.name
+    ignore_missing: true
+    description: 'Removes cloud.account.name when it is empty'
+    if: ctx.cloud?.account?.name == ''
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -14,11 +14,6 @@ processors:
     copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
     if: ctx.cluster_id != null && ctx.orchestrator?.cluster?.id == null
-- remove:
-    field: cloud.account.name
-    ignore_missing: true
-    description: 'Removes cloud.account.name when it is empty'
-    if: ctx.cloud?.account?.name == ''
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.9.0-preview01"
+version: "1.9.0-preview02"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
### Summary

This PR Fixes the Ingest Pipeline Error, this error was due to a missing check for the presence of the `cluster_id` field used in the copy_from.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] no pipeline errors in the latest findings docs

## How to test this PR locally

Follow the guide described [here](https://docs.elastic.dev/security-solution/cloud-security/qa/test-integration-package) to test this PR locally.

To collect the necessary data you can execute the following Reindex command in the dev tools (The pipeline is the important part!), point host and credentials to one of the long-running environments

## Related issues

- It fixes https://github.com/elastic/integrations/issues/9435