### PR TITLE
[aws_logs] Add custom settings variable

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.0"
+  changes:
+    - description: Add a custom settings variable to allow passing additional settings to the input.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9512
 - version: "1.1.0"
   changes:
     - description: Update the package format_version to 3.0.2 and enable 'secret' for the sensitive fields

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-cloudwatch.yml.hbs
@@ -104,3 +104,4 @@ publisher_pipeline.disable_host: true
 processors:
 {{processors}}
 {{/if}}
+{{custom}}

--- a/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
+++ b/packages/aws_logs/data_stream/generic/agent/stream/aws-s3.yml.hbs
@@ -152,3 +152,4 @@ processors:
 parsers:
 {{parsers}}
 {{/if}}
+{{custom}}

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -136,6 +136,13 @@ streams:
           The Ingest Node pipeline ID to be used by the integration.
         required: false
         show_user: true
+      - name: custom
+        title: Custom configurations
+        description: >
+          Additional settings to be added to the configuration. Be careful using this as it might break the input as those settings are not validated and can override the settings specified above. See [`aws-cloudwatch` input settings docs](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-cloudwatch.html) for details.
+
+        type: yaml
+        default: ""
   - input: aws-s3
     enabled: false
     template_path: aws-s3.yml.hbs
@@ -361,6 +368,13 @@ streams:
           The Ingest Node pipeline ID to be used by the integration.
         required: false
         show_user: true
+      - name: custom
+        title: Custom configurations
+        description: >
+          Additional settings to be added to the configuration. Be careful using this as it might break the input as those settings are not validated and can override the settings specified above. See [`aws-s3` input settings docs](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html) for details.
+
+        type: yaml
+        default: ""
 # Ensures agents have permissions to write data to `logs-*-*`
 elasticsearch:
   dynamic_dataset: true

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.1.0"
+version: "1.2.0"
 categories:
   - observability
   - custom


### PR DESCRIPTION
## Proposed commit message

Add a `custom` variable to allow passing additional settings to the input.

Closes #9509

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues


- Closes #9509
