### PR TITLE
[cisco_asa] Improve ECS event categorization

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.33.0"
   changes:
-    - description: Improve methods for apply ECS categorizations.
+    - description: Improve methods for applying ECS categorizations.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9548
 - version: "2.32.1"

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.33.0"
+  changes:
+    - description: Improve ECS categorization.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9548
 - version: "2.32.1"
   changes:
     - description: Fix ingest pipeline regex warnings

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.33.0"
   changes:
-    - description: Improve ECS categorization.
+    - description: Improve methods for apply ECS categorizations.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9548
 - version: "2.32.1"

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -4463,7 +4463,7 @@
             "event": {
                 "action": "firewall-rule",
                 "category": [
-                    "network"
+                    "iam"
                 ],
                 "code": "502103",
                 "kind": "event",
@@ -4471,7 +4471,8 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "group",
+                    "change"
                 ]
             },
             "host": {
@@ -5288,11 +5289,19 @@
             },
             "event": {
                 "action": "drop",
+                "category": [
+                    "network"
+                ],
                 "code": "434002",
+                "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-434002: SFR requested to drop TCP packet from sourceInterfaceName:81.2.69.144/8888 to destinationInterfaceName:192.168.2.2/514514",
                 "outcome": "unknown",
                 "severity": 4,
-                "timezone": "UTC"
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "denied"
+                ]
             },
             "host": {
                 "hostname": "dev01"
@@ -5533,11 +5542,19 @@
             },
             "event": {
                 "action": "created",
+                "category": [
+                    "network"
+                ],
                 "code": "602303",
+                "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-602303: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xF81283) between 81.2.69.144 and 192.168.2.2 (user= admin) has been created.",
                 "outcome": "success",
                 "severity": 6,
-                "timezone": "UTC"
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
             },
             "host": {
                 "hostname": "dev01"

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1,21 +1,27 @@
 ---
 description: "Pipeline for Cisco ASA logs"
 processors:
-  - rename:
+  - set:
+      field: event.original
+      copy_from: message
+  - remove:
       field: message
-      target_field: event.original
-      tag: "rename_message"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
-      ignore_missing: true
-      if: ctx.event?.original == null
   - set:
       field: ecs.version
       value: '8.11.0'
+  - set:
+      field: event.kind
+      value: event
+  - set:
+      field: event.category
+      value: [ network ]
+  - set:
+      field: event.type
+      value: [ info ]
+  - set:
+      field: event.action
+      value: firewall-rule
+
   #
   # Parse the syslog header
   #
@@ -23,7 +29,7 @@ processors:
   # from the header and stores the message contents in _temp_.full_message.
   - grok:
       field: event.original
-      tag: "grok_event_original"
+      tag: grok_event_original
       if: ctx.event?.original != null
       patterns:
         - "(?:%{SYSLOG_HEADER})?\\s*%{GREEDYDATA:_temp_.full_message}"
@@ -41,15 +47,9 @@ processors:
         # exactly match the syntax for firepower management logs
         PROCESS_HOST: "(?:%{PROCESS:process.name}:\\s%{SYSLOGHOST:host.name})"
         HOST_PROCESS: "(?:%{SYSLOGHOST:host.hostname}:?\\s+)?(?:%{PROCESS:process.name}?(?:\\[%{POSINT:process.pid:long}\\])?)?"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - script:
       lang: painless
-      tag: "script_log_syslog"
+      tag: script_log_syslog
       source: |
         if (ctx.log?.syslog?.priority != null) {
           def severity = new HashMap();
@@ -59,10 +59,6 @@ processors:
           facility['code'] = ctx.log.syslog.priority>>3;
           ctx.log.syslog['facility'] = facility;
         }
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
 
   #
   # Parse FTD/ASA style message
@@ -71,7 +67,7 @@ processors:
   - grok:
       field: _temp_.full_message
       if: ctx._temp_?.full_message != null
-      tag: "grok_full_message"
+      tag: grok_full_message
       patterns:
         - "%{FTD_PREFIX}-(?:%{FTD_SUFFIX:_temp_.cisco.suffix}-)?%{NONNEGINT:event.severity:int}-%{POSINT:_temp_.cisco.message_id}?:?\\s*%{GREEDYDATA:message}"
         # Before version 6.3, messages for connection, security intelligence, and intrusion events didn't include an event type ID in the message header.
@@ -80,12 +76,6 @@ processors:
         FTD_SUFFIX: "[^0-9-]+"
         # Before version 6.3, FTD used ASA prefix in syslog messages
         FTD_PREFIX: "%{DATA}%(?:[A-Z]+)"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   #
   # Create missing fields when no %FTD label is present
@@ -179,10 +169,6 @@ processors:
               - "MMM dd yyyy HH:mm:ss z"
               - "EEE MMM  d yyyy HH:mm:ss z"
               - "EEE MMM dd yyyy HH:mm:ss z"
-            on_failure:
-              - append:
-                  field: error.message
-                  value: "{{{ _ingest.on_failure_message }}}"
 
   #
   # Set log.level
@@ -224,84 +210,44 @@ processors:
   # Firewall messages
   #
   # This set of messages is shared between FTD and ASA.
-  - set:
-      if: 'ctx._temp_?.cisco?.message_id != ""'
-      field: "event.action"
-      value: "firewall-rule"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106001'"
-      tag: "dissect_message_id_106001"
+      tag: parse_106001
       field: "message"
       description: "106001"
-      pattern: "%{network.direction} %{network.transport} connection %{event.outcome} from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} flags %{} on interface %{_temp_.cisco.source_interface}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      pattern: "%{network.direction} %{network.transport} connection denied from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} flags %{} on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106002'"
-      tag: "dissect_message_id_106002"
+      tag: parse_106002
       field: "message"
       description: "106002"
-      pattern: "%{network.transport} Connection %{event.outcome} by %{network.direction} list %{_temp_.cisco.list_id} src %{source.address} dest %{destination.address}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      pattern: "%{network.transport} Connection denied by %{network.direction} list %{_temp_.cisco.list_id} src %{source.address} dest %{destination.address}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106006'"
-      tag: "dissect_message_id_106006"
+      tag: parse_106006
       field: "message"
       description: "106006"
-      pattern: "%{event.outcome} %{network.direction} %{network.transport} from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} on interface %{_temp_.cisco.source_interface}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      pattern: "Deny %{network.direction} %{network.transport} from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106007'"
-      tag: "dissect_message_id_106007"
+      tag: parse_106007
       field: "message"
       description: "106007"
-      pattern: "%{event.outcome} %{network.direction} %{network.transport} from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} due to %{network.protocol} %{}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      pattern: "Deny %{network.direction} %{network.transport} from %{source.address}/%{source.port} to %{destination.address}/%{destination.port} due to %{network.protocol} %{}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '106010'"
-      tag: "grok_message_id_106010"
+      tag: parse_106010
       field: "message"
       description: "106010"
       patterns:
-      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}/%{POSINT:source.port} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{POSINT:destination.port}(%{GREEDYDATA})?"
-      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}(/%{POSINT:source.port})? (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}(/%{POSINT:destination.port})?(%{GREEDYDATA})?"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      - "Deny %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}/%{POSINT:source.port} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{POSINT:destination.port}(%{GREEDYDATA})?"
+      - "Deny %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}(/%{POSINT:source.port})? (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}(/%{POSINT:destination.port})?(%{GREEDYDATA})?"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106013'"
-      tag: "dissect_message_id_106013"
+      tag: parse_106013
       field: "message"
       description: "106013"
       pattern: "Dropping echo request from %{source.address} to PAT address %{destination.address}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - set:
       if: "ctx._temp_.cisco.message_id == '106013'"
       field: "network.transport"
