### PR TITLE
Remove curly brackets in the changelog description

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -6,7 +6,7 @@
       link: https://github.com/elastic/integrations/pull/9486
 - version: "2.23.1"
   changes:
-    - description: Fix errors processing empty userRiskData.{risk,trust,general} values.
+    - description: Fix errors processing empty userRiskData.[risk,trust,general] values.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9483
 - version: "2.23.0"


### PR DESCRIPTION
This PR removes curly brackets `{ }` in the Akamai changelog file as they are breaking the doc build.

We can’t have any curly brackets in MDX files or they break the build.
This is blocking https://github.com/elastic/integration-docs/pull/368 from being merged.
Going forward, https://github.com/elastic/integration-docs/pull/369  should fix it.

Relates to https://github.com/elastic/integrations/pull/9483

