### PR TITLE
[Logstash] Fix node cel script type checking issue

### DIFF
--- a/packages/logstash/_dev/deploy/docker/config/logstash.yml
+++ b/packages/logstash/_dev/deploy/docker/config/logstash.yml
@@ -1,7 +1,7 @@
 http.host: "0.0.0.0"
 config.reload.automatic: true
 path.logs: /usr/share/logstash/logs
-log.format: json
+log.format: plain
 slowlog.threshold.warn: 1nanos
 slowlog.threshold.info: 1nanos
 slowlog.threshold.debug: 1nanos

--- a/packages/logstash/_dev/deploy/docker/docker-compose.yml
+++ b/packages/logstash/_dev/deploy/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.3"
 services:
   logstash:
     user: root
-    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.7.0}"
+    image: "docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.12.2}"
     healthcheck:
       test: ["CMD", "curl", "-f", "-u", "elastic:changeme", "http://127.0.0.1:9600/"]
       retries: 300

--- a/packages/logstash/_dev/deploy/variants.yml
+++ b/packages/logstash/_dev/deploy/variants.yml
@@ -1,4 +1,5 @@
 variants:
-  logstash_8.7.0:
-    ELASTIC_VERSION: 8.7.0
-default: logstash_8.7.0
+  logstash_8.12.2:
+    ELASTIC_VERSION: 8.12.2
+
+default: logstash_8.12.2

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.4"
+  changes:
+    - description: Fix type checking issue with latest version of beats/cel-go
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9339
 - version: "2.4.3"
   changes:
     - description: Add missing queue.capacity.* mappings

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix type checking issue with latest version of beats/cel-go
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9339
+      link: https://github.com/elastic/integrations/pull/9556
 - version: "2.4.3"
   changes:
     - description: Add missing queue.capacity.* mappings

--- a/packages/logstash/data_stream/log/_dev/test/system/test-default-config.yml
+++ b/packages/logstash/data_stream/log/_dev/test/system/test-default-config.yml
@@ -2,4 +2,4 @@ input: logfile
 data_stream:
   vars:
     paths:
-      - "{{SERVICE_LOGS_DIR}}/logstash-json.log"
+      - "{{SERVICE_LOGS_DIR}}/logstash-plain.log"

--- a/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
@@ -24,7 +24,7 @@ program: |
              "events":body.events,
              "jvm":{
                 "uptime_in_millis":body.jvm.uptime_in_millis,
-                "mem":body.jvm['mem'].drop("pools"),
+                "mem":[body.jvm['mem']].drop("pools")[0],
                 "threads":body.jvm.threads
               },
              "queue":body.queue,

--- a/packages/logstash/data_stream/slowlog/_dev/test/system/test-default-config.yml
+++ b/packages/logstash/data_stream/slowlog/_dev/test/system/test-default-config.yml
@@ -2,4 +2,4 @@ input: logfile
 data_stream:
   vars:
     paths:
-      - "{{SERVICE_LOGS_DIR}}/logstash-slowlog-json.log"
+      - "{{SERVICE_LOGS_DIR}}/logstash-slowlog-plain.log"

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.3
+version: 2.4.4
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
An update to the cel-go library added stricter type checking, and made certain overload operations invalid in CEL scripts. This is a work-around to "hide" the type in an array, until a better fix is available.

Closes: #9546,#9319

