### PR TITLE
Consolidate content on Azure metrics pages

### DIFF
--- a/packages/azure_metrics/_dev/build/docs/compute_vm.md
+++ b/packages/azure_metrics/_dev/build/docs/compute_vm.md
@@ -1,51 +1,18 @@
 # Azure Compute VM Integration
 
-The Azure Compute VM data stream collects and aggregates storage account related metrics from azure virtual machine type resources where it can be used for analysis, visualization, and alerting.
-The Azure Compute VM will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+The Azure Compute VM data stream collects and aggregates virtual machine related metrics from Azure Compute VM type resources where it can be used for analysis, visualization, and alerting.
+The Azure Compute VM will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-## Integration specific configuration notes
+## Requirements
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-Required credentials for the `azure_metrics` integration:
+## Setup
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `compute_vm` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -57,7 +24,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all virtual machines inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
 
 ## Guest metrics
 
@@ -72,11 +38,5 @@ To enable the diagnostic agent:
 1. From the **Sinks** tab, check **Enable Azure Monitor** to view your data from Azure Monitor dashboards.
 
 For more information on sending guest OS metrics to Azure Monitor, check the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/collect-custom-metrics-guestos-resource-manager-vm).
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: Dedicated authentication token will be created and updated regularly, it is advised to not share the credentials entered.
 
 {{fields "compute_vm"}}

--- a/packages/azure_metrics/_dev/build/docs/compute_vm_scaleset.md
+++ b/packages/azure_metrics/_dev/build/docs/compute_vm_scaleset.md
@@ -1,52 +1,18 @@
 # Azure Compute VM Scaleset Integration
 
+The Azure Compute Scaleset VM data stream collects and aggregates compute scaleset VM related metrics from Azure Virtual Machine scaleset type resources where it can be used for analysis, visualization, and alerting.
+The Azure Compute VM Scaleset will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Compute Scaleset VM data stream collects and aggregates storage account related metrics from azure virtual machine scaleset type resources where it can be used for analysis, visualization, and alerting.
-The Azure Compute Scaleset will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `compute_vm_scaleset` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,13 +24,5 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all virtual machine scalesets inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 {{fields "compute_vm_scaleset"}}

--- a/packages/azure_metrics/_dev/build/docs/container_instance.md
+++ b/packages/azure_metrics/_dev/build/docs/container_instance.md
@@ -2,11 +2,11 @@
 
 The Azure Container Instance data stream collects and aggregates container instance related metrics from Azure Container instance type resources where it can be used for analysis, visualization, and alerting.
 The Azure Container Instance will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional Azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 

--- a/packages/azure_metrics/_dev/build/docs/container_registry.md
+++ b/packages/azure_metrics/_dev/build/docs/container_registry.md
@@ -1,7 +1,7 @@
 # Azure Container Registry Integration
 
 The Azure Container Registry data stream collects and aggregates container registry related metrics from Azure Container Registry type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Registry will periodically retrieve the Azure monitor metrics using the Azure REST APIs as MetricList.
+The Azure Container Registry will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
 Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements

--- a/packages/azure_metrics/_dev/build/docs/container_registry.md
+++ b/packages/azure_metrics/_dev/build/docs/container_registry.md
@@ -1,12 +1,12 @@
 # Azure Container Registry Integration
 
-The Azure Container Registry data stream collects and aggregates container registry related metrics from azure container registry type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Registry will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+The Azure Container Registry data stream collects and aggregates container registry related metrics from Azure Container Registry type resources where it can be used for analysis, visualization, and alerting.
+The Azure Container Registry will periodically retrieve the Azure monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 

--- a/packages/azure_metrics/_dev/build/docs/container_service.md
+++ b/packages/azure_metrics/_dev/build/docs/container_service.md
@@ -1,52 +1,18 @@
 # Azure Container Service Integration
 
+The Azure Container Service data stream collects and aggregates container service related metrics from Azure Container Service type resources where it can be used for analysis, visualization, and alerting.
+The Azure Container Service will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Container Service data stream collects and aggregates storage account related metrics from azure container service type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Service will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `container_service` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,14 +24,5 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all container services inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 {{fields "container_service"}}

--- a/packages/azure_metrics/_dev/build/docs/database_account.md
+++ b/packages/azure_metrics/_dev/build/docs/database_account.md
@@ -1,52 +1,18 @@
 # Azure Database Account Integration
 
+The Azure Database Account data stream collects and aggregates database account related metrics from Azure Database Account type resources where it can be used for analysis, visualization, and alerting.
+The Azure Database Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Database Account data stream collects and aggregates storage account related metrics from azure database account type resources where it can be used for analysis, visualization, and alerting.
-The Azure Database Account will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `database_account` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,12 +24,5 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all database accounts inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 {{fields "database_account"}}

