### PR TITLE
Skip ignored fields check for offending data streams

### DIFF
--- a/packages/activemq/data_stream/log/_dev/test/system/test-logfile-config.yml
+++ b/packages/activemq/data_stream/log/_dev/test/system/test-logfile-config.yml
@@ -1,5 +1,7 @@
 service: activemq
 input: logfile
+skip_ignored_fields:
+  - error.stack_trace
 data_stream:
   vars:
     paths:

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/system/test-default-config.yml
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/system/test-default-config.yml
@@ -1,4 +1,9 @@
 input: aws-s3
+skip_ignored_fields:
+  - crowdstrike.ConfigStateData
+  - crowdstrike.FeatureVector
+  - crowdstrike.OSVersionFileData
+  - process.command_line
 data_stream:
   vars:
     access_key_id: "{{AWS_ACCESS_KEY_ID}}"

--- a/packages/crowdstrike/data_stream/fdr/_dev/test/system/test-keep-metadata-config.yml
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/system/test-keep-metadata-config.yml
@@ -1,4 +1,9 @@
 input: aws-s3
+skip_ignored_fields:
+  - crowdstrike.ConfigStateData
+  - crowdstrike.FeatureVector
+  - crowdstrike.OSVersionFileData
+  - process.command_line
 data_stream:
   vars:
     access_key_id: "{{AWS_ACCESS_KEY_ID}}"

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-logfile-config.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-logfile-config.yml
@@ -1,5 +1,7 @@
 service: fortinet-fortimanager-logfile
 input: filestream
+skip_ignored_fields:
+  - fortimanager.log.changes
 data_stream:
   vars:
     paths:

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-tcp-config.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-tcp-config.yml
@@ -1,6 +1,8 @@
 service: fortinet-fortimanager-tcp
 service_notify_signal: SIGHUP
 input: tcp
+skip_ignored_fields:
+  - fortimanager.log.changes
 data_stream:
   vars:
     listen_address: 0.0.0.0

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-tls-config.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-tls-config.yml
@@ -1,6 +1,8 @@
 service: fortinet-fortimanager-tls
 service_notify_signal: SIGHUP
 input: tcp
+skip_ignored_fields:
+  - fortimanager.log.changes
 data_stream:
   vars:
     listen_address: 0.0.0.0

--- a/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-udp-config.yml
+++ b/packages/fortinet_fortimanager/data_stream/log/_dev/test/system/test-udp-config.yml
@@ -1,6 +1,8 @@
 service: fortinet-fortimanager-udp
 service_notify_signal: SIGHUP
 input: udp
+skip_ignored_fields:
+  - fortimanager.log.changes
 data_stream:
   vars:
     listen_address: 0.0.0.0

--- a/packages/m365_defender/data_stream/incident/_dev/test/system/test-default-config.yml
+++ b/packages/m365_defender/data_stream/incident/_dev/test/system/test-default-config.yml
@@ -1,5 +1,7 @@
 input: httpjson
 service: m365-defender-incident-http
+skip_ignored_fields:
+  - m365_defender.incident.alert.recommended_actions
 vars:
   login_url: http://{{Hostname}}:{{Port}}
   client_id: xxxx

--- a/packages/mysql/data_stream/slowlog/_dev/test/system/test-default-config.yml
+++ b/packages/mysql/data_stream/slowlog/_dev/test/system/test-default-config.yml
@@ -1,4 +1,6 @@
 vars: ~
+skip_ignored_fields:
+  - mysql.slowlog.query
 data_stream:
   vars:
     paths:

--- a/packages/oracle/data_stream/database_audit/_dev/test/system/test-logfile-config.yml
+++ b/packages/oracle/data_stream/database_audit/_dev/test/system/test-logfile-config.yml
@@ -1,6 +1,8 @@
 service: oracle-database-audit-logfile
 vars: ~
 input: filestream
+skip_ignored_fields:
+  - oracle.database_audit.action
 data_stream:
   vars:
     paths:

--- a/packages/panw/data_stream/panos/_dev/test/system/test-logfile-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-logfile-config.yml
@@ -1,5 +1,7 @@
 service: panw-logfile
 input: logfile
+skip_ignored_fields:
+  - panw.panos.after_change_detail
 data_stream:
   vars:
     preserve_original_event: true

--- a/packages/panw/data_stream/panos/_dev/test/system/test-tcp-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-tcp-config.yml
@@ -1,6 +1,8 @@
 service: panw-panos-tcp
 service_notify_signal: SIGHUP
 input: tcp
+skip_ignored_fields:
+  - panw.panos.after_change_detail
 data_stream:
   vars:
     syslog_host: 0.0.0.0