@@ -314,80 +260,61 @@ processors:
       value: inbound
   - grok:
       if: "ctx._temp_.cisco.message_id == '106014'"
-      tag: "grok_message_id_106014"
+      tag: parse_106014
       field: "message"
       description: "106014"
       patterns:
-      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:(?<destination.address>[^ (]*)(%{GREEDYDATA})?"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      - "Deny %{NOTSPACE:network.direction} %{NOTSPACE:network.transport} src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:(?<destination.address>[^ (]*)(%{GREEDYDATA})?"
   - grok:
       if: "ctx._temp_.cisco.message_id == '106015'"
-      tag: "grok_message_id_106015"
+      tag: parse_106015
       field: "message"
       description: "106015"
       patterns:
-      - "%{NOTSPACE:event.outcome} %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IPORHOST:source.address}/%{POSINT:source.port} to %{IPORHOST:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+      - "Deny %{NOTSPACE:network.transport} %{NOTSPACE} %{NOTSPACE} from %{IPORHOST:source.address}/%{POSINT:source.port} to %{IPORHOST:destination.address}/%{POSINT:destination.port} flags %{DATA} on interface %{NOTSPACE:_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106016'"
-      tag: "dissect_message_id_106016"
+      tag: parse_106016
       field: "message"
-      pattern: "%{event.outcome} IP spoof from (%{source.address}) to %{destination.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Deny IP spoof from (%{source.address}) to %{destination.address} on interface %{_temp_.cisco.source_interface}"
       description: "106016"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106017'"
-      tag: "dissect_message_id_106017"
+      tag: parse_106017
       field: "message"
-      pattern: "%{event.outcome} IP due to Land Attack from %{source.address} to %{destination.address}"
+      pattern: "Deny IP due to Land Attack from %{source.address} to %{destination.address}"
       description: "106017"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106018'"
+      tag: parse_106018
       field: "message"
-      pattern: "%{network.transport} packet type %{_temp_.cisco.icmp_type} %{event.outcome} by %{network.direction} list %{_temp_.cisco.list_id} src %{source.address} dest %{destination.address}"
+      pattern: "%{network.transport} packet type %{_temp_.cisco.icmp_type} denied by %{network.direction} list %{_temp_.cisco.list_id} src %{source.address} dest %{destination.address}"
       description: "106018"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106020'"
+      tag: parse_106020
       field: "message"
-      pattern: "%{event.outcome} IP teardrop fragment (size = %{}, offset = %{}) from %{source.address} to %{destination.address}"
+      pattern: "Deny IP teardrop fragment (size = %{}, offset = %{}) from %{source.address} to %{destination.address}"
       description: "106020"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106021'"
+      tag: parse_106021
       field: "message"
-      pattern: "%{event.outcome} %{network.transport} reverse path check from %{source.address} to %{destination.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Deny %{network.transport} reverse path check from %{source.address} to %{destination.address} on interface %{_temp_.cisco.source_interface}"
       description: "106021"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106022'"
+      tag: parse_106022
       field: "message"
-      pattern: "%{event.outcome} %{network.transport} connection spoof from %{source.address} to %{destination.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Deny %{network.transport} connection spoof from %{source.address} to %{destination.address} on interface %{_temp_.cisco.source_interface}"
       description: "106022"
   - grok:
       if: "ctx._temp_.cisco.message_id == '106023'"
+      tag: parse_106023
       field: "message"
       description: "106023"
       patterns:
-        - ^%{NOTSPACE:event.outcome} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{NUMBER:source.port})?\s*(\(%{CISCO_USER_OR_SGT_SRC}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{NUMBER:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
+        - ^Deny ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTCOLON:_temp_.cisco.source_interface}:%{IPORHOST:source.address}(/%{NUMBER:source.port})?\s*(\(%{CISCO_USER_OR_SGT_SRC}\) )?dst %{NOTCOLON:_temp_.cisco.destination_interface}:%{IPORHOST:destination.address}(/%{NUMBER:destination.port})?%{DATA}by access-group "%{NOTSPACE:_temp_.cisco.list_id}"
       pattern_definitions:
         HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
@@ -397,56 +324,51 @@ processors:
         CISCO_SGT: (?:, *)?%{NUMBER}(?::%{WORD})?
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106027'"
+      tag: parse_106027
       field: "message"
       description: "106027"
-      pattern: '%{} %{event.outcome} src %{source.address} dst %{destination.address} by access-group "%{_temp_.cisco.list_id}"'
+      pattern: '%{} Deny src %{source.address} dst %{destination.address} by access-group "%{_temp_.cisco.list_id}"'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106100'"
+      tag: parse_106100
       field: "message"
       description: "106100"
-      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
+      pattern: "access-list %{_temp_.cisco.list_id} %{_temp_.outcome} %{network.transport} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
   - dissect:
-      if: "ctx._temp_.cisco.message_id == '106102' || ctx._temp_.cisco.message_id == '106103'"
+      if: "ctx._temp_.cisco.message_id == '106102'"
+      tag: parse_106102
+      field: "message"
+      description: "106102"
+      pattern: "access-list %{_temp_.cisco.list_id} %{_temp_.outcome} %{network.transport} for user %{user.name} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '106103'"
+      tag: parse_106103
       field: "message"
       description: "106103"
-      pattern: "access-list %{_temp_.cisco.list_id} %{event.outcome} %{network.transport} for user %{user.name} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
+      pattern: "access-list %{_temp_.cisco.list_id} denied %{network.transport} for user %{user.name} %{_temp_.cisco.source_interface}/%{source.address}(%{source.port})%{}-> %{_temp_.cisco.destination_interface}/%{destination.address}(%{destination.port})%{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '111004'"
+      tag: parse_111004
       field: "message"
       description: "111004"
-      pattern: "%{source.address} end configuration: %{_temp_.cisco.cli_outcome}"
-  - set:
-      field: event.outcome
-      description: "111004"
-      value: "success"
-      if: "ctx._temp_.cisco.message_id == '111004' && ctx?._temp_?.cisco?.cli_outcome == 'OK'"
-  - set:
-      field: event.outcome
-      description: "111004"
-      value: "failure"
-      if: "ctx._temp_.cisco.message_id == '111004' && ctx?._temp_?.cisco?.cli_outcome == 'FAILED'"
-  - remove:
-      field: _temp_.cisco.cli_outcome
-      ignore_missing: true
-  - append:
-      field: event.type
-      description: "111004"
-      value: "change"
-      if: "ctx._temp_.cisco.message_id == '111004'"
+      pattern: "%{source.address} end configuration: %{_temp_.outcome}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '111009'"
+      tag: parse_111009
       description: "111009"
       field: "message"
       patterns:
       - "^%{NOTSPACE} '%{NOTSPACE:server.user.name}' executed %{NOTSPACE} %{GREEDYDATA:_temp_.cisco.command_line_arguments}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '111010'"
+      tag: parse_111010
       field: "message"
       description: "111010"
       patterns:
       - "User '%{NOTSPACE:server.user.name}', running %{QUOTEDSTRING} from IP %{IP:source.address}, executed %{QUOTEDSTRING:_temp_.cisco.command_line_arguments}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '113004'"
+      tag: parse_113004
       field: "message"
       description: "113004"
       patterns:
@@ -455,6 +377,7 @@ processors:
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
   - grok:
       if: "ctx._temp_.cisco.message_id == '113005'"
+      tag: parse_113005
       description: "113005"
       field: "message"
       patterns:
@@ -466,6 +389,7 @@ processors:
         IPORNONE: (%{IP:source.address}|None)
   - grok:
       if: "ctx._temp_.cisco.message_id == '113012'"
+      tag: parse_113012
       field: "message"
       description: "113012"
       patterns:
@@ -474,6 +398,7 @@ processors:
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
   - grok:
       if: "ctx._temp_.cisco.message_id == '113015'"
+      tag: parse_113015
       field: "message"
       description: "113015"
       patterns:
@@ -484,21 +409,25 @@ processors:
 
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113019'"
+      tag: parse_113019
       field: "message"
       description: "113019"
       pattern: "Group = %{source.user.group.name}, Username = %{source.user.name}, IP = %{destination.address}, Session disconnected. Session Type: %{_temp_.cisco.session_type}, Duration: %{_temp_.duration_hms}, Bytes xmt: %{source.bytes}, Bytes rcv: %{destination.bytes}, Reason: %{event.reason}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113021'"
+      tag: parse_113021
       field: "message"
       description: "113021"
       pattern: "Attempted console login failed. User %{source.user.name} did NOT have appropriate Admin Rights."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113040'"
+      tag: parse_113040
       field: "message"
       description: "113040"
       pattern: "Terminating the VPN connection attempt from %{source.user.group.name}. Reason: This connection is group locked to %{}."
   - grok:
       if: '["113029","113030","113031","113032","113033","113034","113035","113036","113038","113039"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_113029-113039
       field: "message"
       description: "113029, 113030, 113031, 113032, 113033, 113034, 113035, 113036, 113038, 113039"
       patterns:
@@ -510,12 +439,14 @@ processors:
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_302013-302015
       field: "message"
       description: "302013, 302015"
       patterns:
         - Built %{NOTSPACE:network.direction} %{GREEDYDATA:_temp_.var_302013_302015}
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id) && ctx.network.direction == "inbound"'
+      tag: parse_302013-302015_inbound
       field: "_temp_.var_302013_302015"
       description: "inbound: 302013, 302015"
       patterns:
@@ -533,6 +464,7 @@ processors:
 # https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslogs3.html#con_4770603
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id) && ctx.network.direction == "outbound"'
+      tag: parse_302013-302015_outbound
       field: "_temp_.var_302013_302015"
       description: "outbound: 302013, 302015"
       patterns:
@@ -547,11 +479,13 @@ processors:
         CISCO_SGT: (?:, *)?%{NUMBER}(?::%{WORD})?
   - dissect:
       if: "ctx._temp_.cisco.message_id == '303002'"
+      tag: parse_303002
       field: "message"
       description: "303002"
       pattern: "%{network.protocol} connection from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}, user %{client.user.name} %{} file %{file.path}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '305012'"
+      tag: parse_305012
       field: "message"
       description: "305012"
       patterns:
@@ -563,13 +497,9 @@ processors:
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(%{HOSTNAME}\\)?(?:%{USERNAME})\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?(?:%{NUMBER}:%{DATA})?))
         DURATION: "%{INT}:%{MINUTE}:%{SECOND}"
