### PR TITLE
[nginx] Update test nginx configuration file to listen in ipv6 too 

### DIFF
--- a/packages/nginx/_dev/deploy/docker/nginx.conf
+++ b/packages/nginx/_dev/deploy/docker/nginx.conf
@@ -20,6 +20,7 @@ http {
     access_log  /var/log/nginx/access.log main;
 
     server {
+        listen [::]:80;
         listen 80;
         server_name localhost;
 


### PR DESCRIPTION
## Proposed commit message

Add support in nginx test configuration file (nginx.conf) to listen also in ipv6.

Latest versions of docker (from 26.0.0) runs healthchecks with ipv6:
- https://docs.docker.com/engine/release-notes/26.0/#bug-fixes-and-enhancements-2

> By default, IPv6 will remain enabled on a container's loopback interface when the container is not connected to an IPv6-enabled network. For example, containers that are only connected to an IPv4-only network now have the ::1 address on their loopback interface.

If not added this setting, container cannot be started due to the failing healthcheck:

```
 $ docker logs -f elastic-package-service-nginx-1
...
2024/04/26 09:32:41 [error] 29#29: *42 open() "/usr/share/nginx/html/server-status" failed (2: No such file or directory), client: ::1, server: localhost, request: "GET /server-status HTTP/1.1", host: "localhost"
2024/04/26 09:32:42 [error] 29#29: *43 open() "/usr/share/nginx/html/server-status" failed (2: No such file or directory), client: ::1, server: localhost, request: "GET /server-status HTTP/1.1", host: "localhost"
```

Docker version that I'm running for these tests: 26.1.0

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
- Run docker at least version 26.0.0
- Remove line `listen [::]:80;`  from the `nginx.conf` file
- Run system tests
    - Service nginx should not be able to run
- Re-adding line `listen [::]:80;` to the `nginx.conf` file
- Run system tests again
    - Service nginx should be able to start and system tests succeed.



