### PR TITLE
Add AWS Lambda Async metrics

### DIFF
--- a/packages/aws/changelog.yml
+++ b/packages/aws/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.15.0"
+  changes:
+    - description: Add async envent age and async event drops metrics, and implemented sum aggregation of a few existing lambda metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.14.2"
   changes:
     - description: Update aggregation function for AWS lambda invocation metric.

--- a/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
+++ b/packages/aws/data_stream/lambda/agent/stream/stream.yml.hbs
@@ -56,6 +56,8 @@ metrics:
   - IteratorAge
   - ConcurrentExecutions
   - UnreservedConcurrentExecutions
+  - AsyncEventAge
+  - AsyncEventsReceived
 - namespace: AWS/Lambda
   resource_type: lambda
   statistic: ["Maximum"]
@@ -69,3 +71,7 @@ metrics:
   - ProvisionedConcurrencyInvocations
   - ProvisionedConcurrencySpilloverInvocations
   - Invocations
+  - Throttles
+  - Errors
+  - DeadLetterErrors
+  - DestinationDeliveryFailures

--- a/packages/aws/data_stream/lambda/fields/fields.yml
+++ b/packages/aws/data_stream/lambda/fields/fields.yml
@@ -33,15 +33,27 @@
             - name: Errors.avg
               metric_type: gauge
               type: double
-              description: The number of invocations that result in a function error.
+              description: The average number of invocations that result in a function error.
+            - name: Errors.sum
+              metric_type: gauge
+              type: double
+              description: The total number of invocations that result in a function error.
             - name: DeadLetterErrors.avg
               type: double
               metric_type: gauge
-              description: For asynchronous invocation, the number of times Lambda attempts to send an event to a dead-letter queue but fails.
+              description: For asynchronous invocation, the average number of times Lambda attempts to send an event to a dead-letter queue but fails.
+            - name: DeadLetterErrors.sum
+              type: double
+              metric_type: gauge
+              description: For asynchronous invocation, the total number of times Lambda attempts to send an event to a dead-letter queue but fails.
             - name: DestinationDeliveryFailures.avg
               type: double
               metric_type: gauge
-              description: For asynchronous invocation, the number of times Lambda attempts to send an event to a destination but fails.
+              description: For asynchronous invocation, the average number of times Lambda attempts to send an event to a destination but fails.
+            - name: DestinationDeliveryFailures.sum
+              type: double
+              metric_type: gauge
+              description: For asynchronous invocation, the total number of times Lambda attempts to send an event to a destination but fails.
             - name: Duration.avg
               type: double
               metric_type: gauge
@@ -49,7 +61,11 @@
             - name: Throttles.avg
               type: double
               metric_type: gauge
-              description: The number of invocation requests that are throttled.
+              description: The average number of invocation requests that are throttled.
+            - name: Throttles.sum
+              type: double
+              metric_type: gauge
+              description: The total number of invocation requests that are throttled.
             - name: IteratorAge.avg
               type: double
               metric_type: gauge
@@ -78,6 +94,15 @@
               type: long
               metric_type: gauge
               description: The number of times your function code is executed on standard concurrency when all provisioned concurrency is in use.
+            - name: AsyncEventsReceived.avg
+              type: long
+              metric_type: gauge
+              description: The number of events that Lambda successfully queues for processing.
+            - name: AsyncEventAge.avg
+              type: long
+              unit: ms
+              metric_type: gauge
+              description: The time between whem Lambda successfully queues the event and when the function is invoked.
     - name: cloudwatch
       type: group
       fields:

--- a/packages/aws/docs/lambda.md
+++ b/packages/aws/docs/lambda.md
@@ -118,67 +118,73 @@ An example event for `lambda` looks as following:
 
 **Exported fields**
 
