### PR TITLE
[cisco_nexus]: remove redundant nested repeat operator

### DIFF
--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Fix ingest pipeline warnings
+      type: bugfix
+      link: https://github.com/elastic/integrations/pulls/9570
 - version: "1.1.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/cisco_nexus/data_stream/log/elasticsearch/ingest_pipeline/pipeline_extract_message.yml
+++ b/packages/cisco_nexus/data_stream/log/elasticsearch/ingest_pipeline/pipeline_extract_message.yml
@@ -5,13 +5,13 @@ processors:
       field: message
       if: "['IF_DOWN_ADMIN_DOWN','IF_ADMIN_UP','SPEED','IF_DUPLEX','IF_RX_FLOW_CONTROL','IF_TX_FLOW_CONTROL','IF_UP','IF_XCVR_WARNING'].contains(ctx.event?.code.toUpperCase())"
       patterns:
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name} is up in mode %{DATA:cisco_nexus.log.interface.mode}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name} is %{GREEDYDATA}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational speed changed to %{DATA:cisco_nexus.log.operational.speed}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational duplex mode changed to %{DATA:cisco_nexus.log.operational.duplex_mode}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational Receive Flow Control state changed to %{DATA:cisco_nexus.log.operational.receive_flow_control_state}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational Transmit Flow Control state changed to %{DATA:cisco_nexus.log.operational.transmit_flow_control_state}$'
-        - '^(?:%{GREEDYDATA}%{SPACE}?(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, %{GREEDYDATA}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name} is up in mode %{DATA:cisco_nexus.log.interface.mode}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name} is %{GREEDYDATA}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational speed changed to %{DATA:cisco_nexus.log.operational.speed}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational duplex mode changed to %{DATA:cisco_nexus.log.operational.duplex_mode}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational Receive Flow Control state changed to %{DATA:cisco_nexus.log.operational.receive_flow_control_state}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, operational Transmit Flow Control state changed to %{DATA:cisco_nexus.log.operational.transmit_flow_control_state}$'
+        - '^(?:%{GREEDYDATA}%{SPACE}(?i)interface)%{SPACE}%{DATA:cisco_nexus.log.interface.name}, %{GREEDYDATA}$'
       ignore_failure: true
   - grok:
       description: Extract VSHD_SYSLOG_CONFIG_I, DETECT_MULTIPLE_PEERS, UPDOWN, CFGWRITE_STARTED, LINEPROTO MNEMONIC.

--- a/packages/cisco_nexus/manifest.yml
+++ b/packages/cisco_nexus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_nexus
 title: Cisco Nexus
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs from Cisco Nexus with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

After tackling [this issue](https://github.com/elastic/integrations/issues/9489), a respective [PR](https://github.com/elastic/elastic-package/pull/1755) was created to `elastic-package` to mainstream the detection of similar warnings. Thus this PR fixes the following similar to the former issue regex-related warning for `cisco_nexus`
```
detected ingest pipeline warnings: 1: regular expression has redundant nested repeat operator * /(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?) is up in mode (?<DATA:cisco_nexus.log.interface.mode>.*?)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?) is (?:.*)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?), operational speed changed to (?<DATA:cisco_nexus.log.operational.speed>.*?)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?), operational duplex mode changed to (?<DATA:cisco_nexus.log.operational.duplex_mode>.*?)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?), operational Receive Flow Control state changed to (?<DATA:cisco_nexus.log.operational.receive_flow_control_state>.*?)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?), operational Transmit Flow Control state changed to (?<DATA:cisco_nexus.log.operational.transmit_flow_control_state>.*?)$)|(?:^(?:(?:.*)(?:\s*)?(?i)interface)(?:\s*)(?<DATA:cisco_nexus.log.interface.name>.*?), (?:.*)$)/
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
N/A

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
N/A