### PR TITLE
Microsoft Defender for Endpoint: Logstash compatibility. Remove message field if event.original exists

### DIFF
--- a/packages/microsoft_defender_endpoint/changelog.yml
+++ b/packages/microsoft_defender_endpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.24.2"
+  changes:
+    - description: Fix bug handling message field when events are received from Logstash with `ecs_compatibility` turned on.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9522
 - version: "2.24.1"
   changes:
     - description: Fix handling of empty arrays.

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -9,6 +9,11 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+  - remove:
+      field: message
+      ignore_missing: true
+      if: 'ctx.event?.original != null'
+      description: 'The `message` field is no longer required if the document has an `event.original` field.'
   - json:
       field: event.original
       target_field: json

--- a/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,7 @@ processors:
       field: message
       ignore_missing: true
       if: 'ctx.event?.original != null'
-      description: 'The `message` field is no longer required if the document has an `event.original` field.'
+      description: 'The `message` field is no longer required if the document has an `event.original` field. Helps to maintain compatibility with the Logstash `ecs_compatibility feature`.'
   - json:
       field: event.original
       target_field: json

--- a/packages/microsoft_defender_endpoint/manifest.yml
+++ b/packages/microsoft_defender_endpoint/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_defender_endpoint
 title: Microsoft Defender for Endpoint
-version: "2.24.1"
+version: "2.24.2"
 description: Collect logs from Microsoft Defender for Endpoint with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
- Bug

## Proposed commit message

In instances where the event.original field already exists when received by the ingest pipeline, such as when the sender is Logstash with ecs_compatibility set to either v1 or v8, not specifically removing the message field breaks the [rename processor where `json.title` is moved to the `message` field](https://github.com/elastic/integrations/blob/45558de341d56b6796e75f665f26d6230a0b4861/packages/microsoft_defender_endpoint/data_stream/log/elasticsearch/ingest_pipeline/default.yml#L81-L84). 

To solve that issue, this PR adds a separate remove processor that remove the `message` field, if the `event.original` field is present. This then allows the later `json.title` rename processor to work.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
