### PR TITLE
[O11y][Azure Metrics] Migrate Blob Storage Overview dashboard to lens

### DIFF
--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.4"
+  changes:
+    - description: Migrate Blob Storage Overview dashboard to lens.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.4.3"
   changes:
     - description: Remove suffix from Compute VMs Overview dashboard.

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Migrate Blob Storage Overview dashboard to lens.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/9503
 - version: "1.4.3"
   changes:
     - description: Remove suffix from Compute VMs Overview dashboard.

--- a/packages/azure_metrics/kibana/dashboard/azure_metrics-b165ef60-32f7-11ea-a83e-25b8612d00cc.json
+++ b/packages/azure_metrics/kibana/dashboard/azure_metrics-b165ef60-32f7-11ea-a83e-25b8612d00cc.json
@@ -1,14 +1,12 @@
 {
-    "id": "azure_metrics-b165ef60-32f7-11ea-a83e-25b8612d00cc",
-    "type": "dashboard",
-    "namespaces": [
-        "default"
-    ],
-    "updated_at": "2023-08-08T06:46:29.879Z",
-    "version": "WzgzMywxXQ==",
     "attributes": {
+        "controlGroupInput": {
+            "chainingSystem": "HIERARCHICAL",
+            "controlStyle": "oneLine",
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"7eb82f60-7b2e-473f-960b-35b3fa5392d5\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"7eb82f60-7b2e-473f-960b-35b3fa5392d5\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription\",\"singleSelect\":true,\"enhancements\":{}}},\"269e473e-2b24-402e-9721-3c9b3bd85458\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"269e473e-2b24-402e-9721-3c9b3bd85458\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"enhancements\":{}}},\"192cb16e-8bf4-4e63-b95c-338b8fc0fcfa\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"192cb16e-8bf4-4e63-b95c-338b8fc0fcfa\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"singleSelect\":false,\"enhancements\":{}}}}"
+        },
         "description": "This dashboard shows metrics for the blob storage type in Azure.",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -42,971 +40,1599 @@
         },
         "optionsJSON": {
             "hidePanelTitles": false,
+            "syncColors": false,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
             {
-                "version": "8.3.0",
-                "type": "visualization",
-                "gridData": {
-                    "h": 5,
-                    "i": "ed5f5642-c94a-481b-a8c2-7dfe4c6a4f05",
-                    "w": 9,
-                    "x": 0,
-                    "y": 0
-                },
-                "panelIndex": "ed5f5642-c94a-481b-a8c2-7dfe4c6a4f05",
                 "embeddableConfig": {
                     "enhancements": {},
+                    "hidePanelTitles": false,
                     "savedVis": {
-                        "title": "Navigation Blob Storage Overview [Azure Metrics]",
+                        "data": {
+                            "aggs": [],
+                            "searchSource": {
+                                "filter": [],
+                                "query": {
+                                    "language": "kuery",
+                                    "query": ""
+                                }
+                            }
+                        },
                         "description": "",
-                        "uiState": {},
                         "params": {
                             "fontSize": 10,
                             "markdown": "### Azure Storage\n\n[Overview](#/dashboard/azure_metrics-1a151f80-32db-11ea-a83e-25b8612d00cc) | [**Blob**](#/dashboard/azure_metrics-b165ef60-32f7-11ea-a83e-25b8612d00cc) | [File](#/dashboard/azure_metrics-dff7a080-32f7-11ea-a83e-25b8612d00cc) | [Table](#/dashboard/azure_metrics-ff2fe020-32f7-11ea-a83e-25b8612d00cc) | [Queue](#/dashboard/azure_metrics-10efa340-32f8-11ea-a83e-25b8612d00cc) ",
                             "openLinksInNewTab": false
                         },
+                        "title": "Navigation Blob Storage Overview",
                         "type": "markdown",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        }
+                        "uiState": {}
                     }
-                }
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
+                },
                 "gridData": {
-                    "h": 9,
-                    "i": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
-                    "w": 5,
-                    "x": 9,
+                    "h": 5,
+                    "i": "ed5f5642-c94a-481b-a8c2-7dfe4c6a4f05",
+                    "w": 48,
+                    "x": 0,
                     "y": 0
                 },
-                "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
+                "panelIndex": "ed5f5642-c94a-481b-a8c2-7dfe4c6a4f05",
+                "title": "Navigation Blob Storage Overview",
+                "type": "visualization",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Availability [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
-                                {
-                                    "background_color": "rgba(104,204,202,1)",
-                                    "id": "18f616c0-32e2-11ea-867b-37070aefa392",
-                                    "operator": "gte",
-                                    "value": 100
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "eaeec0a4-4154-40ae-b023-88b8b8cd9a15": {
+                                            "columnOrder": [
+                                                "6ab423e8-6223-4f5a-9332-5ac7b8aa7d1e",
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105",
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105X0",
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105X1"
+                                            ],
+                                            "columns": {
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "overall_max(last_value(azure.storage_account.blob_capacity.avg))",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "overall_max(last_value(azure.storage_account.blob_capacity.avg))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "03f75b15-78c2-4392-bf4c-9cec8e77d105X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.blob_capacity.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.blob_capacity.avg))",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.blob_capacity.avg"
+                                                },
+                                                "03f75b15-78c2-4392-bf4c-9cec8e77d105X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.blob_capacity.avg))",
+                                                    "operationType": "overall_max",
+                                                    "references": [
+                                                        "03f75b15-78c2-4392-bf4c-9cec8e77d105X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "6ab423e8-6223-4f5a-9332-5ac7b8aa7d1e": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Blob Capacity",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes"
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.blob_capacity.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
                                 },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
                                 {
-                                    "background_color": "rgba(244,78,59,1)",
-                                    "id": "998b1c90-32e2-11ea-867b-37070aefa392",
-                                    "operator": "lt",
-                                    "value": 100
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-eaeec0a4-4154-40ae-b023-88b8b8cd9a15",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "28142cf0-32e2-11ea-867b-37070aefa392"
-                                }
-                            ],
-                            "drop_last_bucket": 0,
-                            "filter": {
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "29808e30-32e2-11ea-867b-37070aefa392"
-                                }
-                            ],
-                            "gauge_inner_width": "7",
-                            "gauge_style": "circle",
-                            "gauge_width": 10,
-                            "id": "0e91b810-32e2-11ea-a93d-dd20c62559b3",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(22,165,165,1)",
-                                    "fill": "0.6",
-                                    "formatter": "number",
-                                    "hide_in_legend": 1,
-                                    "id": "0e91b811-32e2-11ea-a93d-dd20c62559b3",
-                                    "label": "Availability",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.availability.avg",
-                                            "id": "0e91b812-32e2-11ea-a93d-dd20c62559b3",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "terms_field": null,
-                                    "type": "timeseries",
-                                    "value_template": "{{value}} %"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "time_range_mode": "last_value",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
+                            "visualization": {
+                                "color": "#009CE0",
+                                "layerId": "eaeec0a4-4154-40ae-b023-88b8b8cd9a15",
+                                "layerType": "data",
+                                "maxAccessor": "03f75b15-78c2-4392-bf4c-9cec8e77d105",
+                                "metricAccessor": "6ab423e8-6223-4f5a-9332-5ac7b8aa7d1e"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
+                        "title": "Storage Blob Capacity",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
-                "title": "Availability"
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
                 "gridData": {
                     "h": 9,
                     "i": "0c873134-b025-487d-be81-f727dbff0174",
                     "w": 5,
-                    "x": 14,
-                    "y": 0
+                    "x": 0,
+                    "y": 5
                 },
                 "panelIndex": "0c873134-b025-487d-be81-f727dbff0174",
+                "title": "Storage Blob Capacity",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Blob Capacity [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color": null,
-                            "background_color_rules": [
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "d2cfe212-5327-4afa-b09d-4cea0f4abe67": {
+                                            "columnOrder": [
+                                                "7772aa00-2719-4fb3-a52a-732158558669",
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117X0",
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117X1",
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117"
+                                            ],
+                                            "columns": {
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "overall_max(last_value(azure.storage_account.blob_count.avg))",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "overall_max(last_value(azure.storage_account.blob_count.avg))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "2fd4f627-1d0e-40a7-a622-e57e790e5117X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.blob_count.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.blob_count.avg))",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.blob_count.avg"
+                                                },
+                                                "2fd4f627-1d0e-40a7-a622-e57e790e5117X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.blob_count.avg))",
+                                                    "operationType": "overall_max",
+                                                    "references": [
+                                                        "2fd4f627-1d0e-40a7-a622-e57e790e5117X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "7772aa00-2719-4fb3-a52a-732158558669": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Blob Count",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number"
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.blob_count.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
                                 {
-                                    "id": "71978870-32e4-11ea-af9e-d70582a45bda"
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-d2cfe212-5327-4afa-b09d-4cea0f4abe67",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "f11cfd90-32e5-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "drilldown_url": "",
-                            "filter": {
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "9c09ed50-32e4-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "gauge_inner_color": null,
-                            "gauge_inner_width": "6",
-                            "gauge_style": "circle",
-                            "gauge_width": "10",
-                            "hide_last_value_indicator": true,
-                            "id": "61fb4190-32e4-11ea-b9f8-4d0b340ad993",
-                            "index_pattern": "metrics-*",
-                            "interval": "60m",
-                            "isModelInvalid": false,
-                            "pivot_id": "azure.resource.name",
-                            "pivot_label": "Resource Name",
-                            "pivot_rows": "30",
-                            "pivot_type": "string",
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(0,156,224,1)",
-                                    "fill": "1.2",
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "bytes",
-                                    "id": "61fb4191-32e4-11ea-b9f8-4d0b340ad993",
-                                    "label": "Blob Capacity",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.blob_capacity.avg",
-                                            "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "terms_field": "azure.resource.name",
-                                    "terms_order_by": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "gauge",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
+                            "visualization": {
+                                "color": "#009CE0",
+                                "layerId": "d2cfe212-5327-4afa-b09d-4cea0f4abe67",
+                                "layerType": "data",
+                                "maxAccessor": "2fd4f627-1d0e-40a7-a622-e57e790e5117",
+                                "metricAccessor": "7772aa00-2719-4fb3-a52a-732158558669"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                }
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
+                        "title": "Storage Blob Count",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 9,
                     "i": "41faed50-ba96-4484-b6dc-71ed3e2d3427",
                     "w": 5,
-                    "x": 19,
-                    "y": 0
+                    "x": 5,
+                    "y": 5
                 },
                 "panelIndex": "41faed50-ba96-4484-b6dc-71ed3e2d3427",
+                "title": "Storage Blob Count",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Blob Count [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color": null,
-                            "background_color_rules": [
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b0d96c20-3261-4140-be71-84129244491f": {
+                                            "columnOrder": [
+                                                "39df78b2-9658-4a1d-a2b4-7a84e6f13a45",
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0X0",
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0X1",
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0"
+                                            ],
+                                            "columns": {
+                                                "39df78b2-9658-4a1d-a2b4-7a84e6f13a45": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Container Count",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number"
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.container_count.avg"
+                                                },
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "overall_max(last_value(azure.storage_account.container_count.avg))",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "overall_max(last_value(azure.storage_account.container_count.avg))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "cae2423e-1cef-4c5f-af30-c8c57fce42c0X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.container_count.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.container_count.avg))",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.container_count.avg"
+                                                },
+                                                "cae2423e-1cef-4c5f-af30-c8c57fce42c0X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of overall_max(last_value(azure.storage_account.container_count.avg))",
+                                                    "operationType": "overall_max",
+                                                    "references": [
+                                                        "cae2423e-1cef-4c5f-af30-c8c57fce42c0X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
                                 {
-                                    "id": "71978870-32e4-11ea-af9e-d70582a45bda"
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-b0d96c20-3261-4140-be71-84129244491f",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "f11cfd90-32e5-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "drilldown_url": "",
-                            "filter": {
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "9c09ed50-32e4-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "gauge_inner_color": null,
-                            "gauge_inner_width": "6",
-                            "gauge_style": "circle",
-                            "gauge_width": "10",
-                            "hide_last_value_indicator": true,
-                            "id": "61fb4190-32e4-11ea-b9f8-4d0b340ad993",
-                            "index_pattern": "metrics-*",
-                            "interval": "60m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(0,156,224,1)",
-                                    "fill": "1.2",
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "'0'",
-                                    "id": "61fb4191-32e4-11ea-b9f8-4d0b340ad993",
-                                    "label": "Blob Count",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.blob_count.avg",
-                                            "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "terms_field": "azure.resource.name",
-                                    "terms_order_by": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "gauge",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
+                            "visualization": {
+                                "color": "#68BC00",
+                                "layerId": "b0d96c20-3261-4140-be71-84129244491f",
+                                "layerType": "data",
+                                "maxAccessor": "cae2423e-1cef-4c5f-af30-c8c57fce42c0",
+                                "metricAccessor": "39df78b2-9658-4a1d-a2b4-7a84e6f13a45"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                }
+                        "title": "Storage Container Count",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "34aa5ce7-4f4b-4712-836f-3765e7c3fb3f",
+                    "w": 5,
+                    "x": 10,
+                    "y": 5
+                },
+                "panelIndex": "34aa5ce7-4f4b-4712-836f-3765e7c3fb3f",
+                "title": "Storage Container Count",
+                "type": "lens",
+                "version": "8.7.0"
             },
             {
-                "version": "8.3.0",
-                "type": "visualization",
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "094e2c52-4d02-4bf5-8971-1d17db5677da": {
+                                            "columnOrder": [
+                                                "f8f4ab4a-0a11-4da5-8c51-289a226c9bf4",
+                                                "da185728-bcee-4457-82d3-1520127e3664"
+                                            ],
+                                            "columns": {
+                                                "da185728-bcee-4457-82d3-1520127e3664": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.availability.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Availability",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": " %"
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.availability.avg"
+                                                },
+                                                "f8f4ab4a-0a11-4da5-8c51-289a226c9bf4": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-094e2c52-4d02-4bf5-8971-1d17db5677da",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.6,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "da185728-bcee-4457-82d3-1520127e3664"
+                                        ],
+                                        "layerId": "094e2c52-4d02-4bf5-8971-1d17db5677da",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "area",
+                                        "xAccessor": "f8f4ab4a-0a11-4da5-8c51-289a226c9bf4",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(22,165,165,1)",
+                                                "forAccessor": "da185728-bcee-4457-82d3-1520127e3664"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": false,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": false
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Storage Availability",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
+                    "w": 14,
+                    "x": 15,
+                    "y": 5
+                },
+                "panelIndex": "a9456b9b-efa6-410d-a56c-4b66aa8c499e",
+                "title": "Availability",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": false,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "96b37a76-3db8-4552-ae26-45004aa4e892": {
+                                            "columnOrder": [
+                                                "d4d768f9-effd-43f3-b30a-e6ad938d3483",
+                                                "6297e28c-ea13-4b49-af52-f1b78a6e3abc",
+                                                "2092a1f3-dc5b-4462-9551-c6de4a2a7b78"
+                                            ],
+                                            "columns": {
+                                                "2092a1f3-dc5b-4462-9551-c6de4a2a7b78": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "avg(azure.storage_account.transactions.total)",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.transactions.total"
+                                                },
+                                                "6297e28c-ea13-4b49-af52-f1b78a6e3abc": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.dimensions.response_type",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "2092a1f3-dc5b-4462-9551-c6de4a2a7b78",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.dimensions.response_type"
+                                                },
+                                                "d4d768f9-effd-43f3-b30a-e6ad938d3483": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-96b37a76-3db8-4552-ae26-45004aa4e892",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "2092a1f3-dc5b-4462-9551-c6de4a2a7b78"
+                                        ],
+                                        "layerId": "96b37a76-3db8-4552-ae26-45004aa4e892",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar",
+                                        "splitAccessor": "6297e28c-ea13-4b49-af52-f1b78a6e3abc",
+                                        "xAccessor": "d4d768f9-effd-43f3-b30a-e6ad938d3483",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#3185FC",
+                                                "forAccessor": "2092a1f3-dc5b-4462-9551-c6de4a2a7b78"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
+                        },
+                        "title": "Storage Transactions",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 9,
                     "i": "1d623c03-4d02-4a81-b91e-49e82e112016",
                     "w": 19,
                     "x": 29,
-                    "y": 0
+                    "y": 5
                 },
                 "panelIndex": "1d623c03-4d02-4a81-b91e-49e82e112016",
