### PR TITLE
[Cloud Security] Backport 1.7.5

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -8,7 +8,7 @@
 # 1.2.x - 8.7.x
 - version: "1.7.5"
   changes:
-    - description: Remove cloud.account.name null fields, Set cloud.account.id for azure and gcp when not available, fix cluster_id missing pipeline error
+    - description: Remove cloud.account.name null fields, Set cloud.account.id for azure, aws and gcp when not available, fix cluster_id missing pipeline error
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9668
 - version: "1.7.4"

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -6,6 +6,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.7.5"
+  changes:
+    - description: Remove cloud.account.name null fields, Set cloud.account.id for azure and gcp when not available, fix cluster_id missing pipeline error
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9668
 - version: "1.7.4"
   changes:
     - description: Revert to have diabled fields removed

--- a/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cloud_security_posture/data_stream/findings/elasticsearch/ingest_pipeline/default.yml
@@ -13,7 +13,28 @@ processors:
     field: orchestrator.cluster.id
     copy_from: cluster_id
     description: 'Backward compatibility cloudbeat version < 8.8'
+    ignore_empty_value: true
     if: ctx.orchestrator?.cluster?.id == null
+- set:
+    field: cloud.account.id
+    value: 'azure'
+    description: 'Sets placeholder value for azure account id when it is not available'
+    if: (ctx.cloud?.account?.id == null || ctx.cloud?.account?.id == '') && ctx.cloud?.provider == 'azure'
+- set:
+    field: cloud.account.id
+    value: 'gcp'
+    description: 'Sets placeholder value for gcp account id when it is not available'
+    if: (ctx.cloud?.account?.id == null || ctx.cloud?.account?.id == '' ) && ctx.cloud?.provider == 'gcp'
+- set:
+    field: cloud.account.id
+    value: 'aws'
+    description: 'Sets placeholder value for aws account id when it is not available'
+    if: (ctx.cloud?.account?.id == null || ctx.cloud?.account?.id == '' ) && ctx.cloud?.provider == 'aws'
+- remove:
+    field: cloud.account.name
+    ignore_missing: true
+    description: 'Removes cloud.account.name when it is empty'
+    if: ctx.cloud?.account?.name == ''
 on_failure:
   - set:
       field: event.kind

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.7.4"
+version: "1.7.5"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
## Summary

This PR adds a backport version to cloud_security_posture package 1.7.*, it includes the following changes:

- Fixed Pipeline Ingest Error due to missing cluster_id used in the `copy_from`;
Reasoning: Pipeline error were preventing the following pipelines from being executed + generating unnecessary data

- Sets placeholder value for azure `cloud.account.id` when it is not available;
- Sets placeholder value for gcp `cloud.account.id` when it is not available;
- Sets placeholder value for aws `cloud.account.id` when it is not available;

Reasoning:  GCP and Azure agents version 8.12 can push data belonging to a CSPM Organization where the `cloud.account.id` field can be missing, but The Cloud Security features in Kibana 8.12 require the field `cloud.account.id` to be always available in the Cloud Security Posture indices. The same setting for aws was also added for safety.

- Removes `cloud.account.name` when it is empty;

Reasoning:  GCP integration can push data belonging to a CSPM Organization where the `cloud.account.name` is empty when it should be missing. 


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] No records with empty `cloud.account.name`

<img width="1258" alt="image" src="https://github.com/elastic/integrations/assets/19270322/04dbf4fd-5992-4b2a-9dbf-ba5c6d8abeac">

- [x] No records with missing or empty `cloud.account.id` 

<img width="1491" alt="image" src="https://github.com/elastic/integrations/assets/19270322/bf15d943-cdcd-4f58-9792-c71e2089aeb6">

<img width="1512" alt="image" src="https://github.com/elastic/integrations/assets/19270322/769b805d-78b1-40f3-87d3-df816d92cf11">


## How to test this PR locally

Checkout Kibana locally 8.12.2 and follow the guide describe [here](https://docs.elastic.dev/security-solution/cloud-security/qa/test-integration-package) to test this PR locally.

To collect the necessary data you can execute the following Reindex command in the dev tools (The pipeline is the important part!), point host and credentials to one of the long-running environments

```
POST _reindex?wait_for_completion=true
{
  "conflicts": "proceed", 
  "source": {
     "remote": {
      "host": "${ES_REMOTE_HOST}",
      "username": "${ES_REMOTE_USER}",
      "password": "${ES_REMOTE_PASS}"
    },
    "index": "logs-cloud_security_posture.findings_latest-default",
    "query": {
      "match_all": {}  
    }
  },
  "dest": {
    "op_type": "create",
    "index": "logs-cloud_security_posture.findings_latest-default",
    "pipeline": "logs-cloud_security_posture.findings-1.7.5"
  }
}
```

## Related issues

- https://github.com/elastic/kibana/issues/178904
- https://github.com/elastic/security-team/issues/8874