### PR TITLE
[Cloud Security] add the cloud formation credentials url

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 # version map:
+# 1.10.x - 8.15.x
 # 1.9.x - 8.14.x
 # 1.8.x - 8.13.x
 # 1.7.x - 8.12.x
@@ -8,6 +9,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.10.0-preview01"
+  changes:
+    - description: Add cloud formation template url to create direct access keys credentials
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9828
 - version: "1.9.0-preview05"
   changes:
     - description: Revert secret of textarea field

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,11 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-<<<<<<< HEAD
-version: "1.9.0-preview05"
-=======
 version: "1.10.0-preview01"
->>>>>>> f300b5a76e5 (add the cloud formation credentials url)
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -119,10 +115,7 @@ policy_templates:
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-<<<<<<< HEAD
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.14.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
-=======
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.13.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
           - name: cloud_formation_credentials_template
             type: text
             title: CloudFormation Credentials Template
@@ -132,7 +125,6 @@ policy_templates:
             description: Template URL to create cloud credentials to Create Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-direct-access-key-ACCOUNT-TYPE-8.14.0.yml
->>>>>>> f300b5a76e5 (add the cloud formation credentials url)
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -122,9 +122,9 @@ policy_templates:
             multi: false
             required: true
             show_user: false
-            description: Template URL to create cloud credentials to Create Stack
+            description: Template URL to Cloud Formation Cloud Credentials Stack 
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
-            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-direct-access-key-ACCOUNT-TYPE-8.14.0.yml
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-direct-access-key-ACCOUNT_TYPE-8.15.0.yml
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,11 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
+<<<<<<< HEAD
 version: "1.9.0-preview05"
+=======
+version: "1.10.0-preview01"
+>>>>>>> f300b5a76e5 (add the cloud formation credentials url)
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"
@@ -11,7 +15,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^8.14.0"
+    version: "^8.15.0"
   elastic:
     subscription: basic
     capabilities:
@@ -115,7 +119,20 @@ policy_templates:
             show_user: false
             description: Template URL to Cloud Formation Quick Create Stack
             # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+<<<<<<< HEAD
             default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.14.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+=======
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.13.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+          - name: cloud_formation_credentials_template
+            type: text
+            title: CloudFormation Credentials Template
+            multi: false
+            required: true
+            show_user: false
+            description: Template URL to create cloud credentials to Create Stack
+            # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+            default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-direct-access-key-ACCOUNT-TYPE-8.14.0.yml
+>>>>>>> f300b5a76e5 (add the cloud formation credentials url)
       - type: cloudbeat/cis_gcp
         title: GCP
         description: CIS Benchmark for Google Cloud Platform Foundations


### PR DESCRIPTION

## Proposed commit message
Add cloud formation credentials template url which help users create stack to automate direct access keys to copy and paste to input fields

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).




## Related issues

- Relates [#175977](https://github.com/elastic/kibana/issues/175977)


## Screenshots
<img width="890" alt="image" src="https://github.com/elastic/integrations/assets/17135495/d9b1a9d2-5cb5-4920-87d2-b346f8bf587f">
