### PR TITLE
[Apache] Rename apache2.error.integration to apache.error.module

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.2"
+  changes:
+    - description: Rename field "apache2.error.integration" to "apache.error.module" in the Apache error visualizations.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9822
 - version: "1.17.1"
   changes:
     - description: Update grok for accepting user-identity.

--- a/packages/apache/kibana/dashboard/apache-Logs-Apache-Dashboard.json
+++ b/packages/apache/kibana/dashboard/apache-Logs-Apache-Dashboard.json
@@ -30,7 +30,7 @@
                     "columns": [
                         "source.address",
                         "log.level",
-                        "apache2.error.integration",
+                        "apache.error.module",
                         "message"
                     ],
                     "enhancements": {},

--- a/packages/apache/kibana/search/apache-errors-log.json
+++ b/packages/apache/kibana/search/apache-errors-log.json
@@ -3,7 +3,7 @@
         "columns": [
             "source.address",
             "log.level",
-            "apache2.error.integration",
+            "apache.error.module",
             "message"
         ],
         "description": "",

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apache
 title: Apache HTTP Server
-version: "1.17.1"
+version: "1.17.2"
 license: basic
 source:
   license: Elastic-2.0


### PR DESCRIPTION
## Proposed commit message

Rename `apache2.error.integration` to `apache.error.module`

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- https://github.com/elastic/beats/pull/39481 
- https://github.com/elastic/beats/issues/39480

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
