### PR TITLE
Enable synthetic source for Elastic-Agent datastreams

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Enable synthetic source for Elastic-Agent datastreams
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/42
 - version: "1.19.0"
   changes:
     - description: Add queue full percentage fields

--- a/packages/elastic_agent/data_stream/apm_server_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/apm_server_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/auditbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/manifest.yml
@@ -5,3 +5,9 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic
+      properties:
+        decision_id:
+          type: text
+          store: true

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/manifest.yml
@@ -5,3 +5,9 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic
+      properties:
+        decision_id:
+          type: text
+          store: true

--- a/packages/elastic_agent/data_stream/elastic_agent_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_logs/manifest.yml
@@ -6,3 +6,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/endpoint_sercurity_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/endpoint_sercurity_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/filebeat_input_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_logs/manifest.yml
@@ -7,3 +7,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: true
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/filebeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/filebeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/fleet_server_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/heartbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/metricbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/osquerybeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/packetbeat_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/data_stream/pf_host_agent_logs/manifest.yml
+++ b/packages/elastic_agent/data_stream/pf_host_agent_logs/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+      _source:
+        mode: synthetic

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -3,7 +3,7 @@ title: Elastic Agent
 version: 1.20.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
-format_version: 1.0.0
+format_version: 3.1.4
 license: basic
 categories: ["elastic_stack"]
 conditions:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.19.0
+version: 1.20.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0
@@ -8,7 +8,7 @@ license: basic
 categories: ["elastic_stack"]
 conditions:
   kibana:
-    version: "^8.11.2"
+    version: "^8.15.0"
 owner:
   github: elastic/elastic-agent
 icons:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -8,7 +8,7 @@ license: basic
 categories: ["elastic_stack"]
 conditions:
   kibana:
-    version: "^8.15.0"
+    version: "^8.14.1"
 owner:
   github: elastic/elastic-agent
 icons:


### PR DESCRIPTION
## Proposed commit message

This commit enables the synthetic source for all Elastic-Agent datastreams except for `cloudbeat_logs` and `cloud_defend_logs` that are not compatible with synthetic source because they define a `decision_id` field as text.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist
 - [ ] Update `format-version` to `3.1.4` in a separated PR

## How to test this PR locally
1. Build the integration and bring up a stack with it
2. Go to Fleet, there should be no error/warning from Kibana.
3. Go to DevTools
4. Run the following query: `GET _component_template/logs-elastic_agent.*@package`
5. Ensure all component templates contain:
   ```
            "_source": {
              "mode": "synthetic"
            },
   ```

~~## Related issues~~
~~## Screenshots~~
