### PR TITLE
[Buildkite] Skip install package command in serverless builds for some packages

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -755,6 +755,19 @@ build_zip_package() {
     return 0
 }
 
+skip_installation_step() {
+    local package=$1
+    if ! is_serverless ; then
+        return 1
+    fi
+
+    if [[ "$package" == "security_detection_engine" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
 install_package() {
     local package=$1
     echo "Install package: ${package}"
@@ -814,10 +827,7 @@ run_tests_package() {
         fi
     fi
 
-    if ! is_serverless ; then
-        # Just run install command on non serverless projects,
-        # "elastic-paackage test asset" command already installs the package via upload API
-        # as it does "elastic-package install" command
+    if ! skip_installation_step "${package}" ; then
         echo "--- [${package}] test installation"
         if ! install_package "${package}" ; then
             return 1

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -814,10 +814,16 @@ run_tests_package() {
         fi
     fi
 
-    echo "--- [${package}] test installation"
-    if ! install_package "${package}" ; then
-        return 1
+    if ! is_serverless ; then
+        # Just run install command on non serverless projects,
+        # "elastic-paackage test asset" command already installs the package via upload API
+        # as it does "elastic-package install" command
+        echo "--- [${package}] test installation"
+        if ! install_package "${package}" ; then
+            return 1
+        fi
     fi
+
     echo "--- [${package}] run test suites"
     if is_serverless; then
         if ! test_package_in_serverless "${package}" ; then

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -309,7 +309,6 @@ create_kind_cluster() {
     kind create cluster --config "${WORKSPACE}/kind-config.yaml" --image "kindest/node:${K8S_VERSION}"
 }
 
-
 delete_kind_cluster() {
     echo "--- Delete kind cluster"
     kind delete cluster || true
@@ -409,7 +408,6 @@ is_package_excluded() {
     fi
     return 1
 }
-
 
 is_supported_capability() {
     if [ "${SERVERLESS_PROJECT}" == "" ]; then


### PR DESCRIPTION
## Proposed commit message

Skip "elastic-package install" command in Serverless builds. "elastic-package test asset" already performs the installation of the package too.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

