### PR TITLE
[kubernetes] Remove deprecated fields, add missing status.last_terminated_reason metric

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 1.61.0
   changes:
-    - description: Remove deprecated fields
+    - description: Remove deprecated fields and add missing status.last_terminated_reason metric
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9736
 - version: 1.60.0

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.61.0
+  changes:
+    - description: Remove deprecated fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9685
 - version: 1.60.0
   changes:
     - description: Updating `Memory used vs total memory` and `Cores used vs total cores` visualisations in Cluster Overview Dashboard

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove deprecated fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9685
+      link: https://github.com/elastic/integrations/pull/9736
 - version: 1.60.0
   changes:
     - description: Updating `Memory used vs total memory` and `Cores used vs total cores` visualisations in Cluster Overview Dashboard

--- a/packages/kubernetes/data_stream/state_container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/fields.yml
@@ -25,8 +25,13 @@
         - name: reason
           dimension: true
           type: keyword
-          description: |
-            Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason.
+          description: >
+            The reason the container is currently in waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull,
+            ImagePullBackoff) or terminated (Completed, ContainerCannotRun, Error, OOMKilled) state.
+        - name: last_terminated_reason
+          type: keyword
+          description: >
+            The last reason the container was in terminated state (Completed, ContainerCannotRun, Error or OOMKilled).
     - name: cpu
       type: group
       fields:

--- a/packages/kubernetes/data_stream/state_container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/fields.yml
@@ -40,16 +40,6 @@
           metric_type: gauge
           description: |
             Container CPU requested cores
-        - name: limit.nanocores
-          type: long
-          metric_type: gauge
-          description: |
-            Container CPU nanocores limit
-        - name: request.nanocores
-          type: long
-          metric_type: gauge
-          description: |
-            Container CPU requested nanocores
     - name: memory
       type: group
       fields:

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -193,9 +193,7 @@ An example event for `state_container` looks as following:
 | host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
 | kubernetes.annotations.\* | Kubernetes annotations map | object |  |  |
 | kubernetes.container.cpu.limit.cores | Container CPU cores limit | float |  | gauge |
-| kubernetes.container.cpu.limit.nanocores | Container CPU nanocores limit | long |  | gauge |
 | kubernetes.container.cpu.request.cores | Container CPU requested cores | float |  | gauge |
-| kubernetes.container.cpu.request.nanocores | Container CPU requested nanocores | long |  | gauge |
 | kubernetes.container.id | Container id | keyword |  |  |
 | kubernetes.container.memory.limit.bytes | Container memory limit in bytes | long | byte | gauge |
 | kubernetes.container.memory.request.bytes | Container requested memory in bytes | long | byte | gauge |

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -198,9 +198,10 @@ An example event for `state_container` looks as following:
 | kubernetes.container.memory.limit.bytes | Container memory limit in bytes | long | byte | gauge |
 | kubernetes.container.memory.request.bytes | Container requested memory in bytes | long | byte | gauge |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
+| kubernetes.container.status.last_terminated_reason | The last reason the container was in terminated state (Completed, ContainerCannotRun, Error or OOMKilled). | keyword |  |  |
 | kubernetes.container.status.phase | Container phase (running, waiting, terminated) | keyword |  |  |
 | kubernetes.container.status.ready | Container ready status | boolean |  |  |
-| kubernetes.container.status.reason | Waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or termination (Completed, ContainerCannotRun, Error, OOMKilled) reason. | keyword |  |  |
+| kubernetes.container.status.reason | The reason the container is currently in waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or terminated (Completed, ContainerCannotRun, Error, OOMKilled) state. | keyword |  |  |
 | kubernetes.container.status.restarts | Container restarts count | integer |  | counter |
 | kubernetes.cronjob.name | Name of the CronJob to which the Pod belongs | keyword |  |  |
 | kubernetes.daemonset.name | Kubernetes daemonset name | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.60.0
+version: 1.61.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- WHAT: remove deprecated fields, see https://github.com/elastic/beats/pull/28046
- WHY:  align with the beats implementation

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
