### PR TITLE
[System] Fix typos in Failed and Blocked Accounts dashboard

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.55.2"
+  changes:
+    - description: Fix typos in Failed and Block Accounts dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9426
 - version: "1.55.1"
   changes:
     - description: Add missing preserve_original_event tag when toggled on.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -2,8 +2,8 @@
 - version: "1.55.2"
   changes:
     - description: Fix typos in Failed and Block Accounts dashboard.
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/9426
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9691
 - version: "1.55.1"
   changes:
     - description: Add missing preserve_original_event tag when toggled on.

--- a/packages/system/kibana/dashboard/system-d401ef40-a7d5-11e9-a422-d144027429da.json
+++ b/packages/system/kibana/dashboard/system-d401ef40-a7d5-11e9-a422-d144027429da.json
@@ -384,7 +384,7 @@
                                 "valueAccessor": "91c9816d-3c25-42e9-8682-4c6b83971006"
                             }
                         },
-                        "title": "Blocked Acoounts (converted)",
+                        "title": "Blocked Accounts (converted)",
                         "type": "lens",
                         "visualizationType": "lnsTagcloud"
                     },
@@ -399,7 +399,7 @@
                     "y": 35
                 },
                 "panelIndex": "3",
-                "title": "Blocked Acoounts",
+                "title": "Blocked Accounts",
                 "type": "lens"
             },
             {
@@ -738,7 +738,7 @@
                                 "valueAccessor": "efe4287e-cd4e-4e00-8ad4-208ee067a301"
                             }
                         },
-                        "title": "Logon Failed Acconts [Windows System Security] (converted)",
+                        "title": "Logon Failed Accounts [Windows System Security] (converted)",
                         "type": "lens",
                         "visualizationType": "lnsTagcloud"
                     },
@@ -753,7 +753,7 @@
                     "y": 35
                 },
                 "panelIndex": "5",
-                "title": "Logon Failed Acconts",
+                "title": "Logon Failed Accounts",
                 "type": "lens"
             },
             {

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: 1.55.1
+version: 1.55.2
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message
The PR fixes a few typos in the Failed and Blocked Accounts Dashboard in the System Integration wherein the word Account(s) was misspelled as `Acoounts` or `Acconts`
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist
- All typos fixed
- No breaking changes, and no errors reported while building the package

## How to test this PR locally
- Run `elastic-package check && elastic-package test`