--- a/packages/azure_metrics/_dev/build/docs/database_account.md
+++ b/packages/azure_metrics/_dev/build/docs/database_account.md
@@ -2,7 +2,7 @@
 
 The Azure Database Account data stream collects and aggregates database account related metrics from Azure Database Account type resources where it can be used for analysis, visualization, and alerting.
 The Azure Database Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 

--- a/packages/azure_metrics/_dev/build/docs/monitor.md
+++ b/packages/azure_metrics/_dev/build/docs/monitor.md
@@ -2,14 +2,14 @@
 
 The Azure Monitor feature collects and aggregates logs and metrics from a variety of sources into a common data platform where it can be used for analysis, visualization, and alerting.
 
-The azure monitor metrics are numerical values that describe some aspect of a system at a particular point in time. They are collected at regular intervals and are identified with a timestamp, a name, a value, and one or more defining labels.
+The Azure Monitor metrics are numerical values that describe some aspect of a system at a particular point in time. They are collected at regular intervals and are identified with a timestamp, a name, a value, and one or more defining labels.
 
 The Azure Resource Metrics will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional Azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 
@@ -34,7 +34,6 @@ Check the following resources API:
 `resource_type`:: (_string_) As mentioned above this will be a filter option for the resource group api, will check for all resources under the specified group that are the type under this configuration.
 
 `resource_query`:: (_string_) Should contain a filter entered by the user, the output will be a list of resources.
-
 
 ## Resource metric configurations
 

--- a/packages/azure_metrics/_dev/build/docs/storage_account.md
+++ b/packages/azure_metrics/_dev/build/docs/storage_account.md
@@ -1,52 +1,18 @@
 # Azure Storage Account Integration
 
+The Azure Storage Account data stream collects and aggregates storage account related metrics from Azure Storage Account type resources where it can be used for analysis, visualization, and alerting.
+The Azure Storage Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Storage Account data stream collects and aggregates storage account related metrics from azure storage account type resources where it can be used for analysis, visualization, and alerting.
-The Azure Storage Account will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `storage_account` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -60,12 +26,5 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all storage accounts inside the subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 {{fields "storage_account"}}

--- a/packages/azure_metrics/changelog.yml
+++ b/packages/azure_metrics/changelog.yml
@@ -1,4 +1,9 @@
 
+- version: "1.6.4"
+  changes:
+    - description: Consolidate content on Azure metrics pages.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9674
 - version: "1.6.3"
   changes:
     - description: Consolidate content on the Azure Container Instance Metrics doc page.

--- a/packages/azure_metrics/docs/compute_vm.md
+++ b/packages/azure_metrics/docs/compute_vm.md
@@ -1,51 +1,18 @@
 # Azure Compute VM Integration
 
-The Azure Compute VM data stream collects and aggregates storage account related metrics from azure virtual machine type resources where it can be used for analysis, visualization, and alerting.
-The Azure Compute VM will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+The Azure Compute VM data stream collects and aggregates virtual machine related metrics from Azure Compute VM type resources where it can be used for analysis, visualization, and alerting.
+The Azure Compute VM will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-## Integration specific configuration notes
+## Requirements
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-Required credentials for the `azure_metrics` integration:
+## Setup
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `compute_vm` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -57,7 +24,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all virtual machines inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
 
 ## Guest metrics
 
@@ -72,12 +38,6 @@ To enable the diagnostic agent:
 1. From the **Sinks** tab, check **Enable Azure Monitor** to view your data from Azure Monitor dashboards.
 
 For more information on sending guest OS metrics to Azure Monitor, check the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/collect-custom-metrics-guestos-resource-manager-vm).
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: Dedicated authentication token will be created and updated regularly, it is advised to not share the credentials entered.
 
 **Exported fields**
 

--- a/packages/azure_metrics/docs/compute_vm_scaleset.md
+++ b/packages/azure_metrics/docs/compute_vm_scaleset.md
@@ -1,52 +1,18 @@
 # Azure Compute VM Scaleset Integration
 
+The Azure Compute Scaleset VM data stream collects and aggregates compute scaleset VM related metrics from Azure Virtual Machine scaleset type resources where it can be used for analysis, visualization, and alerting.
+The Azure Compute VM Scaleset will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Compute Scaleset VM data stream collects and aggregates storage account related metrics from azure virtual machine scaleset type resources where it can be used for analysis, visualization, and alerting.
-The Azure Compute Scaleset will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `compute_vm_scaleset` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,14 +24,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all virtual machine scalesets inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 **Exported fields**
 

