### PR TITLE
[O11y][MongoDB] Update README with support of LDAP authentication

### DIFF
--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -23,6 +23,18 @@ When using the `directConnection=true` parameter in the connection URI, all oper
 
 The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
+Additional URI Support for LDAP Authentication in MongoDB:
+
+- URI: `mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]`
+
+- Example URI: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
+
+When specifying `authMechanism` as PLAIN, it indicates the use of the PLAIN authentication mechanism, which is commonly associated with LDAP.
+
+`authSource` can be used to specify the name of the database that has the collection with the user credentials.
+
+In MongoDB, `authSource=$external` is a special authentication database used for authenticating users externally, such as via LDAP.
+
 ## Compatibility
 
 The `log` dataset is tested with logs from versions v3.2.11 and v4.4.4 in
@@ -48,6 +60,10 @@ db.createUser(
         roles: ["clusterMonitor"]
     }
 )
+```
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
+```
+db.auth(user, pass)
 ```
 
 You can use the following command in Mongo shell to grant the role to an 

--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -21,19 +21,15 @@ Additional supported URI examples include:
 
 When using the `directConnection=true` parameter in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI as it won't be automatically added.
 
-The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
-
-Additional URI Support for LDAP Authentication in MongoDB:
-
-- URI: `mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]`
-
-- Example URI: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
+- Authentication: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
 
 When specifying `authMechanism` as PLAIN, it indicates the use of the PLAIN authentication mechanism, which is commonly associated with LDAP.
 
 `authSource` can be used to specify the name of the database that has the collection with the user credentials.
 
 In MongoDB, `authSource=$external` is a special authentication database used for authenticating users externally, such as via LDAP.
+
+The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
 ## Compatibility
 
@@ -61,7 +57,7 @@ db.createUser(
     }
 )
 ```
-You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` database by using the command `db` in Mongo shell).
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
 ```
 db.auth(user, pass)
 ```

--- a/packages/mongodb/_dev/build/docs/README.md
+++ b/packages/mongodb/_dev/build/docs/README.md
@@ -61,7 +61,7 @@ db.createUser(
     }
 )
 ```
-You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` database by using the command `db` in Mongo shell).
 ```
 db.auth(user, pass)
 ```

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update README with support of LDAP authentication.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/9526
 - version: 1.13.2
   changes:
     - description: Update the Kibana version to fix the disk space exhaustion.

--- a/packages/mongodb/changelog.yml
+++ b/packages/mongodb/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.13.3
+  changes:
+    - description: Update README with support of LDAP authentication.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: 1.13.2
   changes:
     - description: Update the Kibana version to fix the disk space exhaustion.

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -23,6 +23,18 @@ When using the `directConnection=true` parameter in the connection URI, all oper
 
 The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
+Additional URI Support for LDAP Authentication in MongoDB:
+
+- URI: `mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]`
+
+- Example URI: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
+
+When specifying `authMechanism` as PLAIN, it indicates the use of the PLAIN authentication mechanism, which is commonly associated with LDAP.
+
+`authSource` can be used to specify the name of the database that has the collection with the user credentials.
+
+In MongoDB, `authSource=$external` is a special authentication database used for authenticating users externally, such as via LDAP.
+
 ## Compatibility
 
 The `log` dataset is tested with logs from versions v3.2.11 and v4.4.4 in
@@ -48,6 +60,10 @@ db.createUser(
         roles: ["clusterMonitor"]
     }
 )
+```
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
+```
+db.auth(user, pass)
 ```
 
 You can use the following command in Mongo shell to grant the role to an 

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -21,19 +21,15 @@ Additional supported URI examples include:
 
 When using the `directConnection=true` parameter in the connection URI, all operations are executed on the specified host. It's important to explicitly include `directConnection=true` in the URI as it won't be automatically added.
 
-The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
-
-Additional URI Support for LDAP Authentication in MongoDB:
-
-- URI: `mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]`
-
-- Example URI: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
+- Authentication: `mongodb://username:password@host:port/authSource=$external?authMechanism=PLAIN`
 
 When specifying `authMechanism` as PLAIN, it indicates the use of the PLAIN authentication mechanism, which is commonly associated with LDAP.
 
 `authSource` can be used to specify the name of the database that has the collection with the user credentials.
 
 In MongoDB, `authSource=$external` is a special authentication database used for authenticating users externally, such as via LDAP.
+
+The username and password can either be included in the URI or set using the respective configuration options. If included in the URI, these credentials take precedence over any configured username and password configuration options.
 
 ## Compatibility
 
@@ -61,7 +57,7 @@ db.createUser(
     }
 )
 ```
-You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` database by using the command `db` in Mongo shell).
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
 ```
 db.auth(user, pass)
 ```

--- a/packages/mongodb/docs/README.md
+++ b/packages/mongodb/docs/README.md
@@ -61,7 +61,7 @@ db.createUser(
     }
 )
 ```
-You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` db by using `db` command in Mongo shell).
+You can use the following command in Mongo shell to authenticate a user against a specific database with the provided username and password (make sure you are using the `admin` database by using the command `db` in Mongo shell).
 ```
 db.auth(user, pass)
 ```

--- a/packages/mongodb/manifest.yml
+++ b/packages/mongodb/manifest.yml
@@ -1,6 +1,6 @@
 name: mongodb
 title: MongoDB
-version: "1.13.2"
+version: "1.13.3"
 description: Collect logs and metrics from MongoDB instances with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- Update README with support of LDAP authentication.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #9263