### PR TITLE
[cisco_ios] fix timezone with offset parsing

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.7"
+  changes:
+    - description: Fix parsing timezone with offset
+      type: bugfix
+      link: https://github.com/elastic/integrations/pulls/9890
 - version: "1.26.6"
   changes:
     - description: Fix handling of ACCESSLOGSP logs

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log
@@ -2,6 +2,7 @@
 <189>: Jan  6 2022 20:54:26.961: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
 <190>: Jan  6 2022 20:55:50.671: %SEC-6-IPACCESSLOGDP: list 100 denied icmp 172.16.0.26 -> 10.100.8.34 (3/3), 20 packets
 <189>: sw01: Jan  6 2022 21:01:34.964: %SYS-5-CONFIG_I: Configured from console by akroh on vty0 (10.100.11.10)
+<189>387448: host-01: May 6 16:13:09.123 UTC+1: %DOT1X-5-FAIL: Authentication failed for client (001e.0b80.13b5) on Interface Gi1/0/16 AuditSessionID 000000000000011D51B826E5
 <191>2637085: rt401-rk30409: Aug 18 07:15:04.461 CEST: NTP Core (NOTICE): Clock synchronization lost.
 <191>2637086: rt401-rk30409: Aug 18 07:15:04.461 CEST: NTP Core (INFO): 10.200.1.105 961A 8A sys_peer
 <191>2637087: rt401-rk30409: Aug 18 07:15:04.461 CEST: NTP Core (NOTICE): Clock is synchronized.

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog.log-expected.json
@@ -188,6 +188,48 @@
             ]
         },
         {
+            "@timestamp": "2024-05-06T16:13:09.123Z",
+            "cisco": {
+                "ios": {
+                    "facility": "DOT1X",
+                    "message_count": 387448
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "FAIL",
+                "original": "<189>387448: host-01: May 6 16:13:09.123 UTC+1: %DOT1X-5-FAIL: Authentication failed for client (001e.0b80.13b5) on Interface Gi1/0/16 AuditSessionID 000000000000011D51B826E5",
+                "provider": "firewall",
+                "sequence": 387448,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "host-01",
+                    "priority": 189
+                }
+            },
+            "message": "Authentication failed for client (001e.0b80.13b5) on Interface Gi1/0/16 AuditSessionID 000000000000011D51B826E5",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2024-08-18T07:15:04.461Z",
             "cisco": {
                 "ios": {

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -43,7 +43,7 @@ processors:
         CISCO_TIMESTAMP: '[*]?%{CISCOTIMESTAMP:_temp_.cisco_timestamp}(?: %{CISCO_TZ:_temp_.tz})?'
         CISCO_UPTIME: '[0-9a-zA-Z]+'
         CISCO_HOSTNAME: '[a-zA-Z][0-9a-zA-Z_-]{0,61}[0-9a-zA-Z]?'
-        CISCO_TZ: '[a-zA-Z]{1,4}'
+        CISCO_TZ: '[a-zA-Z]{1,4}([+-]\d{1,2}|[+-]\d{2}:\d{2)?'
   - grok:
       field: _temp_.message
       tag: grok_message

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.26.6"
+version: "1.26.7"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR fixes parsing issues with syslog messages that contain a timezone with offset in their timestamp

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
`elastic-package test pipeline -v`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/9857

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->

N/A