-| Field | Description | Type | Metric Type |
-|---|---|---|---|
-| @timestamp | Event timestamp. | date |  |
-| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |
-| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |
-| aws.dimensions.ExecutedVersion | Use the ExecutedVersion dimension to compare error rates for two versions of a function that are both targets of a weighted alias. | keyword |  |
-| aws.dimensions.FunctionName | Lambda function name. | keyword |  |
-| aws.dimensions.Resource | Resource name. | keyword |  |
-| aws.lambda.metrics.ConcurrentExecutions.avg | The number of function instances that are processing events. | double | gauge |
-| aws.lambda.metrics.DeadLetterErrors.avg | For asynchronous invocation, the number of times Lambda attempts to send an event to a dead-letter queue but fails. | double | gauge |
-| aws.lambda.metrics.DestinationDeliveryFailures.avg | For asynchronous invocation, the number of times Lambda attempts to send an event to a destination but fails. | double | gauge |
-| aws.lambda.metrics.Duration.avg | The amount of time that your function code spends processing an event. | double | gauge |
-| aws.lambda.metrics.Errors.avg | The number of invocations that result in a function error. | double | gauge |
-| aws.lambda.metrics.Invocations.avg | The average number of times your function code is executed, including successful executions and executions that result in a function error. | double | gauge |
-| aws.lambda.metrics.Invocations.sum | The total number of times your function code is executed, including successful executions and executions that result in a function error. | double | gauge |
-| aws.lambda.metrics.IteratorAge.avg | For event source mappings that read from streams, the age of the last record in the event. | double | gauge |
-| aws.lambda.metrics.ProvisionedConcurrencyInvocations.sum | The number of times your function code is executed on provisioned concurrency. | long | gauge |
-| aws.lambda.metrics.ProvisionedConcurrencySpilloverInvocations.sum | The number of times your function code is executed on standard concurrency when all provisioned concurrency is in use. | long | gauge |
-| aws.lambda.metrics.ProvisionedConcurrencyUtilization.max | For a version or alias, the value of ProvisionedConcurrentExecutions divided by the total amount of provisioned concurrency allocated. | long | gauge |
-| aws.lambda.metrics.ProvisionedConcurrentExecutions.max | The number of function instances that are processing events on provisioned concurrency. | long | gauge |
-| aws.lambda.metrics.Throttles.avg | The number of invocation requests that are throttled. | double | gauge |
-| aws.lambda.metrics.UnreservedConcurrentExecutions.avg | For an AWS Region, the number of events that are being processed by functions that don't have reserved concurrency. | double | gauge |
-| aws.tags | Tag key value pairs from aws resources. | flattened |  |
-| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |
-| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |
-| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |
-| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |
-| cloud.image.id | Image ID for the cloud instance. | keyword |  |
-| cloud.instance.id | Instance ID of the host machine. | keyword |  |
-| cloud.instance.name | Instance name of the host machine. | keyword |  |
-| cloud.machine.type | Machine type of the host machine. | keyword |  |
-| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |  |
-| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |
-| cloud.region | Region in which this host, resource, or service is located. | keyword |  |
-| container.id | Unique container id. | keyword |  |
-| container.image.name | Name of the image the container was built on. | keyword |  |
-| container.labels | Image labels. | object |  |
-| container.name | Container name. | keyword |  |
-| data_stream.dataset | Data stream dataset. | constant_keyword |  |
-| data_stream.namespace | Data stream namespace. | constant_keyword |  |
-| data_stream.type | Data stream type. | constant_keyword |  |
-| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |
-| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |  |
-| error.message | Error message. | match_only_text |  |
-| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | constant_keyword |  |
-| event.module | Event module | constant_keyword |  |
-| host.architecture | Operating system architecture. | keyword |  |
-| host.containerized | If the host is a container. | boolean |  |
-| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |
-| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |
-| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |
-| host.ip | Host ip addresses. | ip |  |
-| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |  |
-| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |  |
-| host.os.build | OS build information. | keyword |  |
-| host.os.codename | OS codename, if any. | keyword |  |
-| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |
-| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |
-| host.os.name | Operating system name, without the version. | keyword |  |
-| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |  |
-| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |
-| host.os.version | Operating system version as a raw string. | keyword |  |
-| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |
-| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |
+| Field | Description | Type | Unit | Metric Type |
+|---|---|---|---|---|
+| @timestamp | Event timestamp. | date |  |  |
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |  |  |
+| aws.cloudwatch.namespace | The namespace specified when query cloudwatch api. | keyword |  |  |
+| aws.dimensions.ExecutedVersion | Use the ExecutedVersion dimension to compare error rates for two versions of a function that are both targets of a weighted alias. | keyword |  |  |
+| aws.dimensions.FunctionName | Lambda function name. | keyword |  |  |
+| aws.dimensions.Resource | Resource name. | keyword |  |  |
+| aws.lambda.metrics.AsyncEventAge.avg | The time between whem Lambda successfully queues the event and when the function is invoked. | long | ms | gauge |
+| aws.lambda.metrics.AsyncEventsReceived.avg | The number of events that Lambda successfully queues for processing. | long |  | gauge |
+| aws.lambda.metrics.ConcurrentExecutions.avg | The number of function instances that are processing events. | double |  | gauge |
+| aws.lambda.metrics.DeadLetterErrors.avg | For asynchronous invocation, the average number of times Lambda attempts to send an event to a dead-letter queue but fails. | double |  | gauge |
+| aws.lambda.metrics.DeadLetterErrors.sum | For asynchronous invocation, the total number of times Lambda attempts to send an event to a dead-letter queue but fails. | double |  | gauge |
+| aws.lambda.metrics.DestinationDeliveryFailures.avg | For asynchronous invocation, the average number of times Lambda attempts to send an event to a destination but fails. | double |  | gauge |
+| aws.lambda.metrics.DestinationDeliveryFailures.sum | For asynchronous invocation, the total number of times Lambda attempts to send an event to a destination but fails. | double |  | gauge |
+| aws.lambda.metrics.Duration.avg | The amount of time that your function code spends processing an event. | double |  | gauge |
+| aws.lambda.metrics.Errors.avg | The average number of invocations that result in a function error. | double |  | gauge |
+| aws.lambda.metrics.Errors.sum | The total number of invocations that result in a function error. | double |  | gauge |
+| aws.lambda.metrics.Invocations.avg | The average number of times your function code is executed, including successful executions and executions that result in a function error. | double |  | gauge |
+| aws.lambda.metrics.Invocations.sum | The total number of times your function code is executed, including successful executions and executions that result in a function error. | double |  | gauge |
+| aws.lambda.metrics.IteratorAge.avg | For event source mappings that read from streams, the age of the last record in the event. | double |  | gauge |
+| aws.lambda.metrics.ProvisionedConcurrencyInvocations.sum | The number of times your function code is executed on provisioned concurrency. | long |  | gauge |
+| aws.lambda.metrics.ProvisionedConcurrencySpilloverInvocations.sum | The number of times your function code is executed on standard concurrency when all provisioned concurrency is in use. | long |  | gauge |
+| aws.lambda.metrics.ProvisionedConcurrencyUtilization.max | For a version or alias, the value of ProvisionedConcurrentExecutions divided by the total amount of provisioned concurrency allocated. | long |  | gauge |
+| aws.lambda.metrics.ProvisionedConcurrentExecutions.max | The number of function instances that are processing events on provisioned concurrency. | long |  | gauge |
+| aws.lambda.metrics.Throttles.avg | The average number of invocation requests that are throttled. | double |  | gauge |
+| aws.lambda.metrics.Throttles.sum | The total number of invocation requests that are throttled. | double |  | gauge |
+| aws.lambda.metrics.UnreservedConcurrentExecutions.avg | For an AWS Region, the number of events that are being processed by functions that don't have reserved concurrency. | double |  | gauge |
+| aws.tags | Tag key value pairs from aws resources. | flattened |  |  |
+| cloud | Fields related to the cloud or infrastructure the events are coming from. | group |  |  |
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | keyword |  |  |
+| cloud.account.name | The cloud account name or alias used to identify different entities in a multi-tenant environment. Examples: AWS account name, Google Cloud ORG display name. | keyword |  |  |
+| cloud.availability_zone | Availability zone in which this host, resource, or service is located. | keyword |  |  |
+| cloud.image.id | Image ID for the cloud instance. | keyword |  |  |
+| cloud.instance.id | Instance ID of the host machine. | keyword |  |  |
+| cloud.instance.name | Instance name of the host machine. | keyword |  |  |
+| cloud.machine.type | Machine type of the host machine. | keyword |  |  |
+| cloud.project.id | The cloud project identifier. Examples: Google Cloud Project id, Azure Project id. | keyword |  |  |
+| cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | keyword |  |  |
+| cloud.region | Region in which this host, resource, or service is located. | keyword |  |  |
+| container.id | Unique container id. | keyword |  |  |
+| container.image.name | Name of the image the container was built on. | keyword |  |  |
+| container.labels | Image labels. | object |  |  |
+| container.name | Container name. | keyword |  |  |
+| data_stream.dataset | Data stream dataset. | constant_keyword |  |  |
+| data_stream.namespace | Data stream namespace. | constant_keyword |  |  |
+| data_stream.type | Data stream type. | constant_keyword |  |  |
+| ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |  |  |
+| error | These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error. | group |  |  |
+| error.message | Error message. | match_only_text |  |  |
+| event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | constant_keyword |  |  |
+| event.module | Event module | constant_keyword |  |  |
+| host.architecture | Operating system architecture. | keyword |  |  |
+| host.containerized | If the host is a container. | boolean |  |  |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |  |  |
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |  |  |
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |  |  |
+| host.ip | Host ip addresses. | ip |  |  |
+| host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |  |  |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |  |  |
+| host.os.build | OS build information. | keyword |  |  |
+| host.os.codename | OS codename, if any. | keyword |  |  |
+| host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |  |  |
+| host.os.kernel | Operating system kernel version as a raw string. | keyword |  |  |
+| host.os.name | Operating system name, without the version. | keyword |  |  |
+| host.os.name.text | Multi-field of `host.os.name`. | match_only_text |  |  |
+| host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |  |  |
+| host.os.version | Operating system version as a raw string. | keyword |  |  |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |  |  |
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | keyword |  |  |

