### PR TITLE
[Cloud Security] [Findings Ingest Pipeline] Remove cloud.account.id and cloud.account.name empty fields from the latest findings document

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,7 +10,7 @@
 # 1.2.x - 8.7.x
 - version: "1.9.0-preview03"
   changes:
-    - description: Update findings ingest pipeline to Remove empty fields from the document
+    - description: Update findings ingest pipeline to Remove empty cloud.account.id and cloud.account.name
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9470
 - version: "1.9.0-preview02"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -12,7 +12,7 @@
   changes:
     - description: Update findings ingest pipeline to Remove empty fields from the document
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9468
+      link: https://github.com/elastic/integrations/pull/9470
 - version: "1.9.0-preview02"
   changes:
     - description: Fix cluster_id missing error in the Ingest Pipeline

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -10,7 +10,7 @@
 # 1.2.x - 8.7.x
 - version: "1.9.0-preview03"
   changes:
-    - description: Update findings ingest pipeline to Remove empty cloud.account.id and cloud.account.name
+    - description: Update findings ingest pipeline to remove empty cloud.account.id and cloud.account.name
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9470
 - version: "1.9.0-preview02"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -8,6 +8,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.9.0-preview03"
+  changes:
+    - description: Update findings ingest pipeline to Remove empty fields from the document
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9468
 - version: "1.9.0-preview02"
   changes:
     - description: Fix cluster_id missing error in the Ingest Pipeline

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json
@@ -1,0 +1,84 @@
+{
+  "events": [
+    {
+      "rule": {
+        "benchmark": {
+          "name": "CIS Microsoft Azure Foundations",
+          "rule_number": "1.23",
+          "id": "cis_azure",
+          "version": "v2.0.0",
+          "posture_type": "cspm"
+        }
+      },
+      "cloud": {
+        "provider": "azure",
+        "account": {
+          "id": "",
+          "name": ""
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "rule": {
+        "benchmark": {
+          "name": "CIS Microsoft Azure Foundations",
+          "rule_number": "1.23",
+          "id": "cis_azure",
+          "version": "v2.0.0",
+          "posture_type": "cspm"
+        }
+      },
+      "cloud": {
+        "provider": "azure",
+        "account": {
+          "id": "test",
+          "name": ""
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "rule": {
+        "benchmark": {
+          "name": "CIS Microsoft Azure Foundations",
+          "rule_number": "1.23",
+          "id": "cis_azure",
+          "version": "v2.0.0",
+          "posture_type": "cspm"
+        }
+      },
+      "cloud": {
+        "provider": "azure",
+        "account": {
+          "id": "test-2",
+          "name": "test 2"
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "rule": {
+        "benchmark": {
+          "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+          "rule_number": "3.2.5",
+          "id": "cis_eks",
+          "version": "v1.0.1"
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "rule": {
+        "benchmark": {
+          "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+          "rule_number": "3.2.5",
+          "id": "cis_eks",
+          "version": "v1.0.1",
+          "posture_type": "kspm"
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    }
+  ]
+}

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json
@@ -79,6 +79,38 @@
         }
       },
       "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "cluster_id": "cluster_test_1",
+      "rule": {
+        "benchmark": {
+          "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+          "rule_number": "3.2.5",
+          "id": "cis_eks",
+          "version": "v1.0.1",
+          "posture_type": "kspm"
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
+    },
+    {
+      "cluster_id": "cluster_test_1",
+      "orchestrator": {
+        "cluster": {
+          "name": "cluster_test",
+          "id": "cluster_test"
+        }
+      },
+      "rule": {
+        "benchmark": {
+          "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+          "rule_number": "3.2.5",
+          "id": "cis_eks",
+          "version": "v1.0.1",
+          "posture_type": "kspm"
+        }
+      },
+      "@timestamp": "2024-04-04T16:32:27.398Z"
     }
   ]
 }

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json-expected.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json-expected.json
@@ -91,6 +91,49 @@
                     "version": "v1.0.1"
                 }
             }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "cluster_id": "cluster_test_1",
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "orchestrator": {
+                "cluster": {
+                    "id": "cluster_test_1"
+                }
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_eks",
+                    "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+                    "posture_type": "kspm",
+                    "rule_number": "3.2.5",
+                    "version": "v1.0.1"
+                }
+            }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "cluster_id": "cluster_test_1",
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "orchestrator": {
+                "cluster": {
+                    "id": "cluster_test",
+                    "name": "cluster_test"
+                }
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_eks",
+                    "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+                    "posture_type": "kspm",
+                    "rule_number": "3.2.5",
+                    "version": "v1.0.1"
+                }
+            }
         }
     ]
 }

