### PR TITLE
Promote packages to GA

### DIFF
--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: eset_protect
 title: ESET PROTECT
-version: 0.5.0
+version: 1.0.0
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: 0.3.0
+version: 1.0.0
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: lumos
 title: "Lumos"
-version: 0.1.0
+version: 1.0.0
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:

--- a/packages/menlo/manifest.yml
+++ b/packages/menlo/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: menlo
 title: "Menlo Security"
-version: 0.1.0
+version: 1.0.0
 source:
   license: "Elastic-2.0"
 description: "Collect logs from Menlo Security products with Elastic Agent"

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "0.14.1"
+version: "1.0.0"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: 0.5.4
+version: 1.0.0
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: 0.3.0
+version: 1.0.0
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: 0.1.0
+version: 1.0.0
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
Promote packages to GA (#)

Promote the following packages to GA:
- eset_protect
- imperva_cloud_waf
- lumos
- menlo
- sentinel_one_cloud_funnel
- ti_crowdstrike
- ti_eclecticiq
- ti_eset
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Requires #9778
- Closes #9601