### PR TITLE
cef - add ignore_failure to community_id proc

### DIFF
--- a/packages/cef/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cef/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -106,6 +106,8 @@ processors:
       name: '{{ IngestPipeline "cp-pipeline" }}'
       tag: checkpoint pipeline
   - community_id:
+      ignore_missing: true
+      ignore_failure: true
       tag: community id processor
   # Ensure source.mac and destination.mac are formatted to ECS specifications.
   - gsub:


### PR DESCRIPTION
## Proposed commit message

Add `ignore_failure: true` to the community_id processor to prevent failures from skipping the execution of the remaining processors.

Fixes #9835

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Fixes #9835
