### PR TITLE
pipeline tests - Ignore url.extension for ES < 8.14

### DIFF
--- a/packages/azure/data_stream/graphactivitylogs/_dev/test/pipeline/test-common-config.yml
+++ b/packages/azure/data_stream/graphactivitylogs/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,8 @@
 fields:
   tags:
     - preserve_original_event
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,8 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/iis/data_stream/error/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/error/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,8 @@
 fields:
   tags:
     - preserve_original_event
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/imperva_cloud_waf/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,8 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-common-config.yml
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-common-config.yml
@@ -1,5 +1,8 @@
 dynamic_fields:
   "event.ingested": "^.*$"
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'
 fields:
   tags:
     - preserve_original_event

--- a/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-common-config.yml
+++ b/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,8 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/netskope/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
+++ b/packages/netskope/data_stream/alerts/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,9 @@
 fields:
   tags:
     - preserve_original_event
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  netskope.alerts.url.extension: '^.*$'
+  netskope.alerts.page.url.extension: '^.*$'

--- a/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
+++ b/packages/netskope/data_stream/events/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,8 @@
 fields:
   tags:
     - preserve_original_event
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  netskope.events.url.extension: '^.*$'

--- a/packages/ti_crowdstrike/data_stream/intel/_dev/test/pipeline/test-common-config.yml
+++ b/packages/ti_crowdstrike/data_stream/intel/_dev/test/pipeline/test-common-config.yml
@@ -2,3 +2,8 @@ fields:
   tags:
     - preserve_original_event
     - preserve_duplicate_custom_fields
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  url.extension: '^.*$'

--- a/packages/ti_rapid7_threat_command/data_stream/ioc/_dev/test/pipeline/test-common-config.yml
+++ b/packages/ti_rapid7_threat_command/data_stream/ioc/_dev/test/pipeline/test-common-config.yml
@@ -1,3 +1,8 @@
 fields:
   tags:
     - preserve_original_event
+
+dynamic_fields:
+  # This can be removed after ES 8.14 is the minimum version.
+  # Relates: https://github.com/elastic/elasticsearch/pull/105689
+  threat.indicator.url.extension: '^.*$'


### PR DESCRIPTION
## Proposed commit message

Ignore the existence of an invalid  `url.extension` field. Stack versions < 8.14 had a bug that populated the field with bad data. After a package uses a minimum stack version of 8.14.0 then this addition to `dynamic_fields` can be removed.

This fixes errors like this which occur under v8.14.0

    test case failed: Expected results are different from actual ones: --- want
    +++ got
    @@ -1797,7 +1797,6 @@
                     "preserve_duplicate_custom_fields"
                 ],
                 "url": {
    -                "extension": "com/page",
                     "original": "www.example.com/page",
                     "path": "www.example.com/page"
                 }

Relates: https://github.com/elastic/elasticsearch/pull/105689

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates: https://github.com/elastic/elasticsearch/pull/105689

## CI

- https://buildkite.com/elastic/integrations/builds/10450