-  - set:
-      if: '["302020"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "flow-creation"
-      description: "302020"
   - grok:
       if: "ctx._temp_.cisco.message_id == '302020'"
+      tag: parse_302020
       field: "message"
       description: "302020"
       patterns:
@@ -587,48 +517,51 @@ processors:
         CISCO_SGT: (?:, *)?%{NUMBER}(?::%{WORD})?
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302022'"
+      tag: parse_302022
       field: "message"
       description: "302022"
       pattern: "Built %{} stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} %{} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302023'"
+      tag: parse_302023
       field: "message"
       description: "302023"
       pattern: "Teardown stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} duration %{_temp_.duration_hms} forwarded bytes %{network.bytes} %{event.reason}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '304001'"
+      tag: parse_304001
       field: "message"
       description: "304001"
       patterns:
         - "(%{NOTSPACE:source.user.name}@)?%{IP:source.address}(\\(%{DATA}\\))? %{DATA} (%{NOTSPACE}@)?%{IPORHOST:destination.address}:%{GREEDYDATA:url.original}"
-  - set:
-      if: "ctx._temp_.cisco.message_id == '304001'"
-      field: "event.outcome"
-      description: "304001"
-      value: allowed
   - dissect:
       if: "ctx._temp_.cisco.message_id == '304002'"
+      tag: parse_304002
       field: "message"
       description: "304002"
-      pattern: "Access %{event.outcome} URL %{url.original} SRC %{source.address} %{}EST %{destination.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Access denied URL %{url.original} SRC %{source.address} %{}EST %{destination.address} on interface %{_temp_.cisco.source_interface}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '305011'"
+      tag: parse_305011
       field: "message"
       description: "305011"
       patterns:
         - Built %{NOTSPACE} %{NOTSPACE:network.transport} translation from %{NOTSPACE:_temp_.cisco.source_interface}:%{IPORHOST:source.address}/%{NUMBER:source.port}(\(%{NOTSPACE:source.user.name}\))? to %{NOTSPACE:_temp_.cisco.destination_interface}:%{IP:destination.address}/%{NUMBER:destination.port}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313001'"
+      tag: parse_313001
       field: "message"
       description: "313001"
-      pattern: "%{event.outcome} %{network.transport} type=%{_temp_.cisco.icmp_type}, code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Denied %{network.transport} type=%{_temp_.cisco.icmp_type}, code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313004'"
+      tag: parse_313004
       field: "message"
       description: "313004"
-      pattern: "%{event.outcome} %{network.transport} type=%{_temp_.cisco.icmp_type}, from%{}addr %{source.address} on interface %{_temp_.cisco.source_interface} to %{destination.address}: no matching session"
+      pattern: "Denied %{network.transport} type=%{_temp_.cisco.icmp_type}, from%{}addr %{source.address} on interface %{_temp_.cisco.source_interface} to %{destination.address}: no matching session"
   - grok:
       if: "ctx._temp_.cisco.message_id == '313005'"
+      tag: parse_313005
       field: "message"
       description: "313005"
       patterns:
@@ -647,24 +580,28 @@ processors:
         CISCO_SGT: (?:, *)?%{NUMBER}(?::%{WORD})?
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313008'"
+      tag: parse_313008
       field: "message"
       description: "313008"
-      pattern: "%{event.outcome} %{network.transport} type=%{_temp_.cisco.icmp_type}, code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
+      pattern: "Denied %{network.transport} type=%{_temp_.cisco.icmp_type}, code=%{_temp_.cisco.icmp_code} from %{source.address} on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '313009'"
+      tag: parse_313009
       field: "message"
       description: "313009"
-      pattern: "%{event.outcome} invalid %{network.transport} code %{_temp_.cisco.icmp_code}, for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}"
+      pattern: "Denied invalid %{network.transport} code %{_temp_.cisco.icmp_code}, for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
+      tag: parse_322001
       field: "message"
       description: "322001"
-      pattern: "%{event.outcome} MAC address %{source.mac}, possible spoof attempt on interface %{_temp_.cisco.source_interface}"
+      pattern: "Deny MAC address %{source.mac}, possible spoof attempt on interface %{_temp_.cisco.source_interface}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338001'"
+      tag: parse_338001
       field: "message"
       description: "338001"
-      pattern: "Dynamic filter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic filter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338001'"
       field: "server.domain"
@@ -673,9 +610,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338002'"
+      tag: parse_338002
       field: "message"
       description: "338002"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338002'"
       field: "server.domain"
@@ -684,19 +622,22 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338003'"
+      tag: parse_338003
       field: "message"
       description: "338003"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338004'"
+      tag: parse_338004
       field: "message"
       description: "338004"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338005'"
+      tag: parse_338005
       field: "message"
       description: "338005"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338005'"
       field: "server.domain"
@@ -705,9 +646,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338006'"
+      tag: parse_338006
       field: "message"
       description: "338006"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338006'"
       field: "server.domain"
@@ -716,19 +658,22 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338007'"
+      tag: parse_338007
       field: "message"
       description: "338007"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338008'"
+      tag: parse_338008
       field: "message"
       description: "338008"
