### PR TITLE
[Azure_Functions] Remove `add_cloud_metadata` flag from the Agent config

### DIFF
--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.4.1
+  changes:
+    - description: Enable secrets for sensitive fields. For more details, refer https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-secret-values
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9790
 - version: 0.4.0
   changes:
     - description: Enable secrets for sensitive fields. For more details, refer https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-secret-values

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.4.1
   changes:
-    - description: Enable secrets for sensitive fields. For more details, refer https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-secret-values
+    - description: Remove Add Cloud Metadata flag from agent config.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9790
 - version: 0.4.0

--- a/packages/azure_functions/data_stream/metrics/agent/stream/stream.yml.hbs
+++ b/packages/azure_functions/data_stream/metrics/agent/stream/stream.yml.hbs
@@ -1,6 +1,5 @@
 metricsets: ["monitor"]
 default_resource_type: "Microsoft.Web/sites"
-add_cloud_metadata: true
 period: {{period}}
 {{#if client_id}}
 client_id: {{client_id}}

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.4.0"
+version: "0.4.1"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
The PR contains a change to remove the`add_cloud_metadata` flag. As seen from the [code](https://github.com/elastic/beats/blob/ff424ea42bbd9256725683354a41983d23957759/x-pack/metricbeat/module/azure/data.go#L285), if set to true, the metricset tries to look for a VM using a dimension value or the actual resource ID. This isn't required for Azure Functions. Hence, it is being removed.
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).