+                "title": "Transactions",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Transactions [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "filter": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "779215db-6202-4568-89a9-46601c8c2fb4": {
+                                            "columnOrder": [
+                                                "b03e8e6d-ed51-421f-8eb3-62191d2045ce",
+                                                "69665708-1c47-435e-b185-3ed5a8f59cfe",
+                                                "1d0a1f41-5061-414a-8e99-aa5d192a6525"
+                                            ],
+                                            "columns": {
+                                                "1d0a1f41-5061-414a-8e99-aa5d192a6525": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.success_server_latency.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "SuccessServerLatency (ms)",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": " ms"
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.success_server_latency.avg"
+                                                },
+                                                "69665708-1c47-435e-b185-3ed5a8f59cfe": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.dimensions.api_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "1d0a1f41-5061-414a-8e99-aa5d192a6525",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.dimensions.api_name"
+                                                },
+                                                "b03e8e6d-ed51-421f-8eb3-62191d2045ce": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-779215db-6202-4568-89a9-46601c8c2fb4",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "id": "c9fd65d0-32e8-11ea-84f4-e9593f8ba8f6",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "bar",
-                                    "color": "#3185FC",
-                                    "fill": 0.5,
-                                    "formatter": "number",
-                                    "id": "c9fd8ce0-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "label": "avg(azure.storage_account.transactions.total)",
-                                    "line_width": "1",
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.transactions.total",
-                                            "id": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                            "type": "max"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "azure.dimensions.response_type",
-                                    "terms_order_by": "c9fd8ce1-32e8-11ea-84f4-e9593f8ba8f6",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
-                        },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Transactions"
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
-                "gridData": {
-                    "h": 15,
-                    "i": "ff6441f8-d66d-4399-bae5-25d3d861b299",
-                    "w": 9,
-                    "x": 0,
-                    "y": 5
-                },
-                "panelIndex": "ff6441f8-d66d-4399-bae5-25d3d861b299",
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Filters [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "controls": [
-                                {
-                                    "fieldName": "azure.subscription_id",
-                                    "id": "1549397251041",
-                                    "indexPatternRefName": "control_0_index_pattern",
-                                    "label": "Subscription",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": false,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
                                 },
-                                {
-                                    "fieldName": "azure.resource.group",
-                                    "id": "1549512142947",
-                                    "indexPatternRefName": "control_1_index_pattern",
-                                    "label": "Resource Group",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
                                 },
-                                {
-                                    "fieldName": "azure.resource.name",
-                                    "id": "1578578146383",
-                                    "indexPatternRefName": "control_2_index_pattern",
-                                    "label": "Resource Name",
-                                    "options": {
-                                        "dynamicOptions": true,
-                                        "multiselect": true,
-                                        "order": "desc",
-                                        "size": 5,
-                                        "type": "terms"
-                                    },
-                                    "parent": "",
-                                    "type": "list"
-                                }
-                            ],
-                            "pinFilters": false,
-                            "updateFiltersOnChange": true,
-                            "useTimeFilter": false
-                        },
-                        "type": "input_control_vis",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "1d0a1f41-5061-414a-8e99-aa5d192a6525"
+                                        ],
+                                        "layerId": "779215db-6202-4568-89a9-46601c8c2fb4",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar",
+                                        "splitAccessor": "69665708-1c47-435e-b185-3ed5a8f59cfe",
+                                        "xAccessor": "b03e8e6d-ed51-421f-8eb3-62191d2045ce",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#3185FC",
+                                                "forAccessor": "1d0a1f41-5061-414a-8e99-aa5d192a6525"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
                             }
