### PR TITLE
[Kubernetes] remove percent unit for the pod memory metrics that are reported in bytes

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.61.1
+  changes:
+    - description: Remove percent unit for pod memory metrics
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9736
 - version: 1.61.0
   changes:
     - description: Remove deprecated fields and add missing status.last_terminated_reason metric

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove percent unit for pod memory metrics
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9736
+      link: https://github.com/elastic/integrations/pull/9780
 - version: 1.61.0
   changes:
     - description: Remove deprecated fields and add missing status.last_terminated_reason metric

--- a/packages/kubernetes/data_stream/pod/fields/fields.yml
+++ b/packages/kubernetes/data_stream/pod/fields/fields.yml
@@ -97,7 +97,6 @@
             - name: bytes
               type: long
               format: bytes
-              unit: percent
               metric_type: gauge
               description: |
                 Total memory available
@@ -107,7 +106,6 @@
             - name: bytes
               type: long
               format: bytes
-              unit: percent
               metric_type: gauge
               description: |
                 Total working set memory
@@ -125,7 +123,6 @@
             - name: bytes
               type: long
               format: bytes
-              unit: percent
               metric_type: gauge
               description: |
                 Total resident set size memory

--- a/packages/kubernetes/docs/kubelet.md
+++ b/packages/kubernetes/docs/kubelet.md
@@ -741,14 +741,14 @@ An example event for `pod` looks as following:
 | kubernetes.pod.cpu.usage.nanocores | CPU used nanocores | long | byte | gauge |
 | kubernetes.pod.cpu.usage.node.pct | CPU usage as a percentage of the total node CPU | scaled_float | percent | gauge |
 | kubernetes.pod.ip | Kubernetes pod IP | ip |  |  |
-| kubernetes.pod.memory.available.bytes | Total memory available | long | percent | gauge |
+| kubernetes.pod.memory.available.bytes | Total memory available | long |  | gauge |
 | kubernetes.pod.memory.major_page_faults | Total major page faults | long |  | counter |
 | kubernetes.pod.memory.page_faults | Total page faults | long |  | counter |
-| kubernetes.pod.memory.rss.bytes | Total resident set size memory | long | percent | gauge |
+| kubernetes.pod.memory.rss.bytes | Total resident set size memory | long |  | gauge |
 | kubernetes.pod.memory.usage.bytes | Total memory usage | long | byte | gauge |
 | kubernetes.pod.memory.usage.limit.pct | Memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited) | scaled_float | percent | gauge |
 | kubernetes.pod.memory.usage.node.pct | Memory usage as a percentage of the total node allocatable memory | scaled_float | percent | gauge |
-| kubernetes.pod.memory.working_set.bytes | Total working set memory | long | percent | gauge |
+| kubernetes.pod.memory.working_set.bytes | Total working set memory | long |  | gauge |
 | kubernetes.pod.memory.working_set.limit.pct | Working set memory usage as a percentage of the defined limit for the pod containers (or total node allocatable memory if unlimited) | scaled_float | percent | gauge |
 | kubernetes.pod.name | Kubernetes pod name | keyword |  |  |
 | kubernetes.pod.network.rx.bytes | Received bytes | long | byte | counter |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.61.0
+version: 1.61.1
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

- WHAT: remove percent unit for the pod memory metrics that are reported in bytes
- WHY:  metrics are represented in kibana incorrectly when `unit: percent` is defined

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
