### PR TITLE
Add tags and processors on GCP Compute, Firestore, PostgreSQL

### DIFF
--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.34.0"
+  changes:
+    - description: Add tags and processors to GCP Compute, Firestore, PostgreSQL.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9508
 - version: "2.33.2"
   changes:
     - description: Add tags and processors to GCP Storage 

--- a/packages/gcp/data_stream/cloudsql_postgresql/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/cloudsql_postgresql/agent/stream/stream.yml.hbs
@@ -11,6 +11,14 @@ credentials_json: '{{credentials_json}}'
 region: {{region}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - aligner: ALIGN_NONE
     service: cloudsql

--- a/packages/gcp/data_stream/cloudsql_postgresql/manifest.yml
+++ b/packages/gcp/data_stream/cloudsql_postgresql/manifest.yml
@@ -23,5 +23,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-cloudsql-postgresql
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/compute/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/compute/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: compute
     metric_types:

--- a/packages/gcp/data_stream/compute/manifest.yml
+++ b/packages/gcp/data_stream/compute/manifest.yml
@@ -37,5 +37,22 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-compute
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 elasticsearch:
   index_mode: "time_series"

--- a/packages/gcp/data_stream/firestore/agent/stream/stream.yml.hbs
+++ b/packages/gcp/data_stream/firestore/agent/stream/stream.yml.hbs
@@ -20,6 +20,14 @@ regions:
 {{/each}}
 {{/if}}
 exclude_labels: {{exclude_labels}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}
+tags:
+{{#each tags as |tag|}}
+  - {{tag}}
+{{/each}}
 metrics:
   - service: firestore
     metric_types:

--- a/packages/gcp/data_stream/firestore/manifest.yml
+++ b/packages/gcp/data_stream/firestore/manifest.yml
@@ -37,3 +37,20 @@ streams:
         multi: false
         required: false
         show_user: true
+      - name: tags
+        type: text
+        title: Tags
+        description: Tags to include in the published event
+        multi: true
+        required: false
+        show_user: false
+        default:
+          - gcp-firestore
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.33.2"
+version: "2.34.0"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
### Proposed commit message
Add custom processors and tags to gcp Compute, Firestore and PostgreSQL integrations

### Checklist

- [x]  I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ]  I have verified that all data streams collect metrics or logs.
- [x]  I have added an entry to my package's changelog.yml file.
- [x]  I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).