-      pattern: "Dynamic %{}ilter %{event.outcome} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} black%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338101'"
+      tag: parse_338101
       field: "message"
       description: "338101"
-      pattern: "Dynamic %{}ilter %{event.outcome} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}"
+      pattern: "Dynamic %{}ilter %{} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338101'"
       field: "server.domain"
@@ -737,9 +682,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338102'"
+      tag: parse_338102
       field: "message"
       description: "338102"
-      pattern: "Dynamic %{}ilter %{event.outcome} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}"
+      pattern: "Dynamic %{}ilter %{} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338102'"
       field: "server.domain"
@@ -748,19 +694,22 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338103'"
+      tag: parse_338103
       field: "message"
       description: "338103"
-      pattern: "Dynamic %{}ilter %{event.outcome} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}"
+      pattern: "Dynamic %{}ilter %{} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338104'"
+      tag: parse_338104
       field: "message"
       description: "338104"
-      pattern: "Dynamic %{}ilter %{event.outcome} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}"
+      pattern: "Dynamic %{}ilter %{} white%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338201'"
+      tag: parse_338201
       field: "message"
       description: "338201"
-      pattern: "Dynamic %{}ilter %{event.outcome} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338201'"
       field: "server.domain"
@@ -769,9 +718,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338202'"
+      tag: parse_338202
       field: "message"
       description: "338202"
-      pattern: "Dynamic %{}ilter %{event.outcome} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338202'"
       field: "server.domain"
@@ -780,9 +730,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338203'"
+      tag: parse_338203
       field: "message"
       description: "338203"
-      pattern: "Dynamic %{}ilter %{event.outcome} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}source %{} resolved from %{_temp_.cisco.list_id} list: %{source.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338203'"
       field: "server.domain"
@@ -791,9 +742,10 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338204'"
+      tag: parse_338204
       field: "message"
       description: "338204"
-      pattern: "Dynamic %{}ilter %{event.outcome} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
+      pattern: "Dynamic %{}ilter %{} grey%{}d %{network.transport} traffic from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}destination %{} resolved from %{_temp_.cisco.list_id} list: %{destination.domain}, threat-level: %{_temp_.cisco.threat_level}, category: %{_temp_.cisco.threat_category}"
   - set:
       if: "ctx._temp_.cisco.message_id == '338204'"
       field: "server.domain"
@@ -802,6 +754,7 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '338301'"
+      tag: parse_338301
       field: "message"
       description: "338301"
       pattern: "Intercepted DNS reply for domain %{source.domain} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}, matched %{_temp_.cisco.list_id}"
@@ -831,45 +784,38 @@ processors:
       ignore_empty_value: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '502103'"
+      tag: parse_502103
       field: "message"
       description: "502103"
       pattern: "User priv level changed: Uname: %{server.user.name} From: %{_temp_.cisco.privilege.old} To: %{_temp_.cisco.privilege.new}"
-  - append:
-      if: "ctx._temp_.cisco.message_id == '502103'"
-      field: "event.type"
-      description: "502103"
-      value:
-        - "group"
-        - "change"
-  - append:
-      if: "ctx._temp_.cisco.message_id == '502103'"
-      field: "event.category"
-      description: "502103"
-      value: "iam"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '507003'"
+      tag: parse_507003
       field: "message"
       description: "507003"
       pattern: "%{network.transport} flow from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} terminated by inspection engine, reason - %{message}"
   - dissect:
       if: '["605004", "605005"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_605004-605005
       field: "message"
       description: "605004, 605005"
-      pattern: 'Login %{event.outcome} from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{network.protocol} for user "%{source.user.name}"'
+      pattern: 'Login %{} from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{network.protocol} for user "%{source.user.name}"'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '609001'"
+      tag: parse_609001
       field: "message"
       description: "609001"
       pattern: "Built local-host %{_temp_.cisco.source_interface}:%{source.address}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '607001'"
+      tag: parse_607001
       field: "message"
       description: "607001"
       pattern: "Pre-allocate SIP %{_temp_.cisco.connection_type} secondary channel for %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} to %{_temp_.cisco.source_interface}:%{source.address} from %{_temp_.cisco.message} message"
   - grok:
       if: "ctx._temp_.cisco.message_id == '607001'"
+      tag: parse_607001_connection_type
       description: "607001"
-      tag: "grok_connection_type"
       field: "_temp_.cisco.connection_type"
       patterns:
         - "%{CONNECTION}"
@@ -877,48 +823,41 @@ processors:
         TRANSPORTS: "(?:UDP|TCP)"
         PROTOCOLS: "(?:RTP|RTCP)"
         CONNECTION: "(?:%{TRANSPORTS:network.transport}|%{PROTOCOLS:network.protocol})"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '609002'"
+      tag: parse_609002
       field: "message"
       description: "609002"
       pattern: "Teardown local-host %{_temp_.cisco.source_interface}:%{source.address} duration %{_temp_.duration_hms}"
   - dissect:
       if: '["611102", "611101"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_611101-611102
       field: "message"
       description: "611102, 611101"
-      pattern: 'User authentication %{event.outcome}: IP address: %{source.address}, Uname: %{server.user.name}'
+      pattern: 'User authentication %{}: IP address: %{source.address}, Uname: %{server.user.name}'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '710003'"
+      tag: parse_710003
       field: "message"
       description: "710003"
-      pattern: "%{network.transport} access %{event.outcome} by ACL from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+      pattern: "%{network.transport} access denied by ACL from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '710005'"
+      tag: parse_710005
       field: "message"
       description: "710005"
-      pattern: "%{network.transport} request %{event.outcome} from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
-  - grok:
+      pattern: "%{network.transport} request discarded from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+  - grok: 
       if: "ctx._temp_.cisco.message_id == '713049'"
-      tag: "grok_message_713049"
+      tag: parse_713049
       field: "message"
       description: "713049"
       patterns:
         - "Group = %{NOTSPACE}, IP = %{IP:source.address}, Security negotiation complete for LAN-to-LAN Group (%{DATA}) %{DATA}, Inbound SPI = %{DATA}, Outbound SPI = %{DATA}"
         - "Group = %{NOTSPACE}, Username = %{NOTSPACE:user.name}, IP = %{IP:source.address}, Security negotiation complete for User (%{DATA}) %{DATA}, Inbound SPI = %{DATA}, Outbound SPI = %{DATA}"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '716002'"
+      tag: parse_716002
       field: "message"
       description: "716002"
       patterns:
@@ -926,15 +865,15 @@ processors:
         - "Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} WebVPN session terminated: %{GREEDYDATA:event.reason}."
   - grok:
       if: "ctx._temp_.cisco.message_id == '722011'"
+      tag: parse_722011
       field: "message"
       description: "722011"
       patterns:
         - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> SVC Message: %{GREEDYDATA:event.reason}\.'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC Message: %{GREEDYDATA:event.reason}\.'
-
-
   - grok:
       if: '["722022", "722023"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_722022-722023
       field: "message"
       description: "722022, 722023"
       patterns:
@@ -942,6 +881,7 @@ processors:
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} %{GREEDYDATA:event.reason}'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722033'"
+      tag: parse_722033
       field: "message"
       description: "722033"
       patterns:
@@ -949,6 +889,7 @@ processors:
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722034'"
+      tag: parse_722034
       field: "message"
       description: "722034"
       patterns:
@@ -956,6 +897,7 @@ processors:
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722037'"
+      tag: parse_722037
       field: "message"
       description: "722037"
       patterns:
@@ -963,6 +905,7 @@ processors:
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC closing connection: %{GREEDYDATA:event.reason}\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722051'"
+      tag: parse_722051
       field: "message"
       description: "722051"
       patterns:
@@ -970,170 +913,105 @@ processors:
         - "Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} IPv4 Address %{IP:_temp_.cisco.assigned_ip} %{GREEDYDATA}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '733100'"
