### PR TITLE
cisco_ios: Fix hostname parsing for names that contain '_' underscore characters

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.4"
+  changes:
+    - description: Fix hostname parsing for names that contain '_' underscore characters.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.26.3"
   changes:
     - description: Fix bad auth grok processor handling of missing MD5 sums.

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix hostname parsing for names that contain '_' underscore characters.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/9481
 - version: "1.26.3"
   changes:
     - description: Fix bad auth grok processor handling of missing MD5 sums.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
@@ -8,3 +8,5 @@
 <190>3352436: 3352457: Aug 12 2023 12:14:24.412 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807766185951588 %FW-6-SESS_AUDIT_TRAIL: (target:class) (ZP_PROCESS_TO_CORPORATE:CM_PROCESS_TO_CORPORATE):Stop dns session: initiator (10.50.14.44:33207) sent 48 bytes -- responder (10.120.42.6:53) sent 40 bytes, from GigabitEthernet10/0/2.6
 <190>3352460: 3352481: Aug 12 2023 12:15:33.963 mdt: %IOSXE-6-PLATFORM: R0/0: cpp_cp: QFP:0.0 Thread:001 TS:00013807835737559120 %FW-6-DROP_PKT: Dropping tcp pkt from GigabitEthernet1/0/2.6 10.50.14.44:53836 => 89.160.20.128:80(target:class)-(ZP_PROCESS_TO_CORPORATE:class-default) due to Policy drop:classify result with ip ident 13017 tcp flag 0x2, seq 4266642156, ack 0
 <191>: rt401-rk30409: Aug 18 07:15:04.461 CEST: last message repeated 66 times
+<189>1469087: chswitchm1: Mar 29 07:40:10.863 CDT: %ILPOWER-5-SENSE_POWER_INVALID: Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV
+<189>1469087: ch_switch_m-1: Mar 29 07:40:10.863 CDT: %ILPOWER-5-SENSE_POWER_INVALID: Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -477,6 +477,90 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-03-29T07:40:10.863Z",
+            "cisco": {
+                "ios": {
+                    "facility": "ILPOWER",
+                    "message_count": 1469087
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "SENSE_POWER_INVALID",
+                "original": "<189>1469087: chswitchm1: Mar 29 07:40:10.863 CDT: %ILPOWER-5-SENSE_POWER_INVALID: Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV",
+                "provider": "firewall",
+                "sequence": 1469087,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "chswitchm1",
+                    "priority": 189
+                }
+            },
+            "message": "Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-03-29T07:40:10.863Z",
+            "cisco": {
+                "ios": {
+                    "facility": "ILPOWER",
+                    "message_count": 1469087
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "SENSE_POWER_INVALID",
+                "original": "<189>1469087: ch_switch_m-1: Mar 29 07:40:10.863 CDT: %ILPOWER-5-SENSE_POWER_INVALID: Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV",
+                "provider": "firewall",
+                "sequence": 1469087,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "ch_switch_m-1",
+                    "priority": 189
+                }
+            },
+            "message": "Interface Gi1/0/25: invalid power sense 78054 milliwatts current 515 mA voltage 151562 mV",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -42,7 +42,7 @@ processors:
         CISCO_PRIORITY_MSGCOUNT: '<%{NONNEGINT:log.syslog.priority:long}>(?:%{NONNEGINT:cisco.ios.message_count})?(?:: )?'
         CISCO_TIMESTAMP: '[*]?%{CISCOTIMESTAMP:_temp_.cisco_timestamp}(?: %{CISCO_TZ:_temp_.tz})?'
         CISCO_UPTIME: '[0-9a-zA-Z]+'
-        CISCO_HOSTNAME: '[a-zA-Z][0-9a-zA-Z-]{0,61}[0-9a-zA-Z]?'
+        CISCO_HOSTNAME: '[a-zA-Z][0-9a-zA-Z-_]{0,61}[0-9a-zA-Z]?'
         CISCO_TZ: '[a-zA-Z]{1,4}'
   - grok:
       field: _temp_.message

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.26.3"
+version: "1.26.4"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

cisco_ios: Fix hostname parsing for names that contain '_' underscore characters

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/4567