-                        }
-                    }
-                }
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
+                        },
+                        "title": "Storage Success Server Latency",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 15,
                     "i": "87066244-7840-4555-9d12-026d64977f1a",
-                    "w": 20,
-                    "x": 9,
-                    "y": 9
+                    "w": 24,
+                    "x": 0,
+                    "y": 14
                 },
                 "panelIndex": "87066244-7840-4555-9d12-026d64977f1a",
+                "title": "Success Server Latency",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Success Server Latency [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "filter": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "75e28cd0-af63-4d76-bc48-27ab36ecee8f": {
+                                            "columnOrder": [
+                                                "e38795c4-e485-443d-a00f-5d1bf2ef7220",
+                                                "9825f6c6-fbdc-478d-a02e-e3f67ccd16ff",
+                                                "9e9be992-df58-4b34-ad97-ba789b63accd"
+                                            ],
+                                            "columns": {
+                                                "9825f6c6-fbdc-478d-a02e-e3f67ccd16ff": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.dimensions.api_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "9e9be992-df58-4b34-ad97-ba789b63accd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.dimensions.api_name"
+                                                },
+                                                "9e9be992-df58-4b34-ad97-ba789b63accd": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "azure.storage_account.success_e2elatency.avg: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Success E2E Latency (ms)",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": " ms"
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.success_e2elatency.avg"
+                                                },
+                                                "e38795c4-e485-443d-a00f-5d1bf2ef7220": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-75e28cd0-af63-4d76-bc48-27ab36ecee8f",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "id": "e9a40230-32e9-11ea-bda2-69435df36a5c",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "bar",
-                                    "color": "#3185FC",
-                                    "fill": 0.5,
-                                    "formatter": "number",
-                                    "id": "e9a40231-32e9-11ea-bda2-69435df36a5c",
-                                    "label": "SuccessServerLatency (ms)",
-                                    "line_width": "1",
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.success_server_latency.avg",
-                                            "id": "e9a40232-32e9-11ea-bda2-69435df36a5c",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "azure.dimensions.api_name",
-                                    "terms_order_by": "e9a40232-32e9-11ea-bda2-69435df36a5c",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}} ms"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0.5,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "9e9be992-df58-4b34-ad97-ba789b63accd"
+                                        ],
+                                        "layerId": "75e28cd0-af63-4d76-bc48-27ab36ecee8f",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "bar",
+                                        "splitAccessor": "9825f6c6-fbdc-478d-a02e-e3f67ccd16ff",
+                                        "xAccessor": "e38795c4-e485-443d-a00f-5d1bf2ef7220",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "#3185FC",
+                                                "forAccessor": "9e9be992-df58-4b34-ad97-ba789b63accd"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
-                "title": "Success Server Latency"
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
                 "gridData": {
                     "h": 15,
                     "i": "756da375-e6a2-4668-af43-0cd294878254",
-                    "w": 19,
-                    "x": 29,
-                    "y": 9
+                    "w": 24,
+                    "x": 24,
+                    "y": 14
                 },
                 "panelIndex": "756da375-e6a2-4668-af43-0cd294878254",
