### PR TITLE
ti_threatconnect: add error handling to API requests

### DIFF
--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.5.0"
+  changes:
+    - description: Add error handling to API requests.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9830
 - version: "0.4.0"
   changes:
     - description: Refactor CEL collection code.

--- a/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
+++ b/packages/ti_threatconnect/data_stream/indicator/agent/stream/cel.yml.hbs
@@ -72,51 +72,64 @@ program: |
               ],
               "Timestamp": [string(int(now))],
           }
-      }))).do_request().as(resp, bytes(resp.Body).decode_json().as(body, {
-          "events": body.data.map(e, {
-              "message": e.encode_json(),
-          }),
-          "url": state.url.trim_right("/"),
-          "counter": has(body.next) && body.next != null && body.next != "" ? int(state.counter) + int(state.batch) : 0,
-          "access_id": state.access_id,
-          "secret_key": state.secret_key,
-          "want_more": has(body.next) && body.next != null && body.next != "",
-          "batch": state.batch,
-          "initial_interval": state.initial_interval,
-          "event_list": state.event_list,
-          ?"tql_filter": state.?tql_filter,
-          "next_url": (
-              has(body.next) && body.next != null && body.next != "" ?
-                  state.url.trim_right("/") + "/api/v3/indicators?" + {
-                      "fields": state.event_list,
-                      "resultStart": [string(int(state.counter) + body.data.size())],
-                      "resultLimit": [string(state.batch)],
-                      "sorting": ["lastModified asc"],
-                      "tql": tql,
-                  }.format_query()
-              :
-                  state.url.trim_right("/")
-          ),
-          "cursor": {
-              ?"last_timestamp": (
-                  has(body.data) && body.data.size() > 0 ?
-                      optional.of(body.data.map(e, timestamp(e.lastModified)).max() + duration("1s"))
+      }))).do_request().as(resp, resp.StatusCode == 200 ?
+          bytes(resp.Body).decode_json().as(body, {
+              "events": body.data.map(e, {
+                  "message": e.encode_json(),
+              }),
+              "url": state.url.trim_right("/"),
+              "counter": has(body.next) && body.next != null && body.next != "" ? int(state.counter) + int(state.batch) : 0,
+              "access_id": state.access_id,
+              "secret_key": state.secret_key,
+              "want_more": has(body.next) && body.next != null && body.next != "",
+              "batch": state.batch,
+              "initial_interval": state.initial_interval,
+              "event_list": state.event_list,
+              ?"tql_filter": state.?tql_filter,
+              "next_url": (
+                  has(body.next) && body.next != null && body.next != "" ?
+                      state.url.trim_right("/") + "/api/v3/indicators?" + {
+                          "fields": state.event_list,
+                          "resultStart": [string(int(state.counter) + body.data.size())],
+                          "resultLimit": [string(state.batch)],
+                          "sorting": ["lastModified asc"],
+                          "tql": tql,
+                      }.format_query()
                   :
-                      state.?cursor.last_timestamp
+                      state.url.trim_right("/")
               ),
-              "first_timestamp": (
-                  has(body.data) && state.?cursor.first_timestamp.orValue(null) != null ?
-                      (
-                          has(body.next) && body.next != null && body.next != "" ?
-                              state.cursor.first_timestamp
-                          :
-                              state.cursor.last_timestamp
-                      )
-                  :
-                      string(now - duration(state.initial_interval))
-              ),
-          }
-      }))
+              "cursor": {
+                  ?"last_timestamp": (
+                      has(body.data) && body.data.size() > 0 ?
+                          optional.of(body.data.map(e, timestamp(e.lastModified)).max() + duration("1s"))
+                      :
+                          state.?cursor.last_timestamp
+                  ),
+                  "first_timestamp": (
+                      has(body.data) && state.?cursor.first_timestamp.orValue(null) != null ?
+                          (
+                              has(body.next) && body.next != null && body.next != "" ?
+                                  state.cursor.first_timestamp
+                              :
+                                  state.cursor.last_timestamp
+                          )
+                      :
+                          string(now - duration(state.initial_interval))
+                  ),
+              }
+          })
+      :
+          state.with({
+              "events": {
+                  "error": {
+                      "code": string(resp.StatusCode),
+                      "id": string(resp.Status),
+                      "message": string(resp.Body),
+                  },
+              },
+              "want_more": false,
+          })
+      )
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: 0.4.0
+version: 0.5.0
 description: Collect logs from ThreatConnect with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
All non-200 HTTP status codes are treated as error conditions. The ThreatConnect API docs[1] indicate that 200 and 201 are success codes used by their API, but this integration does not make use of object creation, so 201 is not handled here.

[1]https://docs.threatconnect.com/en/latest/rest_api/v3/http_status_codes.html

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

See title.

## Note

This has been manually tested by altering the system test deployment to be
```
rules:
  - path: /api/v3/indicators
    methods: ["GET"]
    query_params:
      resultStart: 0
      resultLimit: 2
    responses:
      - status_code: 401
        headers:
          Content-Type:
            - application/json
        body: |-
          {"error": "unauthorized"}
```
Running the system test then results in the following event, as expected.
```
{
  "@timestamp": "2024-05-10T00:00:33.092Z",
  "agent": {
    "ephemeral_id": "83e99073-f08a-477e-9ed5-992d452b7960",
    "id": "4a07add5-7ce8-434c-bd58-2b0c9027e21c",
    "name": "docker-fleet-agent",
    "type": "filebeat",
    "version": "8.13.0"
  },
  "data_stream": {
    "dataset": "ti_threatconnect.indicator",
    "namespace": "ep",
    "type": "logs"
  },
  "ecs": {
    "version": "8.11.0"
  },
  "elastic_agent": {
    "id": "4a07add5-7ce8-434c-bd58-2b0c9027e21c",
    "snapshot": false,
    "version": "8.13.0"
  },
  "error": {
    "code": "401",
    "id": "401 Unauthorized",
    "message": [
      "{\"error\": \"unauthorized\"}",
      "Processor json with tag json_event_original in pipeline logs-ti_threatconnect.indicator-0.5.0 failed with message: field [original] not present as part of path [event.original]"
    ]
  },
  "event": {
    "agent_id_status": "verified",
    "category": [
      "threat"
    ],
    "dataset": "ti_threatconnect.indicator",
    "ingested": "2024-05-10T00:00:45Z",
    "kind": [
      "enrichment",
      "pipeline_error"
    ],
    "type": [
      "indicator"
    ]
  },
  "input": {
    "type": "cel"
  },
  "tags": [
    "preserve_original_event",
    "forwarded",
    "threatconnect-indicator"
  ],
  "threat": {
    "indicator": {
      "provider": "ThreatConnect"
    }
  },
  "threat_connect": {
    "indicator": {
      "expiration_duration": "90d"
    }
  }
}
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #9829

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
