### PR TITLE
[windows] Set sensitive values as secret

### DIFF
--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.45.0"
+  changes:
+    - description: Set sensitive values as secret.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.44.5"
   changes:
     - description: Fix splitting of parameters for event 600 where it can hold multiline values in parameters.

--- a/packages/windows/data_stream/forwarded/fields/ecs.yml
+++ b/packages/windows/data_stream/forwarded/fields/ecs.yml
@@ -11,8 +11,6 @@
 - external: ecs
   name: destination.user.name
 - external: ecs
-  name: dns.answers
-- external: ecs
   name: dns.answers.class
 - external: ecs
   name: dns.answers.data

--- a/packages/windows/data_stream/forwarded/fields/fields.yml
+++ b/packages/windows/data_stream/forwarded/fields/fields.yml
@@ -76,30 +76,31 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: array
+      type: group
       description: >
         An array of objects containing detailed information of the executed command.
 
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
 
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
 
-      example: System.IO.Compression.FileSystem
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/data_stream/powershell/fields/fields.yml
+++ b/packages/windows/data_stream/powershell/fields/fields.yml
@@ -38,30 +38,31 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: array
+      type: group
       description: >
         An array of objects containing detailed information of the executed command.
 
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
 
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
 
-      example: System.IO.Compression.FileSystem
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/data_stream/powershell_operational/fields/fields.yml
+++ b/packages/windows/data_stream/powershell_operational/fields/fields.yml
@@ -38,30 +38,31 @@
       description: The invoked command.
       example: Import-LocalizedData  LocalizedData -filename ArchiveResources
     - name: invocation_details
-      type: array
+      type: group
       description: >
         An array of objects containing detailed information of the executed command.
 
-    - name: invocation_details.type
-      type: keyword
-      description: The type of detail.
-      example: CommandInvocation
-    - name: invocation_details.related_command
-      type: keyword
-      description: The command to which the detail is related to.
-      example: Add-Type
-    - name: invocation_details.name
-      type: keyword
-      description: >
-        Only used for ParameterBinding detail type. Indicates the parameter name.
+      fields:
+        - name: type
+          type: keyword
+          description: The type of detail.
+          example: CommandInvocation
+        - name: related_command
+          type: keyword
+          description: The command to which the detail is related to.
+          example: Add-Type
+        - name: name
+          type: keyword
+          description: >
+            Only used for ParameterBinding detail type. Indicates the parameter name.
 
-      example: AssemblyName
-    - name: invocation_details.value
-      type: text
-      description: >
-        The value of the detail. The meaning of it will depend on the detail type.
+          example: AssemblyName
+        - name: value
+          type: text
+          description: >
+            The value of the detail. The meaning of it will depend on the detail type.
 
-      example: System.IO.Compression.FileSystem
+          example: System.IO.Compression.FileSystem
 - name: powershell.connected_user
   type: group
   fields:

--- a/packages/windows/docs/README.md
+++ b/packages/windows/docs/README.md
@@ -1756,7 +1756,6 @@ An example event for `powershell` looks as following:
 | input.type | Type of Filebeat input. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
-| powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | array |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
 | powershell.command.invocation_details.type | The type of detail. | keyword |
@@ -2093,7 +2092,6 @@ An example event for `powershell_operational` looks as following:
 | input.type | Type of Filebeat input. | keyword |
 | log.level | Original log level of the log event. If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity). Some examples are `warn`, `err`, `i`, `informational`. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
-| powershell.command.invocation_details | An array of objects containing detailed information of the executed command. | array |
 | powershell.command.invocation_details.name | Only used for ParameterBinding detail type. Indicates the parameter name. | keyword |
 | powershell.command.invocation_details.related_command | The command to which the detail is related to. | keyword |
 | powershell.command.invocation_details.type | The type of detail. | keyword |

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.44.5
+version: 1.45.0
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:
@@ -11,9 +11,7 @@ icons:
     title: logo windows
     size: 32x32
     type: image/svg+xml
-format_version: 1.0.0
-license: basic
-release: ga
+format_version: 2.9.0
 conditions:
   kibana:
     version: "^8.8.0"
@@ -65,6 +63,7 @@ policy_templates:
             title: Splunk REST API Password
             show_user: true
             required: false
+            secret: true
           - name: token
             type: password
             title: Splunk Authorization Token
@@ -74,6 +73,7 @@ policy_templates:
               and password.
             show_user: true
             required: false
+            secret: true
           - name: ssl
             type: yaml
             title: SSL Configuration


### PR DESCRIPTION
## Proposed commit message

- Marked sensitive config values as secret
- Updated package format to 2.9.0. Unfortunately, cannot go higher than this due to dynamic metrics fields in perfmon
- Fixed field definitions per package spec

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/windows
elastic-package test
```

## Related issues

- TODO