+                "title": "Success E2E Latency",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Success E2E Latency [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "filter": {
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a88483ec-4907-4b37-932e-c8f321dd4e0f": {
+                                            "columnOrder": [
+                                                "7d007119-a64e-4bb9-b766-c98e88020f08",
+                                                "fd2e7314-5a94-49b1-95b1-c0459f6399b0",
+                                                "2145e43c-e9ba-4cb2-9d0f-988e3f3febcd"
+                                            ],
+                                            "columns": {
+                                                "2145e43c-e9ba-4cb2-9d0f-988e3f3febcd": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Storage Accounts Egress Total",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes"
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.egress.total"
+                                                },
+                                                "7d007119-a64e-4bb9-b766-c98e88020f08": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fd2e7314-5a94-49b1-95b1-c0459f6399b0": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.dimensions.api_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "2145e43c-e9ba-4cb2-9d0f-988e3f3febcd",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.dimensions.api_name"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
+                                {
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-a88483ec-4907-4b37-932e-c8f321dd4e0f",
+                                    "type": "index-pattern"
+                                }
+                            ],
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "id": "da4459b0-32ea-11ea-be35-cb10be813609",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "bar",
-                                    "color": "#3185FC",
-                                    "fill": 0.5,
-                                    "formatter": "number",
-                                    "id": "da4459b1-32ea-11ea-be35-cb10be813609",
-                                    "label": "Success E2E Latency (ms)",
-                                    "line_width": "1",
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.success_e2elatency.avg",
-                                            "id": "da4459b2-32ea-11ea-be35-cb10be813609",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "rainbow",
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "azure.dimensions.api_name",
-                                    "terms_order_by": "da4459b2-32ea-11ea-be35-cb10be813609",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}} ms"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "2145e43c-e9ba-4cb2-9d0f-988e3f3febcd"
+                                        ],
+                                        "layerId": "a88483ec-4907-4b37-932e-c8f321dd4e0f",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "fd2e7314-5a94-49b1-95b1-c0459f6399b0",
+                                        "xAccessor": "7d007119-a64e-4bb9-b766-c98e88020f08",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(0,149,177,1)",
+                                                "forAccessor": "2145e43c-e9ba-4cb2-9d0f-988e3f3febcd"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Success E2E Latency"
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
-                "gridData": {
-                    "h": 9,
-                    "i": "34aa5ce7-4f4b-4712-836f-3765e7c3fb3f",
-                    "w": 5,
-                    "x": 24,
-                    "y": 0
-                },
-                "panelIndex": "34aa5ce7-4f4b-4712-836f-3765e7c3fb3f",
-                "embeddableConfig": {
+                        "title": "Storage Account Egress Traffic",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
                     "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Container Count [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color": null,
-                            "background_color_rules": [
-                                {
-                                    "id": "71978870-32e4-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "f11cfd90-32e5-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "drilldown_url": "",
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "9c09ed50-32e4-11ea-af9e-d70582a45bda"
-                                }
-                            ],
-                            "gauge_inner_color": null,
-                            "gauge_inner_width": "6",
-                            "gauge_style": "circle",
-                            "gauge_width": "10",
-                            "hide_last_value_indicator": true,
-                            "id": "61fb4190-32e4-11ea-b9f8-4d0b340ad993",
-                            "index_pattern": "metrics-*",
-                            "interval": "60m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": "1.2",
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "'0'",
-                                    "id": "61fb4191-32e4-11ea-b9f8-4d0b340ad993",
-                                    "label": "Container Count",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.container_count.avg",
-                                            "id": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                            "type": "avg"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_mode": "everything",
-                                    "stacked": "none",
-                                    "terms_field": "azure.resource.name",
-                                    "terms_order_by": "61fb4192-32e4-11ea-b9f8-4d0b340ad993",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "gauge",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
-                        },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                }
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
+                    "hidePanelTitles": false
+                },
                 "gridData": {
                     "h": 14,
                     "i": "a715fafc-ca38-410c-9253-12ba506eabc0",
-                    "w": 20,
-                    "x": 9,
-                    "y": 24
+                    "w": 24,
+                    "x": 0,
+                    "y": 29
                 },
                 "panelIndex": "a715fafc-ca38-410c-9253-12ba506eabc0",
