### PR TITLE
Add panel to dashboard, add percent field

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add queue full percentage fields
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8690
+      link: https://github.com/elastic/integrations/pull/9765
 - version: "1.18.0"
   changes:
     - description: Add metrics dashboard for httpjson, http_endpoint, filestream and CEL, fix decimal numbers on certain counters, add field mappings for filebeat_input.id, and component fields to filebeat_input logs

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Add queue full percentage fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8690
 - version: "1.18.0"
   changes:
     - description: Add metrics dashboard for httpjson, http_endpoint, filestream and CEL, fix decimal numbers on certain counters, add field mappings for filebeat_input.id, and component fields to filebeat_input logs

--- a/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/fields/fields.yml
@@ -71,3 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -70,3 +70,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/beat-stats-fields.yml
@@ -140,6 +140,10 @@
               type: long
             - name: queue.max_events
               type: long
+            - name: queue.filled.pct.events
+              type: float
+              metric_type: gauge
+              description: Maximum number of events in a queue
             - name: events
               type: group
               fields:

--- a/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/fields/fields.yml
@@ -71,3 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/fields/fields.yml
@@ -74,3 +74,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/fields/fields.yml
@@ -71,3 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/fields/fields.yml
@@ -71,3 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/fields/fields.yml
@@ -71,3 +71,7 @@
       type: long
       metric_type: counter
       description: Maximum number of events in a queue
+    - name: queue.filled.pct.events
+      type: float
+      metric_type: gauge
+      description: Maximum number of events in a queue

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -2171,7 +2171,9 @@
                                             "columnOrder": [
                                                 "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
                                                 "6093c949-5f5d-4c72-baba-5a84ce2f1a9b",
-                                                "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171",
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171X1",
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171X0"
                                             ],
                                             "columns": {
                                                 "0a3d2e1f-e2f5-4001-b02b-927904b0ab94": {
@@ -2186,10 +2188,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "c37367a6-4c26-4f3f-86eb-10db67933171",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -2215,18 +2217,65 @@
                                                 "c37367a6-4c26-4f3f-86eb-10db67933171": {
                                                     "customLabel": true,
                                                     "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Queue usage",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "average(monitoring.metrics.libbeat.pipeline.queue.filled.pct.events, kql='')*100",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "c37367a6-4c26-4f3f-86eb-10db67933171X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
                                                         "query": ""
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Queue depth",
-                                                    "operationType": "max",
+                                                    "label": "Part of Queue usage",
+                                                    "operationType": "average",
                                                     "params": {
-                                                        "emptyAsNull": true
+                                                        "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "monitoring.metrics.libbeat.pipeline.queue.filled.pct.events"
+                                                },
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Queue usage",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "c37367a6-4c26-4f3f-86eb-10db67933171X0",
+                                                                100
+                                                            ],
+                                                            "location": {
+                                                                "max": 80,
+                                                                "min": 0
+                                                            },
+                                                            "name": "multiply",
+                                                            "text": "average(monitoring.metrics.libbeat.pipeline.queue.filled.pct.events, kql='')*100",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "c37367a6-4c26-4f3f-86eb-10db67933171X0"
+                                                    ],
+                                                    "scale": "ratio"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -2340,7 +2389,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-04-30T15:39:45.578Z",
+    "created_at": "2024-05-01T20:29:40.958Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -49,8 +49,7 @@
                         "title": "",
                         "type": "markdown",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 27,
@@ -61,8 +60,7 @@
                 },
                 "panelIndex": "443b1597-9d5f-4b9c-8848-643d0381b2f4",
                 "title": "Table of Contents",
-                "type": "visualization",
-                "version": "8.9.0"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -172,8 +170,7 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 9,
@@ -184,8 +181,7 @@
                 },
                 "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
                 "title": "[Elastic Agent] CPU Usage",
-                "type": "visualization",
-                "version": "8.9.0"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -335,8 +331,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -347,8 +342,7 @@
                 },
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -470,8 +464,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -482,8 +475,7 @@
                 },
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -661,8 +653,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -673,8 +664,7 @@
                 },
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -860,8 +850,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -872,8 +861,7 @@
                 },
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1052,8 +1040,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1064,8 +1051,7 @@
                 },
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1243,8 +1229,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1255,8 +1240,7 @@
                 },
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1437,8 +1421,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1449,8 +1432,7 @@
                 },
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1620,8 +1602,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1632,8 +1613,7 @@
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1808,8 +1788,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -1820,8 +1799,7 @@
                 },
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                 "title": "[Elastic Agent] Queue depth",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1964,8 +1942,7 @@
                         },
                         "type": "metrics",
                         "uiState": {}
-                    },
-                    "type": "visualization"
+                    }
                 },
                 "gridData": {
                     "h": 9,
@@ -1976,8 +1953,7 @@
                 },
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
-                "type": "visualization",
-                "version": "8.9.0"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -2162,8 +2138,7 @@
                         "visualizationType": "lnsXY"
                     },
                     "enhancements": {},
-                    "hidePanelTitles": false,
-                    "type": "lens"
+                    "hidePanelTitles": false
                 },
                 "gridData": {
                     "h": 9,
@@ -2174,8 +2149,190 @@
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
-                "type": "lens",
-                "version": "8.9.0"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "logs-*",
+                                    "layers": {
+                                        "38cd2447-deab-49b7-9d84-400f2ba12511": {
+                                            "columnOrder": [
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b",
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                            ],
+                                            "columns": {
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of component.id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "c37367a6-4c26-4f3f-86eb-10db67933171",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "component.id"
+                                                },
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Queue depth",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "monitoring.metrics.libbeat.pipeline.queue.filled.pct.events"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logs-*",
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        }
+                                    }
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "97ad75be-db47-4cb4-bb1e-0c0320d04edd",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                        ],
+                                        "layerId": "38cd2447-deab-49b7-9d84-400f2ba12511",
+                                        "layerType": "data",
+                                        "seriesType": "area_stacked",
+                                        "splitAccessor": "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                        "xAccessor": "6093c949-5f5d-4c72-baba-5a84ce2f1a9b"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
+                            }
+                        },
+                        "title": "[Elastic Agent] Queue depth",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
+                    "w": 24,
+                    "x": 0,
+                    "y": 63
+                },
+                "panelIndex": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
+                "title": "[Elastic Agent] Queue Usage",
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -2183,9 +2340,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-12-11T11:37:02.295Z",
+    "created_at": "2024-04-30T15:39:45.578Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -2290,6 +2447,11 @@
         {
             "id": "metrics-*",
             "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "bf48fd17-63ec-4d90-8b6a-328bb74b466a:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.18.0
+version: 1.19.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
closes: https://github.com/elastic/beats/issues/38708
For more context: https://github.com/elastic/beats/pull/39205

This PR adds support in integrations for the new queue percentage full metric. As part of this, we:

- Add a `Queue Usage` panel to the agent metrics dashboard
- Add a `queue.filled.pct.events` field to the integrations

I haven't tinkered with integrations in ages, so...I hopefully haven't broken anything.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


<img width="950" alt="Screenshot 2024-05-01 at 1 49 16 PM" src="https://github.com/elastic/integrations/assets/8418476/7332d8b1-e937-4994-b807-6b2f7c1172ee">
