### PR TITLE
Add Buildkite pipeline to publish packages (DRY_RUN mode enabled)

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -74,8 +74,16 @@ if [ -n "${ELASTIC_PACKAGE_LINKS_FILE_PATH+x}" ]; then
     export ELASTIC_PACKAGE_LINKS_FILE_PATH=${BASE_DIR}/${ELASTIC_PACKAGE_LINKS_FILE_PATH}
 fi
 
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations-publish" ]]; then
+    if [[ "${BUILDKITE_STEP_KEY}" == "trigger-publish" ]]; then
+        BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token ${BUILDKITE_API_TOKEN_PATH})
+        export BUILDKITE_API_TOKEN
+    fi
+fi
+
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "trigger-publish" ]]; then
+        # TODO: To be removed
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token ${BUILDKITE_API_TOKEN_PATH})
         export BUILDKITE_API_TOKEN
     fi

--- a/.buildkite/pipeline.publish.yml
+++ b/.buildkite/pipeline.publish.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: "v0.5.1"
+  SETUP_GVM_VERSION: "v0.5.2"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false"

--- a/.buildkite/pipeline.publish.yml
+++ b/.buildkite/pipeline.publish.yml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+env:
+  SETUP_GVM_VERSION: "v0.5.1"
+  LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
+  DOCKER_COMPOSE_VERSION: "v2.24.1"
+  DOCKER_VERSION: "false"
+  YQ_VERSION: 'v4.35.2'
+  JQ_VERSION: '1.7'
+  # Elastic package settings
+  # Manage docker output/logs
+  ELASTIC_PACKAGE_COMPOSE_DISABLE_ANSI: "true"
+  ELASTIC_PACKAGE_COMPOSE_DISABLE_PULL_PROGRESS_INFORMATION: "true"
+  # Default license to use by `elastic-package build`
+  ELASTIC_PACKAGE_REPOSITORY_LICENSE: "licenses/Elastic-2.0.txt"
+  # Link definitions path (full path to be set in the corresponding step)
+  ELASTIC_PACKAGE_LINKS_FILE_PATH: "links_table.yml"
+  # Disable comparison of results in pipeline tests to avoid errors related to GeoIP fields
+  ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
+  NOTIFY_TO: "ecosystem-team@elastic.co"
+
+steps:
+  - label: ":white_check_mark: Check go sources"
+    key: "check"
+    command: ".buildkite/scripts/check_sources.sh"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "4G"
+
+  - label: ":package: Build packages"
+    key: "build-packages"
+    command: ".buildkite/scripts/build_packages.sh"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+      cpu: "8"
+      memory: "8G"
+    env:
+      ARTIFACTS_FOLDER: "artifacts-to-sign"
+      DRY_RUN: "true"
+    depends_on:
+      - step: "check"
+        allow_failure: false
+    artifact_paths:
+      - artifacts-to-sign/*.zip
+
+notify:
+  - email: "$NOTIFY_TO"
+    if: "build.state == 'failed' && build.env('BUILDKITE_PULL_REQUEST') == 'false'"

--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -60,3 +60,10 @@ steps:
     depends_on:
       - step: "check"
         allow_failure: false
+
+  - label: ":package: Publish missing packages"
+    key: "trigger-integrations-publish"
+    trigger: "integrations-publish"
+    depends_on:
+      - step: "check"
+        allow_failure: false

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: "v0.5.1"
+  SETUP_GVM_VERSION: "v0.5.2"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 
 env:
-  SETUP_GVM_VERSION: "v0.5.1"
+  SETUP_GVM_VERSION: "v0.5.2"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
   DOCKER_VERSION: "false"

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -47,6 +47,22 @@
       "skip_target_branches": [],
       "skip_ci_on_only_changed": [],
       "always_require_ci_on_changed": []
+    },
+    {
+      "enabled": false,
+      "pipelineSlug": "integrations-publish",
+      "allow_org_users": true,
+      "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": [],
+      "set_commit_status": false,
+      "build_on_commit": false,
+      "build_on_comment": false,
+      "trigger_comment_regex": "",
+      "always_trigger_comment_regex": "",
+      "skip_ci_labels": [],
+      "skip_target_branches": [],
+      "skip_ci_on_only_changed": [],
+      "always_require_ci_on_changed": []
     }
   ]
 }

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -199,3 +199,47 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: BUILD_AND_READ
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-integrations-publish
+  description: 'Pipeline for the Integrations project to publish packages'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/integrations-publish
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: integrations-publish
+      description: 'Pipeline for the Integrations project to publish packages'
+    spec:
+      # TODO: add backport-* in `branch_configuration` when these brances are updated
+      # branch_configuration: "main backport-*"
+      branch_configuration: "main"
+      pipeline_file: ".buildkite/pipeline.publish.yml"
+      provider_settings:
+        build_pull_request_forks: false
+        build_pull_requests: false # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        build_tags: false
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/integrations
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main !backport-*'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main !backport-*'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
## Proposed commit message

Add a new Buildkite pipeline to publish packages out of the testing (main) pipeline https://buildkite.com/elastic/integrations

For now, the steps related to publish packages are set as DRY_RUN mode, so they will not publish any package. In this PR, it is kept the publication process in the testing (main) pipeline.

## Related issues

- Relates #9357 