+                "title": "Egress Traffic by APIName",
+                "type": "lens",
+                "version": "8.7.0"
+            },
+            {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Account Egress Traffic [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
+                    "attributes": {
+                        "references": [],
+                        "state": {
+                            "adHocDataViews": {
+                                "tsvb_ad_hoc_metrics-*/@timestamp": {
+                                    "allowNoIndex": true,
+                                    "fieldAttrs": {},
+                                    "fieldFormats": {},
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "metrics-*",
+                                    "runtimeFieldMap": {},
+                                    "sourceFilters": [],
+                                    "timeFieldName": "@timestamp",
+                                    "title": "metrics-*"
+                                }
+                            },
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "ba544caa-968e-43a4-ad08-778383139364": {
+                                            "columnOrder": [
+                                                "08d7ec3c-6bc4-4327-b957-128f9af2c893",
+                                                "8b3a854f-c648-4b43-96f6-e3c5fdc02aae",
+                                                "cbf67182-5598-4083-9e67-f0118755f9e2"
+                                            ],
+                                            "columns": {
+                                                "08d7ec3c-6bc4-4327-b957-128f9af2c893": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "8b3a854f-c648-4b43-96f6-e3c5fdc02aae": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of azure.dimensions.api_name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "cbf67182-5598-4083-9e67-f0118755f9e2",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "azure.dimensions.api_name"
+                                                },
+                                                "cbf67182-5598-4083-9e67-f0118755f9e2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Storage Accounts Ingress Total",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes"
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.storage_account.ingress.total"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [
                                 {
-                                    "id": "0791c5a0-32d8-11ea-98d2-1194b9f2bfc0"
+                                    "id": "tsvb_ad_hoc_metrics-*/@timestamp",
+                                    "name": "indexpattern-datasource-layer-ba544caa-968e-43a4-ad08-778383139364",
+                                    "type": "index-pattern"
                                 }
                             ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "fca016e0-32de-11ea-a435-e7199eba380d"
-                                }
-                            ],
-                            "filter": {
+                            "query": {
                                 "language": "kuery",
                                 "query": ""
                             },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "fb8be7c0-32de-11ea-a435-e7199eba380d"
-                                }
-                            ],
-                            "gauge_inner_width": 10,
-                            "gauge_style": "half",
-                            "gauge_width": 10,
-                            "id": "f0edca80-32d5-11ea-b19d-fb5049b980ca",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(0,149,177,1)",
-                                    "fill": 0,
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "bytes",
-                                    "hidden": false,
-                                    "id": "f0edf190-32d5-11ea-b19d-fb5049b980ca",
-                                    "label": "Storage Accounts Egress Total",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.egress.total",
-                                            "id": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
-                                            "type": "max"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_filters": [
-                                        {
-                                            "color": "rgba(0,98,177,1)",
-                                            "filter": {
-                                                "language": "kuery",
-                                                "query": ""
-                                            },
-                                            "id": "283dc410-32d9-11ea-98d2-1194b9f2bfc0"
-                                        }
-                                    ],
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "azure.dimensions.api_name",
-                                    "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": false,
+                                    "yRight": true
+                                },
+                                "fillOpacity": 0,
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "cbf67182-5598-4083-9e67-f0118755f9e2"
+                                        ],
+                                        "layerId": "ba544caa-968e-43a4-ad08-778383139364",
+                                        "layerType": "data",
+                                        "palette": {
+                                            "name": "default",
+                                            "type": "palette"
+                                        },
+                                        "seriesType": "line",
+                                        "splitAccessor": "8b3a854f-c648-4b43-96f6-e3c5fdc02aae",
+                                        "xAccessor": "08d7ec3c-6bc4-4327-b957-128f9af2c893",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "color": "rgba(104,188,0,1)",
+                                                "forAccessor": "cbf67182-5598-4083-9e67-f0118755f9e2"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "maxLines": 1,
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yLeftScale": "linear",
+                                "yRightExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightScale": "linear"
+                            }
                         },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