--- a/packages/aws/kibana/dashboard/aws-7ac8e1d0-28d2-11ea-ba6c-49a884eb104f.json
+++ b/packages/aws/kibana/dashboard/aws-7ac8e1d0-28d2-11ea-ba6c-49a884eb104f.json
@@ -170,9 +170,9 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 10,
+                    "h": 11,
                     "i": "443a9699-3451-44f7-8415-99a16c3f45b3",
-                    "w": 48,
+                    "w": 24,
                     "x": 0,
                     "y": 0
                 },
@@ -302,11 +302,11 @@
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 14,
+                    "h": 11,
                     "i": "349ef0d1-fea1-4b91-b95d-7a668914e10b",
-                    "w": 48,
-                    "x": 0,
-                    "y": 10
+                    "w": 24,
+                    "x": 24,
+                    "y": 0
                 },
                 "panelIndex": "349ef0d1-fea1-4b91-b95d-7a668914e10b",
                 "title": "Lambda Function Duration in Milliseconds",
@@ -448,7 +448,7 @@
                     "i": "048b1577-5aed-48e5-8f90-147aa3d56c1a",
                     "w": 24,
                     "x": 0,
-                    "y": 24
+                    "y": 11
                 },
                 "panelIndex": "048b1577-5aed-48e5-8f90-147aa3d56c1a",
                 "title": "Top Invoked Lambda Functions",
