### PR TITLE
[Logstash] Add condition to Logstash cel streams

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.6"
+  changes:
+    - description: Fix support for conditions in Logstash cel inputs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9838
 - version: "2.4.5"
   changes:
     - description: Add plugin_id parsing for plain format logs

--- a/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
@@ -12,6 +12,9 @@ auth.basic.user: {{escape_string username}}
 {{#if password}}
 auth.basic.password: {{escape_string password}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 
 redact:
   fields: ~

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -12,6 +12,9 @@ auth.basic.user: {{escape_string username}}
 {{#if password}}
 auth.basic.password: {{escape_string password}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 
 redact:
   fields: ~

--- a/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/plugins/agent/stream/cel.yml.hbs
@@ -12,6 +12,9 @@ auth.basic.user: {{escape_string username}}
 {{#if password}}
 auth.basic.password: {{escape_string password}}
 {{/if}}
+{{#if condition}}
+condition: {{ condition }}
+{{/if}}
 
 redact:
   fields: ~

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.5
+version: 2.4.6
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
While `condition` is an option for the Logstash cel-based metrics, the condition parameter was not specified in the stream definitions.

Fixes: #9800
