### PR TITLE
[O11y][Redis] Add AUTH (username) and SSL/TLS support

### DIFF
--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Support authentication with username and ssl.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/9777
 - version: "1.14.0"
   changes:
     - description: Enable 'secret' for the sensitive fields.

--- a/packages/redis/changelog.yml
+++ b/packages/redis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Support authentication with username and ssl.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.14.0"
   changes:
     - description: Enable 'secret' for the sensitive fields.

--- a/packages/redis/data_stream/info/agent/stream/stream.yml.hbs
+++ b/packages/redis/data_stream/info/agent/stream/stream.yml.hbs
@@ -12,7 +12,13 @@ maxconn: {{maxconn}}
 {{#if network}}
 network: {{network}}
 {{/if}}
+{{#if username}}
+username: {{username}}
+{{/if}}
 {{#if password}}
 password: {{password}}
+{{/if}}
+{{#if ssl}}
+{{ssl}}
 {{/if}}
 period: {{period}}

--- a/packages/redis/data_stream/key/agent/stream/stream.yml.hbs
+++ b/packages/redis/data_stream/key/agent/stream/stream.yml.hbs
@@ -15,7 +15,13 @@ maxconn: {{maxconn}}
 {{#if network}}
 network: {{network}}
 {{/if}}
+{{#if username}}
+username: {{username}}
+{{/if}}
 {{#if password}}
 password: {{password}}
+{{/if}}
+{{#if ssl}}
+{{ssl}}
 {{/if}}
 period: {{period}}

--- a/packages/redis/data_stream/keyspace/agent/stream/stream.yml.hbs
+++ b/packages/redis/data_stream/keyspace/agent/stream/stream.yml.hbs
@@ -12,7 +12,13 @@ maxconn: {{maxconn}}
 {{#if network}}
 network: {{network}}
 {{/if}}
+{{#if username}}
+username: {{username}}
+{{/if}}
 {{#if password}}
 password: {{password}}
+{{/if}}
+{{#if ssl}}
+{{ssl}}
 {{/if}}
 period: {{period}}

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -117,7 +117,8 @@ policy_templates:
               #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
               #   7RhLQyWn2u00L7/9Omw=
               #   -----END CERTIFICATE-----
-            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            description: |
+              This section allows for the configuration of SSL settings to enable secure communication between the client and server. Both common and specific SSL options can be customized to ensure a secure and reliable connection. Example: [certificate_authorities](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities), [supported-protocols](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#supported-protocols), [verification-mode](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-verification-mode), [key](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-key), [certificate](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate), etc.
             multi: false
             required: false
             show_user: false

--- a/packages/redis/manifest.yml
+++ b/packages/redis/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: redis
 title: Redis
-version: "1.14.0"
+version: "1.15.0"
 description: Collect logs and metrics from Redis servers with Elastic Agent.
 type: integration
 categories:
@@ -72,6 +72,14 @@ policy_templates:
             required: false
             show_user: false
             default: tcp
+          - name: username
+            type: text
+            title: Username
+            secret: false
+            multi: false
+            required: false
+            show_user: false
+            default: ""
           - name: password
             type: password
             title: Password
@@ -80,6 +88,39 @@ policy_templates:
             required: false
             show_user: false
             default: ""
+          - name: ssl
+            type: yaml
+            title: SSL Configuration
+            default: |
+              # ssl.certificate_authorities: |
+              #   -----BEGIN CERTIFICATE-----
+              #   MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
+              #   AlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHROb2RlMDExFjAUBgNV
+              #   BAsTDURlZmF1bHRDZWxsMDExGTAXBgNVBAsTEFJvb3QgQ2VydGlmaWNhdGUxEjAQ
+              #   BgNVBAMTCWxvY2FsaG9zdDAeFw0yMTEyMTQyMjA3MTZaFw0yMjEyMTQyMjA3MTZa
+              #   MF8xCzAJBgNVBAYTAlVTMQwwCgYDVQQKEwNJQk0xFjAUBgNVBAsTDURlZmF1bHRO
+              #   b2RlMDExFjAUBgNVBAsTDURlZmF1bHRDZWxsMDExEjAQBgNVBAMTCWxvY2FsaG9z
+              #   dDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMv5HCsJZIpI5zCy+jXV
+              #   z6lmzNc9UcVSEEHn86h6zT6pxuY90TYeAhlZ9hZ+SCKn4OQ4GoDRZhLPTkYDt+wW
+              #   CV3NTIy9uCGUSJ6xjCKoxClJmgSQdg5m4HzwfY4ofoEZ5iZQ0Zmt62jGRWc0zuxj
+              #   hegnM+eO2reBJYu6Ypa9RPJdYJsmn1RNnC74IDY8Y95qn+WZj//UALCpYfX41hko
+              #   i7TWD9GKQO8SBmAxhjCDifOxVBokoxYrNdzESl0LXvnzEadeZTd9BfUtTaBHhx6t
+              #   njqqCPrbTY+3jAbZFd4RiERPnhLVKMytw5ot506BhPrUtpr2lusbN5svNXjuLeea
+              #   MMUCAwEAAaOBoDCBnTATBgNVHSMEDDAKgAhOatpLwvJFqjAdBgNVHSUEFjAUBggr
+              #   BgEFBQcDAQYIKwYBBQUHAwIwVAYDVR0RBE0wS4E+UHJvZmlsZVVVSUQ6QXBwU3J2
+              #   MDEtQkFTRS05MDkzMzJjMC1iNmFiLTQ2OTMtYWI5NC01Mjc1ZDI1MmFmNDiCCWxv
+              #   Y2FsaG9zdDARBgNVHQ4ECgQITzqhA5sO8O4wDQYJKoZIhvcNAQELBQADggEBAKR0
+              #   gY/BM69S6BDyWp5dxcpmZ9FS783FBbdUXjVtTkQno+oYURDrhCdsfTLYtqUlP4J4
+              #   CHoskP+MwJjRIoKhPVQMv14Q4VC2J9coYXnePhFjE+6MaZbTjq9WaekGrpKkMaQA
+              #   iQt5b67jo7y63CZKIo9yBvs7sxODQzDn3wZwyux2vPegXSaTHR/rop/s/mPk3YTS
+              #   hQprs/IVtPoWU4/TsDN3gIlrAYGbcs29CAt5q9MfzkMmKsuDkTZD0ry42VjxjAmk
+              #   xw23l/k8RoD1wRWaDVbgpjwSzt+kl+vJE/ip2w3h69eEZ9wbo6scRO5lCO2JM4Pr
+              #   7RhLQyWn2u00L7/9Omw=
+              #   -----END CERTIFICATE-----
+            description: i.e. certificate_authorities, supported_protocols, verification_mode etc.
+            multi: false
+            required: false
+            show_user: false
         title: Collect Redis metrics
         description: Collecting info, key and keyspace metrics from Redis instances
 owner:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Add AUTH (username) and SSL/TLS support for key, keyspace, and info data streams.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #5427 