### PR TITLE
[Jamf Protect] Adding process.parent.entity_id ECS mapping

### DIFF
--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding parent.process_entity_id.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9576
+      link: https://github.com/elastic/integrations/pull/9577
 - version: "0.1.0"
   changes:
     - description: Initial release of Jamf Protect integration for Elastic.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.1.1"
+- version: "0.2.0"
   changes:
     - description: Adding parent.process_entity_id.
       type: enhancement

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Adding parent.process_entity_id.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9135
 - version: "0.1.0"
   changes:
     - description: Initial release of Jamf Protect integration for Elastic.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding parent.process_entity_id.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9135
+      link: https://github.com/elastic/integrations/pull/9576
 - version: "0.1.0"
   changes:
     - description: Initial release of Jamf Protect integration for Elastic.

--- a/packages/jamf_protect/data_stream/alerts/_dev/test/pipeline/test-jamf-protect-alerts-sample-logs.log-expected.json
+++ b/packages/jamf_protect/data_stream/alerts/_dev/test/pipeline/test-jamf-protect-alerts-sample-logs.log-expected.json
@@ -203,6 +203,7 @@
                         "status": "No error.",
                         "team_id": "483DWKW443"
                     },
+                    "entity_id": "a382cfda-8964-4388-8c19-49d4eaef2ae7",
                     "executable": "/Library/Application Support/JAMF/Remote Assist/jamfRemoteAssistLauncher",
                     "name": "jamfRemoteAssistLauncher",
                     "pid": 3099,
@@ -348,6 +349,7 @@
                         "signing_id": "com.apple.zsh",
                         "status": "No error."
                     },
+                    "entity_id": "8afa3e04-ab59-48f1-87fa-bd42b2b1e71c",
                     "executable": "/bin/zsh",
                     "name": "zsh",
                     "pid": 4204,

--- a/packages/jamf_protect/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_protect/data_stream/alerts/elasticsearch/ingest_pipeline/default.yml
@@ -307,6 +307,7 @@ processors:
                 ctx.process.parent.name = parentProcess.name;
                 ctx.process.parent.pid = parentProcess.pid;
                 ctx.process.parent.executable = parentProcess.path;
+                ctx.process.parent.entity_id = parentProcess.uuid;
 
                 if (parentProcess.containsKey('startTimestamp')) {
                     ctx.process.parent.start = Instant.ofEpochSecond(parentProcess.startTimestamp).toString();

--- a/packages/jamf_protect/data_stream/alerts/fields/ecs.yml
+++ b/packages/jamf_protect/data_stream/alerts/fields/ecs.yml
@@ -239,6 +239,8 @@
 - external: ecs
   name: process.parent.executable
 - external: ecs
+  name: process.parent.entity_id
+- external: ecs
   name: process.parent.start
 - external: ecs
   name: process.parent.code_signature.signing_id

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -314,6 +314,7 @@ An example event for `alerts` looks as following:
 | process.parent.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple \*OS only. | keyword |
 | process.parent.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | process.parent.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple \*OS only. | keyword |
+| process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.parent.executable | Absolute path to the process executable. | keyword |
 | process.parent.executable.text | Multi-field of `process.parent.executable`. | match_only_text |
 | process.parent.name | Process name. Sometimes called program name or similar. | keyword |

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: jamf_protect
 title: Jamf Protect
-version: "0.1.0"
+version: "0.1.1"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: jamf_protect
 title: Jamf Protect
-version: "0.1.1"
+version: "0.2.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message
- Adding `process.parent.entity_id` to prepare for Kibana updates.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```elastic-package stack down && elastic-package build && elastic-package stack up -d -v && eval "$(elastic-package stack shellinit)" && elastic-package test system --generate  -v```

```
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬───────────────────────────────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME                                                             │ RESULT │ TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼───────────────────────────────────────────────────────────────────────┼────────┼──────────────┤
│ jamf_protect │                    │ asset     │ dashboard jamf_protect-e9b86210-c65c-11ee-882f-57f79af43d7f is loaded │ PASS   │      50.75µs │
│ jamf_protect │ alerts             │ asset     │ index_template logs-jamf_protect.alerts is loaded                     │ PASS   │        500ns │
│ jamf_protect │ alerts             │ asset     │ ingest_pipeline logs-jamf_protect.alerts-0.1.1 is loaded              │ PASS   │        250ns │
│ jamf_protect │ telemetry          │ asset     │ index_template logs-jamf_protect.telemetry is loaded                  │ PASS   │        333ns │
│ jamf_protect │ telemetry          │ asset     │ ingest_pipeline logs-jamf_protect.telemetry-0.1.1 is loaded           │ PASS   │        333ns │
│ jamf_protect │ web_threat_events  │ asset     │ index_template logs-jamf_protect.web_threat_events is loaded          │ PASS   │        333ns │
│ jamf_protect │ web_threat_events  │ asset     │ ingest_pipeline logs-jamf_protect.web_threat_events-0.1.1 is loaded   │ PASS   │        875ns │
│ jamf_protect │ web_traffic_events │ asset     │ index_template logs-jamf_protect.web_traffic_events is loaded         │ PASS   │        333ns │
│ jamf_protect │ web_traffic_events │ asset     │ ingest_pipeline logs-jamf_protect.web_traffic_events-0.1.1 is loaded  │ PASS   │        375ns │
╰──────────────┴────────────────────┴───────────┴───────────────────────────────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: jamf_protect - END   ---
Done
Run pipeline tests for the package
2024/04/12 09:14:48 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:50 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:52 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:53 DEBUG Package does not embed ECS mappings
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬─────────────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME                                   │ RESULT │ TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼─────────────────────────────────────────────┼────────┼──────────────┤
│ jamf_protect │ alerts             │ pipeline  │ test-jamf-protect-alerts-sample-logs.log    │ PASS   │     19.285ms │
│ jamf_protect │ telemetry          │ pipeline  │ test-jamf-protect-telemetry-sample-logs.log │ PASS   │  20.002333ms │
│ jamf_protect │ web_threat_events  │ pipeline  │ test-jamf-protect-threat-sample-logs.log    │ PASS   │   6.344583ms │
│ jamf_protect │ web_traffic_events │ pipeline  │ test-jamf-protect-traffic-sample-logs.log   │ PASS   │   6.782542ms │
╰──────────────┴────────────────────┴───────────┴─────────────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: jamf_protect - END   ---
Done
Run static tests for the package
2024/04/12 09:14:53 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:53 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:53 DEBUG Package does not embed ECS mappings
2024/04/12 09:14:53 DEBUG Package does not embed ECS mappings
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬──────────────────────────┬────────┬──────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME                │ RESULT │ TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼──────────────────────────┼────────┼──────────────┤
│ jamf_protect │ alerts             │ static    │ Verify sample_event.json │ PASS   │    74.1365ms │
│ jamf_protect │ telemetry          │ static    │ Verify sample_event.json │ PASS   │  40.947542ms │
│ jamf_protect │ web_threat_events  │ static    │ Verify sample_event.json │ PASS   │  63.086292ms │
│ jamf_protect │ web_traffic_events │ static    │ Verify sample_event.json │ PASS   │  60.883458ms │
╰──────────────┴────────────────────┴───────────┴──────────────────────────┴────────┴──────────────╯
--- Test results for package: jamf_protect - END   ---
Done
Run system tests for the package
2024/04/12 09:14:53 DEBUG GET https://127.0.0.1:5601/api/status
--- Test results for package: jamf_protect - START ---
No test results
--- Test results for package: jamf_protect - END   ---
Done```
