### PR TITLE
[cisco_asa] Improve ECS categorizations

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.34.0"
+  changes:
+    - description: Improve ECS categorizations.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9616
 - version: "2.33.2"
   changes:
     - description: Fix categorization of protocols.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -562,7 +562,7 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "start"
+                    "end"
                 ]
             },
             "host": {
@@ -4532,6 +4532,7 @@
                 "code": "502103",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-502103: User priv level changed: Uname: enable_15 From: 1 To: 15",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -5700,7 +5701,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "deleted",
+                "action": "sa-deleted",
                 "category": [
                     "network"
                 ],

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -25,17 +25,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302013: Built inbound TCP connection 111111111 for net:10.10.10.10/53500 (81.2.69.144/53500) to fw111:192.168.2.2/53500 (81.2.69.144/53500)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -113,17 +115,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302015: Built inbound UDP connection 111111111 for net:10.10.10.10/53500 (81.2.69.144/53500) to fw111:192.168.2.2/53500 (81.2.69.144/53500)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -200,6 +204,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 81.2.69.144/0 laddr 192.168.2.2/0 type 3 code 3",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -316,7 +321,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -327,7 +332,7 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -387,6 +392,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 81.2.69.144/0 laddr 192.168.2.2/0 type 3 code 1",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -691,9 +697,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "ftp",
                 "category": [
-                    "network"
+                    "network",
+                    "file"
                 ],
                 "code": "303002",
                 "kind": "event",
@@ -701,7 +708,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "access"
                 ]
             },
             "file": {
@@ -763,10 +770,12 @@
                 "code": "710006",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-7-710006: VRRP request discarded from 192.168.2.2 to fw111:192.18.4",
+                "outcome": "failure",
                 "severity": 7,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -819,7 +828,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -899,7 +909,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -990,7 +1001,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -1077,7 +1089,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "input": {
@@ -1158,7 +1171,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -1238,6 +1252,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "May  5 18:16:21 dev01: %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/0 gaddr 81.2.69.144/2 laddr 10.10.10.10/2 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1294,7 +1309,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
@@ -1305,7 +1320,7 @@
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "end"
+                    "start"
                 ]
             },
             "host": {
@@ -1424,6 +1439,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built inbound ICMP connection for faddr 10.10.10.10/0 gaddr 81.2.69.144/0 laddr 10.192.46.90/0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1492,6 +1508,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302020: Built outbound ICMP connection for faddr 10.10.10.10/0 gaddr 81.2.69.144/0 laddr 192.168.2.2/0 type 3 code 3",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1563,6 +1580,7 @@
                 "end": "2024-05-05T18:29:32.000Z",
                 "kind": "event",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302014: Teardown TCP connection 2960892904 for out111:10.10.10.10/443 to fw111:192.168.2.2/55225 duration 0:00:00 bytes 0 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2024-05-05T18:29:32.000Z",
@@ -1643,17 +1661,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "May  5 18:29:32 dev01: %ASA-6-302013: Built outbound TCP connection 1588662 for intfacename:192.168.2.2/80 (81.2.69.144/80) to net:10.10.10.10/54839 (81.2.69.144/54839)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1723,21 +1743,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 0,
                 "end": "2024-05-05T18:29:32.000Z",
                 "kind": "event",
                 "original": "May  5 18:29:32 dev01: %ASA-6-305012: Teardown dynamic UDP translation from fw111:10.10.10.10/54230 to out111:192.168.2.2/54230 duration 0:00:00",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2024-05-05T18:29:32.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -1808,7 +1829,6 @@
                 "code": "313004",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-4-313004: Denied ICMP type=0, from laddr 10.10.10.10 on interface fw502 to 192.168.2.2: no matching session",
-                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1872,9 +1892,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -1882,7 +1903,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -2029,6 +2050,7 @@
                 "end": "2024-05-05T18:40:50.000Z",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302016: Teardown UDP connection 1671727 for intfacename:10.10.10.10/161 to net:1192.168.2.2/53356 duration 0:02:04 bytes 64585",
+                "outcome": "success",
                 "severity": 2,
                 "start": "2024-05-05T18:38:46.000Z",
                 "timezone": "UTC",
@@ -2107,17 +2129,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (81.2.69.144/161) to net:192.168.2.2/22638 (81.2.69.144/22638)",
+                "outcome": "success",
                 "severity": 2,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2195,17 +2219,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-2-302015: Built outbound UDP connection 1743372 for intfacename:10.10.10.10/161 (81.2.69.144/161) to net:192.168.2.2/22638 (81.2.69.144/22638)",
+                "outcome": "success",
                 "severity": 2,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2706,17 +2732,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302022",
                 "kind": "event",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built director stub TCP connection for fw1111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (81.2.69.144/10051)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2781,17 +2809,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302022",
                 "kind": "event",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built forwarder  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (81.2.69.144/10051)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2856,17 +2886,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302022",
                 "kind": "event",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302022: Built backup  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.1682.2.2/10051 (81.2.69.144/10051)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2930,7 +2962,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
@@ -2939,12 +2971,14 @@
                 "end": "2024-05-05T19:02:58.000Z",
                 "kind": "event",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for fw111:10.10.10.10/39210 to net:192.168.2.2/10051 duration 0:00:00 forwarded bytes 0 Cluster flow with CLU closed on owner",
+                "outcome": "success",
                 "reason": "Cluster flow with CLU closed on owner",
                 "severity": 6,
                 "start": "2024-05-05T19:02:58.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -3010,7 +3044,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
@@ -3019,12 +3053,14 @@
                 "end": "2024-05-05T19:02:58.000Z",
                 "kind": "event",
                 "original": "May  5 19:02:58 dev01: %ASA-6-302023: Teardown stub TCP connection for net:10.10.10.10/10051 to unknown:192.168.2.2/39222 duration 0:00:00 forwarded bytes 0 Forwarding or redirect flow removed to create director or backup flow",
+                "outcome": "success",
                 "reason": "Forwarding or redirect flow removed to create director or backup flow",
                 "severity": 6,
                 "start": "2024-05-05T19:02:58.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -3084,13 +3120,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "configuration",
                 "category": [
-                    "network"
+                    "configuration"
                 ],
                 "code": "111009",
                 "kind": "event",
                 "original": "May  5 19:03:27 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list fw211111_access_out brief",
+                "outcome": "success",
                 "severity": 7,
                 "timezone": "UTC",
                 "type": [
@@ -3137,13 +3174,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "configuration",
                 "category": [
-                    "network"
+                    "configuration"
                 ],
                 "code": "111009",
                 "kind": "event",
                 "original": "May  5 19:02:26 dev01: %ASA-7-111009: User 'aaaa' executed cmd: show access-list aaa_out brief",
+                "outcome": "success",
                 "severity": 7,
                 "timezone": "UTC",
                 "type": [
@@ -3341,17 +3379,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "302027",
                 "kind": "event",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302027: Teardown stub ICMP connection for fw1111:10.10.10.10/6426 to net:192.168.2.2/0 duration 1:00:04 forwarded bytes 56 Cluster flow with CLU closed on owner",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -3381,17 +3421,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302026",
                 "kind": "event",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302026: Built director stub ICMP connection for fw111:10.10.10.10/32004 (8.8.8.5) to net:192.168.2.2/0 (81.2.69.144)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3492,17 +3534,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-expiration",
                 "category": [
                     "network"
                 ],
                 "code": "302025",
                 "kind": "event",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302025: Teardown stub UDP connection for net:192.168.2.2/123 to unknown:10.10.10.10/123 duration 0:01:00 forwarded bytes 48 Cluster flow with CLU removed from due to idle timeout",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -3532,17 +3576,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302024",
                 "kind": "event",
                 "original": "May  5 19:02:26 dev01: %ASA-6-302024: Built backup stub UDP connection for net:192.168.2.2/9051 (8.8.8.5(19051) to fw111:10.10.10.10/123 (81.2.69.144/123)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3855,7 +3901,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -3866,7 +3912,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -3914,7 +3960,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -3925,7 +3971,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -3973,7 +4019,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -3984,7 +4030,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -4032,7 +4078,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -4043,7 +4089,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -4347,9 +4393,9 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "configuration",
                 "category": [
-                    "network"
+                    "configuration"
                 ],
                 "code": "111004",
                 "kind": "event",
@@ -4358,7 +4404,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "change"
                 ]
             },
             "host": {
@@ -4398,17 +4444,18 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "configuration",
                 "category": [
-                    "network"
+                    "configuration"
                 ],
                 "code": "111010",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-111010: User 'enable_15', running 'CLI' from IP 10.10.0.87, executed 'clear'",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "change"
                 ]
             },
             "host": {
@@ -4649,8 +4696,9 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "logged-in",
                 "category": [
+                    "authentication",
                     "network"
                 ],
                 "code": "605005",
@@ -4660,8 +4708,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "allowed"
+                    "allowed",
+                    "info"
                 ]
             },
             "host": {
@@ -4782,7 +4830,8 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4928,6 +4977,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -4992,7 +5042,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -5065,7 +5116,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -5125,7 +5177,6 @@
                 "code": "710003",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 81.2.69.144/6370 to outside:192.168.157.61/23",
-                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -5209,7 +5260,6 @@
                 "code": "434004",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-434004: SFR requested ASA to bypass further packet redirection and process TCP flow from sourceInterfaceName:81.2.69.144/8888 to destinationInterfaceName:192.168.2.2/123123 locally",
-                "outcome": "unknown",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -5289,18 +5339,16 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "drop",
+                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "434002",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-434002: SFR requested to drop TCP packet from sourceInterfaceName:81.2.69.144/8888 to destinationInterfaceName:192.168.2.2/514514",
-                "outcome": "unknown",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
                     "denied"
                 ]
             },
@@ -5376,7 +5424,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "error",
                 "category": [
                     "network"
                 ],
@@ -5388,8 +5436,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "denied"
+                    "connection"
                 ]
             },
             "host": {
@@ -5637,7 +5684,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info",
+                    "connection",
                     "end"
                 ]
             },
@@ -5788,7 +5835,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection"
                 ]
             },
             "host": {
@@ -5858,6 +5905,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -5906,6 +5954,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -5943,14 +5992,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
+                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "713905",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713905: Group = 100.60.140.10, IP = 192.168.1.1, All IPSec SA proposals found unacceptable!",
-                "outcome": "failure",
                 "reason": "All IPSec SA proposals found unacceptable!",
                 "severity": 6,
                 "timezone": "UTC",
@@ -5992,14 +6040,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
+                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "713904",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713904: All IPSec SA proposals found unacceptable!",
-                "outcome": "failure",
                 "reason": "All IPSec SA proposals found unacceptable!",
                 "severity": 6,
                 "timezone": "UTC",
@@ -6041,7 +6088,6 @@
                 "code": "713903",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-6-713903: IP = 192.168.1.1, All IPSec SA proposals found unacceptable!",
-                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -6075,7 +6121,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
+                "action": "client-vpn-error",
                 "category": [
                     "network"
                 ],
@@ -6117,7 +6163,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
+                "action": "client-vpn-error",
                 "category": [
                     "network"
                 ],
@@ -6176,7 +6222,8 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -6447,6 +6494,7 @@
                 "end": "2020-04-27T02:03:03.000Z",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-302016: Teardown UDP connection 123364823 for OUTSIDE:67.43.156.13/500 to identity:216.160.83.61/500 duration 92:24:20 bytes 4671944",
+                "outcome": "success",
                 "severity": 4,
                 "start": "2020-04-23T05:38:43.000Z",
                 "timezone": "UTC",
@@ -7985,16 +8033,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "logon-failed",
                 "category": [
+                    "authentication",
                     "network"
                 ],
                 "code": "113015",
                 "kind": "event",
                 "original": "<166>Oct 12 2023 16:00:00 fw123-vc456 : %ASA-6-113015: AAA user authentication Rejected : reason = Invalid password : local database : user = a2bcde : user IP = 81.2.69.143",
+                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
+                    "denied",
                     "info"
                 ]
             },
@@ -8064,16 +8115,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "logon-failed",
                 "category": [
+                    "authentication",
                     "network"
                 ],
                 "code": "113015",
                 "kind": "event",
                 "original": "<166>Oct 12 2023 16:00:00 fw123-vc456 : %ASA-6-113015: AAA user authentication Rejected : reason = Invalid password : local database : user = ***** : user IP = 81.2.69.143",
+                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
+                    "denied",
                     "info"
                 ]
             },

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -269,6 +269,7 @@
                 "end": "2024-05-05T17:51:17.000Z",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609002: Teardown local-host net:192.168.2.2 duration 0:00:00",
+                "outcome": "success",
                 "severity": 7,
                 "start": "2024-05-05T17:51:17.000Z",
                 "timezone": "UTC",
@@ -328,6 +329,7 @@
                 "code": "609001",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-7-609001: Built local-host net:192.168.2.2",
