### PR TITLE
[crowdstrike] Fix cache option name in FDR data stream.

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.32.1"
+  changes:
+    - description: Fix cache option name in FDR data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9436
 - version: "1.32.0"
   changes:
     - description: Set sensitive value as secret in cel input.

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/aws-s3.yml.hbs
@@ -72,7 +72,7 @@ processors:
           capacity: {{metadata_cache_capacity}}
           file:
             id: aidmaster
-            write_period: {{metadata_cache_write_period}}
+            write_interval: {{metadata_cache_write_interval}}
         put:
           ttl: {{metadata_ttl}}
           key_field: crowdstrike.aid
@@ -94,7 +94,7 @@ processors:
               capacity: {{metadata_cache_capacity}}
               file:
                 id: userinfo
-                write_period: {{metadata_cache_write_period}}
+                write_interval: {{metadata_cache_write_interval}}
             put:
               ttl: {{metadata_ttl}}
               key_field: crowdstrike.UserSid_readable

--- a/packages/crowdstrike/data_stream/fdr/agent/stream/stream.yml.hbs
+++ b/packages/crowdstrike/data_stream/fdr/agent/stream/stream.yml.hbs
@@ -37,7 +37,7 @@ processors:
           capacity: {{metadata_cache_capacity}}
           file:
             id: aidmaster
-            write_period: {{metadata_cache_write_period}}
+            write_interval: {{metadata_cache_write_interval}}
         put:
           ttl: {{metadata_ttl}}
           key_field: crowdstrike.aid
@@ -59,7 +59,7 @@ processors:
               capacity: {{metadata_cache_capacity}}
               file:
                 id: userinfo
-                write_period: {{metadata_cache_write_period}}
+                write_interval: {{metadata_cache_write_interval}}
             put:
               ttl: {{metadata_ttl}}
               key_field: crowdstrike.UserSid_readable

--- a/packages/crowdstrike/data_stream/fdr/manifest.yml
+++ b/packages/crowdstrike/data_stream/fdr/manifest.yml
@@ -76,10 +76,10 @@ streams:
         type: text
         multi: false
         default: 0
-      - name: metadata_cache_write_period
+      - name: metadata_cache_write_interval
         required: true
         show_user: false
-        title: Metadata cache write period
+        title: Metadata cache write interval
         description: The interval between periodic cache writes to the backing file. Valid time units are h, m, s, ms, us/µs and ns. The contents are always written out to the backing file when the processor is closed. Default is zero, no periodic writes.
         type: text
         multi: false

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.32.0"
+version: "1.32.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.0"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Fix cache option naming for FDR data stream: `write_period` to `write_interval`

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

Relates https://github.com/elastic/beats/pull/38561
