### PR TITLE
[cisco_asa] Fix categorization of network protocols

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix categorization of protocols.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/9642
 - version: "2.33.1"
   changes:
     - description: Allow apostrophes in usernames.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.33.2"
+  changes:
+    - description: Fix categorization of protocols.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.33.1"
   changes:
     - description: Allow apostrophes in usernames.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -215,7 +215,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "dev01",
@@ -402,7 +402,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "dev01",
@@ -1439,7 +1439,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "dev01",
@@ -1507,7 +1507,7 @@
             },
             "network": {
                 "direction": "outbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "dev01",
@@ -5223,7 +5223,8 @@
                 "level": "notification"
             },
             "network": {
-                "protocol": "tcp"
+                "iana_number": "6",
+                "transport": "tcp"
             },
             "observer": {
                 "egress": {
@@ -5310,7 +5311,8 @@
                 "level": "warning"
             },
             "network": {
-                "protocol": "tcp"
+                "iana_number": "6",
+                "transport": "tcp"
             },
             "observer": {
                 "egress": {
@@ -5397,7 +5399,8 @@
                 "level": "informational"
             },
             "network": {
-                "protocol": "tcp"
+                "iana_number": "6",
+                "transport": "tcp"
             },
             "observer": {
                 "hostname": "dev01",
@@ -5478,7 +5481,8 @@
                 "level": "warning"
             },
             "network": {
-                "protocol": "tcp"
+                "iana_number": "6",
+                "transport": "tcp"
             },
             "observer": {
                 "egress": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-non-canonical.log-expected.json
@@ -1070,7 +1070,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "81.2.69.142",
@@ -1145,7 +1145,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "81.2.69.142",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sample.log-expected.json
@@ -5570,7 +5570,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "product": "asa",
@@ -5667,7 +5667,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "product": "asa",
@@ -5768,7 +5768,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "product": "asa",

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-sgt-tag-name.log-expected.json
@@ -509,7 +509,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "myAsaHostname",
@@ -1377,7 +1377,7 @@
             },
             "network": {
                 "direction": "outbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "myAsaHostname",
@@ -2046,7 +2046,7 @@
             },
             "network": {
                 "direction": "inbound",
-                "protocol": "icmp"
+                "type": "icmp"
             },
             "observer": {
                 "hostname": "myAsaHostname",

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -511,7 +511,7 @@ processors:
       field: "message"
       description: "302020"
       patterns:
-        - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.protocol} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER_OR_SGT_DST}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER_OR_SGT_SRC}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
+        - "Built %{NOTSPACE:network.direction} %{NOTSPACE:network.type} connection for faddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSDESTIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER_OR_SGT_DST}\\) )?gaddr (?:%{NOTCOLON}:)?%{MAPPEDSRC}/%{NUMBER} laddr (?:%{NOTCOLON:_temp_.cisco.source_interface}:)?%{ECSSOURCEIPORHOST}/%{NUMBER}\\s*(?:\\(%{CISCO_USER_OR_SGT_SRC}\\) )?(type %{NUMBER:_temp_.cisco.icmp_type} code %{NUMBER:_temp_.cisco.icmp_code})?"
       pattern_definitions:
         HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
@@ -955,17 +955,17 @@ processors:
       if: "ctx._temp_.cisco.message_id == '434002'"
       tag: parse_434002
       field: "message"
-      pattern: "SFR requested to drop %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+      pattern: "SFR requested to drop %{network.transport} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '434004'"
       tag: parse_434004
       field: "message"
-      pattern: "SFR requested ASA to bypass further packet redirection and process %{network.protocol} flow from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} locally"
+      pattern: "SFR requested ASA to bypass further packet redirection and process %{network.transport} flow from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} locally"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '110002'"
       tag: parse_110002
       field: "message"
-      pattern: "%{event.reason} for %{network.protocol} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{destination.address}/%{destination.port}"
+      pattern: "%{event.reason} for %{network.transport} from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '419002'"
       tag: parse_419002
@@ -1013,7 +1013,7 @@ processors:
   - set:
       if: '["419002"].contains(ctx._temp_.cisco.message_id)'
       tag: parse_419002
-      field: "network.protocol"
+      field: "network.transport"
       value: "tcp"
 
   #

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.33.1"
+version: "2.33.2"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Remapped layer 3 protocols (`icmp`) to `network.type`
- Remapped layer 4 protocols (`tcp`) to `network.transport`

Reference for Cisco ASA message types: https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslog-messages-101001-to-199021.html

## Proposed commit message

- Ensure that network protocols are assigned to the correct ECS field based on their layer.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package 
```

## Related issues

- Relates elastic/sdh-beats#4627