+                "outcome": "success",
                 "severity": 7,
                 "timezone": "UTC",
                 "type": [
@@ -462,17 +464,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-offload-started",
                 "category": [
                     "network"
                 ],
                 "code": "805001",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805001: Offloaded TCP Flow for connection 111111111 from fw111:10.10.10.10/111 (81.2.69.144/111) to fw111:192.168.2.2/111 (81.2.69.144/111)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -546,17 +550,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-offload-ended",
                 "category": [
                     "network"
                 ],
                 "code": "805002",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-805002: TCP Flow is no longer offloaded for connection 941243214 from net:10.192.18.4/51261 (10.192.18.4/51261) to fw109:10.192.70.66/443 (10.192.70.66/443)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -705,6 +711,7 @@
                 "code": "303002",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-6-303002: FTP connection from net:192.168.2.2/63656 to fw111:10.192.18.4/21, user testuser Stored file /export/home/sysm/ftproot/sdsdsds/tmp.log",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -825,6 +832,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 3) on myif interface. Original IP payload: udp src 192.168.2.2/53 dst 192.168.2.3/10872.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -906,6 +914,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2(LOCAL\\testgroup\\testuser) dst dstif:192.168.2.3 (type 3, code 3) on myif interface.  Original IP payload: udp src 192.168.2.2/53 dst 192.168.2.3/10872.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -998,6 +1007,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "May  5 17:51:17 dev01: %FTD-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2(LOCAL\\testuser) dst dstif:192.168.2.3 (type 3, code 3) on myif interface.  Original IP payload: udp src 192.168.2.2/53 dst 192.168.2.3/10872.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1086,6 +1096,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<188>May  5 17:51:17: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: icmp src 192.168.2.2 dst 192.168.2.3 (type 0, code 0).",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1168,6 +1179,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<188>May  5 17:51:17 dev01: %ASA-4-313005: No matching connection for ICMP error message: icmp src srcif:192.168.2.2 dst dstif:192.168.2.3 (type 3, code 2) on srcif interface. Original IP payload: protocol 51 src 192.168.2.2 dst 192.168.2.3.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1316,6 +1328,7 @@
                 "code": "609001",
                 "kind": "event",
                 "original": "May  5 18:22:35 dev01: %ASA-7-609001: Built local-host net:10.10.10.10",
+                "outcome": "success",
                 "severity": 7,
                 "timezone": "UTC",
                 "type": [
@@ -1376,6 +1389,7 @@
                 "end": "2024-05-05T18:24:31.000Z",
                 "kind": "event",
                 "original": "May  5 18:24:31 dev01: %ASA-7-609002: Teardown local-host identity:10.10.10.10 duration 0:00:00",
+                "outcome": "success",
                 "severity": 7,
                 "start": "2024-05-05T18:24:31.000Z",
                 "timezone": "UTC",
@@ -1829,6 +1843,7 @@
                 "code": "313004",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-4-313004: Denied ICMP type=0, from laddr 10.10.10.10 on interface fw502 to 192.168.2.2: no matching session",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1900,6 +1915,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "May  5 18:40:50 dev01: %ASA-6-305011: Built dynamic TCP translation from fw111:10.10.10.10/57006 to out111:192.168.2.2/57006",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -3706,7 +3722,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -3833,7 +3848,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-termination",
                 "category": [
                     "network"
                 ],
@@ -3843,7 +3858,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -4166,6 +4182,7 @@
                 "end": "2024-04-27T04:12:23.000Z",
                 "kind": "event",
                 "original": "Apr 27 04:12:23 dev01: %ASA-6-302304: Teardown TCP state-bypass connection 2751765169 from server.deflan:81.2.69.144/54242 to server.deflan:81.2.69.144/9101 duration 1:00:02 bytes 245 Connection timeout",
+                "outcome": "success",
                 "reason": "Connection timeout",
                 "severity": 6,
                 "start": "2024-04-27T03:12:21.000Z",
@@ -4508,7 +4525,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "privilege-level-changed",
                 "category": [
                     "iam"
                 ],
@@ -4518,7 +4535,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "group",
+                    "user",
                     "change"
                 ]
             },
@@ -4827,6 +4844,7 @@
                 "code": "713049",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 81.2.69.144, IP = 81.2.69.144, Security negotiation complete for LAN-to-LAN Group (81.2.69.144) Responder, Inbound SPI = 0x276b1da2, Outbound SPI = 0x0e1a581d",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -4911,6 +4929,7 @@
                 "end": "2024-04-27T02:03:03.000Z",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-113019: Group = 81.2.69.144, Username = 81.2.69.144, IP = 81.2.69.144, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested",
+                "outcome": "success",
                 "reason": "User Requested",
                 "severity": 4,
                 "start": "2024-04-27T01:30:47.000Z",
@@ -4967,13 +4986,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "address-assigned",
                 "category": [
                     "network"
                 ],
                 "code": "722051",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-722051: Group <VPN5Policy> User <john> IP <192.168.50.3> IPv4 Address <192.168.50.5> IPv6 address <::> assigned to session",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -5031,13 +5051,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "client-vpn-disconnected",
                 "category": [
                     "network"
                 ],
                 "code": "716002",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User testuser IP 81.2.69.144 WebVPN session terminated: User Requested.",
+                "outcome": "success",
                 "reason": "User Requested",
                 "severity": 6,
                 "timezone": "UTC",
@@ -5105,13 +5126,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "client-vpn-disconnected",
                 "category": [
                     "network"
                 ],
                 "code": "716002",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.",
+                "outcome": "success",
                 "reason": "Idle timeout",
                 "severity": 6,
                 "timezone": "UTC",
@@ -5177,6 +5199,7 @@
                 "code": "710003",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 81.2.69.144/6370 to outside:192.168.157.61/23",
+                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -5346,9 +5369,11 @@
                 "code": "434002",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-434002: SFR requested to drop TCP packet from sourceInterfaceName:81.2.69.144/8888 to destinationInterfaceName:192.168.2.2/514514",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "denied"
                 ]
             },
@@ -5424,7 +5449,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
+                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -5436,7 +5461,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "connection"
+                    "connection",
+                    "info"
                 ]
             },
             "host": {
@@ -5518,6 +5544,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -5592,7 +5619,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "created",
+                "action": "sa-created",
                 "category": [
                     "network"
                 ],
@@ -5757,12 +5784,13 @@
                 "code": "750002",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-5-750002: Local:81.2.69.144:7777 Remote:192.168.2.2:7777 Username:admin Received a IKE_INIT_SA request",
+                "outcome": "success",
                 "reason": "Received a IKE_INIT_SA request",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "start",
-                    "connection"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5824,18 +5852,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "error",
                 "category": [
                     "network"
                 ],
                 "code": "750003",
                 "kind": "event",
                 "original": "Apr 27 2020 02:03:03 dev01: %ASA-4-750003: Local:81.2.69.144:7777 Remote:192.168.2.2:7777 Username:admin Negotiation aborted due to ERROR: Failed to locate an item in the database",
+                "outcome": "failure",
                 "reason": "Negotiation aborted due to Failed to locate an item in the database",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "connection"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5992,7 +6021,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6040,7 +6068,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6081,7 +6108,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6219,6 +6245,7 @@
                 "code": "713049",
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 100.60.140.10, Username = test_user, IP = 81.2.69.143, Security negotiation complete for User (test_user) Responder, Inbound SPI = 0x0000000, Outbound SPI = 0x0000000",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -6580,7 +6607,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6633,7 +6659,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6686,7 +6711,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -6739,7 +6763,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
@@ -13,6 +13,7 @@
                 "code": "113029",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113029: Group VPN_USERS User example.user IP 67.43.156.14 Session could not be established: session limit of 5 reached",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -86,6 +87,7 @@
                 "code": "113030",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113030: Group VPN_USERS User example.user IP 67.43.156.14 User ACL acl from AAA doesn't exist on the device, terminating connection.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -159,6 +161,7 @@
                 "code": "113031",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113031: Group VPN_USERS User example.user IP 67.43.156.14 AnyConnect vpn-filter filter is an IPv6 ACL; ACL not applied.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -232,6 +235,7 @@
                 "code": "113032",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113032: Group VPN_USERS User example.user IP 67.43.156.14 AnyConnect ipv6-vpn-filter filter is an IPv4 ACL; ACL not applied.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -305,6 +309,7 @@
                 "code": "113033",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-113033: Group VPN_USERS User example.user IP 67.43.156.14 AnyConnect session not allowed. ACL parse error.",
+                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -378,6 +383,7 @@
                 "code": "113034",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113034: Group VPN_USERS User example.user IP 67.43.156.14 User ACL ACL123 from AAA ignored, AV-PAIR ACL used instead.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -451,6 +457,7 @@
                 "code": "113035",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113035: Group VPN_USERS User example.user IP 67.43.156.14 Session terminated: AnyConnect not enabled or invalid AnyConnect image on the ASA.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -524,6 +531,7 @@
                 "code": "113036",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113036: Group VPN_USERS User example.user IP 67.43.156.14 AAA parameter PARAM value invalid.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -597,6 +605,7 @@
                 "code": "113037",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-113037: Reboot pending, new sessions disabled. Denied user login.",
+                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -642,6 +651,7 @@
                 "code": "113038",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113038: Group VPN_USERS User example.user IP 67.43.156.14 Unable to create AnyConnect parent session.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -716,6 +726,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-113039: Group VPN_USERS User example.user IP 67.43.156.14 AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -789,6 +800,7 @@
                 "code": "113040",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113040: Terminating the VPN connection attempt from VPN_USERS. Reason: This connection is group locked to OTHER_VPN_USERS.",
+                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -842,6 +854,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "<166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy_Remote-VPN> User <user-1> IP <81.2.69.144> AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -921,6 +934,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "<166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy_Remote-VPN> User <first.o'last@example.com> IP <81.2.69.144> AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -29,6 +29,7 @@
                 "end": "2020-04-17T14:08:08.000Z",
                 "kind": "event",
                 "original": "Apr 17 2020 14:08:08 SNL-ASA-VPN-A01 : %ASA-6-302016: Teardown UDP connection 110577675 for Outside:10.123.123.123/53723(LOCAL\\Elastic) to Inside:10.233.123.123/53 duration 0:00:00 bytes 148 (zzzzzz)",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2020-04-17T14:08:08.000Z",
                 "timezone": "UTC",
@@ -391,7 +392,6 @@
                 "code": "313008",
                 "kind": "event",
                 "original": "Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1",
-                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -465,7 +465,6 @@
                 "code": "313009",
                 "kind": "event",
                 "original": "Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8",
-                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -679,7 +678,7 @@
                 "code": "106102",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:37: %ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -> inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
-                "outcome": "success",
+                "outcome": "permitted",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -863,17 +862,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -975,17 +976,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jun 21 2022 11:47:08: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice) to inside:89.160.20.112/9803 (89.160.20.112/9803) (bob)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -1093,17 +1096,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jun 21 2022 11:47:09: %ASA-6-302015: Built inbound UDP connection 7 for outside:81.2.69.142/3424 (81.2.69.142/3424)(LOCAL\\alice, 123) to inside:89.160.20.112/9803 (89.160.20.112/9803)(LOCAL\\dave, 246) (bob)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-fix.log-expected.json
@@ -392,6 +392,7 @@
                 "code": "313008",
                 "kind": "event",
                 "original": "Apr 17 2020 14:15:07 SNL-ASA-VPN-A01 : %ASA-3-313008: Denied IPv6-ICMP type=134, code=0 from fe80::1ff:fe23:4567:890a on interface ISP1",
+                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -465,6 +466,7 @@
                 "code": "313009",
                 "kind": "event",
                 "original": "Jun 08 2020 12:59:57: %ASA-4-313009: Denied invalid ICMP code 9, for Inside:10.255.0.206/8795 (10.255.0.206/8795) to identity:10.12.31.51/0 (10.12.31.51/0), ICMP id 295, ICMP type 8",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -678,7 +680,7 @@
                 "code": "106102",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:37: %ASA-session-3-106102: access-list dev_inward_client permitted udp for user redacted outside/10.123.123.20(49721) -> inside/10.223.223.40(53) hit-cnt 1 first hit [0x3c8b88c1, 0xbee595c3]",
-                "outcome": "permitted",
+                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -37,6 +37,7 @@
                 "end": "2020-06-08T12:59:57.000Z",
                 "kind": "event",
                 "original": "Jun 08 2020 12:59:57: %ASA-4-113019: Group = TheBeatles, Username = Ringo, IP = 67.43.156.12, Session disconnected. Session Type: AnyConnect-Parent, Duration: 0h:01m:52s, Bytes xmt: 32452, Bytes rcv: 0, Reason: User Requested",
+                "outcome": "success",
                 "reason": "User Requested",
                 "severity": 4,
                 "start": "2020-06-08T12:58:05.000Z",
@@ -112,6 +113,7 @@
                 "end": "2019-10-20T15:42:53.000Z",
                 "kind": "event",
                 "original": "Oct 20 2019 15:42:53: %ASA-4-113019: Group = TheBeatles, Username = John, IP = 67.43.156.12, Session disconnected. Session Type: SSL, Duration: 2h:27m:34s, Bytes xmt: 45323434, Bytes rcv: 43252324, Reason: Idle Timeout",
+                "outcome": "success",
                 "reason": "Idle Timeout",
                 "severity": 4,
                 "start": "2019-10-20T13:15:19.000Z",
@@ -156,7 +158,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -219,7 +220,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -275,13 +275,14 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "address-assigned",
                 "category": [
                     "network"
                 ],
                 "code": "722051",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy_TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -337,7 +338,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "svc-message",
                 "category": [
                     "network"
                 ],
@@ -387,13 +387,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722022",
                 "kind": "event",
                 "original": "<190>Jan 24 2024 15:24:40 XYZhost1 : %ASA-6-722022: Group <MY-MFA> User <src_user@myorg.com> IP <67.43.156.118> TCP SVC connection established without compression",
+                "outcome": "success",
                 "reason": "TCP SVC connection established without compression",
                 "severity": 6,
                 "timezone": "UTC",
@@ -469,13 +469,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722023",
                 "kind": "event",
                 "original": "<190>Jan 24 2024 15:25:23 XYZhost1 : %ASA-6-722023: Group <MGMT_Tunnel> User <src_user@myorg.com> IP <81.2.69.142> UDP SVC connection terminated without compression",
+                "outcome": "success",
                 "reason": "UDP SVC connection terminated without compression",
                 "severity": 6,
                 "timezone": "UTC",
@@ -551,13 +551,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722022",
                 "kind": "event",
                 "original": "<190>Feb 21 2024 09:53:46 xxxxxx : %ASA-6-722022: Group MY-MFA User myuser@email.com IP 192.168.0.12 UDP SVC connection established without compression",
+                "outcome": "success",
                 "reason": "UDP SVC connection established without compression",
                 "severity": 6,
                 "timezone": "UTC",
@@ -621,13 +621,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722023",
                 "kind": "event",
                 "original": "<190>Feb 21 2024 09:55:01 xxxxxx: %ASA-6-722023: Group MGMT_Tunnel User my123.org.com IP 192.168.0.228 UDP SVC connection terminated without compression",
+                "outcome": "success",
                 "reason": "UDP SVC connection terminated without compression",
                 "severity": 6,
                 "timezone": "UTC",
