### PR TITLE
Use version 7.17.19 to workaround issue in 7.17 snapshot

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -22,7 +22,8 @@ steps:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 7.17-SNAPSHOT
+        # STACK_VERSION: 7.17-SNAPSHOT # Using 7.17.19 till https://github.com/elastic/fleet-server/issues/3435 is solved.
+        STACK_VERSION: 7.17.19
     depends_on:
       - step: "check"
         allow_failure: false


### PR DESCRIPTION
Builds with 7.17-SNAPSHOT are failing now because Fleet Server cannot bootstrap with the self-signed certificates provided by `elastic-package` (see https://github.com/elastic/fleet-server/issues/3435).

Use latest version known to work.