### PR TITLE
Remove separate codeowners for system package kibana paths.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -304,7 +304,6 @@
 /packages/system/changelog.yml @elastic/obs-infraobs-integrations @elastic/sec-linux-platform @elastic/sec-windows-platform
 /packages/system/data_stream/auth @elastic/sec-windows-platform
 /packages/system/data_stream/security @elastic/sec-linux-platform @elastic/sec-windows-platform
-/packages/system/kibana @elastic/elastic-agent-data-plane @elastic/kibana-visualizations
 /packages/system/manifest.yml @elastic/obs-infraobs-integrations @elastic/sec-linux-platform @elastic/sec-windows-platform
 /packages/system_audit @elastic/sec-linux-platform
 /packages/tanium @elastic/security-service-integrations


### PR DESCRIPTION
Removing separate entry of codeowners for system package kibana paths. This will avoid delays in PRs to system package, as per discussion [here](https://github.com/elastic/integrations/pull/9573#issuecomment-2071593992).