### PR TITLE
.buildkite/pipeline.schedule-daily - Use v8.14 snapshot

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -28,14 +28,14 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version v8.13"
+  - label: "Check integrations local stacks - Stack Version v8.14"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 8.13.0-SNAPSHOT
+        STACK_VERSION: 8.14.0-SNAPSHOT
         PUBLISH_COVERAGE_REPORTS: "true"
     depends_on:
       - step: "check"


### PR DESCRIPTION
## Proposed commit message

Bump to 8.14.0-SNAPSHOT for daily stack testing.