### PR TITLE
[cisco_ios] Fix handling of ACCESSLOGSP logs

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix handling of ACCESSLOGSP logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/1
+      link: https://github.com/elastic/integrations/pulls/9662
 - version: "1.26.5"
   changes:
     - description: Fix ingest pipeline warnings

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.6"
+  changes:
+    - description: Fix handling of ACCESSLOGSP logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pulls/1
 - version: "1.26.5"
   changes:
     - description: Fix ingest pipeline warnings

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log
@@ -24,3 +24,4 @@ Jul 11 09:34:00 my-router-hostname 1663511: Jul 11 09:34:00.209: %FMANFP-6-IPACC
 Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGP:  SIP0: fman_fp_image:  list ACL denied udp 10.10.10.10(52361) -> 10.100.8.34(10001), 1 packet
 Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:34:58.206: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 172.16.0.26 -> 10.100.8.34 (8/0), 2 packets
 Jun 10 23:34:58 10.0.0.1 1663511: Jun 10 23:35:28.207: %FMANFP-6-IPACCESSLOGDP: F0: fman_fp_image:  list ACL_TEST permitted icmp 10.100.8.34 -> 172.16.0.26 (8/0), 1 packet
+Feb  9 04:00:48 192.168.100.2 585918: Feb  9 04:00:47.272: %IPV6_ACL-6-ACCESSLOGSP: list ACL_TEST-allowed/40 denied ipv6 :: -> 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6, 6 packets

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-cisco-ios.log-expected.json
@@ -1614,6 +1614,75 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-02-09T04:00:47.272Z",
+            "cisco": {
+                "ios": {
+                    "access_list": "ACL_TEST-allowed/40",
+                    "facility": "IPV6_ACL",
+                    "sequence": "585918"
+                }
+            },
+            "destination": {
+                "address": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                "geo": {
+                    "continent_name": "Europe",
+                    "country_iso_code": "NO",
+                    "country_name": "Norway",
+                    "location": {
+                        "lat": 62.0,
+                        "lon": 10.0
+                    }
+                },
+                "ip": "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "deny",
+                "category": [
+                    "network"
+                ],
+                "code": "ACCESSLOGSP",
+                "original": "Feb  9 04:00:48 192.168.100.2 585918: Feb  9 04:00:47.272: %IPV6_ACL-6-ACCESSLOGSP: list ACL_TEST-allowed/40 denied ipv6 :: -> 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6, 6 packets",
+                "provider": "firewall",
+                "sequence": 585918,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info",
+                    "denied"
+                ]
+            },
+            "log": {
+                "level": "informational"
+            },
+            "message": "list ACL_TEST-allowed/40 denied ipv6 :: -> 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6, 6 packets",
+            "network": {
+                "packets": 6,
+                "type": "ipv6"
+            },
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "::",
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6"
+                ]
+            },
+            "source": {
+                "address": "::",
+                "ip": "::",
+                "packets": 6
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -174,7 +174,7 @@ processors:
       if: "ctx.event?.code == 'IPACCESSLOGSP'"
   - dissect:
       field: message
-      tag: dissect_gsp
+      tag: dissect_sp
       pattern: "list %{cisco.ios.access_list} %{_temp_.event.action} %{network.type} %{source.address} %{} %{destination.address}, %{source.packets} packet"
       if: "ctx.event?.code == 'ACCESSLOGSP'"
   - dissect:

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -171,7 +171,12 @@ processors:
       field: message
       tag: dissect_gsp
       pattern: "list %{cisco.ios.access_list} %{_temp_.event.action} %{network.transport} %{source.address} %{} %{destination.address} (%{igmp.type}), %{source.packets} packet"
-      if: "['IPACCESSLOGSP', 'ACCESSLOGSP'].contains(ctx.event?.code)"
+      if: "ctx.event?.code == 'IPACCESSLOGSP'"
+  - dissect:
+      field: message
+      tag: dissect_gsp
+      pattern: "list %{cisco.ios.access_list} %{_temp_.event.action} %{network.type} %{source.address} %{} %{destination.address}, %{source.packets} packet"
+      if: "ctx.event?.code == 'ACCESSLOGSP'"
   - dissect:
       field: message
       tag: dissect_gnp

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.26.5"
+version: "1.26.6"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
https://www.cisco.com/c/en/us/td/docs/ios/12_2sy/system/messages/122sysms/sm2sy05.html (see IPV6_ACL-6)

## Proposed commit message

- The existing pattern for IPACCESSLOGSP and ACCESSLOGSP logs only handles IPACCESSLOGSP. ACCESSLOGSP follows a slightly different pattern. Added a new dissect for this log type.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_ios
elastic-package test
```

## Related issues

- Relates elastic/sdh-beats#4623
