### PR TITLE
Fortigate logs parsing with kafka logstash

### DIFF
--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Make sure we always copy the original_message
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9438
 - version: "1.25.0"
   changes:
     - description: Add more sanitization for unwanted characters.

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Make sure we always copy the original_message
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.25.0"
   changes:
     - description: Add more sanitization for unwanted characters.

--- a/packages/fortinet_fortigate/changelog.yml
+++ b/packages/fortinet_fortigate/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.25.1"
   changes:
-    - description: Make sure we always copy the original_message
+    - description: Ensure event.original matches the value of the message field.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9438
 - version: "1.25.0"

--- a/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet-json.json
+++ b/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet-json.json
@@ -1,0 +1,10 @@
+{
+    "events": [
+        {
+            "message": "<188>date=2020-04-23 time=12:17:48 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1587230269052907555 tz=\"-0500\" policyid=100602 sessionid=1234 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 srcport=61930 srcintf=\"port1\" srcintfrole=\"lan\" dstip=67.43.156.13 dstport=443 dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"elastic.co\" profile=\"elasticruleset\" action=\"blocked\" reqtype=\"direct\" url=\"/config/\" sentbyte=1152 rcvdbyte=1130 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=76 catdesc=\"Internet Telephony\"",
+            "event": {
+                "original": "{\\\"message\\\":\\\"<188>date=2020-04-23 time=12:17:48 devname=\\\"testswitch1\\\" devid=\\\"somerouterid\\\" logid=\\\"0316013056\\\" type=\\\"utm\\\" subtype=\\\"webfilter\\\" eventtype=\\\"ftgd_blk\\\" level=\\\"warning\\\" vd=\\\"root\\\" eventtime=1587230269052907555 tz=\\\"-0500\\\" policyid=100602 sessionid=1234 user=\\\"elasticuser\\\" group=\\\"elasticgroup\\\" authserver=\\\"elasticauth\\\" srcip=192.168.2.1 srcport=61930 srcintf=\\\"port1\\\" srcintfrole=\\\"lan\\\" dstip=67.43.156.13 dstport=443 dstintf=\\\"wan1\\\" dstintfrole=\\\"wan\\\" proto=6 service=\\\"HTTPS\\\" hostname=\\\"elastic.co\\\" profile=\\\"elasticruleset\\\" action=\\\"blocked\\\" reqtype=\\\"direct\\\" url=\\\"/config/\\\" sentbyte=1152 rcvdbyte=1130 direction=\\\"outgoing\\\" msg=\\\"URL belongs to a denied category in policy\\\" method=\\\"domain\\\" cat=76 catdesc=\\\"Internet Telephony\\\"\"}"
+            }
+        }
+    ]
+}

--- a/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet-json.json-expected.json
+++ b/packages/fortinet_fortigate/data_stream/log/_dev/test/pipeline/test-fortinet-json.json-expected.json
@@ -1,0 +1,126 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2020-04-23T12:17:48.000-05:00",
+            "destination": {
+                "as": {
+                    "number": 35908
+                },
+                "bytes": 1130,
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.13",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "ftgd_blk",
+                "category": [
+                    "network"
+                ],
+                "code": "0316013056",
+                "kind": "event",
+                "original": "<188>date=2020-04-23 time=12:17:48 devname=\"testswitch1\" devid=\"somerouterid\" logid=\"0316013056\" type=\"utm\" subtype=\"webfilter\" eventtype=\"ftgd_blk\" level=\"warning\" vd=\"root\" eventtime=1587230269052907555 tz=\"-0500\" policyid=100602 sessionid=1234 user=\"elasticuser\" group=\"elasticgroup\" authserver=\"elasticauth\" srcip=192.168.2.1 srcport=61930 srcintf=\"port1\" srcintfrole=\"lan\" dstip=67.43.156.13 dstport=443 dstintf=\"wan1\" dstintfrole=\"wan\" proto=6 service=\"HTTPS\" hostname=\"elastic.co\" profile=\"elasticruleset\" action=\"blocked\" reqtype=\"direct\" url=\"/config/\" sentbyte=1152 rcvdbyte=1130 direction=\"outgoing\" msg=\"URL belongs to a denied category in policy\" method=\"domain\" cat=76 catdesc=\"Internet Telephony\"",
+                "outcome": "success",
+                "start": "2020-04-18T12:17:49.052-05:00",
+                "timezone": "-0500",
+                "type": [
+                    "denied"
+                ]
+            },
+            "fortinet": {
+                "firewall": {
+                    "action": "blocked",
+                    "authserver": "elasticauth",
+                    "cat": "76",
+                    "dstintfrole": "wan",
+                    "method": "domain",
+                    "reqtype": "direct",
+                    "sessionid": "1234",
+                    "srcintfrole": "lan",
+                    "subtype": "webfilter",
+                    "type": "utm",
+                    "vd": "root"
+                }
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 188,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "message": "URL belongs to a denied category in policy",
+            "network": {
+                "bytes": 2282,
+                "direction": "outbound",
+                "iana_number": "6",
+                "protocol": "https",
+                "transport": "tcp"
+            },
+            "observer": {
+                "egress": {
+                    "interface": {
+                        "name": "wan1"
+                    }
+                },
+                "ingress": {
+                    "interface": {
+                        "name": "port1"
+                    }
+                },
+                "name": "testswitch1",
+                "product": "Fortigate",
+                "serial_number": "somerouterid",
+                "type": "firewall",
+                "vendor": "Fortinet"
+            },
+            "related": {
+                "ip": [
+                    "192.168.2.1",
+                    "67.43.156.13"
+                ],
+                "user": [
+                    "elasticuser"
+                ]
+            },
+            "rule": {
+                "category": "Internet Telephony",
+                "id": "100602",
+                "ruleset": "elasticruleset"
+            },
+            "source": {
+                "bytes": 1152,
+                "ip": "192.168.2.1",
+                "port": 61930,
+                "user": {
+                    "group": {
+                        "name": "elasticgroup"
+                    },
+                    "name": "elasticuser"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "elastic.co",
+                "path": "/config/"
+            }
+        }
+    ]
+}

--- a/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortigate/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -4,11 +4,11 @@ processors:
   - set:
       field: ecs.version
       value: '8.11.0'
-  - rename:
+  - set:
+      field: event.original
+      copy_from: message
+  - remove:
       field: message
-      target_field: event.original
-      ignore_missing: true
-      if: ctx.event?.original == null
   - grok:
       field: event.original
       ecs_compatibility: v1

--- a/packages/fortinet_fortigate/manifest.yml
+++ b/packages/fortinet_fortigate/manifest.yml
@@ -1,6 +1,6 @@
 name: fortinet_fortigate
 title: Fortinet FortiGate Firewall Logs
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from Fortinet FortiGate firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

```
[fortigate] Log parsing error fix
In some pipelines, the `event.original_message` field is set before the integration gets the event, which blocks the processor from copying `message` into that field. As there is no need to preserve whatever was already put into that field, we replace the `rename` to a `set` and `remove`.

- A new test was added to verify the problem is addressed
- Existing tests continue to pass
```

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

`elastic-package test pipeline` in the `packages/fortinet_fortigate` directory verifies the update and new test case.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- A fix for https://github.com/elastic/sdh-beats/issues/4534

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