+                        "title": "Storage Account Ingress Traffic",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
                 },
-                "title": "Egress Traffic by APIName"
-            },
-            {
-                "version": "8.3.0",
-                "type": "visualization",
                 "gridData": {
                     "h": 14,
                     "i": "75f72920-be71-47a9-a967-f1c862ab2961",
-                    "w": 19,
-                    "x": 29,
-                    "y": 24
+                    "w": 24,
+                    "x": 24,
+                    "y": 29
                 },
                 "panelIndex": "75f72920-be71-47a9-a967-f1c862ab2961",
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "title": "Storage Account Ingress Traffic [Azure Metrics]",
-                        "description": "",
-                        "uiState": {},
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_min": 0,
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "background_color_rules": [
-                                {
-                                    "id": "0791c5a0-32d8-11ea-98d2-1194b9f2bfc0"
-                                }
-                            ],
-                            "bar_color_rules": [
-                                {
-                                    "id": "fca016e0-32de-11ea-a435-e7199eba380d"
-                                }
-                            ],
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "gauge_color_rules": [
-                                {
-                                    "id": "fb8be7c0-32de-11ea-a435-e7199eba380d"
-                                }
-                            ],
-                            "gauge_inner_width": 10,
-                            "gauge_style": "half",
-                            "gauge_width": 10,
-                            "id": "f0edca80-32d5-11ea-b19d-fb5049b980ca",
-                            "index_pattern": "metrics-*",
-                            "interval": "5m",
-                            "isModelInvalid": false,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "rgba(104,188,0,1)",
-                                    "fill": 0,
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "bytes",
-                                    "hidden": false,
-                                    "id": "f0edf190-32d5-11ea-b19d-fb5049b980ca",
-                                    "label": "Storage Accounts Ingress Total",
-                                    "line_width": 2,
-                                    "metrics": [
-                                        {
-                                            "field": "azure.storage_account.ingress.total",
-                                            "id": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
-                                            "type": "max"
-                                        }
-                                    ],
-                                    "point_size": 0,
-                                    "separate_axis": 0,
-                                    "split_color_mode": "gradient",
-                                    "split_filters": [
-                                        {
-                                            "color": "rgba(0,98,177,1)",
-                                            "filter": {
-                                                "language": "kuery",
-                                                "query": ""
-                                            },
-                                            "id": "283dc410-32d9-11ea-98d2-1194b9f2bfc0"
-                                        }
-                                    ],
-                                    "split_mode": "terms",
-                                    "stacked": "none",
-                                    "terms_field": "azure.dimensions.api_name",
-                                    "terms_order_by": "f0edf191-32d5-11ea-b19d-fb5049b980ca",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "type": "timeseries",
-                            "use_kibana_indexes": false,
-                            "drop_last_bucket": 1
-                        },
-                        "type": "metrics",
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {}
-                        }
-                    }
-                },
-                "title": "Ingress Traffic by APIName"
+                "title": "Ingress Traffic by APIName",
+                "type": "lens",
+                "version": "8.7.0"
             }
         ],
         "timeRestore": false,
         "title": "[Azure Metrics] Blob Storage Overview",
         "version": 1
