### PR TITLE
Declare metadata fields in state_namespace data stream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.59.0
+  changes:
+    - description: Add metadata fields to state_namespace data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9356
 - version: 1.58.0
   changes:
     - description: Migrate to format_version v3.

--- a/packages/kubernetes/data_stream/state_namespace/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_namespace/fields/base-fields.yml
@@ -14,6 +14,7 @@
       dimension: true
       description: >
         Kubernetes namespace
+
     - name: labels.*
       type: object
       object_type: keyword
@@ -27,4 +28,3 @@
       object_type_mapping_type: "*"
       description: >-
         Kubernetes annotations map
-

--- a/packages/kubernetes/data_stream/state_namespace/fields/base-fields.yml
+++ b/packages/kubernetes/data_stream/state_namespace/fields/base-fields.yml
@@ -14,4 +14,17 @@
       dimension: true
       description: >
         Kubernetes namespace
+    - name: labels.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >
+        Kubernetes labels map
+
+    - name: annotations.*
+      type: object
+      object_type: keyword
+      object_type_mapping_type: "*"
+      description: >-
+        Kubernetes annotations map
 

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -1121,6 +1121,8 @@ An example event for `state_namespace` looks as following:
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
 | host.os.version | Operating system version as a raw string. | keyword |  |  |
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
+| kubernetes.labels.\* | Kubernetes labels map | object |  |  |
 | kubernetes.namespace | Kubernetes namespace | keyword |  |  |
 | kubernetes.state_namespace.created.sec | Epoch seconds since the namespace was created. | double | s | gauge |
 | kubernetes.state_namespace.status.active | Whether the namespace is active (true or false). | boolean |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.58.0
+version: 1.59.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:
@@ -10,7 +10,7 @@ categories:
   - kubernetes
 conditions:
   kibana:
-    version: "^8.12.0"
+    version: "^8.14.0"
 screenshots:
   - src: /img/metricbeat_kubernetes_overview.png
     title: Metricbeat Kubernetes Overview


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- WHAT:  declare kubernetes.labels and kubernetes.annotations in state_namespace data stream.
- WHY:  As part of https://github.com/elastic/beats/issues/37243 state_namespace metricset is since beats 8.14.0 enriched with kubernetes metadata.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/9625