--- a/packages/panw/data_stream/panos/_dev/test/system/test-tls-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-tls-config.yml
@@ -1,6 +1,8 @@
 service: panw-panos-tls
 service_notify_signal: SIGHUP
 input: tcp
+skip_ignored_fields:
+  - panw.panos.after_change_detail
 data_stream:
   vars:
     syslog_host: 0.0.0.0

--- a/packages/panw/data_stream/panos/_dev/test/system/test-udp-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-udp-config.yml
@@ -1,6 +1,8 @@
 service: panw-panos-udp
 service_notify_signal: SIGHUP
 input: udp
+skip_ignored_fields:
+  - panw.panos.after_change_detail
 data_stream:
   vars:
     syslog_host: 0.0.0.0

--- a/packages/panw/data_stream/panos/_dev/test/system/test-udp-tz-config.yml
+++ b/packages/panw/data_stream/panos/_dev/test/system/test-udp-tz-config.yml
@@ -1,6 +1,8 @@
 service: panw-panos-udp
 service_notify_signal: SIGHUP
 input: udp
+skip_ignored_fields:
+  - panw.panos.after_change_detail
 data_stream:
   vars:
     syslog_host: 0.0.0.0

--- a/packages/spring_boot/data_stream/http_trace/_dev/test/system/test-default-config.yml
+++ b/packages/spring_boot/data_stream/http_trace/_dev/test/system/test-default-config.yml
@@ -1,4 +1,6 @@
 vars:
   hostname: http://springboot:8090
+skip_ignored_fields:
+  - host.ip
 data_stream:
   vars: ~

--- a/packages/tanium/data_stream/threat_response/_dev/test/system/test-http-endpoint-config.yml
+++ b/packages/tanium/data_stream/threat_response/_dev/test/system/test-http-endpoint-config.yml
@@ -1,6 +1,9 @@
 service: tanium-threat_response-http-endpoint
 service_notify_signal: SIGHUP
 input: http_endpoint
+skip_ignored_fields:
+  - tanium.threat_response.other_parameters.log_details.payload
+  - tanium.threat_response.other_parameters.original
 vars:
   listen_address: 0.0.0.0
 data_stream:

--- a/packages/tanium/data_stream/threat_response/_dev/test/system/test-tcp-config.yml
+++ b/packages/tanium/data_stream/threat_response/_dev/test/system/test-tcp-config.yml
@@ -1,6 +1,9 @@
 service: tanium-tcp-threat_response
 service_notify_signal: SIGHUP
 input: tcp
+skip_ignored_fields:
+  - tanium.threat_response.other_parameters.log_details.payload
+  - tanium.threat_response.other_parameters.original
 vars:
   listen_address: 0.0.0.0
 data_stream:

--- a/packages/tenable_io/data_stream/vulnerability/_dev/test/system/test-default-config.yml
+++ b/packages/tenable_io/data_stream/vulnerability/_dev/test/system/test-default-config.yml
@@ -1,5 +1,8 @@
 input: cel
 service: tenable_io
+skip_ignored_fields:
+  - tenable_io.vulnerability.plugin.description
+  - vulnerability.description
 vars:
   url: http://{{Hostname}}:{{Port}}
   access_key: xxxx

--- a/packages/ti_threatconnect/data_stream/indicator/_dev/test/system/test-default-config.yml
+++ b/packages/ti_threatconnect/data_stream/indicator/_dev/test/system/test-default-config.yml
@@ -1,5 +1,7 @@
 input: cel
 service: threatconnect-indicator
+skip_ignored_fields:
+  - threat_connect.indicator.tags.data.description
 vars:
   url: http://{{Hostname}}:{{Port}}
   access_id: "1234"


### PR DESCRIPTION
## Proposed commit message

https://github.com/elastic/elastic-package/pull/1738 is adding a check to `elastic-package` system tests to validate that no documents are degraded (which means at least one field didn't get indexed correctly and ended up ignored).

As there are [a bunch of existing issues](https://github.com/elastic/integrations/pull/9439) this check is highlighting (see https://github.com/elastic/integrations/issues/9696 and https://github.com/elastic/integrations/issues/9572), this PR is skipping the check for these fields to allow rolling out the check while fixing the issues in parallel.

This addition will currently have no effect at all, but will make sure the release of https://github.com/elastic/elastic-package/pull/1738 won't break the build for these packages.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] ~I have verified that all data streams collect metrics or logs.~
- [ ] ~I have added an entry to my package's `changelog.yml` file.~
- [ ] ~I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~