@@ -566,10 +566,316 @@
                     "i": "4c8e471c-45da-47be-a866-c5bfc6d28a05",
                     "w": 24,
                     "x": 24,
-                    "y": 24
+                    "y": 11
                 },
                 "panelIndex": "4c8e471c-45da-47be-a866-c5bfc6d28a05",
                 "title": "Top Throttled Lambda Functions",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-200980b4-a282-4f5a-91e0-6e030f28f46d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "200980b4-a282-4f5a-91e0-6e030f28f46d": {
+                                            "columnOrder": [
+                                                "eed1d46c-a334-4309-8cd6-d424a65797e2",
+                                                "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb",
+                                                "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b"
+                                            ],
+                                            "columns": {
+                                                "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Duration",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "duration",
+                                                            "params": {
+                                                                "decimals": 0,
+                                                                "fromUnit": "milliseconds",
+                                                                "toUnit": "asMilliseconds"
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.lambda.metrics.AsyncEventAge.avg"
+                                                },
+                                                "eed1d46c-a334-4309-8cd6-d424a65797e2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.FunctionName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.FunctionName"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b"
+                                        ],
+                                        "layerId": "200980b4-a282-4f5a-91e0-6e030f28f46d",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "eed1d46c-a334-4309-8cd6-d424a65797e2",
+                                        "xAccessor": "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "df524086-4f32-4f8d-8bec-ea6107472109",
+                    "w": 24,
+                    "x": 0,
+                    "y": 20
+                },
+                "panelIndex": "df524086-4f32-4f8d-8bec-ea6107472109",
+                "title": "Async Event Age",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-200980b4-a282-4f5a-91e0-6e030f28f46d",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "200980b4-a282-4f5a-91e0-6e030f28f46d": {
+                                            "columnOrder": [
+                                                "eed1d46c-a334-4309-8cd6-d424a65797e2",
+                                                "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb",
+                                                "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b"
+                                            ],
+                                            "columns": {
+                                                "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average Count",
+                                                    "operationType": "median",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 0
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "aws.lambda.metrics.AsyncEventsReceived.avg"
+                                                },
+                                                "eed1d46c-a334-4309-8cd6-d424a65797e2": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of aws.dimensions.FunctionName",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "aws.dimensions.FunctionName"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "e1d944d4-35e7-4ff3-b9b3-b1fe8a16f26b"
+                                        ],
+                                        "layerId": "200980b4-a282-4f5a-91e0-6e030f28f46d",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "bar_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "eed1d46c-a334-4309-8cd6-d424a65797e2",
+                                        "xAccessor": "bb7f37ec-64b9-4f4a-8a39-de422e7b91fb"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 15,
+                    "i": "bc4d39a4-b789-4fd0-937a-d3dd736caa76",
+                    "w": 24,
+                    "x": 24,
+                    "y": 20
+                },
+                "panelIndex": "bc4d39a4-b789-4fd0-937a-d3dd736caa76",
+                "title": "Async Events Received",
                 "type": "lens"
             }
         ],