+      tag: parse_733100
       field: "message"
       description: "733100"
       patterns:
         - \[(%{SPACE})?%{DATA:_temp_.cisco.burst.object}\] drop %{NOTSPACE:_temp_.cisco.burst.id} exceeded. Current burst rate is %{INT:_temp_.cisco.burst.current_rate} per second, max configured rate is %{INT:_temp_.cisco.burst.configured_rate}; Current average rate is %{INT:_temp_.cisco.burst.avg_rate} per second, max configured rate is %{INT:_temp_.cisco.burst.configured_avg_rate}; Cumulative total count is %{INT:_temp_.cisco.burst.cumulative_count}
   - dissect:
       if: "ctx._temp_.cisco.message_id == '734001'"
+      tag: parse_734001
       field: "message"
       description: "734001"
       pattern: "DAP: User %{user.email}, Addr %{source.address}, Connection %{_temp_.cisco.connection_type}: The following DAP records were selected for this connection: %{_temp_.cisco.dap_records->}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '805001'"
+      tag: parse_805001
       field: "message"
       description: "805001"
       pattern: "Offloaded %{network.transport} Flow for connection %{_temp_.cisco.connection_id} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '805002'"
+      tag: parse_805002
       field: "message"
       description: "805002"
       pattern: "%{network.transport} Flow is no longer offloaded for connection %{_temp_.cisco.connection_id} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})"
   - split:
       field: "_temp_.cisco.dap_records"
+      tag: split_dap_records
       separator: ",\\s+"
       ignore_missing: true
   - dissect:
       if: "ctx._temp_.cisco.message_id == '434002'"
+      tag: parse_434002
       field: "message"
-      pattern: "SFR requested to %{event.action} %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+      pattern: "SFR requested to drop %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '434004'"
+      tag: parse_434004
       field: "message"
-      pattern: "SFR requested ASA to %{event.action} further packet redirection and process %{network.protocol} flow from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} locally"
+      pattern: "SFR requested ASA to bypass further packet redirection and process %{network.protocol} flow from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} locally"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '110002'"
+      tag: parse_110002
       field: "message"
       pattern: "%{event.reason} for %{network.protocol} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '419002'"
+      tag: parse_419002
       field: "message"
       pattern: "%{event.reason}from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} %{+event.reason}"
   - dissect:
       if: '["602303", "602304"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_602303-602304
       field: "message"
-      pattern: "%{network.type}: An %{network.direction} %{_temp_.cisco.tunnel_type} SA (SPI= %{}) between %{source.address} and %{destination.address} (user= %{user.name}) has been %{event.action}."
+      pattern: "%{network.type}: An %{network.direction} %{_temp_.cisco.tunnel_type} SA (SPI= %{}) between %{source.address} and %{destination.address} (user= %{user.name}) has been %{}."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750002'"
+      tag: parse_750002
       field: "message"
       pattern: "Local:%{source.address}:%{source.port} Remote:%{destination.address}:%{destination.port} Username:%{user.name} %{event.reason}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '713120'"
+      tag: parse_713120
       field: "message"
       pattern: "Group = %{}, IP = %{source.address}, %{event.reason} (msgid=%{event.id})"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '713202'"
+      tag: parse_713202
       field: "message"
       pattern: "IP = %{source.address}, %{event.reason}. %{} packet."
 # Support masked user
   - grok:
       if: "ctx._temp_.cisco.message_id == '716039'"
+      tag: parse_716039
       field: "message"
       patterns:
         - "Authentication: rejected, group = %{NOTSPACE:source.user.group.name} user = %{USER:source.user.name} , Session Type: %{NOTSPACE:_temp_.cisco.session_type}"
         - "Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750003'"
+      tag: parse_750003
       field: "message"
       pattern: "Local:%{source.address}:%{source.port} Remote:%{destination.address}:%{destination.port} Username:%{user.name} %{event.reason} ERROR:%{+event.reason}"
   - grok:
       if: '["713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_713901-713906
       field: "message"
       patterns:
         - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
-   # Handle ecs action outcome protocol
-  - set:
-      if: '["434002", "434004"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "unknown"
   - set:
       if: '["419002"].contains(ctx._temp_.cisco.message_id)'
+      tag: parse_419002
       field: "network.protocol"
       value: "tcp"
-  - set:
-      if: '["110002"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "dropped"
-  - set:
-      if: '["713120"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "success"
-  - set:
-      if: '["113004", "113012"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "success"
-  - set:
-      if: '["113002", "113005", "113021"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "failure"
-  - set:
-      if: '["602303", "602304", "611101"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "success"
-  - set:
-      if: '["605004", "611102"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "failure"
-  - set:
-      if: '["734001"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "success"
-  - set:
-      if: '["716039"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "failure"
-  - set:
-      if: '["710005"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "dropped"
-  - set:
-      if: '["713901", "713902", "713903", "713904", "713905"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.outcome"
-      value: "failure"
-  - set:
-      if: '["113039"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "client-vpn-connected"
-  - set:
-      if: '["113029","113030","113031","113032","113033","113034","113035","113036","113037","113038","113040"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "client-vpn-error"
-  - set:
-      if: '["113019"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "client-vpn-disconnected"
-  - set:
-      if: '["750002", "750003"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "connection-started"
-  - set:
-      if: '["750003", "713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "error"
-  - set:
-      if: '["113005", "113021", "605004", "611102", "716039"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "logon-failed"
-  - set:
-      if: '["113004", "113012", "611101", "734001"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "logged-in"
-  - append:
-      if: '["750003", "713905", "713904", "713906", "713902", "713901"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.type"
-      value: "error"
 
   #
   # Handle 302xxx messages (Flow expiration a.k.a "Teardown")
   #
-  - set:
-      if: '["305012", "302014", "302016", "302018", "302021", "302036", "302304", "302306", "609001", "609002"].contains(ctx._temp_.cisco.message_id)'
-      field: "event.action"
-      value: "flow-expiration"
-      description: "305012, 302014, 302016, 302018, 302021, 302036, 302304, 302306, 609001, 609002"
   - grok:
       field: "message"
-      tag: "grok_message_302xxx_teardown"
+      tag: parse_302xxx
       if: '["302014", "302016", "302018", "302021", "302036", "302304", "302306"].contains(ctx._temp_.cisco.message_id)'
       description: "302014, 302016, 302018, 302021, 302036, 302304, 302306"
       patterns:
@@ -1156,12 +1034,6 @@ processors:
         CISCO_USER_OR_SGT_DST: (?:%{CISCO_USER:_temp_.cisco.destination_user_or_sgt}|%{CISCO_SGT:_temp_.cisco.destination_user_or_sgt}|\((?:%{CISCO_USER:_temp_.cisco.destination_user_or_sgt}|%{CISCO_SGT:_temp_.cisco.destination_user_or_sgt})\))
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?%{CISCO_SGT}?)|[^$]+)
         CISCO_SGT: (?:, *)?%{NUMBER}(?::%{WORD})?
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   #
   # Decode FTD's Security Event Syslog Messages
@@ -1180,12 +1052,6 @@ processors:
       target_field: "_temp_.orig_security"
       trim_key: " "
       trim_value: " "
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   #
   # Remove _temp_.full_message.
@@ -1196,6 +1062,7 @@ processors:
   - rename:
       description: Retain full log message without the Cisco codes for later search.
       if: ctx.tags != null && ctx.tags.contains('keep_message') && ctx._temp_?.cisco?.full_message == null
+      tag: rename_full_message
       field: message
       target_field: _temp_.cisco.full_message
   - remove:
@@ -1228,6 +1095,7 @@ processors:
   #*******************************************************************************
   - script:
       if: ctx._temp_?.orig_security != null
