### PR TITLE
Remove entrypoint override for elastic/stream

### DIFF
--- a/packages/bluecoat/_dev/deploy/docker/docker-compose.yml
+++ b/packages/bluecoat/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   bluecoat-director-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=udp /sample_logs/bluecoat-director-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=udp /sample_logs/bluecoat-director-*.log
   bluecoat-director-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=tcp /sample_logs/bluecoat-director-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9527 -p=tcp /sample_logs/bluecoat-director-*.log

--- a/packages/cisco_ise/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_ise/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cisco_ise-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tcp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9025 -p=tcp /sample_logs/log.log
   cisco_ise-log-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9026 -p=udp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9026 -p=udp /sample_logs/log.log

--- a/packages/cisco_secure_email_gateway/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cisco_secure_email_gateway/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/*.s /var/log/"
   cisco_secure_email_gateway-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9519 -p=tcp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9519 -p=tcp /sample_logs/log.log
   cisco_secure_email_gateway-log-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9520 -p=udp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9520 -p=udp /sample_logs/log.log

--- a/packages/cyberarkpas/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cyberarkpas/_dev/deploy/docker/docker-compose.yml
@@ -7,20 +7,17 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/audit/* /var/log/"
   cyberarkpas-audit-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/audit/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/audit/*.log
   cyberarkpas-audit-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/audit/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/audit/*.log
   cyberarkpas-audit-tls:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/audit/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/audit/*.log

--- a/packages/cylance/_dev/deploy/docker/docker-compose.yml
+++ b/packages/cylance/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   cylance-protect-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=udp /sample_logs/cylance-protect-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=udp /sample_logs/cylance-protect-*.log
   cylance-protect-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=tcp /sample_logs/cylance-protect-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9529 -p=tcp /sample_logs/cylance-protect-*.log

--- a/packages/f5/_dev/deploy/docker/docker-compose.yml
+++ b/packages/f5/_dev/deploy/docker/docker-compose.yml
@@ -7,17 +7,15 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   f5-bigipapm-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9526 -p=udp /sample_logs/f5-bigipapm-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9526 -p=udp /sample_logs/f5-bigipapm-*.log
   f5-bigipapm-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9526 -p=tcp /sample_logs/f5-bigipapm-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9526 -p=tcp /sample_logs/f5-bigipapm-*.log
   f5-bigipafm-logfile:
     image: alpine
     volumes:
@@ -25,14 +23,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   f5-bigipafm-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9544 -p=udp /sample_logs/f5-bigipafm-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9544 -p=udp /sample_logs/f5-bigipafm-*.log
   f5-bigipafm-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9544 -p=tcp /sample_logs/f5-bigipafm-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9544 -p=tcp /sample_logs/f5-bigipafm-*.log

--- a/packages/fireeye/_dev/deploy/docker/docker-compose.yml
+++ b/packages/fireeye/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   fireeye-nx-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/fireeye-nx.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/fireeye-nx.log
   fireeye-nx-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/fireeye-nx.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/fireeye-nx.log

--- a/packages/infoblox_nios/_dev/deploy/docker/docker-compose.yml
+++ b/packages/infoblox_nios/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   infoblox_nios-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9027 -p=tcp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9027 -p=tcp /sample_logs/log.log
   infoblox_nios-log-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9028 -p=udp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9028 -p=udp /sample_logs/log.log

--- a/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
+++ b/packages/jamf_compliance_reporter/_dev/deploy/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   jamf-compliance-reporter-log-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -9,8 +9,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9551/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/log.log
   jamf-compliance-reporter-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9552 -p=tcp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9552 -p=tcp /sample_logs/log.log

--- a/packages/netscout/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netscout/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   netscout-sightline-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=udp /sample_logs/netscout-sightline-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=udp /sample_logs/netscout-sightline-*.log
   netscout-sightline-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=tcp /sample_logs/netscout-sightline-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9524 -p=tcp /sample_logs/netscout-sightline-*.log

--- a/packages/netskope/_dev/deploy/docker/docker-compose.yml
+++ b/packages/netskope/_dev/deploy/docker/docker-compose.yml
@@ -1,14 +1,12 @@
 version: "2.3"
 services:
   netskope-alerts-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9020 -p=tcp /sample_logs/alerts.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9020 -p=tcp /sample_logs/alerts.log
   netskope-events-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9021 -p=tcp /sample_logs/events.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9021 -p=tcp /sample_logs/events.log

--- a/packages/pfsense/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pfsense/_dev/deploy/docker/docker-compose.yml
@@ -1,19 +1,17 @@
 version: '2.3'
 services:
   pfsense-log-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/*.log
   pfsense-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log
   pfsense-log-tls:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log

--- a/packages/pps/_dev/deploy/docker/docker-compose.yml
+++ b/packages/pps/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   pps-log-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9037 -p=tcp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9037 -p=tcp /sample_logs/log.log
   pps-log-udp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9038 -p=udp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9038 -p=udp /sample_logs/log.log

--- a/packages/qnap_nas/_dev/deploy/docker/docker-compose.yml
+++ b/packages/qnap_nas/_dev/deploy/docker/docker-compose.yml
@@ -1,20 +1,17 @@
 version: '2.3'
 services:
   qnap-nas-udp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=udp /sample_logs/*.log
   qnap-nas-tcp:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tcp /sample_logs/*.log
   qnap-nas-tls:
-    image: docker.elastic.co/observability/stream:v0.6.1
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9999 -p=tls --insecure /sample_logs/*.log

--- a/packages/radware/_dev/deploy/docker/docker-compose.yml
+++ b/packages/radware/_dev/deploy/docker/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=udp /sample_logs/radware-defensepro-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=udp /sample_logs/radware-defensepro-*.log
   radware-defensepro-tcp:
     image: akroh/stream:v0.2.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=tcp /sample_logs/radware-defensepro-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9535 -p=tcp /sample_logs/radware-defensepro-*.log

--- a/packages/sonicwall_firewall/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sonicwall_firewall/_dev/deploy/docker/docker-compose.yml
@@ -7,8 +7,7 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   sonicwall_firewall-syslog:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/log.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9514 -p=udp /sample_logs/log.log

--- a/packages/sophos/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sophos/_dev/deploy/docker/docker-compose.yml
@@ -7,32 +7,27 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   sophos-utm-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-utm*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-utm*.log
   sophos-utm-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-utm*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-utm*.log
   sophos-xg-udp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-xg*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=udp /sample_logs/sophos-xg*.log
   sophos-xg-tcp:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-xg*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9549 -p=tcp /sample_logs/sophos-xg*.log
   sophos-xg-tls:
-    image: docker.elastic.co/observability/stream:v0.7.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9550 -p=tls --insecure /sample_logs/sophos-xg*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9550 -p=tls --insecure /sample_logs/sophos-xg*.log

--- a/packages/squid/_dev/deploy/docker/docker-compose.yml
+++ b/packages/squid/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   squid-log-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=udp /sample_logs/squid-log-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=udp /sample_logs/squid-log-*.log
   squid-log-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=tcp /sample_logs/squid-log-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9537 -p=tcp /sample_logs/squid-log-*.log

--- a/packages/tanium/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tanium/_dev/deploy/docker/docker-compose.yml
@@ -1,43 +1,37 @@
 version: '2.3'
 services:
   tanium-tcp-action_history:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9082 -p=tcp /sample_logs/action_history.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9082 -p=tcp /sample_logs/action_history.log
   tanium-tcp-client_status:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9083 -p=tcp /sample_logs/client_status.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9083 -p=tcp /sample_logs/client_status.log
   tanium-tcp-discover:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9084 -p=tcp /sample_logs/discover.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9084 -p=tcp /sample_logs/discover.log
   tanium-tcp-endpoint_config:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9085 -p=tcp /sample_logs/endpoint_config.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9085 -p=tcp /sample_logs/endpoint_config.log
   tanium-tcp-reporting:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9086 -p=tcp /sample_logs/reporting.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9086 -p=tcp /sample_logs/reporting.log
   tanium-tcp-threat_response:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9087 -p=tcp /sample_logs/threat_response.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9087 -p=tcp /sample_logs/threat_response.log
   tanium-action_history-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -45,7 +39,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9087/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/action_history.log
   tanium-client_status-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -53,7 +47,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9088/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/client_status.log
   tanium-discover-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -61,7 +55,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9089/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/discover.log
   tanium-endpoint_config-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -69,7 +63,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9090/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/endpoint_config.log
   tanium-reporting-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -77,7 +71,7 @@ services:
       - STREAM_ADDR=http://elastic-agent:9091/
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/reporting.log
   tanium-threat_response-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.9.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/thycotic_ss/_dev/deploy/docker/docker-compose.yml
+++ b/packages/thycotic_ss/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   thycotic-ss-log-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=udp /sample_logs/thycotic-ss-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=udp /sample_logs/thycotic-ss-*.log
   thycotic-ss-log-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tcp /sample_logs/thycotic-ss-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9571 -p=tcp /sample_logs/thycotic-ss-*.log

--- a/packages/tomcat/_dev/deploy/docker/docker-compose.yml
+++ b/packages/tomcat/_dev/deploy/docker/docker-compose.yml
@@ -7,14 +7,12 @@ services:
       - ${SERVICE_LOGS_DIR}:/var/log
     command: /bin/sh -c "cp /sample_logs/* /var/log/"
   tomcat-log-udp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/tomcat-log-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=udp /sample_logs/tomcat-log-*.log
   tomcat-log-tcp:
-    image: akroh/stream:v0.2.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/tomcat-log-*.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9523 -p=tcp /sample_logs/tomcat-log-*.log

--- a/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zscaler_zia/_dev/deploy/docker/docker-compose.yml
@@ -1,37 +1,32 @@
 version: "2.3"
 services:
   zscaler-zia-alerts-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9010 -p=tcp /sample_logs/alerts.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9010 -p=tcp /sample_logs/alerts.log
   zscaler-zia-dns-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9011 -p=tcp /sample_logs/dns.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9011 -p=tcp /sample_logs/dns.log
   zscaler-zia-firewall-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9012 -p=tcp /sample_logs/firewall.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9012 -p=tcp /sample_logs/firewall.log
   zscaler-zia-tunnel-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9013 -p=tcp /sample_logs/tunnel.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9013 -p=tcp /sample_logs/tunnel.log
   zscaler-zia-web-tcp:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9014 -p=tcp /sample_logs/web.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9014 -p=tcp /sample_logs/web.log
   zscaler-zia-dns-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -40,7 +35,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/dns-http_endpoint.log
   zscaler-zia-firewall-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -49,7 +44,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/firewall-http_endpoint.log
   zscaler-zia-tunnel-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:
@@ -58,7 +53,7 @@ services:
       - STREAM_WEBHOOK_HEADER=Content-Type=application/ndjson
     command: log --start-signal=SIGHUP --delay=5s /sample_logs/tunnel-http_endpoint.log
   zscaler-zia-web-http-endpoint:
-    image: docker.elastic.co/observability/stream:v0.10.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
     environment:

--- a/packages/zscaler_zpa/_dev/deploy/docker/docker-compose.yml
+++ b/packages/zscaler_zpa/_dev/deploy/docker/docker-compose.yml
@@ -1,32 +1,27 @@
 version: "2.3"
 services:
   zscaler-app-connector-status-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9015 -p=tcp /sample_logs/app_connector_status.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9015 -p=tcp /sample_logs/app_connector_status.log
   zscaler-zpa-audit-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9016 -p=tcp /sample_logs/audit.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9016 -p=tcp /sample_logs/audit.log
   zscaler-zpa-browser-access-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9017 -p=tcp /sample_logs/browser_access.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9017 -p=tcp /sample_logs/browser_access.log
   zscaler-zpa-user-activity-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9018 -p=tcp /sample_logs/user_activity.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9018 -p=tcp /sample_logs/user_activity.log
   zscaler-zpa-user-status-tcp:
-    image: docker.elastic.co/observability/stream:v0.8.0
+    image: docker.elastic.co/observability/stream:v0.15.0
     volumes:
       - ./sample_logs:/sample_logs:ro
-    entrypoint: /bin/bash
-    command: -c "/stream log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9019 -p=tcp /sample_logs/user_status.log"
+    command: log --start-signal=SIGHUP --delay=5s --addr elastic-agent:9019 -p=tcp /sample_logs/user_status.log


### PR DESCRIPTION
## Proposed commit message

Use the default entrypoint (/stream) when running commands using the
elastic/stream image. Version v0.15.0 switches to an alpine base image
which does not have /bin/bash.

The only reason to use a shell entrypoint was for glob expansion and that feature
has been available in elastic/stream since v0.5.0.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