@@ -688,13 +688,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722033",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First UDP SVC connection established for SVC session.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -742,13 +742,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
                 "code": "722033",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -796,7 +796,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -850,7 +849,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -167,7 +167,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "log": {
@@ -229,7 +230,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "log": {
@@ -283,6 +285,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -334,7 +337,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "svc-message",
                 "category": [
                     "network"
                 ],
@@ -395,6 +398,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -476,7 +480,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -557,6 +562,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -626,7 +632,8 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "host": {
@@ -691,7 +698,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -744,7 +752,8 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -797,6 +806,7 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -851,7 +861,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "end"
                 ]
             },
             "log": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
@@ -25,6 +25,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1671,6 +1672,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:192.168.98.44/1188",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2097,6 +2099,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1773 to outside:192.168.98.44/8257",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2264,6 +2267,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1774 to outside:192.168.98.44/8258",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2777,6 +2781,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1775 to outside:192.168.98.44/8259",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2944,6 +2949,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:192.168.98.44/1189",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -3370,6 +3376,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1452 to outside:192.168.98.44/8265",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -3883,6 +3890,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1453 to outside:192.168.98.44/8266",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -4396,6 +4404,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1454 to outside:192.168.98.44/8267",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -4563,6 +4572,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1455 to outside:192.168.98.44/8268",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -4730,6 +4740,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1456 to outside:192.168.98.44/8269",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -5070,6 +5081,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1457 to outside:192.168.98.44/8270",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -5237,6 +5249,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1458 to outside:192.168.98.44/8271",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -5578,6 +5591,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1459 to outside:192.168.98.44/8272",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -5831,6 +5845,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1460 to outside:192.168.98.44/8273",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -6082,6 +6097,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1385 to outside:192.168.98.44/8277",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -6927,6 +6943,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.156.80/1386 to outside:192.168.98.44/8278",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -8160,6 +8177,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1275 to outside:192.168.98.44/8279",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -8327,6 +8345,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic UDP translation from inside:172.31.98.44/56132 to outside:192.168.98.44/1190",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -8753,6 +8772,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1276 to outside:192.168.98.44/8280",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -8920,6 +8940,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1277 to outside:192.168.98.44/8281",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -9174,6 +9195,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1278 to outside:192.168.98.44/8282",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -9428,6 +9450,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1279 to outside:192.168.98.44/8283",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -9769,6 +9792,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1280 to outside:192.168.98.44/8284",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -10023,6 +10047,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1281 to outside:192.168.98.44/8285",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -10190,6 +10215,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1282 to outside:192.168.98.44/8286",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -10357,6 +10383,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1283 to outside:192.168.98.44/8287",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -10524,6 +10551,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1284 to outside:192.168.98.44/8288",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -10952,6 +10980,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1285 to outside:192.168.98.44/8289",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -11119,6 +11148,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1286 to outside:192.168.98.44/8290",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -11373,6 +11403,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1287 to outside:192.168.98.44/8291",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -11801,6 +11832,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1288 to outside:192.168.98.44/8292",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -12227,6 +12259,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1289 to outside:192.168.98.44/8293",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -12741,6 +12774,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1290 to outside:192.168.98.44/8294",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -13770,6 +13804,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1291 to outside:192.168.98.44/8295",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -14110,6 +14145,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1292 to outside:192.168.98.44/8296",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -14277,6 +14313,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1293 to outside:192.168.98.44/8297",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -14444,6 +14481,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1294 to outside:192.168.98.44/8298",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -14698,6 +14736,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1295 to outside:192.168.98.44/8299",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -14865,6 +14904,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1296 to outside:192.168.98.44/8300",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -15293,6 +15333,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1297 to outside:192.168.98.44/8301",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -15460,6 +15501,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1298 to outside:192.168.98.44/8302",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -15887,6 +15929,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1299 to outside:192.168.98.44/8303",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -16054,6 +16097,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1300 to outside:192.168.98.44/8304",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -16395,6 +16439,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1301 to outside:192.168.98.44/8305",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -16562,6 +16607,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1302 to outside:192.168.98.44/8306",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -17989,6 +18035,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1304 to outside:192.168.98.44/8308",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -18670,6 +18717,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1305 to outside:192.168.98.44/8309",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -19758,6 +19806,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1306 to outside:192.168.98.44/8310",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa.log-expected.json
@@ -17,9 +17,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -27,7 +28,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -101,17 +102,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11757 for outside:192.168.205.104/80 (192.168.205.104/80) to inside:172.31.98.44/1772 (172.31.98.44/1772)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -191,6 +194,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11749 for outside:192.168.211.242/80 to inside:172.31.98.44/1758 duration 0:01:07 bytes 38110 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:49.000Z",
@@ -277,6 +281,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11748 for outside:192.168.211.242/80 to inside:172.31.98.44/1757 duration 0:01:07 bytes 44010 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:49.000Z",
@@ -363,6 +368,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11745 for outside:192.168.185.90/80 to inside:172.31.98.44/1755 duration 0:01:07 bytes 7652 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:49.000Z",
@@ -449,6 +455,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11744 for outside:192.168.185.90/80 to inside:172.31.98.44/1754 duration 0:01:07 bytes 7062 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:49.000Z",
@@ -535,6 +542,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11742 for outside:192.168.160.197/80 to inside:172.31.98.44/1752 duration 0:01:08 bytes 5738 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:48.000Z",
@@ -621,6 +629,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11738 for outside:192.168.205.14/80 to inside:172.31.98.44/1749 duration 0:01:08 bytes 4176 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:48.000Z",
@@ -707,6 +716,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11739 for outside:192.168.124.33/80 to inside:172.31.98.44/1750 duration 0:01:08 bytes 1715 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:48.000Z",
@@ -793,6 +803,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11731 for outside:192.168.35.9/80 to inside:172.31.98.44/1747 duration 0:01:09 bytes 45595 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:47.000Z",
@@ -879,6 +890,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11723 for outside:192.168.211.242/80 to inside:172.31.98.44/1742 duration 0:01:09 bytes 27359 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:47.000Z",
@@ -965,6 +977,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11715 for outside:192.168.218.21/80 to inside:172.31.98.44/1741 duration 0:01:09 bytes 4457 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:47.000Z",
@@ -1051,6 +1064,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11711 for outside:192.168.198.27/80 to inside:172.31.98.44/1739 duration 0:01:09 bytes 26709 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:47.000Z",
@@ -1137,6 +1151,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11712 for outside:192.168.198.27/80 to inside:172.31.98.44/1740 duration 0:01:09 bytes 22097 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:47.000Z",
@@ -1223,6 +1238,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11708 for outside:192.168.202.211/80 to inside:172.31.98.44/1738 duration 0:01:10 bytes 2209 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:46.000Z",
@@ -1309,6 +1325,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11746 for outside:192.168.124.15/80 to inside:172.31.98.44/1756 duration 0:01:07 bytes 10404 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:49.000Z",
@@ -1395,6 +1412,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11706 for outside:192.168.124.15/80 to inside:172.31.98.44/1737 duration 0:01:10 bytes 123694 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:46.000Z",
@@ -1481,6 +1499,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11702 for outside:192.168.209.247/80 to inside:172.31.98.44/1736 duration 0:01:11 bytes 35835 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:33:45.000Z",
@@ -1567,6 +1586,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11753 for outside:192.168.35.162/80 to inside:172.31.98.44/1765 duration 0:00:30 bytes 0 SYN Timeout",
+                "outcome": "success",
                 "reason": "SYN Timeout",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
@@ -1643,9 +1663,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -1653,7 +1674,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -1727,17 +1748,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11758 for outside:192.168.80.32/53 (192.168.80.32/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1817,6 +1840,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11758 for outside:192.168.80.32/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 148",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -1897,17 +1921,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11759 for outside:192.168.252.6/53 (192.168.252.6/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1987,6 +2013,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11759 for outside:192.168.252.6/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 164",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -2062,9 +2089,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -2072,7 +2100,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -2146,17 +2174,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11760 for outside:192.168.252.226/80 (192.168.252.226/80) to inside:172.31.98.44/1773 (172.31.98.44/1773)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2226,9 +2256,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -2236,7 +2267,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -2310,17 +2341,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11761 for outside:192.168.252.226/80 (192.168.252.226/80) to inside:172.31.98.44/1774 (172.31.98.44/1774)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2395,17 +2428,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11762 for outside:192.168.238.126/53 (192.168.238.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2480,17 +2515,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11763 for outside:192.168.93.51/53 (192.168.93.51/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2570,6 +2607,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11762 for outside:192.168.238.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 111",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -2655,6 +2693,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11763 for outside:192.168.93.51/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 237",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -2730,9 +2769,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -2740,7 +2780,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -2814,17 +2854,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11764 for outside:192.168.225.103/443 (192.168.225.103/443) to inside:172.31.98.44/1775 (172.31.98.44/1775)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -2894,9 +2936,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -2904,7 +2947,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -2978,17 +3021,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11772 for outside:192.168.240.126/53 (192.168.240.126/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3063,17 +3108,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11773 for outside:192.168.44.45/53 (192.168.44.45/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3153,6 +3200,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11772 for outside:192.168.240.126/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 87",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -3238,6 +3286,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11773 for outside:192.168.44.45/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 221",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -3313,9 +3362,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -3323,7 +3373,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -3397,17 +3447,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11774 for outside:192.168.179.219/80 (192.168.179.219/80) to inside:172.31.98.44/1452 (172.31.98.44/1452)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3482,17 +3534,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11775 for outside:192.168.157.232/53 (192.168.157.232/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3567,17 +3621,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11776 for outside:192.168.178.133/53 (192.168.178.133/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3657,6 +3713,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11775 for outside:192.168.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 101",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -3742,6 +3799,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11776 for outside:192.168.178.133/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 126",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -3817,9 +3875,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -3827,7 +3886,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -3901,17 +3960,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11777 for outside:192.168.133.112/80 (192.168.133.112/80) to inside:172.31.98.44/1453 (172.31.98.44/1453)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -3991,6 +4052,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11777 for outside:192.168.133.112/80 to inside:172.31.98.44/1453 duration 0:00:00 bytes 862 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -4072,17 +4134,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11779 for outside:192.168.204.197/53 (192.168.204.197/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4162,6 +4226,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11778 for outside:192.168.157.232/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -4247,6 +4312,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11779 for outside:192.168.204.197/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 176",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -4322,9 +4388,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -4332,7 +4399,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -4406,17 +4473,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11780 for outside:192.168.128.3/80 (192.168.128.3/80) to inside:172.31.98.44/1454 (172.31.98.44/1454)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4486,9 +4555,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -4496,7 +4566,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -4570,17 +4640,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11781 for outside:192.168.128.3/80 (192.168.128.3/80) to inside:172.31.98.44/1455 (172.31.98.44/1455)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4650,9 +4722,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -4660,7 +4733,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -4734,17 +4807,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11782 for outside:192.168.128.3/80 (192.168.128.3/80) to inside:172.31.98.44/1456 (172.31.98.44/1456)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4819,17 +4894,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11783 for outside:192.168.100.4/53 (192.168.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -4909,6 +4986,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11783 for outside:192.168.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -4984,9 +5062,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -4994,7 +5073,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -5068,17 +5147,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11784 for outside:192.168.198.40/80 (192.168.198.40/80) to inside:172.31.98.44/1457 (172.31.98.44/1457)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5148,9 +5229,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -5158,7 +5240,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -5232,17 +5314,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11785 for outside:192.168.198.40/80 (192.168.198.40/80) to inside:172.31.98.44/1458 (172.31.98.44/1458)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5317,17 +5401,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11786 for outside:192.168.1.107/53 (192.168.1.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5407,6 +5493,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11784 for outside:192.168.198.40/80 to inside:172.31.98.44/1457 duration 0:00:00 bytes 593 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -5483,9 +5570,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -5493,7 +5581,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -5567,17 +5655,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11787 for outside:192.168.198.40/80 (192.168.198.40/80) to inside:172.31.98.44/1459 (172.31.98.44/1459)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5657,6 +5747,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11786 for outside:192.168.1.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 375",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -5732,9 +5823,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -5742,7 +5834,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -5816,17 +5908,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11788 for outside:192.168.192.44/80 (192.168.192.44/80) to inside:172.31.98.44/1460 (172.31.98.44/1460)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -5896,21 +5990,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1454 to outside:192.168.98.44/8267 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -5979,9 +6074,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -5989,7 +6085,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -6063,17 +6159,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11797 for outside:192.168.19.254/80 (192.168.19.254/80) to inside:172.31.156.80/1385 (172.31.156.80/1385)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -6143,21 +6241,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1455 to outside:192.168.98.44/8268 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6226,21 +6325,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1456 to outside:192.168.98.44/8269 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6309,21 +6409,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1457 to outside:192.168.98.44/8270 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6392,21 +6493,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1458 to outside:192.168.98.44/8271 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6475,21 +6577,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1459 to outside:192.168.98.44/8272 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6558,21 +6661,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1460 to outside:192.168.98.44/8273 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -6651,6 +6755,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11564 for outside:192.168.115.46/80 to inside:172.31.156.80/1382 duration 0:05:25 bytes 575 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:29:31.000Z",
@@ -6737,6 +6842,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11797 for outside:192.168.19.254/80 to inside:172.31.156.80/1385 duration 0:00:00 bytes 5391 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -6813,9 +6919,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -6823,7 +6930,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -6897,17 +7004,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11798 for outside:192.168.115.46/80 (192.168.115.46/80) to inside:172.31.156.80/1386 (172.31.156.80/1386)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8043,9 +8152,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -8053,7 +8163,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -8127,17 +8237,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11799 for outside:192.168.205.99/80 (192.168.205.99/80) to inside:172.31.98.44/1275 (172.31.98.44/1275)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8207,9 +8319,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -8217,7 +8330,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -8291,17 +8404,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11800 for outside:192.168.14.30/53 (192.168.14.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8381,6 +8496,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11800 for outside:192.168.14.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 373",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -8461,17 +8577,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11801 for outside:192.168.252.210/53 (192.168.252.210/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8551,6 +8669,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11801 for outside:192.168.252.210/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 207",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -8626,9 +8745,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -8636,7 +8756,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -8710,17 +8830,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11802 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1276 (172.31.98.44/1276)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8790,9 +8912,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -8800,7 +8923,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -8874,17 +8997,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11803 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1277 (172.31.98.44/1277)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -8964,6 +9089,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11802 for outside:192.168.98.165/80 to inside:172.31.98.44/1276 duration 0:00:00 bytes 12853 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -9040,9 +9166,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -9050,7 +9177,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -9124,17 +9251,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11804 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1278 (172.31.98.44/1278)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -9214,6 +9343,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11803 for outside:192.168.98.165/80 to inside:172.31.98.44/1277 duration 0:00:00 bytes 5291 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -9290,9 +9420,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -9300,7 +9431,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -9374,17 +9505,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11805 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1279 (172.31.98.44/1279)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -9464,6 +9597,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11804 for outside:192.168.98.165/80 to inside:172.31.98.44/1278 duration 0:00:00 bytes 965 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -9550,6 +9684,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11805 for outside:192.168.98.165/80 to inside:172.31.98.44/1279 duration 0:00:00 bytes 8605 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -9626,9 +9761,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -9636,7 +9772,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -9710,17 +9846,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11806 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1280 (172.31.98.44/1280)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -9800,6 +9938,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11806 for outside:192.168.98.165/80 to inside:172.31.98.44/1280 duration 0:00:00 bytes 3428 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -9876,9 +10015,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -9886,7 +10026,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -9960,17 +10100,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11807 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1281 (172.31.98.44/1281)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -10040,9 +10182,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -10050,7 +10193,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -10124,17 +10267,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11808 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1282 (172.31.98.44/1282)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -10204,9 +10349,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -10214,7 +10360,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -10288,17 +10434,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11809 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1283 (172.31.98.44/1283)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -10368,9 +10516,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -10378,7 +10527,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -10452,17 +10601,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11810 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1284 (172.31.98.44/1284)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -10542,6 +10693,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11807 for outside:192.168.98.165/80 to inside:172.31.98.44/1281 duration 0:00:00 bytes 2028 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -10628,6 +10780,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11808 for outside:192.168.98.165/80 to inside:172.31.98.44/1282 duration 0:00:00 bytes 1085 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -10714,6 +10867,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11809 for outside:192.168.98.165/80 to inside:172.31.98.44/1283 duration 0:00:00 bytes 868 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -10790,9 +10944,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -10800,7 +10955,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -10874,17 +11029,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11811 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1285 (172.31.98.44/1285)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -10954,9 +11111,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -10964,7 +11122,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -11038,17 +11196,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11812 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1286 (172.31.98.44/1286)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -11128,6 +11288,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11810 for outside:192.168.98.165/80 to inside:172.31.98.44/1284 duration 0:00:00 bytes 4439 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -11204,9 +11365,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -11214,7 +11376,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -11288,17 +11450,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11813 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1287 (172.31.98.44/1287)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -11378,6 +11542,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11811 for outside:192.168.98.165/80 to inside:172.31.98.44/1285 duration 0:00:00 bytes 914 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -11464,6 +11629,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11812 for outside:192.168.98.165/80 to inside:172.31.98.44/1286 duration 0:00:00 bytes 871 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -11545,17 +11711,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11814 for outside:192.168.100.107/53 (192.168.100.107/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -11625,9 +11793,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -11635,7 +11804,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -11709,17 +11878,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11815 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1288 (172.31.98.44/1288)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -11799,6 +11970,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11814 for outside:192.168.100.107/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 384",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -11879,17 +12051,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11816 for outside:192.168.104.8/53 (192.168.104.8/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -11969,6 +12143,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11816 for outside:192.168.104.8/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 94",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -12044,9 +12219,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -12054,7 +12230,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -12128,17 +12304,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11817 for outside:192.168.123.191/80 (192.168.123.191/80) to inside:172.31.98.44/1289 (172.31.98.44/1289)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -12218,6 +12396,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11815 for outside:192.168.98.165/80 to inside:172.31.98.44/1288 duration 0:00:00 bytes 945 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -12304,6 +12483,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11813 for outside:192.168.98.165/80 to inside:172.31.98.44/1287 duration 0:00:00 bytes 13284 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -12385,17 +12565,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11818 for outside:192.168.100.4/53 (192.168.100.4/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -12475,6 +12657,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11818 for outside:192.168.100.4/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -12550,9 +12733,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -12560,7 +12744,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -12634,17 +12818,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11819 for outside:192.168.198.25/80 (192.168.198.25/80) to inside:172.31.98.44/1290 (172.31.98.44/1290)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -12724,6 +12910,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 9828 for outside:192.168.48.1/67 to NP Identity Ifc:255.255.255.255/68 duration 0:58:46 bytes 58512",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T11:36:10.000Z",
                 "timezone": "UTC",
@@ -12799,21 +12986,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1272 to outside:192.168.98.44/8276 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -12887,17 +13075,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11820 for outside:192.168.3.39/53 (192.168.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -12972,17 +13162,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11821 for outside:192.168.162.30/53 (192.168.162.30/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -13062,6 +13254,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11820 for outside:192.168.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 168",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -13142,17 +13335,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11822 for outside:192.168.3.39/53 (192.168.3.39/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -13232,6 +13427,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11821 for outside:192.168.162.30/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 198",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -13317,6 +13513,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11822 for outside:192.168.3.39/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -13397,17 +13594,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11823 for outside:192.168.48.186/53 (192.168.48.186/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -13487,6 +13686,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11823 for outside:192.168.48.186/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 84",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -13562,9 +13762,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -13572,7 +13773,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -13646,17 +13847,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11824 for outside:192.168.54.190/80 (192.168.54.190/80) to inside:172.31.98.44/1291 (172.31.98.44/1291)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -13731,17 +13934,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11825 for outside:192.168.254.94/53 (192.168.254.94/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -13821,6 +14026,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11825 for outside:192.168.254.94/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 188",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -13896,9 +14102,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -13906,7 +14113,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -13980,17 +14187,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11826 for outside:192.168.54.190/80 (192.168.54.190/80) to inside:172.31.98.44/1292 (172.31.98.44/1292)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -14060,9 +14269,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -14070,7 +14280,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -14144,17 +14354,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11827 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1293 (172.31.98.44/1293)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -14224,9 +14436,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -14234,7 +14447,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -14308,17 +14521,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11828 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1294 (172.31.98.44/1294)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -14398,6 +14613,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11827 for outside:192.168.98.165/80 to inside:172.31.98.44/1293 duration 0:00:00 bytes 5964 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -14474,9 +14690,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -14484,7 +14701,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -14558,17 +14775,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11829 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1295 (172.31.98.44/1295)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -14638,9 +14857,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -14648,7 +14868,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -14722,17 +14942,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11830 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1296 (172.31.98.44/1296)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -14812,6 +15034,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11828 for outside:192.168.98.165/80 to inside:172.31.98.44/1294 duration 0:00:00 bytes 6694 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -14898,6 +15121,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11829 for outside:192.168.98.165/80 to inside:172.31.98.44/1295 duration 0:00:00 bytes 1493 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -14984,6 +15208,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11830 for outside:192.168.98.165/80 to inside:172.31.98.44/1296 duration 0:00:00 bytes 893 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -15060,9 +15285,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -15070,7 +15296,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -15144,17 +15370,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11831 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1297 (172.31.98.44/1297)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -15224,9 +15452,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -15234,7 +15463,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -15308,17 +15537,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11832 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1298 (172.31.98.44/1298)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -15393,17 +15624,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11833 for outside:192.168.179.9/53 (192.168.179.9/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -15483,6 +15716,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11833 for outside:192.168.179.9/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 150",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -15568,6 +15802,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11831 for outside:192.168.98.165/80 to inside:172.31.98.44/1297 duration 0:00:00 bytes 2750 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -15644,9 +15879,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -15654,7 +15890,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -15728,17 +15964,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11834 for outside:192.168.247.99/80 (192.168.247.99/80) to inside:172.31.98.44/1299 (172.31.98.44/1299)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -15808,9 +16046,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -15818,7 +16057,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -15892,17 +16131,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11835 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1300 (172.31.98.44/1300)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -15982,6 +16223,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11832 for outside:192.168.98.165/80 to inside:172.31.98.44/1298 duration 0:00:00 bytes 881 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -16068,6 +16310,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11835 for outside:192.168.98.165/80 to inside:172.31.98.44/1300 duration 0:00:00 bytes 2202 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
@@ -16144,9 +16387,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -16154,7 +16398,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -16228,17 +16472,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11836 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1301 (172.31.98.44/1301)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -16308,9 +16554,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -16318,7 +16565,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -16392,17 +16639,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11837 for outside:192.168.98.165/80 (192.168.98.165/80) to inside:172.31.98.44/1302 (172.31.98.44/1302)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -16472,21 +16721,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1276 to outside:192.168.98.44/8280 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16555,21 +16805,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1277 to outside:192.168.98.44/8281 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16638,21 +16889,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1278 to outside:192.168.98.44/8282 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16721,21 +16973,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1279 to outside:192.168.98.44/8283 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16804,21 +17057,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1280 to outside:192.168.98.44/8284 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16887,21 +17141,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1281 to outside:192.168.98.44/8285 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -16970,21 +17225,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1282 to outside:192.168.98.44/8286 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17053,21 +17309,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1283 to outside:192.168.98.44/8287 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17136,21 +17393,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1284 to outside:192.168.98.44/8288 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17219,21 +17477,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1285 to outside:192.168.98.44/8289 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17302,21 +17561,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1286 to outside:192.168.98.44/8290 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17385,21 +17645,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1287 to outside:192.168.98.44/8291 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17468,21 +17729,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1288 to outside:192.168.98.44/8292 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17551,21 +17813,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1293 to outside:192.168.98.44/8297 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17634,21 +17897,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1294 to outside:192.168.98.44/8298 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17717,9 +17981,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -17727,7 +17992,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -17801,17 +18066,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11840 for outside:192.168.205.99/80 (192.168.205.99/80) to inside:172.31.98.44/1304 (172.31.98.44/1304)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -17881,21 +18148,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1295 to outside:192.168.98.44/8299 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -17964,21 +18232,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1296 to outside:192.168.98.44/8300 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18052,17 +18321,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11841 for outside:192.168.0.124/53 (192.168.0.124/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -18137,17 +18408,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302015: Built outbound UDP connection 11842 for outside:192.168.160.2/53 (192.168.160.2/53) to inside:172.31.98.44/56132 (172.31.98.44/56132)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -18227,6 +18500,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11841 for outside:192.168.0.124/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 318",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -18312,6 +18586,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302016: Teardown UDP connection 11842 for outside:192.168.160.2/53 to inside:172.31.98.44/56132 duration 0:00:00 bytes 104",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:56.000Z",
                 "timezone": "UTC",
@@ -18387,9 +18662,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -18397,7 +18673,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -18471,17 +18747,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11843 for outside:192.168.124.24/80 (192.168.124.24/80) to inside:172.31.98.44/1305 (172.31.98.44/1305)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -18551,21 +18829,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1297 to outside:192.168.98.44/8301 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18634,21 +18913,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1298 to outside:192.168.98.44/8302 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18717,21 +18997,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1299 to outside:192.168.98.44/8303 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18800,21 +19081,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1300 to outside:192.168.98.44/8304 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18883,21 +19165,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1301 to outside:192.168.98.44/8305 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -18966,21 +19249,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1302 to outside:192.168.98.44/8306 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -19049,21 +19333,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305012: Teardown dynamic TCP translation from inside:172.31.98.44/1303 to outside:192.168.98.44/8307 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2018-10-10T12:34:26.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -19142,6 +19427,7 @@
                 "end": "2018-10-10T12:34:56.000Z",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302014: Teardown TCP connection 11843 for outside:192.168.124.24/80 to inside:172.31.98.44/1305 duration 0:00:04 bytes 410333 TCP Reset-I",
+                "outcome": "success",
                 "reason": "TCP Reset-I",
                 "severity": 6,
                 "start": "2018-10-10T12:34:52.000Z",
@@ -19464,9 +19750,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -19474,7 +19761,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -19548,17 +19835,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-302013: Built outbound TCP connection 11844 for outside:192.168.124.24/80 (192.168.124.24/80) to inside:172.31.98.44/1306 (172.31.98.44/1306)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -22339,17 +22628,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "<166>Jan 11 2023 13:34:06 localhost : %ASA-6-302013: Built outbound TCP connection 353540142 for outside-noanet:192.168.124.24/443 (192.168.124.24/443) to inside:172.31.98.44/49234 (172.31.98.44/49234)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-filtered.log-expected.json
@@ -6,7 +6,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -14,10 +13,7 @@
                 "kind": "event",
                 "original": "Jan  1 01:00:27 beats asa[1234]: %ASA-7-999999: This message is not filtered.",
                 "severity": 7,
-                "timezone": "UTC",
-                "type": [
-                    "info"
-                ]
+                "timezone": "UTC"
             },
             "host": {
                 "hostname": "beats"
@@ -50,7 +46,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
                 "category": [
                     "network"
                 ],
@@ -58,10 +53,7 @@
                 "kind": "event",
                 "original": "Jan  1 01:00:30 beats asa[1234]: %ASA-8-999999: This phony message is dropped due to log level.",
                 "severity": 8,
-                "timezone": "UTC",
-                "type": [
-                    "info"
-                ]
+                "timezone": "UTC"
             },
             "host": {
                 "hostname": "beats"

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-hostnames.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-hostnames.log-expected.json
@@ -21,6 +21,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Oct 10 2019 10:21:36 localhost: %ASA-6-302021: Teardown ICMP connection for faddr target.destination.hostname.local/10005 gaddr 10.0.55.66/0 laddr Prod-host.name.addr/0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -88,6 +89,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jun 04 2011 21:59:52 MYHOSTNAME : %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.15/0 gaddr 192.168.2.134/57808 laddr 192.168.2.134/57808 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -22,17 +22,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jul 15 13:38:14 216.160.83.56 : %ASA-6-302013: Built inbound TCP connection 3263493120 for DMZ:shule/5802 (shule/5802) to SERVERS:10.10.227.121/80 (10.10.227.121/80)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -102,17 +104,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jul 15 13:38:11 216.160.83.56 : %ASA-6-302013: Built outbound TCP connection 3263492189 for MG:exp_srv/10050 (exp_srv/10050) to SERVERS:10.10.227.170/46145 (10.10.224.1/46145)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -186,17 +190,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jul 15 13:38:08 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108828 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/48347 (89.160.20.128/48347)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -270,17 +276,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jul 15 13:38:03 81.2.69.142 %ASA-6-302015: Built outbound UDP connection 743108738 for outside:ns10/53 (ns10/53) to MND_sec:192.168.174.100/55653 (81.2.69.192/55653)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -519,21 +527,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 41000000000,
                 "end": "2024-07-15T13:38:47.000Z",
                 "kind": "event",
                 "original": "Jul 15 13:38:47 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/62409 to outside:81.2.69.142/62409 duration 0:00:41",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2024-07-15T13:38:06.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -609,21 +618,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 30000000000,
                 "end": "2024-07-15T13:37:33.000Z",
                 "kind": "event",
                 "original": "Jul 15 13:37:33 216.160.83.56 : %ASA-6-305012: Teardown dynamic UDP translation from SERVERS:exp-wait/56421 to outside:81.2.69.142/56421 duration 0:00:30",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2024-07-15T13:37:03.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "host": {
@@ -699,9 +709,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -709,7 +720,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -785,9 +796,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -795,7 +807,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "host": {
@@ -1055,6 +1067,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "Jul 15 13:30:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1130,6 +1143,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "Jul 14 01:45:09 81.2.69.142 %ASA-6-302020: Built inbound ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1205,6 +1219,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jul 15 13:30:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/6553 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1280,6 +1295,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jul 14 01:45:09 81.2.69.142 %ASA-6-302021: Teardown ICMP connection for faddr eth0_fw/8396 gaddr 81.2.69.192/0 laddr 81.2.69.192/0 type 8 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1346,6 +1362,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "Jul 15 12:18:51 81.2.69.192 %ASA-6-113039: Group <novpn> User <nt\\minsk> IP <216.160.83.56> AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1421,6 +1438,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "Jul  1 09:27:13 216.160.83.56 : %ASA-6-113039: Group <Group_VPN> User <support\\column> IP <81.2.69.192> AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1489,7 +1507,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -1500,7 +1518,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -717,6 +717,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Jul 15 13:39:04 216.160.83.56 : %ASA-6-305011: Built dynamic TCP translation from SERVERS:exp-srv/50578 to outside:81.2.69.142/50578",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -804,6 +805,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Jul 15 13:37:02 216.160.83.56 : %ASA-6-305011: Built dynamic UDP translation from SERVERS:exp-wait/56570 to outside:81.2.69.142/56570",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -189,6 +189,7 @@
                 "code": "338204",
                 "kind": "event",
                 "original": "Jan  2 2020 11:33:20 localhost : %ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-not-ip.log-expected.json
@@ -115,6 +115,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jan  1 2020 10:42:53 localhost : %ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr mydomain.example.net/17233 laddr 192.168.132.46/17233",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -181,14 +182,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "dynamic-filter",
                 "category": [
                     "network"
                 ],
                 "code": "338204",
                 "kind": "event",
                 "original": "Jan  2 2020 11:33:20 localhost : %ASA-4-338204: Dynamic filter dropped greylisted TCP traffic from eth0:10.10.10.1/1234 (source.example.net/11234) to wan:172.24.177.3/80 (www.example.org/80), destination malicious address resolved from dynamic list: example.org, threat-level: high, category: malware",
-                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -6655,7 +6655,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "deleted",
+                "action": "sa-deleted",
                 "category": [
                     "network"
                 ],

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -394,6 +394,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4952 to outside:192.168.2.130/12834",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -542,6 +543,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic UDP translation from outside:10.123.1.35/52925 to outside:192.168.2.130/25882",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -694,6 +696,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from outside:10.123.3.42/4953 to outside:192.168.2.130/45392",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1163,6 +1166,7 @@
                 "code": "305011",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-305011: Built dynamic TCP translation from inside:192.168.3.42/4954 to outside:192.168.0.130/10879",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -4639,6 +4643,7 @@
                 "code": "313001",
                 "kind": "event",
                 "original": "Sep 12 2014 06:53:02 GIFRCHN01 : %ASA-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
+                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -4706,6 +4711,7 @@
                 "code": "313004",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:13: %ASA-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -4942,6 +4948,7 @@
                 "code": "338008",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.168.2.223/80 (192.168.2.223/80), destination 192.168.2.223 resolved from dynamic list: 192.168.2.223/255.255.255.255, threat-level: very-high, category: Malware",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -5117,7 +5124,7 @@
                 "code": "304002",
                 "kind": "event",
                 "original": "Nov 16 2009 14:12:37: %ASA-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.168.0.19 on interface inside",
-                "outcome": "failure",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -386,9 +386,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -396,7 +397,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "log": {
@@ -459,17 +460,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743274 for outside:192.168.2.43/443 (192.168.2.43/443) to outside:10.123.3.42/4952 (10.123.3.42/12834)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -531,9 +534,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -541,7 +545,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "log": {
@@ -607,17 +611,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302015: Built outbound UDP connection 89743275 for outside:192.168.2.222/53 (192.168.2.43/53) to outside:10.123.1.35/52925 (10.123.1.35/25882)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -680,9 +686,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -690,7 +697,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "log": {
@@ -753,17 +760,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743276 for outside:192.168.2.1/80 (192.168.2.1/80) to outside:10.123.3.42/4953 (10.123.3.130/45392)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -837,6 +846,7 @@
                 "end": "2013-04-29T12:59:50.000Z",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302016: Teardown UDP connection 89743275 for outside:192.168.2.222/53 to inside:10.123.1.35/52925 duration 1:23:45 bytes 140",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2013-04-29T11:36:05.000Z",
                 "timezone": "UTC",
@@ -916,6 +926,7 @@
                 "end": "2013-04-29T12:59:50.000Z",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302016: Teardown UDP connection 666 for outside:192.168.2.222/53 user1 to inside:10.123.1.35/52925 user2 duration 10:00:00 bytes 9999999",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2013-04-29T02:59:50.000Z",
                 "timezone": "UTC",
@@ -1005,6 +1016,7 @@
                 "end": "2013-04-29T12:59:50.000Z",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302016: Teardown UDP connection 666 for outside:192.168.2.222/53 Speciäl Ö1 to inside:10.123.1.35/52925 Speciäl Ö2 duration 10:00:00 bytes 9999999",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2013-04-29T02:59:50.000Z",
                 "timezone": "UTC",
@@ -1084,6 +1096,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jun 04 2011 21:59:52 FJSG2NRFW01 : %ASA-6-302021: Teardown ICMP connection for faddr 172.24.177.29/0 gaddr 192.168.132.46/17233 laddr 192.168.132.46/17233",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1142,9 +1155,10 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305011",
                 "kind": "event",
@@ -1152,7 +1166,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "creation"
                 ]
             },
             "log": {
@@ -1215,17 +1229,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Apr 29 2013 12:59:50: %ASA-6-302013: Built outbound TCP connection 89743277 for outside:192.168.0.17/80 (192.168.0.17/80) to inside:192.168.3.42/4954 (10.0.0.130/10879)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -2891,17 +2907,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:24 <IP>: %ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -3116,17 +3134,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:31 <IP>: %ASA-6-302013: Built outbound TCP connection 447236 for outside:192.168.2.222/1234 (192.168.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -3194,17 +3214,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:31 <IP>: %ASA-6-302013: Built outbound TCP connection 447236 for outside:192.168.2.222/1234 (192.168.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -3277,6 +3299,7 @@
                 "end": "2018-12-11T08:01:31.000Z",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:31 <IP>: %ASA-6-302014: Teardown TCP connection 447236 for outside:192.168.2.222/1234 to dmz:192.168.1.34/5678 duration 0:00:00 bytes 14804 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-12-11T08:01:31.000Z",
@@ -3355,6 +3378,7 @@
                 "end": "2018-12-11T08:01:38.000Z",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:38 <IP>: %ASA-6-302014: Teardown TCP connection 447234 for outside:192.168.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-12-11T08:00:30.000Z",
@@ -3433,6 +3457,7 @@
                 "end": "2018-12-11T08:01:38.000Z",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:38 <IP>: %ASA-6-302014: Teardown TCP connection 447234 for outside:192.168.2.222/1234 to dmz:192.168.1.35/5678 duration 0:01:08 bytes 134781 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-12-11T08:00:30.000Z",
@@ -3714,17 +3739,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:53 <IP>: %ASA-6-302013: Built outbound TCP connection 447237 for outside:192.168.2.222/1234 (192.168.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -3791,17 +3818,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:53 <IP>: %ASA-6-302013: Built outbound TCP connection 447237 for outside:192.168.2.222/1234 (192.168.2.222/1234) to dmz:192.168.1.34/65000 (192.168.1.34/65000)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -3873,6 +3902,7 @@
                 "end": "2018-12-11T08:01:53.000Z",
                 "kind": "event",
                 "original": "Dec 11 2018 08:01:53 <IP>: %ASA-6-302014: Teardown TCP connection 447237 for outside:192.168.2.222/1234 to dmz:10.10.10.10/1235 duration 23:59:59 bytes 11420 TCP FINs",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2018-12-10T08:01:54.000Z",
@@ -3951,6 +3981,7 @@
                 "end": "2012-08-15T23:30:09.000Z",
                 "kind": "event",
                 "original": "Aug 15 2012 23:30:09 : %ASA-6-302016 Teardown UDP connection 40 for outside:10.44.4.4/500 to inside:10.44.2.2/500 duration 0:02:02 bytes 1416",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2012-08-15T23:28:07.000Z",
                 "timezone": "UTC",
@@ -4608,7 +4639,6 @@
                 "code": "313001",
                 "kind": "event",
                 "original": "Sep 12 2014 06:53:02 GIFRCHN01 : %ASA-3-313001: Denied ICMP type=3, code=3 from 10.2.3.5 on interface Outside",
-                "outcome": "success",
                 "severity": 3,
                 "timezone": "UTC",
                 "type": [
@@ -4676,7 +4706,6 @@
                 "code": "313004",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:13: %ASA-4-313004: Denied ICMP type=0, from laddr 172.16.30.2 on interface inside to 172.16.1.10: no matching session",
-                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -4739,19 +4768,18 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "dynamic-filter",
                 "category": [
                     "network"
                 ],
                 "code": "338002",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338002: Dynamic Filter permitted black listed TCP traffic from inside:10.1.1.45/6798 (192.168.99.1/7890) to outside:192.168.99.129/80 (192.168.99.129/80), destination 192.168.99.129 resolved from dynamic list: bad.example.com",
-                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
                     "connection",
-                    "allowed"
+                    "info"
                 ]
             },
             "log": {
@@ -4827,18 +4855,17 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "dynamic-filter",
                 "category": [
-                    "network",
-                    "intrusion_detection"
+                    "network"
                 ],
                 "code": "338004",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338004: Dynamic Filter monitored blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.168.2.223/80 (192.168.2.223/80), destination 192.168.2.223 resolved from dynamic list: 192.168.2.223/255.255.255.255, threat-level: very-high, category: Malware",
-                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
+                    "connection",
                     "info"
                 ]
             },
@@ -4908,14 +4935,13 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "dynamic-filter",
                 "category": [
                     "network"
                 ],
                 "code": "338008",
                 "kind": "event",
                 "original": "Jan 14 2015 13:16:14: %ASA-4-338008: Dynamic Filter dropped blacklisted TCP traffic from inside:10.1.1.1/33340 (10.2.1.1/33340) to outsidet:192.168.2.223/80 (192.168.2.223/80), destination 192.168.2.223 resolved from dynamic list: 192.168.2.223/255.255.255.255, threat-level: very-high, category: Malware",
-                "outcome": "failure",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -4975,7 +5001,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -4986,7 +5012,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -5026,7 +5052,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -5037,7 +5063,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -5084,18 +5110,18 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
                 "code": "304002",
                 "kind": "event",
                 "original": "Nov 16 2009 14:12:37: %ASA-5-304002: Access denied URL http://www.example.net/images/favicon.ico SRC 10.69.6.39 DEST 192.168.0.19 on interface inside",
-                "outcome": "success",
+                "outcome": "failure",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "denied"
                 ]
             },
@@ -5169,17 +5195,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-6-302013: Built inbound TCP connection 27215708 for internet:10.2.3.4/49926 (81.2.69.144/49926)(LOCAL\\username) to vlan-42:81.2.69.144/80 (81.2.69.144/80) (username)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -5240,7 +5268,7 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "url-access",
                 "category": [
                     "network"
                 ],
@@ -5251,7 +5279,7 @@
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "connection",
+                    "access",
                     "allowed"
                 ]
             },
@@ -5326,17 +5354,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-5-302013: Built inbound TCP connection 195207391 for OUTSIDE:175.16.199.1/12312 (81.2.69.193/34534)(LOCAL\\USER001) to OUTSIDE:67.43.156.15/443 (67.43.156.15/443) (USER001)",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -5437,17 +5467,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-5-302013: Built inbound TCP connection 195207391 for OUTSIDE:175.16.199.1/12312 (81.2.69.193/34534)(LOCAL\\user@domain.tld) to OUTSIDE:67.43.156.15/443 (67.43.156.15/443) (user@domain.tld)",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -5558,6 +5590,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-5-302020: Built inbound ICMP connection for faddr 175.16.199.1/0(LOCAL\\USER001) gaddr 67.43.156.15/0 laddr 67.43.156.15/0 (USER001) type 3 code 3",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -5655,6 +5688,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-5-302020: Built inbound ICMP connection for faddr 175.16.199.1/0(LOCAL\\user@domain.tld) gaddr 67.43.156.15/0 laddr 67.43.156.15/0 (user@domain.tld) type 3 code 3",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -5756,6 +5790,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "Jan 13 2021 19:12:37: %ASA-5-302020: Built inbound ICMP connection for faddr 175.16.199.1/0(AD\\USER002) gaddr 67.43.156.15/0 laddr 67.43.156.15/0 (USER002) type 3 code 3",
+                "outcome": "success",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -5843,21 +5878,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 0,
                 "end": "2021-01-15T19:12:37.000Z",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-305012: Teardown dynamic TCP translation from OUTSIDE:192.168.0.1/59677(LOCAL\\USER001) to OUTSIDE:67.43.156.14/18449 duration 0:00:00",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2021-01-15T19:12:37.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "log": {
@@ -5928,6 +5964,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302021: Teardown ICMP connection for faddr ff02::1/0 gaddr fe80::2205:baff:fe9d:f637/0 laddr fe80::2205:baff:fe9d:f637/0 type 134 code 0",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -5994,17 +6031,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302013: Built inbound TCP connection 251933191 for OUTSIDE:2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6/62477 (2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6/62477) to OUTSIDE:2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6/443 (2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6/443) (soc@danskecommodities.com)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -6084,21 +6123,22 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "flow-expiration",
+                "action": "nat-slot",
                 "category": [
-                    "network"
+                    "network",
+                    "configuration"
                 ],
                 "code": "305012",
                 "duration": 125000000000,
                 "end": "2021-01-15T19:12:37.000Z",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-305012: Teardown dynamic TCP translation from OUTSIDE:67.43.156.15/50120(LOCAL\\domain\\USER001) to OUTSIDE:67.43.156.13/50120 duration 0:02:05",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2021-01-15T19:10:32.000Z",
                 "timezone": "UTC",
                 "type": [
-                    "connection",
-                    "end"
+                    "deletion"
                 ]
             },
             "log": {
@@ -6197,6 +6237,7 @@
                 "end": "2021-01-15T19:12:37.000Z",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302014: Teardown TCP connection 261246338 for OUTSIDE:67.43.156.15/50120(LOCAL\\domain\\USER001) to OUTSIDE:1.128.3.4/443 duration 0:02:05 bytes 9610 TCP FINs from OUTSIDE (domain\\USER001)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2021-01-15T19:10:32.000Z",
@@ -6291,17 +6332,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302015: Built inbound UDP connection 261311655 for OUTSIDE:67.43.156.15/63790 (81.2.69.193/63790)(LOCAL\\domain\\USER001) to INSIDE:192.168.0.1/53 (192.168.0.1/53) (domain\\USER001)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -6398,6 +6441,7 @@
                 "end": "2021-01-15T19:12:37.000Z",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302016: Teardown UDP connection 261311655 for OUTSIDE:67.43.156.15/63790(LOCAL\\domain\\USER001) to INSIDE:192.168.0.1/53 duration 0:00:00 bytes 139 (domain\\USER001)",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2021-01-15T19:12:37.000Z",
                 "timezone": "UTC",
@@ -6497,17 +6541,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "Jan 15 2021 19:12:37: %ASA-6-302013: Built inbound TCP connection 261246338 for OUTSIDE:67.43.156.15/50120 (81.2.69.193/50120)(LOCAL\\domain\\USER001) to OUTSIDE:1.128.3.4/443 (1.128.3.4/443) (domain\\USER001)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "log": {
@@ -6613,7 +6659,7 @@
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info",
+                    "connection",
                     "end"
                 ]
             },
@@ -6690,6 +6736,7 @@
                 "end": "2023-11-17T11:05:08.000Z",
                 "kind": "event",
                 "original": "Nov 17 2023 11:05:08: %ASA-6-302014: Teardown TCP connection 261246338 for outside:67.43.156.15/63790(LOCAL\\First Last) to inside:192.168.0.1/53 duration 0:35:58 bytes 27451 TCP FINs from outside (First Last)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-11-17T10:29:10.000Z",
@@ -6786,6 +6833,7 @@
                 "end": "2023-11-17T11:05:08.000Z",
                 "kind": "event",
                 "original": "Nov 17 2023 11:05:08: %ASA-6-302014: Teardown TCP connection 261246338 for outside:67.43.156.15/63790(LOCAL\\Speciäl Ö01) to inside:192.168.0.1/53 duration 0:35:58 bytes 27451 TCP FINs from outside (Speciäl Ö01)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-11-17T10:29:10.000Z",
@@ -6882,6 +6930,7 @@
                 "end": "2023-11-17T11:05:08.000Z",
                 "kind": "event",
                 "original": "Nov 17 2023 11:05:08: %ASA-6-302014: Teardown TCP connection 261246338 for outside:67.43.156.15/63790(LOCAL\\domain\\Speciäl Ö1) to inside:192.168.0.1/53 duration 0:35:58 bytes 27451 TCP FINs from outside (domain\\Speciäl Ö1)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-11-17T10:29:10.000Z",
@@ -6982,6 +7031,7 @@
                 "end": "2023-11-17T11:05:08.000Z",
                 "kind": "event",
                 "original": "Nov 17 2023 11:05:08: %ASA-6-302014: Teardown TCP connection 261246338 for outside:67.43.156.15/63790(LOCAL\\First Middle Last) to inside:192.168.0.1/53 duration 0:35:58 bytes 27451 TCP FINs from outside (First Middle Last)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-11-17T10:29:10.000Z",
@@ -7078,6 +7128,7 @@
                 "end": "2023-11-17T11:05:08.000Z",
                 "kind": "event",
                 "original": "Nov 17 2023 11:05:08: %ASA-6-302014: Teardown TCP connection 261246338 for outside:67.43.156.15/63790(LOCAL\\First-Middle Last) to inside:192.168.0.1/53 duration 0:35:58 bytes 27451 TCP FINs from outside (domain\\First-Middle Last)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-11-17T10:29:10.000Z",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
@@ -113,17 +113,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 09:22:19 myAsaHostname : %ASA-6-302013: Built inbound TCP connection 990568095 for outside:192.168.2.2/61921 (192.168.2.2/61921)(9999:my_SgtName) to inside:192.168.2.3/443 (192.168.2.3/443)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -211,6 +213,7 @@
                 "end": "2023-10-06T09:22:19.000Z",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 09:22:19 myAsaHostname : %ASA-6-302014: Teardown TCP connection 990458751 for outside:192.168.2.2/55745(9999:my_SgtName) to inside:192.168.2.3/443 duration 0:01:29 bytes 17859 TCP Reset-O from outside",
+                "outcome": "success",
                 "reason": "TCP Reset-O",
                 "severity": 6,
                 "start": "2023-10-06T09:20:50.000Z",
@@ -299,17 +302,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 09:22:19 myAsaHostname : %ASA-6-302015: Built inbound UDP connection 990568116 for outside:192.168.2.2/61701 (192.168.2.2/61701)(9999:my_SgtName) to inside:192.168.2.3/53 (192.168.2.3/53)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -396,6 +401,7 @@
                 "end": "2023-10-06T09:22:19.000Z",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 09:22:19 myAsaHostname : %ASA-6-302016: Teardown UDP connection 990568122 for outside:192.168.2.2/63727(9999:my_SgtName) to inside:192.168.2.3/53 duration 0:00:00 bytes 225",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2023-10-06T09:22:19.000Z",
                 "timezone": "UTC",
@@ -485,6 +491,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:06:32 myAsaHostname : %ASA-6-302020: Built inbound ICMP connection for faddr 192.168.2.2/1(9999:my_SgtName) gaddr 192.168.2.3/0 laddr 192.168.2.3/0 type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -560,6 +567,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:08:00 myAsaHostname : %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/1(9999:my_SgtName) gaddr 192.168.2.3/0 laddr 192.168.2.3/0 type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -641,7 +649,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -734,7 +743,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -880,6 +890,7 @@
                 "code": "113039",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:37:59 myAsaHostname : %ASA-6-113039: Group <my_GroupName> User <myUser1234$> IP <192.168.2.2> AnyConnect parent session started.",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -959,17 +970,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:26:54 myAsaHostname : %ASA-6-302013: Built inbound TCP connection 79766144 for outside:192.168.2.2/62848 (192.168.2.2/62848)(LOCAL\\myUser1234, 9999:my_SgtName) to inside:192.168.2.3/443 (192.168.2.3/443) (myUser1234)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1065,6 +1078,7 @@
                 "end": "2023-10-06T10:17:54.000Z",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:17:54 myAsaHostname : %ASA-6-302014: Teardown TCP connection 79710069 for outside:192.168.2.2/59774(LOCAL\\myUser1234, 9999:my_SgtName) to inside:192.168.2.3/443 duration 0:01:04 bytes 16874 TCP FINs from outside (myUser1234)",
+                "outcome": "success",
                 "reason": "TCP FINs",
                 "severity": 6,
                 "start": "2023-10-06T10:16:50.000Z",
@@ -1161,17 +1175,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:29:03 myAsaHostname : %ASA-6-302015: Built inbound UDP connection 79778185 for outside:192.168.2.2/61881 (192.168.2.2/61881)(LOCAL\\myUser1234, 9999:my_SgtName) to inside:192.168.2.3/53 (192.168.2.3/53) (myUser1234)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1264,6 +1280,7 @@
                 "end": "2023-10-06T10:30:18.000Z",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:30:18 myAsaHostname : %ASA-6-302016: Teardown UDP connection 79784719 for outside:192.168.2.2/60556(9999:my_SgtName) to inside:192.168.2.3/53 duration 0:00:00 bytes 221",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2023-10-06T10:30:18.000Z",
                 "timezone": "UTC",
@@ -1353,6 +1370,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:34:45 myAsaHostname : %ASA-6-302020: Built outbound ICMP connection for faddr 192.168.2.2/0(9999:my_SgtName) gaddr 192.168.2.3/1 laddr 192.168.2.3/1 type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1433,6 +1451,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "<142>Oct 06 2023 10:32:10 myAsaHostname : %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/29(LOCAL\\myUser1234, 9999:my_SgtName) gaddr 192.168.2.3/0 laddr 192.168.2.3/0 (myUser1234) type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -1524,7 +1543,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -1616,17 +1636,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302013",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:27:06 myAsaHostname : %ASA-6-302013: Built inbound TCP connection 101086093 for outside:192.168.2.2/56824 (192.168.2.2/56824)(LOCAL\\myUser1234$, 9999:my_SgtName) to inside:192.168.2.3/443 (192.168.2.3/443) (myUser1234$)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1721,6 +1743,7 @@
                 "end": "2023-10-25T14:22:19.000Z",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:22:19 myAsaHostname : %ASA-6-302014: Teardown TCP connection 63490259 for outside:192.168.2.2/49786(LOCAL\\myUser1234$, 9999:my_SgtName) to inside:192.168.2.3/5985 duration 0:00:30 bytes 0 SYN Timeout (myUser1234$)",
+                "outcome": "success",
                 "reason": "SYN Timeout",
                 "severity": 6,
                 "start": "2023-10-25T14:21:49.000Z",
@@ -1817,17 +1840,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "flow-creation",
                 "category": [
                     "network"
                 ],
                 "code": "302015",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:29:02 myAsaHostname : %ASA-6-302015: Built inbound UDP connection 101095490 for outside:192.168.2.2/61219 (192.168.2.2/61219)(LOCAL\\myUser1234$, 9999:my_SgtName) to inside:192.168.2.3/53 (192.168.2.3/53) (myUser1234$)",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "start"
                 ]
             },
             "host": {
@@ -1922,6 +1947,7 @@
                 "end": "2023-10-25T14:30:31.000Z",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:30:31 myAsaHostname : %ASA-6-302016: Teardown UDP connection 101101684 for outside:192.168.2.2/62253(LOCAL\\myUser1234$, 9999:my_SgtName) to inside:192.168.2.3/53 duration 0:00:00 bytes 216 (myUser1234$)",
+                "outcome": "success",
                 "severity": 6,
                 "start": "2023-10-25T14:30:31.000Z",
                 "timezone": "UTC",
@@ -2022,6 +2048,7 @@
                 "code": "302020",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:32:55 myAsaHostname : %ASA-6-302020: Built inbound ICMP connection for faddr 192.168.2.2/1(LOCAL\\myUser1234$, 9999:my_SgtName) gaddr 192.168.2.3/0 laddr 192.168.2.3/0 (myUser1234$) type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2111,6 +2138,7 @@
                 "code": "302021",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:27:04 myAsaHostname : %ASA-6-302021: Teardown ICMP connection for faddr 192.168.2.2/1(LOCAL\\myUser1234$, 9999:my_SgtName) gaddr 192.168.2.3/0 laddr 192.168.2.3/0 (myUser1234$) type 8 code 0 ",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -2202,7 +2230,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {
@@ -2279,16 +2308,19 @@
                 "version": "8.11.0"
             },
             "event": {
-                "action": "firewall-rule",
+                "action": "logon-failed",
                 "category": [
+                    "authentication",
                     "network"
                 ],
                 "code": "113015",
                 "kind": "event",
                 "original": "<142>Oct 25 2023 14:35:37 myAsaHostname : %ASA-6-113015: AAA user authentication Rejected : reason = User was not found : local database : user = ***** : user IP = 192.168.2.2",
+                "outcome": "failure",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
+                    "denied",
                     "info"
                 ]
             },
@@ -2361,7 +2393,8 @@
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
-                    "info"
+                    "connection",
+                    "denied"
                 ]
             },
             "host": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
@@ -646,6 +646,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<140>Oct 06 2023 10:11:00 myAsaHostname : %ASA-4-313005: No matching connection for ICMP error message: icmp src outside:192.168.2.2(9999:my_SgtName) dst inside:192.168.2.3 (type 3, code 3) on outside interface.  Original IP payload: udp src 192.168.2.3/53 dst 192.168.2.2/60919.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -740,6 +741,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<140>Oct 06 2023 10:11:00 myAsaHostname : %ASA-4-313005: No matching connection for ICMP error message: icmp src outside:192.168.2.2(9999:my_SgtNameSrc) dst inside:192.168.2.3(8888:my_SgtNameDst) (type 3, code 3) on outside interface.  Original IP payload: udp src 192.168.2.3/53 dst 192.168.2.2/60919.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1540,6 +1542,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<140>Oct 06 2023 10:33:23 myAsaHostname : %ASA-4-313005: No matching connection for ICMP error message: icmp src outside:192.168.2.2(LOCAL\\myUser1234, 9999:my_SgtName) dst inside:192.168.2.3 (type 3, code 3) on outside interface.  Original IP payload: udp src 192.168.2.3/53 dst 192.168.2.2/54860.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -2227,6 +2230,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<140>Oct 25 2023 06:53:06 myAsaHostname : %ASA-4-313005: No matching connection for ICMP error message: icmp src outside:192.168.2.2(LOCAL\\myUser1234$, 9999:my_SgtName) dst inside:192.168.2.3 (type 3, code 3) on outside interface.  Original IP payload: udp src 192.168.2.3/53 dst 192.168.2.2/55735.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -2390,6 +2394,7 @@
                 "code": "313005",
                 "kind": "event",
                 "original": "<164>Oct 25 2023 14:40:42 myAsaHostname : %ASA-4-313005: No matching connection for ICMP error message: icmp src inside:192.168.2.2 dst outside:myComputer1.myDomain.com (type 3, code 3) on inside interface.  Original IP payload: udp src myComputer1.myDomain.com/53 dst 192.168.2.2/58164.",
+                "outcome": "success",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sip.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sip.log-expected.json
@@ -26,6 +26,7 @@
                 "code": "607001",
                 "kind": "event",
                 "original": "Oct 20 2019 15:42:54: %ASA-6-607001: Pre-allocate SIP Via UDP secondary channel for vrf53204:10.13.170.13/5060 to ACI-App_VRF:172.16.90.3 from OPTIONS message",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -94,6 +95,7 @@
                 "code": "607001",
                 "kind": "event",
                 "original": "Jun 08 2020 12:59:57: %ASA-6-607001: Pre-allocate SIP SIGNALLING UDP secondary channel for vrf53204:10.18.133.23/5060 to ACI-App_VRF:172.16.74.3 from OPTIONS message",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -162,6 +164,7 @@
                 "code": "607001",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:37: %ASA-6-607001: Pre-allocate SIP NOTIFY UDP secondary channel for vrf52304:10.18.170.54/5060 to ACI-App_VRF:172.16.72.5 from 200 message",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [
@@ -230,6 +233,7 @@
                 "code": "607001",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:38: %ASA-6-607001: Pre-allocate SIP Via UDP secondary channel for vrf52304:10.13.133.64/5060 to ACI-App_VRF:67.43.156.12 from REGISTER message",
+                "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2194,7 +2194,7 @@ processors:
           permitted:
             type: [ connection, allowed ]
             action: firewall-rule
-            outcome: permitted
+            outcome: success
         "106103":
           type: [ connection, denied ]
           outcome: success

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2151,10 +2151,7 @@ processors:
             outcome: success
             action: configuration
       source: >-
-        if (ctx.event.code == null || !params.containsKey(ctx.event.code) || ctx._temp_?.outcome == null) {
-          return;
-        }
-        params.get(ctx.event.code).get(ctx._temp_.outcome).forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code)?.get(ctx._temp_.outcome)?.forEach((k, v) -> ctx.event[k] = v);
 
   - script:
       tag: script_ecs_categorization
@@ -2640,10 +2637,7 @@ processors:
           outcome: success
           action: flow-offload-ended
       source: >-
-        if (ctx.event.code == null || !params.containsKey(ctx.event.code)) {
-          return;
-        }
-        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
+        params.get(ctx.event.code)?.forEach((k, v) -> ctx.event[k] = v);
 
   # Malware event kind is classified as alert when sha_disposition is "Malware", "Custom Detection" not for other cases.
   - set:

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -15,12 +15,6 @@ processors:
   - set:
       field: event.category
       value: [ network ]
-  - set:
-      field: event.type
-      value: [ info ]
-  - set:
-      field: event.action
-      value: firewall-rule
 
   #
   # Parse the syslog header
@@ -2128,170 +2122,187 @@ processors:
         "106001":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106002":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106006":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106007":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106010":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106013":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106014":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106015":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106016":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106017":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106018":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106020":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106021":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106022":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106023":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106027":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "106100":
           denied:
             type: [ connection, denied ]
-            action: firewall-rule
             outcome: success
+            action: firewall-rule
           permitted:
             type: [ connection, allowed ]
-            action: firewall-rule
             outcome: success
+            action: firewall-rule
           est-allowed:
             type: [ connection, allowed ]
-            action: firewall-rule
             outcome: success
+            action: firewall-rule
         "106102":
           denied:
             type: [ connection, denied ]
-            action: firewall-rule
             outcome: success
+            action: firewall-rule
           permitted:
             type: [ connection, allowed ]
-            action: firewall-rule
             outcome: success
+            action: firewall-rule
         "106103":
           type: [ connection, denied ]
           outcome: success
+          action: firewall-rule
         "110002":
-          type: [ connection ]
-          action: error
+          type: [ connection, info ]
           outcome: failure
+          action: firewall-rule
         "111004":
           failed:
             category: [ configuration ]
             type: [ info ]
-            action: configuration
             outcome: failure
+            action: configuration
           ok:
             category: [ configuration ]
             type: [ change ]
-            action: configuration
             outcome: success
+            action: configuration
         "111009":
           category: [ configuration ]
           type: [ info ]
-          action: configuration
           outcome: success
+          action: configuration
         "111010":
           category: [ configuration ]
           type: [ change ]
-          action: configuration
           outcome: success
+          action: configuration
         "113004":
           category: [ authentication, network ]
           type: [ allowed, info ]
-          action: logged-in
           outcome: success
+          action: logged-in
         "113005":
           category: [ authentication, network ]
           type: [ denied, info ]
-          action: logon-failed
           outcome: failure
+          action: logon-failed
         "113012":
           category: [ authentication, network ]
           type: [ allowed, info ]
-          action: logged-in
           outcome: success
+          action: logged-in
         "113015":
           category: [ authentication, network ]
           type: [ denied, info ]
-          action: logon-failed
           outcome: failure
+          action: logon-failed
         "113019":
           type: [ connection, end ]
+          outcome: success
           action: client-vpn-disconnected
         "113021":
           category: [ authentication, network ]
           type: [ denied, info ]
+          outcome: failure
           action: logon-failed
-          outcome: failure
         "113029":
-          category: [ network ]
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113030":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113031":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113032":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113033":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113034":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113035":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113036":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113037":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113038":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "113039":
           category: [ network, session ]
           type: [ connection, start ]
@@ -2299,102 +2310,119 @@ processors:
           outcome: success
         "113040":
           type: [ connection, denied ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "302013":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302014":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302015":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302016":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302018":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302020":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302021":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302022":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302023":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302024":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302025":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302026":
           type: [ connection, start ]
-          action: flow-creation
           outcome: success
+          action: flow-creation
         "302027":
           type: [ connection, end ]
-          action: flow-expiration
           outcome: success
+          action: flow-expiration
         "302036":
           type: [ connection, end ]
+          outcome: success
           action: flow-expiration
         "302304":
           type: [ connection, end ]
+          outcome: success
           action: flow-expiration
         "302306":
           type: [ connection, end ]
+          outcome: success
           action: flow-expiration
         "303002":
           category: [ network, file ]
           type: [ access ]
+          outcome: success
           action: ftp
         "304001":
           type: [ access, allowed ]
-          action: url-access
           outcome: success
+          action: url-access
         "304002":
           type: [ access, denied ]
+          outcome: success
           action: url-access
-          outcome: failure
         "305011":
           category: [ network, configuration ]
           type: [ creation ]
+          outcome: success
           action: nat-slot
         "305012":
           category: [ network, configuration ]
           type: [ deletion ]
-          action: nat-slot
           outcome: success
+          action: nat-slot
         "313001":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "313004":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "313005":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "313008":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "313009":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "322001":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "338001":
           type: [ connection, info ]
           action: dynamic-filter
@@ -2409,15 +2437,19 @@ processors:
           action: dynamic-filter
         "338005":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338006":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338007":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338008":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338101":
           type: [ connection, info ]
@@ -2439,83 +2471,103 @@ processors:
           action: dynamic-filter
         "338203":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338204":
           type: [ connection, denied ]
+          outcome: success
           action: dynamic-filter
         "338301":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: firewall-rule
         "419002":
-          type: [ info ]
+          type: [ connection, info ]
+          action: firewall-rule
         "434002":
-          type: [ denied ]
+          type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "434004":
           type: [ info ]
           action: bypass
         "502103":
           category: [ iam ]
-          type: [ group, change ]
+          type: [ user, change ]
+          action: privilege-level-changed
         "507003":
-          type: [ info ]
+          type: [ connection, end ]
+          action: flow-termination
         "602303":
           type: [ connection, start ]
-          action: created
+          action: sa-created
           outcome: success
         "602304":
           type: [ connection, end ]
-          action: deleted
           outcome: success
+          action: deleted
         "605004":
           category: [ authentication, network ]
           type: [ denied, info ]
-          action: logon-failed
           outcome: failure
+          action: logon-failed
         "605005":
           category: [ authentication, network ]
           type: [ allowed, info ]
-          action: logged-in
           outcome: success
+          action: logged-in
         "607001":
           type: [ info ]
+          outcome: success
+          action: firewall-rule
         "609001":
           type: [ connection, start ]
+          outcome: success
           action: flow-creation
         "609002":
           type: [ connection, end ]
+          outcome: success
           action: flow-expiration
         "611101":
           category: [ authentication, network ]
           type: [ allowed, info ]
-          action: logged-in
           outcome: success
+          action: logged-in
         "611102":
           category: [ authentication, network ]
           type: [ denied, info ]
-          action: logon-failed
           outcome: failure
+          action: logon-failed
         "710003":
           type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "710005":
           type: [ connection, denied ]
           outcome: failure
+          action: firewall-rule
         "710006":
           type: [ connection, denied ]
           outcome: failure
+          action: firewall-rule
         "713049":
           type: [ connection, start ]
+          outcome: success
+          action: firewall-rule
         "713120":
           type: [ connection, info ]
           outcome: success
+          action: firewall-rule
         "713202":
           type: [ connection, info ]
+          action: firewall-rule
         "713901":
           type: [ info ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "713902":
           type: [ info ]
-          action: client-vpn-error
           outcome: failure
+          action: client-vpn-error
         "713903":
           type: [ info ]
         "713904":
@@ -2526,6 +2578,8 @@ processors:
           type: [ info ]
         "716002":
           type: [ connection, end ]
+          outcome: success
+          action: client-vpn-disconnected
         "716039":
           category: [ authentication, network ]
           type: [ denied, info ]
@@ -2533,36 +2587,45 @@ processors:
           outcome: failure
         "722011":
           type: [ info ]
-          action: svc-message
         "722022":
           type: [ connection, info ]
+          outcome: success
         "722023":
           type: [ connection, end ]
+          outcome: success
         "722033":
           type: [ connection, start ]
+          outcome: success
         "722034":
           type: [ connection, info ]
         "722037":
           type: [ connection, end ]
         "722051":
           type: [ connection, info ]
+          outcome: success
+          action: address-assigned
         "733100":
           type: [ info ]
         "734001":
           category: [ authentication, network ]
           type: [ allowed, info ]
-          action: logged-in
           outcome: success
+          action: logged-in
         "750002":
-          type: [ start, connection ]
+          type: [ connection, start ]
+          outcome: success
           action: connection-started
         "750003":
-          type: [ connection ]
-          action: error
+          type: [ connection, start ]
+          outcome: failure
         "805001":
-          type: [ info ]
+          type: [ connection, start ]
+          outcome: success
+          action: flow-offload-started
         "805002":
-          type: [ info ]
+          type: [ connection, start ]
+          outcome: success
+          action: flow-offload-ended
       source: >-
         if (ctx.event.code == null || !params.containsKey(ctx.event.code)) {
           return;

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2108,16 +2108,61 @@ processors:
       ignore_missing: true
   # ECS categorization
   - script:
+      tag: script_ecs_outcome_categorization
+      lang: painless
+      description: >-
+        Sets the ECS event categorization fields for given message type and outcome.
+        The top-level keys are the Cisco message IDs, which will match against
+        'event.code' in the document. The next level of keys are outcome values,
+        which match against '_temp_.outcome' in the document. The final level of
+        keys are ECS event fields.
+      params:
+        "106100":
+          denied:
+            type: [ connection, denied ]
+            outcome: success
+            action: firewall-rule
+          permitted:
+            type: [ connection, allowed ]
+            outcome: success
+            action: firewall-rule
+          est-allowed:
+            type: [ connection, allowed ]
+            outcome: success
+            action: firewall-rule
+        "106102":
+          denied:
+            type: [ connection, denied ]
+            outcome: success
+            action: firewall-rule
+          permitted:
+            type: [ connection, allowed ]
+            outcome: success
+            action: firewall-rule
+        "111004":
+          failed:
+            category: [ configuration ]
+            type: [ info ]
+            outcome: failure
+            action: configuration
+          ok:
+            category: [ configuration ]
+            type: [ change ]
+            outcome: success
+            action: configuration
+      source: >-
+        if (ctx.event.code == null || !params.containsKey(ctx.event.code) || ctx._temp_?.outcome == null) {
+          return;
+        }
+        params.get(ctx.event.code).get(ctx._temp_.outcome).forEach((k, v) -> ctx.event[k] = v);
+
+  - script:
       tag: script_ecs_categorization
       lang: painless
       description: >-
-        This script will set the ECS event categorization fields for each
-        message type. If a message wrote to _temp_.outcome, the value of this
-        field will be used to conditionally set the ECS event fields.
-        The top-level keys are the Cisco message IDs. The next level of keys are
-        either the ECS event fields or in the case of _temp_.outcome being set,
-        the possible values of _temp_.outcome. In the latter case, the keys
-        contained within will be the ECS event fields.
+        This script will set the ECS event categorization fields for a given
+        message type. The top-level keys are the Cisco message IDs. The next
+        level of keys are ECS event fields.
       params:
         "106001":
           type: [ connection, denied ]
@@ -2183,28 +2228,6 @@ processors:
           type: [ connection, denied ]
           outcome: success
           action: firewall-rule
-        "106100":
-          denied:
-            type: [ connection, denied ]
-            outcome: success
-            action: firewall-rule
-          permitted:
-            type: [ connection, allowed ]
-            outcome: success
-            action: firewall-rule
-          est-allowed:
-            type: [ connection, allowed ]
-            outcome: success
-            action: firewall-rule
-        "106102":
-          denied:
-            type: [ connection, denied ]
-            outcome: success
-            action: firewall-rule
-          permitted:
-            type: [ connection, allowed ]
-            outcome: success
-            action: firewall-rule
         "106103":
           type: [ connection, denied ]
           outcome: success
@@ -2213,17 +2236,6 @@ processors:
           type: [ connection, info ]
           outcome: failure
           action: firewall-rule
-        "111004":
-          failed:
-            category: [ configuration ]
-            type: [ info ]
-            outcome: failure
-            action: configuration
-          ok:
-            category: [ configuration ]
-            type: [ change ]
-            outcome: success
-            action: configuration
         "111009":
           category: [ configuration ]
           type: [ info ]
@@ -2493,18 +2505,19 @@ processors:
         "502103":
           category: [ iam ]
           type: [ user, change ]
+          outcome: success
           action: privilege-level-changed
         "507003":
           type: [ connection, end ]
           action: flow-termination
         "602303":
           type: [ connection, start ]
-          action: sa-created
           outcome: success
+          action: sa-created
         "602304":
           type: [ connection, end ]
           outcome: success
-          action: deleted
+          action: sa-deleted
         "605004":
           category: [ authentication, network ]
           type: [ denied, info ]
@@ -2623,18 +2636,14 @@ processors:
           outcome: success
           action: flow-offload-started
         "805002":
-          type: [ connection, start ]
+          type: [ connection, end ]
           outcome: success
           action: flow-offload-ended
       source: >-
         if (ctx.event.code == null || !params.containsKey(ctx.event.code)) {
           return;
         }
-        if (ctx._temp_?.outcome == null) {
-          params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
-        } else {
-          params.get(ctx.event.code).get(ctx._temp_.outcome).forEach((k, v) -> ctx.event[k] = v);
-        }
+        params.get(ctx.event.code).forEach((k, v) -> ctx.event[k] = v);
 
   # Malware event kind is classified as alert when sha_disposition is "Malware", "Custom Detection" not for other cases.
   - set:

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -2194,18 +2194,35 @@ processors:
           permitted:
             type: [ connection, allowed ]
             action: firewall-rule
-            outcome: success
+            outcome: permitted
         "106103":
           type: [ connection, denied ]
           outcome: success
         "110002":
-          type: [ connection, denied ]
+          type: [ connection ]
+          action: error
           outcome: failure
         "111004":
           failed:
+            category: [ configuration ]
+            type: [ info ]
+            action: configuration
             outcome: failure
           ok:
+            category: [ configuration ]
+            type: [ change ]
+            action: configuration
             outcome: success
+        "111009":
+          category: [ configuration ]
+          type: [ info ]
+          action: configuration
+          outcome: success
+        "111010":
+          category: [ configuration ]
+          type: [ change ]
+          action: configuration
+          outcome: success
         "113004":
           category: [ authentication, network ]
           type: [ allowed, info ]
@@ -2221,6 +2238,11 @@ processors:
           type: [ allowed, info ]
           action: logged-in
           outcome: success
+        "113015":
+          category: [ authentication, network ]
+          type: [ denied, info ]
+          action: logon-failed
+          outcome: failure
         "113019":
           type: [ connection, end ]
           action: client-vpn-disconnected
@@ -2230,48 +2252,71 @@ processors:
           action: logon-failed
           outcome: failure
         "113029":
+          category: [ network ]
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113030":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113031":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113032":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113033":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113034":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113035":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113036":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113037":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113038":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
         "113039":
           category: [ network, session ]
           type: [ connection, start ]
           action: client-vpn-connected
+          outcome: success
         "113040":
           type: [ connection, denied ]
           action: client-vpn-error
+          outcome: failure
+        "302013":
+          type: [ connection, start ]
+          action: flow-creation
+          outcome: success
         "302014":
           type: [ connection, end ]
           action: flow-expiration
+          outcome: success
+        "302015":
+          type: [ connection, start ]
+          action: flow-creation
+          outcome: success
         "302016":
           type: [ connection, end ]
           action: flow-expiration
+          outcome: success
         "302018":
           type: [ connection, end ]
           action: flow-expiration
@@ -2279,9 +2324,35 @@ processors:
         "302020":
           type: [ connection, start ]
           action: flow-creation
+          outcome: success
         "302021":
           type: [ connection, end ]
           action: flow-expiration
+          outcome: success
+        "302022":
+          type: [ connection, start ]
+          action: flow-creation
+          outcome: success
+        "302023":
+          type: [ connection, end ]
+          action: flow-expiration
+          outcome: success
+        "302024":
+          type: [ connection, start ]
+          action: flow-creation
+          outcome: success
+        "302025":
+          type: [ connection, end ]
+          action: flow-expiration
+          outcome: success
+        "302026":
+          type: [ connection, start ]
+          action: flow-creation
+          outcome: success
+        "302027":
+          type: [ connection, end ]
+          action: flow-expiration
+          outcome: success
         "302036":
           type: [ connection, end ]
           action: flow-expiration
@@ -2291,83 +2362,107 @@ processors:
         "302306":
           type: [ connection, end ]
           action: flow-expiration
+        "303002":
+          category: [ network, file ]
+          type: [ access ]
+          action: ftp
         "304001":
-          type: [ connection, allowed ]
+          type: [ access, allowed ]
+          action: url-access
           outcome: success
         "304002":
-          type: [ connection, denied ]
-          outcome: success
+          type: [ access, denied ]
+          action: url-access
+          outcome: failure
+        "305011":
+          category: [ network, configuration ]
+          type: [ creation ]
+          action: nat-slot
         "305012":
-          type: [ connection, end ]
-          action: flow-expiration
+          category: [ network, configuration ]
+          type: [ deletion ]
+          action: nat-slot
+          outcome: success
         "313001":
           type: [ connection, denied ]
-          outcome: success
         "313004":
           type: [ connection, denied ]
-          outcome: success
+        "313005":
+          type: [ connection, denied ]
         "313008":
           type: [ connection, denied ]
-          outcome: success
         "313009":
           type: [ connection, denied ]
-          outcome: success
         "322001":
           type: [ connection, denied ]
         "338001":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338002":
-          type: [ connection, allowed ]
-          outcome: success
+          type: [ connection, info ]
+          action: dynamic-filter
         "338003":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338004":
-          category: [ network, intrusion_detection ]
-          outcome: success
+          type: [ connection, info ]
+          action: dynamic-filter
         "338005":
-          type: [ connection ]
+          type: [ connection, denied ]
+          action: dynamic-filter
         "338006":
-          type: [ connection ]
+          type: [ connection, denied ]
+          action: dynamic-filter
         "338007":
-          type: [ connection ]
+          type: [ connection, denied ]
+          action: dynamic-filter
         "338008":
           type: [ connection, denied ]
-          outcome: failure
+          action: dynamic-filter
         "338101":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338102":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338103":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338104":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338201":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338202":
-          type: [ connection ]
+          type: [ connection, info ]
+          action: dynamic-filter
         "338203":
-          type: [ connection ]
+          type: [ connection, denied ]
+          action: dynamic-filter
         "338204":
           type: [ connection, denied ]
-          outcome: failure
+          action: dynamic-filter
         "338301":
           type: [ connection ]
+        "419002":
+          type: [ info ]
         "434002":
-          type: [ connection, denied ]
-          action: drop
-          outcome: unknown
+          type: [ denied ]
         "434004":
+          type: [ info ]
           action: bypass
-          outcome: unknown
         "502103":
           category: [ iam ]
           type: [ group, change ]
+        "507003":
+          type: [ info ]
         "602303":
           type: [ connection, start ]
           action: created
           outcome: success
         "602304":
-          type: [ info, end ]
+          type: [ connection, end ]
           action: deleted
           outcome: success
         "605004":
@@ -2376,11 +2471,15 @@ processors:
           action: logon-failed
           outcome: failure
         "605005":
-          type: [ connection, allowed ]
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          action: logged-in
           outcome: success
+        "607001":
+          type: [ info ]
         "609001":
-          type: [ connection, end ]
-          action: flow-expiration
+          type: [ connection, start ]
+          action: flow-creation
         "609002":
           type: [ connection, end ]
           action: flow-expiration
@@ -2396,31 +2495,59 @@ processors:
           outcome: failure
         "710003":
           type: [ connection, denied ]
-          outcome: success
         "710005":
           type: [ connection, denied ]
           outcome: failure
+        "710006":
+          type: [ connection, denied ]
+          outcome: failure
+        "713049":
+          type: [ connection, start ]
         "713120":
+          type: [ connection, info ]
           outcome: success
+        "713202":
+          type: [ connection, info ]
         "713901":
-          action: error
+          type: [ info ]
+          action: client-vpn-error
           outcome: failure
         "713902":
-          action: error
+          type: [ info ]
+          action: client-vpn-error
           outcome: failure
         "713903":
-          outcome: failure
+          type: [ info ]
         "713904":
-          action: error
-          outcome: failure
+          type: [ info ]
         "713905":
-          action: error
-          outcome: failure
+          type: [ info ]
+        "713906":
+          type: [ info ]
+        "716002":
+          type: [ connection, end ]
         "716039":
           category: [ authentication, network ]
           type: [ denied, info ]
           action: logon-failed
           outcome: failure
+        "722011":
+          type: [ info ]
+          action: svc-message
+        "722022":
+          type: [ connection, info ]
+        "722023":
+          type: [ connection, end ]
+        "722033":
+          type: [ connection, start ]
+        "722034":
+          type: [ connection, info ]
+        "722037":
+          type: [ connection, end ]
+        "722051":
+          type: [ connection, info ]
+        "733100":
+          type: [ info ]
         "734001":
           category: [ authentication, network ]
           type: [ allowed, info ]
@@ -2430,7 +2557,12 @@ processors:
           type: [ start, connection ]
           action: connection-started
         "750003":
+          type: [ connection ]
           action: error
+        "805001":
+          type: [ info ]
+        "805002":
+          type: [ info ]
       source: >-
         if (ctx.event.code == null || !params.containsKey(ctx.event.code)) {
           return;

--- a/packages/cisco_asa/data_stream/log/sample_event.json
+++ b/packages/cisco_asa/data_stream/log/sample_event.json
@@ -1,7 +1,7 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "811483eb-dc0a-4d28-951a-b73e75321d72",
+        "ephemeral_id": "bb12e06f-beb2-4447-82ba-7dd497fe6283",
         "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -41,9 +41,10 @@
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2024-04-22T15:09:13Z",
+        "ingested": "2024-04-23T19:53:14Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
+        "outcome": "success",
         "severity": 6,
         "timezone": "UTC",
         "type": [
@@ -59,7 +60,7 @@
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.192.4:56356"
+            "address": "192.168.192.4:46208"
         }
     },
     "network": {

--- a/packages/cisco_asa/data_stream/log/sample_event.json
+++ b/packages/cisco_asa/data_stream/log/sample_event.json
@@ -1,11 +1,11 @@
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "3e750a6f-0315-4d23-b673-90c997a5320b",
-        "id": "38e64915-8382-4988-ab00-33b6b749dcdb",
+        "ephemeral_id": "811483eb-dc0a-4d28-951a-b73e75321d72",
+        "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.11.4"
+        "version": "8.13.2"
     },
     "cisco": {
         "asa": {
@@ -28,37 +28,38 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "38e64915-8382-4988-ab00-33b6b749dcdb",
+        "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "snapshot": false,
-        "version": "8.11.4"
+        "version": "8.13.2"
     },
     "event": {
-        "action": "firewall-rule",
+        "action": "nat-slot",
         "agent_id_status": "verified",
         "category": [
-            "network"
+            "network",
+            "configuration"
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2024-02-22T13:07:31Z",
+        "ingested": "2024-04-22T15:09:13Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
         "timezone": "UTC",
         "type": [
-            "info"
+            "creation"
         ]
     },
     "host": {
         "hostname": "localhost"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.18.0.7:33197"
+            "address": "192.168.192.4:56356"
         }
     },
     "network": {

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -17,7 +17,7 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "811483eb-dc0a-4d28-951a-b73e75321d72",
+        "ephemeral_id": "bb12e06f-beb2-4447-82ba-7dd497fe6283",
         "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "name": "docker-fleet-agent",
         "type": "filebeat",
@@ -57,9 +57,10 @@ An example event for `log` looks as following:
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2024-04-22T15:09:13Z",
+        "ingested": "2024-04-23T19:53:14Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
+        "outcome": "success",
         "severity": 6,
         "timezone": "UTC",
         "type": [
@@ -75,7 +76,7 @@ An example event for `log` looks as following:
     "log": {
         "level": "informational",
         "source": {
-            "address": "192.168.192.4:56356"
+            "address": "192.168.192.4:46208"
         }
     },
     "network": {

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -17,11 +17,11 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-10-10T12:34:56.000Z",
     "agent": {
-        "ephemeral_id": "3e750a6f-0315-4d23-b673-90c997a5320b",
-        "id": "38e64915-8382-4988-ab00-33b6b749dcdb",
+        "ephemeral_id": "811483eb-dc0a-4d28-951a-b73e75321d72",
+        "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.11.4"
+        "version": "8.13.2"
     },
     "cisco": {
         "asa": {
@@ -44,37 +44,38 @@ An example event for `log` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "38e64915-8382-4988-ab00-33b6b749dcdb",
+        "id": "6a762ace-ff7a-4a1f-9fc4-cae4c2122d76",
         "snapshot": false,
-        "version": "8.11.4"
+        "version": "8.13.2"
     },
     "event": {
-        "action": "firewall-rule",
+        "action": "nat-slot",
         "agent_id_status": "verified",
         "category": [
-            "network"
+            "network",
+            "configuration"
         ],
         "code": "305011",
         "dataset": "cisco_asa.log",
-        "ingested": "2024-02-22T13:07:31Z",
+        "ingested": "2024-04-22T15:09:13Z",
         "kind": "event",
         "original": "Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-305011: Built dynamic TCP translation from inside:172.31.98.44/1772 to outside:192.168.98.44/8256",
         "severity": 6,
         "timezone": "UTC",
         "type": [
-            "info"
+            "creation"
         ]
     },
     "host": {
         "hostname": "localhost"
     },
     "input": {
-        "type": "udp"
+        "type": "tcp"
     },
     "log": {
         "level": "informational",
         "source": {
-            "address": "172.18.0.7:33197"
+            "address": "192.168.192.4:56356"
         }
     },
     "network": {

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.33.2"
+version: "2.34.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
This is part 2 of a 2 part change. This PR improves the ECS categorizations for various message types. Existing messages have been improved and new message types have been added where necessary.

For an overview of the different message types, [see this spreadsheet](https://docs.google.com/spreadsheets/d/1kAQ5bYZOWp4TBO_k1fWgCot1v11POngMG2HNTLHDBXg/edit?usp=sharing).

## Proposed commit message

- Improve ECS categorizations for messages

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

- Closes #9461 
- Relates elastic/enhancements#19899