+      tag: script_ftd_events
       params:
         ACPolicy:
           target: ac_policy
@@ -1592,6 +1460,7 @@ processors:
   # Normalize ECS field values
   #
   - script:
+      tag: script_normalize_ftd_events
       lang: painless
       params:
         "ctx._temp_.cisco.message_id":
@@ -1687,6 +1556,7 @@ processors:
   # This will fill event.start, event.end and event.duration
   #
   - script:
+      tag: script_process_flow_duration
       lang: painless
       if: "ctx?._temp_?.duration_hms != null"
       source: >
@@ -1731,12 +1601,6 @@ processors:
         CISCO_SGT: (, *(%{CISCO_SGT_TAG}:%{CISCO_SGT_NAME}|%{CISCO_SGT_TAG}))|(%{CISCO_SGT_TAG}:%{CISCO_SGT_NAME})
         CISCO_SGT_TAG: (%{NUMBER:_temp_.cisco.source_user_security_group_tag})
         CISCO_SGT_NAME: (%{WORD:_temp_.cisco.source_user_security_group_tag_name})
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   # Parse Source without User only containing SGT
   - grok:
       field: "_temp_.cisco.source_sgt"
@@ -1746,14 +1610,9 @@ processors:
         - '%{CISCO_SGT}'
       pattern_definitions:
         CISCO_SGT: (, *)?(%{NUMBER:_temp_.cisco.source_user_security_group_tag})?:?%{WORD:_temp_.cisco.source_user_security_group_tag_name}?
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
       field: _temp_.cisco.source_user_security_group_tag
+      tag: convert_source_user_security_group_tag
       type: long
       ignore_missing: true
   - grok:
@@ -1770,12 +1629,6 @@ processors:
         CISCO_SGT: (, *(%{CISCO_SGT_TAG}:%{CISCO_SGT_NAME}|%{CISCO_SGT_TAG}))|(%{CISCO_SGT_TAG}:%{CISCO_SGT_NAME})
         CISCO_SGT_TAG: (%{NUMBER:_temp_.cisco.destination_user_security_group_tag})
         CISCO_SGT_NAME: (%{WORD:_temp_.cisco.destination_user_security_group_tag_name})
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   # Parse Destination without User only containing SGT
   - grok:
       field: "_temp_.cisco.destination_sgt"
@@ -1785,14 +1638,9 @@ processors:
         - '%{CISCO_SGT}'
       pattern_definitions:
         CISCO_SGT: (, *)?(%{NUMBER:_temp_.cisco.destination_user_security_group_tag})?:?%{WORD:_temp_.cisco.destination_user_security_group_tag_name}?
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
       field: _temp_.cisco.destination_user_security_group_tag
+      tag: convert_destination_user_security_group_tag
       type: long
       ignore_missing: true
   - remove: 
@@ -1808,10 +1656,12 @@ processors:
       field: _temp_.cisco.destination_username
       if: ctx._temp_?.cisco?.destination_username != null && ctx._temp_.cisco.destination_username == ""
   - set:
+      tag: set_source_user_name
       field: source.user.name
       value: "{{{ _temp_.cisco.source_username }}}"
       if: 'ctx?.source?.user?.name == null && ctx._temp_?.cisco?.source_username != null'
   - set:
+      tag: set_destination_user_name
       field: destination.user.name
       value: "{{{ _temp_.cisco.destination_username }}}"
       if: 'ctx?.destination?.user?.name == null && ctx._temp_?.cisco?.destination_username != null'
@@ -1829,12 +1679,6 @@ processors:
         CISCO_USER_EMAIL: "%{CISCO_USER}@%{HOSTNAME:source.user.domain}"
         CISCO_USER: "%{USERNAME:source.user.name}"
         CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:source.user.domain}\\)?
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - grok:
       field: "destination.user.name"
       tag: "grok_destination_user_name"
@@ -1847,12 +1691,6 @@ processors:
         CISCO_USER_EMAIL: "%{CISCO_USER}@%{HOSTNAME:destination.user.domain}"
         CISCO_USER: "%{USERNAME:destination.user.name}"
         CISCO_DOMAIN: (LOCAL\\)?(%{HOSTNAME:destination.user.domain}\\)?
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
 
   #
   # Normalize protocol names
@@ -1881,6 +1719,7 @@ processors:
   #
   - script:
       if: "ctx?.network?.transport != null"
+      tag: script_process_iana_number
       lang: painless
       params:
         icmp: 1
@@ -1922,32 +1761,21 @@ processors:
           net['iana_number'] = net.transport;
           net['transport'] = trans;
         }
-  #
-  # Normalize event.outcome
-  #
-  - lowercase:
-      field: "event.outcome"
-      ignore_missing: true
-  - set:
-      field: "event.outcome"
-      if: 'ctx.event?.outcome == "est-allowed"'
-      value: "allowed"
-  - set:
-      field: "event.outcome"
-      if: 'ctx.event?.outcome == "permitted"'
-      value: "allowed"
-  - set:
-      field: "event.outcome"
-      if: 'ctx.event?.outcome == "allow"'
-      value: allowed
-  - set:
-      field: "event.outcome"
-      if: 'ctx.event?.outcome == "deny"'
-      value: denied
   - set:
       field: "network.transport"
       if: 'ctx.network?.transport == "icmpv6"'
       value: "ipv6-icmp"
+
+  #
+  # Normalize event.outcome
+  #
+  - lowercase:
+      field: "_temp_.outcome"
+      ignore_missing: true
+  - lowercase:
+      field: "event.outcome"
+      ignore_missing: true
+
   #
   # Convert numeric fields to integer or long, as output of dissect and kv processors is always a string
   #
@@ -1956,149 +1784,81 @@ processors:
       tag: "convert_source_port"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: destination.port
       tag: "convert_destination_port"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: source.bytes
       tag: "convert_source_bytes"
       type: long
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: destination.bytes
       tag: "convert_destination_bytes"
       type: long
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: network.bytes
       tag: "convert_network_bytes"
       type: long
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: source.packets
       tag: "convert_source_packets"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: destination.packets
       tag: "convert_destination_packets"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: _temp_.cisco.mapped_source_port
       tag: "convert_mapped_source_port"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
       field: _temp_.cisco.mapped_destination_port
       tag: "convert_mapped_destination_port"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - convert:
       field: _temp_.cisco.icmp_code
       tag: "convert_icmp_code"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: _temp_.cisco.icmp_type
       tag: "convert_icmp_type"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: _temp_.cisco.original_iana_number
       tag: "convert_original_iana_number"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: http.response.status_code
       tag: "convert_http_resp_status_code"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: file.size
       tag: "convert_file_size"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: network.iana_number
       tag: "convert_iana_number"
       type: string
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - convert:
       field: sip.to.uri.port
       tag: "convert_sip_to_uri_port"
       type: integer
       ignore_missing: true
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
       
   #
   # Assign ECS .ip fields from .address is a valid IP address is found,
@@ -2110,44 +1870,24 @@ processors:
       tag: "grok_source_address"
       patterns:
         - "^(?:%{IP:source.ip}|%{GREEDYDATA:source.domain})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - grok:
       field: destination.address
       if: ctx.destination?.address != null
       tag: "grok_destination_address"
       patterns:
         - "^(?:%{IP:destination.ip}|%{GREEDYDATA:destination.domain})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - grok:
       field: client.address
       if: ctx.client?.address != null
       tag: "grok_client_address"
       patterns:
         - "^(?:%{IP:client.ip}|%{GREEDYDATA:client.domain})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - grok:
       field: server.address
       if: ctx.server?.address != null
       tag: "grok_server_address"
       patterns:
         - "^(?:%{IP:server.ip}|%{GREEDYDATA:server.domain})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   #
   # Geolocation for source and destination addresses
   #