--- a/packages/azure_metrics/docs/container_instance.md
+++ b/packages/azure_metrics/docs/container_instance.md
@@ -2,11 +2,11 @@
 
 The Azure Container Instance data stream collects and aggregates container instance related metrics from Azure Container instance type resources where it can be used for analysis, visualization, and alerting.
 The Azure Container Instance will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional Azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 

--- a/packages/azure_metrics/docs/container_registry.md
+++ b/packages/azure_metrics/docs/container_registry.md
@@ -1,7 +1,7 @@
 # Azure Container Registry Integration
 
 The Azure Container Registry data stream collects and aggregates container registry related metrics from Azure Container Registry type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Registry will periodically retrieve the Azure monitor metrics using the Azure REST APIs as MetricList.
+The Azure Container Registry will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
 Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements

--- a/packages/azure_metrics/docs/container_registry.md
+++ b/packages/azure_metrics/docs/container_registry.md
@@ -1,12 +1,12 @@
 # Azure Container Registry Integration
 
-The Azure Container Registry data stream collects and aggregates container registry related metrics from azure container registry type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Registry will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+The Azure Container Registry data stream collects and aggregates container registry related metrics from Azure Container Registry type resources where it can be used for analysis, visualization, and alerting.
+The Azure Container Registry will periodically retrieve the Azure monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 

--- a/packages/azure_metrics/docs/container_service.md
+++ b/packages/azure_metrics/docs/container_service.md
@@ -1,52 +1,18 @@
 # Azure Container Service Integration
 
+The Azure Container Service data stream collects and aggregates container service related metrics from Azure Container Service type resources where it can be used for analysis, visualization, and alerting.
+The Azure Container Service will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Container Service data stream collects and aggregates storage account related metrics from azure container service type resources where it can be used for analysis, visualization, and alerting.
-The Azure Container Service will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `container_service` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,15 +24,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all container services inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 **Exported fields**
 

--- a/packages/azure_metrics/docs/database_account.md
+++ b/packages/azure_metrics/docs/database_account.md
@@ -1,52 +1,18 @@
 # Azure Database Account Integration
 
+The Azure Database Account data stream collects and aggregates database account related metrics from Azure Database Account type resources where it can be used for analysis, visualization, and alerting.
+The Azure Database Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Database Account data stream collects and aggregates storage account related metrics from azure database account type resources where it can be used for analysis, visualization, and alerting.
-The Azure Database Account will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `database_account` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -58,13 +24,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all database accounts inside the entire subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 **Exported fields**
 

--- a/packages/azure_metrics/docs/database_account.md
+++ b/packages/azure_metrics/docs/database_account.md
@@ -2,7 +2,7 @@
 
 The Azure Database Account data stream collects and aggregates database account related metrics from Azure Database Account type resources where it can be used for analysis, visualization, and alerting.
 The Azure Database Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 

--- a/packages/azure_metrics/docs/monitor.md
+++ b/packages/azure_metrics/docs/monitor.md
@@ -2,14 +2,14 @@
 
 The Azure Monitor feature collects and aggregates logs and metrics from a variety of sources into a common data platform where it can be used for analysis, visualization, and alerting.
 
-The azure monitor metrics are numerical values that describe some aspect of a system at a particular point in time. They are collected at regular intervals and are identified with a timestamp, a name, a value, and one or more defining labels.
+The Azure Monitor metrics are numerical values that describe some aspect of a system at a particular point in time. They are collected at regular intervals and are identified with a timestamp, a name, a value, and one or more defining labels.
 
 The Azure Resource Metrics will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
-Additional Azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
 ## Requirements
 
-Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) both for Azure and Elastic.
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
 ## Setup
 
@@ -34,7 +34,6 @@ Check the following resources API:
 `resource_type`:: (_string_) As mentioned above this will be a filter option for the resource group api, will check for all resources under the specified group that are the type under this configuration.
 
 `resource_query`:: (_string_) Should contain a filter entered by the user, the output will be a list of resources.
-
 
 ## Resource metric configurations
 

--- a/packages/azure_metrics/docs/storage_account.md
+++ b/packages/azure_metrics/docs/storage_account.md
@@ -1,52 +1,18 @@
 # Azure Storage Account Integration
 
+The Azure Storage Account data stream collects and aggregates storage account related metrics from Azure Storage Account type resources where it can be used for analysis, visualization, and alerting.
+The Azure Storage Account will periodically retrieve the Azure Monitor metrics using the Azure REST APIs as MetricList.
+Additional Azure API calls will be executed to retrieve information regarding the resources targeted by the user.
 
-The Azure Storage Account data stream collects and aggregates storage account related metrics from azure storage account type resources where it can be used for analysis, visualization, and alerting.
-The Azure Storage Account will periodically retrieve the azure monitor metrics using the Azure REST APIs as MetricList.
-Additional azure API calls will be executed in order to retrieve information regarding the resources targeted by the user.
+## Requirements
 
