### PR TITLE
[eset_protect][imperva_cloud_waf][sentinal_one_cloud_funnel][ti_crowdstrike] Use modern ecs@mappings

### DIFF
--- a/packages/eset_protect/_dev/build/build.yml
+++ b/packages/eset_protect/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: git@v8.11.0
-    import_mappings: true

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.1"
+  changes:
+    - description: Use modern ecs@mappings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9778
 - version: "0.5.0"
   changes:
     - description: Update OAuth grant type to password because ESET is deprecating the client_credentials grant type.

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -8,7 +8,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: ^8.12.0
+    version: ^8.13.0
   elastic:
     subscription: basic
 icons:

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: eset_protect
 title: ESET PROTECT
-version: 0.5.0
+version: 0.5.1
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:

--- a/packages/imperva_cloud_waf/_dev/build/build.yml
+++ b/packages/imperva_cloud_waf/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: "git@v8.11.0"
-    import_mappings: true

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Use modern ecs@mappings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9778
 - version: "0.3.0"
   changes:
     - description: Set sensitive values as secret, upgrade to package spec 3.0.3.

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -8,7 +8,7 @@ categories:
   - security
 conditions:
   kibana:
-    version: ^8.12.0
+    version: ^8.13.0
   elastic:
     subscription: basic
 screenshots:

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: 0.3.0
+version: 0.3.1
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/sentinel_one_cloud_funnel/_dev/build/build.yml
+++ b/packages/sentinel_one_cloud_funnel/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: "git@v8.11.0"
-    import_mappings: true

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.14.2"
+  changes:
+    - description: Use modern ecs@mappings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9778
 - version: "0.14.1"
   changes:
     - description: Add missing event preservation template expansions for GCS input.

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -7,7 +7,7 @@ type: integration
 categories: ["security", "edr_xdr"]
 conditions:
   kibana:
-    version: ^8.10.1
+    version: ^8.13.0
   elastic:
     subscription: basic
 screenshots:

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "0.14.1"
+version: "0.14.2"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]

--- a/packages/ti_crowdstrike/_dev/build/build.yml
+++ b/packages/ti_crowdstrike/_dev/build/build.yml
@@ -1,4 +1,3 @@
 dependencies:
   ecs:
     reference: git@v8.11.0
-    import_mappings: true

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.5"
+  changes:
+    - description: Use modern ecs@mappings.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9778
 - version: "0.5.4"
   changes:
     - description: Add the ECS mappings to be useful for threat Intel rules.

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -9,7 +9,7 @@ categories:
   - threat_intel
 conditions:
   kibana:
-    version: ^8.12.0
+    version: ^8.13.0
   elastic:
     subscription: basic
 screenshots:

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: 0.5.4
+version: 0.5.5
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[eset_protect][imperva_cloud_waf][sentinal_one_cloud_funnel][ti_crowdstrike] Use modern ecs@mappings (#)

- Remove `dependencies.ecs.import_mappings: true`.
- Set `8.13` as the minimum stack version.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #9192