@@ -2203,24 +1943,12 @@ processors:
       tag: "grok_natsrcip"
       patterns:
         - "^(?:%{IP:_temp_.cisco.mapped_source_ip}|%{GREEDYDATA:_temp_.cisco.mapped_source_host})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   - grok:
       field: _temp_.natdstip
       if: ctx._temp_?.natdstip != null
       tag: "grok_natdstip"
       patterns:
         - "^(?:%{IP:_temp_.cisco.mapped_destination_ip}|%{GREEDYDATA:_temp_.cisco.mapped_destination_host})$"
-      on_failure:
-        - append:
-            field: error.message
-            value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
-        - fail:
-            message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
   #
   # NAT fields
   #
@@ -2228,38 +1956,46 @@ processors:
   # This populates both nat.ip and nat.port only when some translation is done.
   # Fills nat.ip and nat.port even when only the ip or port changed.
   - set:
+      tag: set_source_nat_ip
       field: source.nat.ip
       value: "{{{_temp_.cisco.mapped_source_ip}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_ip != ctx?.source?.ip"
       ignore_empty_value: true
   - convert:
+      tag: convert_source_nat_ip
       field: source.nat.ip
       type: ip
       ignore_missing: true
   - set:
+      tag: set_source_nat_port
       field: source.nat.port
       value: "{{{_temp_.cisco.mapped_source_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_source_port != ctx?.source?.port"
       ignore_empty_value: true
   - convert:
+      tag: convert_source_nat_port
       field: source.nat.port
       type: long
       ignore_missing: true
   - set:
+      tag: set_destination_nat_ip
       field: destination.nat.ip
       value: "{{{_temp_.cisco.mapped_destination_ip}}}"
       if: "ctx?._temp_?.cisco.mapped_destination_ip != ctx?.destination?.ip"
       ignore_empty_value: true
   - convert:
+      tag: convert_destination_nat_ip
       field: destination.nat.ip
       type: ip
       ignore_missing: true
   - set:
+      tag: set_destination_nat_port
       field: destination.nat.port
       value: "{{{_temp_.cisco.mapped_destination_port}}}"
       if: "ctx?._temp_?.cisco?.mapped_destination_port != ctx?.destination?.port"
       ignore_empty_value: true
   - convert:
+      tag: convert_destination_nat_port
       field: destination.nat.port
       type: long
       ignore_missing: true
@@ -2337,10 +2073,6 @@ processors:
       field: url.original
       tag: "uriparts_url_original"
       if: ctx.url?.original != null
-      on_failure:
-        - append:
-            field: error.message
-            value: "Processor {{{ _ingest.on_failure_processor_type }}} with tag {{{ _ingest.on_failure_processor_tag }}} in pipeline {{{ _ingest.on_failure_pipeline }}} failed with message: {{{ _ingest.on_failure_message }}}"
   - append:
       field: url.domain
       value: "{{{_temp_.url_domain}}}"
@@ -2361,14 +2093,7 @@ processors:
       field: _temp_.cisco
       target_field: "cisco.asa"
       if: ctx._temp_?.cisco != null
-  #
-  # Remove temporary fields
-  #
-  - remove:
-      field:
-        - _temp_
-        - _conf
-      ignore_missing: true
+
   #
   # Rename some 7.x fields
   #
@@ -2378,154 +2103,331 @@ processors:
       ignore_missing: true
   # ECS categorization
   - script:
+      tag: script_ecs_categorization
       lang: painless
+      description: >-
+        This script will set the ECS event categorization fields for each
+        message type. If a message wrote to _temp_.outcome, the value of this
+        field will be used to conditionally set the ECS event fields.
+        The top-level keys are the Cisco message IDs. The next level of keys are
+        either the ECS event fields or in the case of _temp_.outcome being set,
+        the possible values of _temp_.outcome. In the latter case, the keys
+        contained within will be the ECS event fields.
       params:
-        connection-finished:
-          kind: event
-          category:
-            - network
-          type:
-            - end
-        connection-started:
-          kind: event
-          category:
-            - network
-          type:
-            - start
-        file-detected:
-          kind: alert
-          category:
-            - malware
-          type:
-            - info
-        firewall-rule:
-          kind: event
-          category:
-            - network
-          type: []
-        flow-creation:
-          kind: event
-          category:
-            - network
-          type:
-            - connection
-            - start
-        flow-expiration:
-          kind: event
-          category:
-            - network
-          type:
-            - connection
-            - end
-        intrusion-detected:
-          kind: alert
-          category:
-            - intrusion_detection
-          type:
-            - info
-        logged-in:
-          kind: event
-          category:
-            - authentication
-            - network
-          type: ['allowed', 'info']
-        logon-failed:
-          kind: event
-          category:
-            - authentication
-            - network
-          type: ['denied', 'info']
-        malware-detected:
-          kind: alert
-          category:
-            - malware
-          type:
-            - info
-        bypass:
-          kind: event
-          category:
-            - network
-          type:
-            - info
-        error:
-          kind: event
+        "106001":
+          type: [ connection, denied ]
+          outcome: success
+        "106002":
+          type: [ connection, denied ]
+          outcome: success
+        "106006":
+          type: [ connection, denied ]
+          outcome: success
+        "106007":
+          type: [ connection, denied ]
+          outcome: success
+        "106010":
+          type: [ connection, denied ]
+          outcome: success
+        "106013":
+          type: [ connection, denied ]
+          outcome: success
+        "106014":
+          type: [ connection, denied ]
+          outcome: success
+        "106015":
+          type: [ connection, denied ]
+          outcome: success
+        "106016":
+          type: [ connection, denied ]
+          outcome: success
+        "106017":
+          type: [ connection, denied ]
+          outcome: success
+        "106018":
+          type: [ connection, denied ]
+          outcome: success
+        "106020":
+          type: [ connection, denied ]
+          outcome: success
+        "106021":
+          type: [ connection, denied ]
+          outcome: success
+        "106022":
+          type: [ connection, denied ]
+          outcome: success
+        "106023":
+          type: [ connection, denied ]
+          outcome: success
+        "106027":
+          type: [ connection, denied ]
+          outcome: success
+        "106100":
+          denied:
+            type: [ connection, denied ]
+            action: firewall-rule
+            outcome: success
+          permitted:
+            type: [ connection, allowed ]
+            action: firewall-rule
+            outcome: success
+          est-allowed:
+            type: [ connection, allowed ]
+            action: firewall-rule
+            outcome: success
+        "106102":
+          denied:
+            type: [ connection, denied ]
+            action: firewall-rule
+            outcome: success
+          permitted:
+            type: [ connection, allowed ]
+            action: firewall-rule
+            outcome: success
+        "106103":
+          type: [ connection, denied ]
+          outcome: success
+        "110002":
+          type: [ connection, denied ]
           outcome: failure