-## Integration specific configuration notes
+Before you start, check the [Authentication and costs](https://docs.elastic.co/integrations/azure_metrics#authentication-and-costs) section.
 
-All the tasks executed against the Azure Monitor REST API will use the Azure Resource Manager authentication model.
-Therefore, all requests must be authenticated with Azure Active Directory (Azure AD).
-One approach to authenticate the client application is to create an Azure AD service principal and retrieve the authentication (JWT) token.
-For a more detailed walk-through, have a look at using Azure PowerShell to create a service principal to access resources https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-2.7.0.
- It is also possible to create a service principal via the Azure portal https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
-Users will have to make sure the roles assigned to the application contain at least reading permissions to the monitor data, more on the roles here https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles.
+## Setup
 
-Required credentials for the `azure_metrics` integration:
+Follow these [step-by-step instructions](https://docs.elastic.co/integrations/azure_metrics#setup) on how to set up an Azure metrics integration.
 
-`Client ID`:: The unique identifier for the application (also known as Application Id)
-
-`Client Secret`:: The client/application secret/key
-
-`Subscription ID`:: The unique identifier for the azure subscription
-
-`Tenant ID`:: The unique identifier of the Azure Active Directory instance
-
-
-The azure credentials keys can be used if configured `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
-
-`Resource Manager Endpoint` ::
-_string_
-Optional, by default the azure public environment will be used, to override, users can provide a specific resource manager endpoint in order to use a different azure environment.
-Ex:
-https://management.chinacloudapi.cn for azure ChinaCloud
-https://management.microsoftazure.de for azure GermanCloud
-https://management.azure.com for azure PublicCloud
-https://management.usgovcloudapi.net for azure USGovernmentCloud
-
-`Active Directory Endpoint` ::
-_string_
-Optional, by default the associated active directory endpoint to the resource manager endpoint will be used, to override, users can provide a specific active directory endpoint in order to use a different azure environment.
-Ex:
-https://login.microsoftonline.com for azure ChinaCloud
-https://login.microsoftonline.us for azure GermanCloud
-https://login.chinacloudapi.cn for azure PublicCloud
-https://login.microsoftonline.de for azure USGovernmentCloud
-
-
-### Data stream specific configuration notes
+## Data stream specific configuration notes
 
 `Period`:: (_string_) Reporting interval. Metrics will have a timegrain of 5 minutes, so the `Period` configuration option  for `storage_account` should have a value of `300s` or multiple of `300s`for relevant results.
 
@@ -60,13 +26,6 @@ https://login.microsoftonline.de for azure USGovernmentCloud
 If no resource filter is specified, then all storage accounts inside the subscription will be considered.
 
 The primary aggregation value will be retrieved for all the metrics contained in the namespaces. The aggregation options are `avg`, `sum`, `min`, `max`, `total`, `count`.
-
-
-## Additional notes about metrics and costs
-
-Costs: Metric queries are charged based on the number of standard API calls. More information on pricing here https://azure.microsoft.com/en-us/pricing/details/monitor/.
-
-Authentication: we are handling authentication on our side (creating/renewing the authentication token), so we advise users to use dedicated credentials for metricbeat only.
 
 **Exported fields**
 

--- a/packages/azure_metrics/manifest.yml
+++ b/packages/azure_metrics/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_metrics
 title: Azure Resource Metrics
-version: 1.6.3
+version: 1.6.4
 description: Collect metrics from Azure resources with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

This PR:

- Removes duplicate and confusing content related to Kibana configurations, authentication, and costs. 
- Adds references to generic instructions documented on the [Azure Resource Metrics](https://docs.elastic.co/integrations/azure_metrics#setup) page.
- Adds the `Requirements` and `Setup` sections to comply with the [documentation guidelines](https://github.com/elastic/integrations/blob/main/docs/documentation_guidelines.md).
- Fixes product names and capitalization

The doc updates impact the following Azure doc pages:

- [Container service metrics](https://docs.elastic.co/integrations/azure_metrics/container_service)
- [Database Account metrics](https://docs.elastic.co/integrations/azure_metrics/database_account)
- [Storage Account metrics](https://docs.elastic.co/integrations/azure_metrics/storage_account)
- [Virtual machines metrics](https://docs.elastic.co/integrations/azure_metrics/compute_vm)
- [Virtual machines scaleset metrics](https://docs.elastic.co/integrations/azure_metrics/compute_vm_scaleset)

## Related issues

- https://github.com/elastic/integration-docs/issues/332
- https://github.com/elastic/integration-docs/issues/324