@@ -578,7 +884,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-04-23T13:30:02.370Z",
+    "created_at": "2024-05-03T11:40:43.988Z",
     "id": "aws-7ac8e1d0-28d2-11ea-ba6c-49a884eb104f",
     "managed": false,
     "references": [
@@ -605,6 +911,16 @@
         {
             "id": "metrics-*",
             "name": "4c8e471c-45da-47be-a866-c5bfc6d28a05:indexpattern-datasource-layer-9f0dfc51-acc0-42b9-9f0e-af4e0cbcabb3",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "df524086-4f32-4f8d-8bec-ea6107472109:indexpattern-datasource-layer-200980b4-a282-4f5a-91e0-6e030f28f46d",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "bc4d39a4-b789-4fd0-937a-d3dd736caa76:indexpattern-datasource-layer-200980b4-a282-4f5a-91e0-6e030f28f46d",
             "type": "index-pattern"
         },
         {

--- a/packages/aws/manifest.yml
+++ b/packages/aws/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: aws
 title: AWS
-version: 2.14.2
+version: 2.15.0
 description: Collect logs and metrics from Amazon Web Services (AWS) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement


## Proposed commit message

- Add async event age and async event drops metrics. 
- Add sum aggregation metrics for Throttle, Errors, DeadLetterErrors, DestinationDeliveryFailures metrics. 
- Update Error dashboard with sum aggregation metrics
- Update dashboard with async event age and async event drop metrics

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] elastic-package build
- [x] elastic-package stack up -v -d --services package-registry
- [x] Dashboard data verification
- [x] Package upgrade verification
- [x] Index mapping verification

## How to test this PR locally

- elastic-package build
- elastic-package stack up -v -d --services package-registry

## Screenshots

<img width="1725" alt="Screenshot 2024-05-03 at 5 29 14 PM" src="https://github.com/elastic/integrations/assets/101976829/c138e634-41fe-44cd-9369-e9b6f2b7d779">