+    },
+    "coreMigrationVersion": "8.7.0",
+    "created_at": "2024-04-01T13:06:26.269Z",
+    "id": "azure_metrics-b165ef60-32f7-11ea-a83e-25b8612d00cc",
+    "migrationVersion": {
+        "dashboard": "8.7.0"
     },
     "references": [
         {
@@ -1015,23 +1641,20 @@
             "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "ff6441f8-d66d-4399-bae5-25d3d861b299:control_0_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_7eb82f60-7b2e-473f-960b-35b3fa5392d5:optionsListDataView",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "ff6441f8-d66d-4399-bae5-25d3d861b299:control_1_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_269e473e-2b24-402e-9721-3c9b3bd85458:optionsListDataView",
+            "type": "index-pattern"
         },
         {
-            "type": "index-pattern",
-            "name": "ff6441f8-d66d-4399-bae5-25d3d861b299:control_2_index_pattern",
-            "id": "metrics-*"
+            "id": "metrics-*",
+            "name": "controlGroup_192cb16e-8bf4-4e63-b95c-338b8fc0fcfa:optionsListDataView",
+            "type": "index-pattern"
         }
     ],
-    "migrationVersion": {
-        "dashboard": "8.3.0"
-    },
-    "coreMigrationVersion": "8.3.0"
+    "type": "dashboard"
 }

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.4.3
+version: 1.4.4
 release: ga
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration


### PR DESCRIPTION
- Enhancement
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- Migration of the visualizations to lens.
- Please refer the Screenshots mentioned in the description of the PR for comparison. 

## Migration stats

<html>
<body>
<!--StartFragment-->

Azure Metrics | Before Migration |   | After Migration |  
-- | -- | -- | -- | --
  | Lens | Visualization | Lens | Visualization
[Azure Metrics] Blob Storage Overview | 0 | 10 | 10 | 0
<!--EndFragment-->
</body>
</html>

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #7788

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

#### Before

![image](https://github.com/elastic/integrations/assets/118714680/5dedb8bb-c2e2-429e-81e8-4ca1894b7d44)

#### After

![image](https://github.com/elastic/integrations/assets/118714680/306a22b6-5472-484a-92a9-0931c151e20a)