--- a/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json-expected.json
+++ b/packages/cloud_security_posture/data_stream/findings/_dev/test/pipeline/test-findings-log.json-expected.json
@@ -1,0 +1,96 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "cloud": {
+                "account": {},
+                "provider": "azure"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_azure",
+                    "name": "CIS Microsoft Azure Foundations",
+                    "posture_type": "cspm",
+                    "rule_number": "1.23",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "cloud": {
+                "account": {
+                    "id": "test"
+                },
+                "provider": "azure"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_azure",
+                    "name": "CIS Microsoft Azure Foundations",
+                    "posture_type": "cspm",
+                    "rule_number": "1.23",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "cloud": {
+                "account": {
+                    "id": "test-2",
+                    "name": "test 2"
+                },
+                "provider": "azure"
+            },
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_azure",
+                    "name": "CIS Microsoft Azure Foundations",
+                    "posture_type": "cspm",
+                    "rule_number": "1.23",
+                    "version": "v2.0.0"
+                }
+            }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_eks",
+                    "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+                    "posture_type": "kspm",
+                    "rule_number": "3.2.5",
+                    "version": "v1.0.1"
+                }
+            }
+        },
+        {
+            "@timestamp": "2024-04-04T16:32:27.398Z",
+            "ecs": {
+                "version": "8.6.0"
+            },
+            "rule": {
+                "benchmark": {
+                    "id": "cis_eks",
+                    "name": "CIS Amazon Elastic Kubernetes Service (EKS)",
+                    "posture_type": "kspm",
+                    "rule_number": "3.2.5",
+                    "version": "v1.0.1"
+                }
+            }
+        }
+    ]
+}

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -15,27 +15,16 @@ processors:
     description: 'Backward compatibility cloudbeat version < 8.8'
     ignore_empty_value: true
     if: ctx.orchestrator?.cluster?.id == null
-- script:
-    lang: painless
-    description: This script processor remove all empty fields from the findings document.
-    source: |
-        def removeEmptyFields(def map) {
-            map.entrySet().removeIf(entry -> {
-                def value = entry.getValue();
-                if (value == null) {
-                return true;
-                }
-                if (value instanceof String && value.isEmpty()) {
-                return true;
-                }
-                if (value instanceof Map) {
-                removeEmptyFields(value);
-                return value.isEmpty();
-                }
-                return false;
-            });
-        }
-        removeEmptyFields(ctx);
+- remove:
+    field: cloud.account.id
+    ignore_missing: true
+    description: 'Removes cloud.account.id when it is empty'
+    if: ctx.cloud?.account?.id == ''
+- remove:
+    field: cloud.account.name
+    ignore_missing: true
+    description: 'Removes cloud.account.name when it is empty'
+    if: ctx.cloud?.account?.name == ''
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -15,6 +15,27 @@ processors:
     description: 'Backward compatibility cloudbeat version < 8.8'
     ignore_empty_value: true
     if: ctx.orchestrator?.cluster?.id == null
+- script:
+    lang: painless
+    description: This script processor remove all empty fields from the findings document.
+    source: |
+        def removeEmptyFields(def map) {
+            map.entrySet().removeIf(entry -> {
+                def value = entry.getValue();
+                if (value == null) {
+                return true;
+                }
+                if (value instanceof String && value.isEmpty()) {
+                return true;
+                }
+                if (value instanceof Map) {
+                removeEmptyFields(value);
+                return value.isEmpty();
+                }
+                return false;
+            });
+        }
+        removeEmptyFields(ctx);
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.9.0-preview02"
+version: "1.9.0-preview03"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Summary

It fixes https://github.com/elastic/kibana/issues/178904

This PR updates the Findings Ingest Pipeline to remove empty `cloud.account.id` and `cloud.account.name` fields in a Findings document. This fixes issues in Kibana when those fields are empty.

This PR also introduces Ingest Pipelines tests and adds tests to cover pipeline processors in a findings document. It can be tested following the documentation [here](https://github.com/elastic/elastic-package/blob/main/docs/howto/pipeline_testing.md) 

## Screenshot

### Pipeline Tests

![image](https://github.com/elastic/integrations/assets/19270322/6e616a05-220c-493f-b72c-8e0fa687c7d5)


### Kibana Tests

**Before changes:**

Fields with empty `cloud.account.name`
![image](https://github.com/elastic/integrations/assets/19270322/4cae3505-6d04-4d1c-92a8-b1379aee3582)

Bug in group by cloud account visualization, result is hidden due to empty field [#178904](https://github.com/elastic/kibana/issues/178904)

![image](https://github.com/elastic/integrations/assets/19270322/831ded3a-02f3-47de-9bc3-c9d9ccfb64ba)


**After changes:**

No more fields with empty `cloud.account.name`
![image](https://github.com/elastic/integrations/assets/19270322/28534c9c-c0fc-4020-9c89-1f45caa5dd36)

Fields are instead missing (expected behaviour)
![image](https://github.com/elastic/integrations/assets/19270322/a53d4136-f1e9-4818-87d0-68aeac6f4aea)

Group by cloud account visualization shows "No cloud account" (expected behaviour)
![image](https://github.com/elastic/integrations/assets/19270322/2e6a2500-cf18-4a68-a318-834e2caabdfb)
