### PR TITLE
[O11y][StatsD Input] Update to Kibana 8.11 for beats fixes

### DIFF
--- a/packages/statsd_input/_dev/test/system/test-default-config.yml
+++ b/packages/statsd_input/_dev/test/system/test-default-config.yml
@@ -4,4 +4,4 @@ vars:
   listen_port: 8125
   data_stream.dataset: statsd_input.statsd
 assert:
-  hit_count: 3
+  hit_count: 6

--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Update to Kibana 8.11 to support enhanced statsd implementation, and fix system test cases.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "0.2.3"
   changes:
     - description: Improve documentation for the package.

--- a/packages/statsd_input/changelog.yml
+++ b/packages/statsd_input/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update to Kibana 8.11 to support enhanced statsd implementation, and fix system test cases.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/9596
 - version: "0.2.3"
   changes:
     - description: Improve documentation for the package.

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -7,7 +7,7 @@ type: input
 categories:
   - observability
 conditions:
-  kibana.version: "^8.8.0"
+  kibana.version: "^8.11.0"
   elastic.subscription: "basic"
 icons:
   - src: /img/statsd.svg

--- a/packages/statsd_input/manifest.yml
+++ b/packages/statsd_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.0.0
 name: statsd_input
 title: StatsD Input
-version: "0.2.3"
+version: "0.3.0"
 description: StatsD Input Package
 type: input
 categories:

--- a/packages/statsd_input/sample_event.json
+++ b/packages/statsd_input/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-06-19T05:20:48.498Z",
+    "@timestamp": "2024-04-15T14:06:01.418Z",
     "agent": {
-        "ephemeral_id": "19e6fd95-249c-4433-977e-5b1778a5d94e",
-        "id": "741b6193-4f1c-4fec-b58c-e038b4ca671b",
+        "ephemeral_id": "ee629c67-5780-4bfd-83c0-c89a032eba12",
+        "id": "b2bdd114-8042-4441-bd68-123aee9eca3b",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.8.0"
+        "version": "8.11.0"
     },
     "data_stream": {
         "dataset": "statsd_input.statsd",
@@ -16,32 +16,32 @@
         "version": "8.0.0"
     },
     "elastic_agent": {
-        "id": "741b6193-4f1c-4fec-b58c-e038b4ca671b",
+        "id": "b2bdd114-8042-4441-bd68-123aee9eca3b",
         "snapshot": false,
-        "version": "8.8.0"
+        "version": "8.11.0"
     },
     "event": {
         "agent_id_status": "verified",
         "dataset": "statsd_input.statsd",
-        "ingested": "2023-06-19T05:20:49Z",
+        "ingested": "2024-04-15T14:06:02Z",
         "module": "statsd"
     },
     "host": {
         "architecture": "x86_64",
         "containerized": true,
         "hostname": "docker-fleet-agent",
-        "id": "e8978f2086c14e13b7a0af9ed0011d19",
+        "id": "d7fd92f5e61644938d48518adcee73ad",
         "ip": [
-            "192.168.240.7"
+            "172.25.0.7"
         ],
         "mac": [
-            "02-42-C0-A8-F0-07"
+            "02-42-AC-19-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "3.10.0-1160.88.1.el7.x86_64",
+            "kernel": "3.10.0-1160.102.1.el7.x86_64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",
@@ -58,25 +58,6 @@
     "statsd": {
         "python_counter": {
             "count": 4
-        },
-        "python_gauge_foo": {
-            "value": 10
-        },
-        "python_timer_total": {
-            "15m_rate": 0.2022160607980413,
-            "1m_rate": 0.2319822341482707,
-            "5m_rate": 0.206611418471353,
-            "count": 4,
-            "max": 0,
-            "mean": 0,
-            "mean_rate": 2.2908631551250593,
-            "median": 0,
-            "min": 0,
-            "p75": 0,
-            "p95": 0,
-            "p99": 0,
-            "p99_9": 0,
-            "stddev": 0
         }
     }
 }


### PR DESCRIPTION
## Proposed commit message

-  Fixed system tests to new `hit_count` received as now the metrics would be received in individual documents as per this [fix](https://github.com/elastic/beats/pull/36925)
- Updated the Kibana version to `8.11.0` as per [comment](https://github.com/elastic/integrations/pull/8564#issuecomment-1829137937)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. elastic-package check
2. elastic-package stack up -d -v
3. elastic-package test -v

## Related issues

- Closes #9584

## Screenshots
![image](https://github.com/elastic/integrations/assets/124054599/403f05c2-1ce4-4d53-a6dc-7d3bbaa822d0)

