### PR TITLE
[Microsoft Exchange Server] Adjust mapping to include agent & host field to avoid mapping conflicts

### DIFF
--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.1"
+  changes:
+    - description: Adjust mapping to include agent & host field
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9560
 - version: "1.0.0"
   changes:
     - description: GA of Integration, Add Dashbord Panel Titles & added System Tests

--- a/packages/microsoft_exchange_server/changelog.yml
+++ b/packages/microsoft_exchange_server/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adjust mapping to include agent & host field
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9560
+      link: https://github.com/elastic/integrations/pull/9723
 - version: "1.0.0"
   changes:
     - description: GA of Integration, Add Dashbord Panel Titles & added System Tests

--- a/packages/microsoft_exchange_server/data_stream/httpproxy/fields/ecs.yml
+++ b/packages/microsoft_exchange_server/data_stream/httpproxy/fields/ecs.yml
@@ -22,3 +22,37 @@
   name: ecs.version
 - external: ecs
   name: log.file.path
+- external: ecs
+  name: host.architecture
+- external: ecs
+  name: host.hostname
+- external: ecs
+  name: host.id
+- external: ecs
+  name: host.ip
+- external: ecs
+  name: host.mac
+- external: ecs
+  name: host.name
+- external: ecs
+  name: host.os.family
+- external: ecs
+  name: host.os.kernel
+- external: ecs
+  name: host.os.name
+- external: ecs
+  name: host.os.platform
+- external: ecs
+  name: host.os.type
+- external: ecs
+  name: host.os.version
+- external: ecs
+  name: agent.ephemeral_id
+- external: ecs
+  name: agent.id
+- external: ecs
+  name: agent.name
+- external: ecs
+  name: agent.type
+- external: ecs
+  name: agent.version

--- a/packages/microsoft_exchange_server/data_stream/imap4_pop3/fields/ecs.yml
+++ b/packages/microsoft_exchange_server/data_stream/imap4_pop3/fields/ecs.yml
@@ -8,3 +8,37 @@
   name: tags
 - external: ecs
   name: ecs.version
+- external: ecs
+  name: host.architecture
+- external: ecs
+  name: host.hostname
+- external: ecs
+  name: host.id
+- external: ecs
+  name: host.ip
+- external: ecs
+  name: host.mac
+- external: ecs
+  name: host.name
+- external: ecs
+  name: host.os.family
+- external: ecs
+  name: host.os.kernel
+- external: ecs
+  name: host.os.name
+- external: ecs
+  name: host.os.platform
+- external: ecs
+  name: host.os.type
+- external: ecs
+  name: host.os.version
+- external: ecs
+  name: agent.ephemeral_id
+- external: ecs
+  name: agent.id
+- external: ecs
+  name: agent.name
+- external: ecs
+  name: agent.type
+- external: ecs
+  name: agent.version

--- a/packages/microsoft_exchange_server/data_stream/messagetracking/fields/ecs.yml
+++ b/packages/microsoft_exchange_server/data_stream/messagetracking/fields/ecs.yml
@@ -30,3 +30,37 @@
   name: ecs.version
 - external: ecs
   name: log.file.path
+- external: ecs
+  name: host.architecture
+- external: ecs
+  name: host.hostname
+- external: ecs
+  name: host.id
+- external: ecs
+  name: host.ip
+- external: ecs
+  name: host.mac
+- external: ecs
+  name: host.name
+- external: ecs
+  name: host.os.family
+- external: ecs
+  name: host.os.kernel
+- external: ecs
+  name: host.os.name
+- external: ecs
+  name: host.os.platform
+- external: ecs
+  name: host.os.type
+- external: ecs
+  name: host.os.version
+- external: ecs
+  name: agent.ephemeral_id
+- external: ecs
+  name: agent.id
+- external: ecs
+  name: agent.name
+- external: ecs
+  name: agent.type
+- external: ecs
+  name: agent.version

--- a/packages/microsoft_exchange_server/data_stream/smtp/fields/ecs.yml
+++ b/packages/microsoft_exchange_server/data_stream/smtp/fields/ecs.yml
@@ -6,3 +6,37 @@
   name: tags
 - external: ecs
   name: ecs.version
+- external: ecs
+  name: host.architecture
+- external: ecs
+  name: host.hostname
+- external: ecs
+  name: host.id
+- external: ecs
+  name: host.ip
+- external: ecs
+  name: host.mac
+- external: ecs
+  name: host.name
+- external: ecs
+  name: host.os.family
+- external: ecs
+  name: host.os.kernel
+- external: ecs
+  name: host.os.name
+- external: ecs
+  name: host.os.platform
+- external: ecs
+  name: host.os.type
+- external: ecs
+  name: host.os.version
+- external: ecs
+  name: agent.ephemeral_id
+- external: ecs
+  name: agent.id
+- external: ecs
+  name: agent.name
+- external: ecs
+  name: agent.type
+- external: ecs
+  name: agent.version

--- a/packages/microsoft_exchange_server/manifest.yml
+++ b/packages/microsoft_exchange_server/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: microsoft_exchange_server
 title: "Microsoft Exchange Server"
-version: 1.0.0
+version: 1.0.1
 source:
   license: "Elastic-2.0"
 description: Collect logs from Microsoft Exchange Server with Elastic Agent.


### PR DESCRIPTION
Adjust mapping to include agent & host field to avoid mapping conflicts like these:
![image](https://github.com/elastic/integrations/assets/145989254/390b20e9-04fd-4f6e-9246-4e252444fc1d)