-          category:
-            - network
-          type:
-            - info
-        deleted:
-          kind: event
-          category:
-            - network
-          type:
-            - info
-            - end
-        creation:
-          kind: event
-          category:
-            - network
-          type:
-            - info
-            - access
-        client-vpn-connected:
-          kind: event
-          category:
-            - network
-            - session
-          type:
-            - connection
-            - start
-        client-vpn-error:
-          kind: event
-          category:
-            - network
-          type:
-            - connection
-            - denied
-        client-vpn-disconnected:
-          kind: event
-          category:
-            - network
-          type:
-            - connection
-            - end
+        "111004":
+          failed:
+            outcome: failure
+          ok:
+            outcome: success
+        "113004":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          action: logged-in
+          outcome: success
+        "113005":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
+        "113012":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          action: logged-in
+          outcome: success
+        "113019":
+          type: [ connection, end ]
+          action: client-vpn-disconnected
+        "113021":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
+        "113029":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113030":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113031":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113032":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113033":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113034":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113035":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113036":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113037":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113038":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "113039":
+          category: [ network, session ]
+          type: [ connection, start ]
+          action: client-vpn-connected
+        "113040":
+          type: [ connection, denied ]
+          action: client-vpn-error
+        "302014":
+          type: [ connection, end ]
+          action: flow-expiration
+        "302016":
+          type: [ connection, end ]
+          action: flow-expiration
+        "302018":
+          type: [ connection, end ]
+          action: flow-expiration
+          outcome: success
+        "302020":
+          type: [ connection, start ]
+          action: flow-creation
+        "302021":
+          type: [ connection, end ]
+          action: flow-expiration
+        "302036":
+          type: [ connection, end ]
+          action: flow-expiration
+        "302304":
+          type: [ connection, end ]
+          action: flow-expiration
+        "302306":
+          type: [ connection, end ]
+          action: flow-expiration
+        "304001":
+          type: [ connection, allowed ]
+          outcome: success
+        "304002":
+          type: [ connection, denied ]
+          outcome: success
+        "305012":
+          type: [ connection, end ]
+          action: flow-expiration
+        "313001":
+          type: [ connection, denied ]
+          outcome: success
+        "313004":
+          type: [ connection, denied ]
+          outcome: success
+        "313008":
+          type: [ connection, denied ]
+          outcome: success
+        "313009":
+          type: [ connection, denied ]
+          outcome: success
+        "322001":
+          type: [ connection, denied ]
+        "338001":
+          type: [ connection ]
+        "338002":
+          type: [ connection, allowed ]
+          outcome: success
+        "338003":
+          type: [ connection ]
+        "338004":
+          category: [ network, intrusion_detection ]
+          outcome: success
+        "338005":
+          type: [ connection ]
+        "338006":
+          type: [ connection ]
+        "338007":
+          type: [ connection ]
+        "338008":
+          type: [ connection, denied ]
+          outcome: failure
+        "338101":
+          type: [ connection ]
+        "338102":
+          type: [ connection ]
+        "338103":
+          type: [ connection ]
+        "338104":
+          type: [ connection ]
+        "338201":
+          type: [ connection ]
+        "338202":
+          type: [ connection ]
+        "338203":
+          type: [ connection ]
+        "338204":
+          type: [ connection, denied ]
+          outcome: failure
+        "338301":
+          type: [ connection ]
+        "434002":
+          type: [ connection, denied ]
+          action: drop
+          outcome: unknown
+        "434004":
+          action: bypass
+          outcome: unknown
+        "502103":
+          category: [ iam ]
+          type: [ group, change ]
+        "602303":
+          type: [ connection, start ]
+          action: created
+          outcome: success
+        "602304":
+          type: [ info, end ]
+          action: deleted
+          outcome: success
+        "605004":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
+        "605005":
+          type: [ connection, allowed ]
+          outcome: success
+        "609001":
+          type: [ connection, end ]
+          action: flow-expiration
+        "609002":
+          type: [ connection, end ]
+          action: flow-expiration
+        "611101":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          action: logged-in
+          outcome: success
+        "611102":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
+        "710003":
+          type: [ connection, denied ]
+          outcome: success
+        "710005":
+          type: [ connection, denied ]
+          outcome: failure
+        "713120":
+          outcome: success
+        "713901":
+          action: error
+          outcome: failure
+        "713902":
+          action: error
+          outcome: failure
+        "713903":
+          outcome: failure
+        "713904":
+          action: error
+          outcome: failure
+        "713905":
+          action: error
+          outcome: failure
+        "716039":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
+        "734001":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          action: logged-in
+          outcome: success
+        "750002":
+          type: [ start, connection ]
+          action: connection-started
+        "750003":
+          action: error
       source: >-
-        if (ctx?.event?.action == null || !params.containsKey(ctx.event.action)) {
+        if (ctx.event.code == null || !params.containsKey(ctx.event.code)) {
           return;
         }
-
-        ctx.event.kind = params.get(ctx.event.action).get('kind');
-        ctx.event.category = params.get(ctx.event.action).get('category').clone();
-        ctx.event.type = params.get(ctx.event.action).get('type').clone();
-        if (ctx?.event?.outcome == null || (!ctx.event.category.contains('network') && !ctx.event.category.contains('intrusion_detection'))) {
-          if (ctx?.event?.action == 'firewall-rule') {
-            ctx.event.type.add('info');
-          } else if (ctx?.event?.action.startsWith('connection-')) {
-            ctx.event.type.add('connection');
-          }
-          return;
-        }
-        if (ctx.event.outcome == 'allowed') {
-          ctx.event.outcome = 'success';
-          ctx.event.type.add('connection');
-          ctx.event.type.add('allowed');
-        } else if (ctx.event.outcome == 'denied' || ctx.event.outcome == 'block') {
-          ctx.event.outcome = 'success';
-          ctx.event.type.add('connection');
-          ctx.event.type.add('denied');
-        } else if (ctx.event.outcome == 'dropped') {
-          ctx.event.outcome = 'failure';
-          ctx.event.type.add('connection');
-          ctx.event.type.add('denied');
-        } else if (ctx?.event?.action == 'firewall-rule') {
-          ctx.event.type.add('info');
-        } else if (ctx?.event?.action.startsWith('connection-')) {
-          ctx.event.type.add('connection');
-        }
-        if (ctx.event.outcome == 'monitored') {
-          ctx.event.category.add('intrusion_detection');
-          ctx.event.outcome = 'success';
+        if (ctx._temp_?.outcome == null) {
+          params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
+        } else {
+          params.get(ctx.event.code).get(ctx._temp_.outcome).forEach((k, v) -> ctx.event[k] = v);
         }
 
   # Malware event kind is classified as alert when sha_disposition is "Malware", "Custom Detection" not for other cases.
@@ -2553,15 +2455,12 @@ processors:
   - set:
       field: observer.vendor
       value: "Cisco"
-      ignore_empty_value: true
   - set:
       field: observer.type
       value: "firewall"
-      ignore_empty_value: true
   - set:
       field: observer.product
       value: "asa"
-      ignore_empty_value: true
   - set:
       field: observer.egress.interface.name
       value: "{{{ cisco.asa.destination_interface }}}"
@@ -2646,6 +2545,7 @@ processors:
       if: ctx.destination?.user?.domain != null && ctx.destination?.user?.domain != ''
       allow_duplicates: false
   - script:
+      tag: script_remove_null_values
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
       source: |
@@ -2685,6 +2585,12 @@ processors:
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
       ignore_failure: true
       ignore_missing: true
+  - remove:
+      field:
+        - _temp_
+        - _conf
+      ignore_missing: true
+
 on_failure:
   # Copy any fields under _temp_.cisco to its final destination. Those can help
   # with diagnosing the failure.
@@ -2702,5 +2608,5 @@ on_failure:
       field: event.kind
       value: pipeline_error
   - append:
-      field: "error.message"
-      value: "{{{ _ingest.on_failure_message }}}"
+      field: error.message
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.32.1"
+version: "2.33.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This is part 1 of a 2 part change. This PR changes the pipeline so ECS categorization happens in one centralized script processor. Aside from a couple of test cases, ECS categorization of the different message types has not changed in this PR (at least what can be verified through pipeline tests). A follow up PR will apply new categorizations where necessary. This is to reduce diff noise and should make it easier to verify correctness of the pipeline changes.

The related issue mentions removing FTD-related code. I have not yet verified if FTD needs to be handled in this pipeline, and as such, code relating to FTD has not been removed or altered.

## Proposed commit message

- Add script processor with params table to set ECS event categorization fields for messages
- Improve top-level error handling, remove redundant error handlers on processors
- Add tags to relevant processors and standardize naming of tags across existing processors

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

- Relates #9461
