### PR TITLE
[Universal profiling collector] partially revert use of secrets variables

### DIFF
--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: 8.14.0
-  changes:
-    - description: Use secret variables
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/9806
 - version: 8.12.0
   changes:
     - description: Allow customization of telemetry configuration

--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Do not use secrets variables
       type: bugfix
-      link: 
+      link: https://github.com/elastic/integrations/pull/9848 
 - version: 8.14.0
   changes:
     - description: Use secret variables

--- a/packages/universal_profiling_collector/changelog.yml
+++ b/packages/universal_profiling_collector/changelog.yml
@@ -1,4 +1,14 @@
 # newer versions go on top
+- version: 8.14.1
+  changes:
+    - description: Do not use secrets variables
+      type: bugfix
+      link: 
+- version: 8.14.0
+  changes:
+    - description: Use secret variables
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9806
 - version: 8.12.0
   changes:
     - description: Allow customization of telemetry configuration

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -1,6 +1,6 @@
 name: profiler_collector
 title: Universal Profiling Collector
-version: 8.12.0
+version: 8.14.1
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -6,7 +6,7 @@ description: Fleet-wide, whole-system, continuous profiling with zero instrument
 conditions:
   kibana.version: ^8.12.0
   elastic.subscription: basic
-format_version: 2.8.0
+format_version: "3.0.2"
 icons:
   - size: 48x46
     src: /img/profiler-logo-color-48px.svg
@@ -64,6 +64,7 @@ policy_templates:
             type: text
           - name: tls_key_passphrase
             type: text
+            secret: true
           - name: tls_supported_protocols
             type: text
             multi: true
@@ -88,3 +89,4 @@ policy_templates:
 type: integration
 owner:
   github: elastic/profiling
+  type: elastic

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -52,6 +52,10 @@ policy_templates:
               The default value ("") applies a memory limit of 25% of the available memory.
           - name: secret_token
             type: text
+            # NOTE: this field is identified as a potential secret
+            # We are not setting this to true due an open bug.
+            # See https://github.com/elastic/integrations/issues/9845
+            secret: false
             required: true
             description: |
               A sequence of characters used to authenticate the Universal Profiling agents' requests to this component

--- a/packages/universal_profiling_collector/manifest.yml
+++ b/packages/universal_profiling_collector/manifest.yml
@@ -1,12 +1,12 @@
 name: profiler_collector
 title: Universal Profiling Collector
-version: 8.14.0
+version: 8.12.0
 categories: ["elastic_stack", "monitoring"]
 description: Fleet-wide, whole-system, continuous profiling with zero instrumentation.
 conditions:
   kibana.version: ^8.12.0
   elastic.subscription: basic
-format_version: "3.0.2"
+format_version: 2.8.0
 icons:
   - size: 48x46
     src: /img/profiler-logo-color-48px.svg
@@ -53,7 +53,6 @@ policy_templates:
           - name: secret_token
             type: text
             required: true
-            secret: true
             description: |
               A sequence of characters used to authenticate the Universal Profiling agents' requests to this component
           - name: tls_enabled
@@ -65,7 +64,6 @@ policy_templates:
             type: text
           - name: tls_key_passphrase
             type: text
-            secret: true
           - name: tls_supported_protocols
             type: text
             multi: true
@@ -90,4 +88,3 @@ policy_templates:
 type: integration
 owner:
   github: elastic/profiling
-  type: elastic


### PR DESCRIPTION
## Proposed commit message

This partially reverts commit 188bf87, "[Universal profiling collector] use secrets variables (#9806)"
Provide a temporary fix for #9845 by removing `secrets: true` from `secret_token` integration setting introduced in #9806.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- #8610

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
