### PR TITLE
[System] Mark `logs-system.syslog` data stream as requires root

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Mark logs-system.syslog data stream as requires root
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9515
+      link: https://github.com/elastic/integrations/pull/9893
 - version: "1.57.0"
   changes:
     - description: Adjust `winlog.event_data.AttributeValue` ignore_above parameter and add wildcard multi-field.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.58.0"
+  changes:
+    - description: Mark logs-system.syslog data stream as requires root
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9515
 - version: "1.57.0"
   changes:
     - description: Adjust `winlog.event_data.AttributeValue` ignore_above parameter and add wildcard multi-field.

--- a/packages/system/data_stream/application/manifest.yml
+++ b/packages/system/data_stream/application/manifest.yml
@@ -62,7 +62,6 @@ streams:
         default: |-
           # Winlog configuration example
           #batch_read_size: 100
-
   - input: httpjson
     title: Windows Application Events via Splunk Enterprise REST API
     description: Collect Application Events via Splunk Enterprise REST API

--- a/packages/system/data_stream/process/fields/fields.yml
+++ b/packages/system/data_stream/process/fields/fields.yml
@@ -14,6 +14,7 @@
       type: integer
       description: >
         Number of threads in the process
+
     - name: env
       type: flattened
       description: |

--- a/packages/system/data_stream/security/manifest.yml
+++ b/packages/system/data_stream/security/manifest.yml
@@ -62,7 +62,6 @@ streams:
         default: |-
           # Winlog configuration example
           #batch_read_size: 100
-
   - input: httpjson
     title: Windows Security Events via Splunk Enterprise REST API
     description: Collect Security Events via Splunk Enterprise REST API

--- a/packages/system/data_stream/syslog/manifest.yml
+++ b/packages/system/data_stream/syslog/manifest.yml
@@ -54,3 +54,6 @@ streams:
     template_path: log.yml.hbs
     title: System syslog logs (log)
     description: Collect System syslog logs using log input
+agent:
+  privileges:
+    root: true

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 3.0.2
 name: system
 title: System
-version: 1.57.0
+version: 1.58.0
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:
   - os_system
 conditions:
   kibana:
-    version: '^8.12.0'
+    version: "^8.12.0"
 screenshots:
   - src: /img/system-overview.png
     title: system overview


### PR DESCRIPTION
## Proposed commit message

Mark logs-system.syslog data stream as requires root

Reading syslog files requires root, so if this data stream is in use the agent will require root privileges. Adding `agent.privileges.root: true` makes Fleet/Agent aware of the requirement for escalated privileges. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Run an agent with the system integration and verify it collects data when run as a root user. I don't think the majority of the non-root agent work is "wired up" so there won't be anything obvious to test at this time. See https://github.com/elastic/kibana/pull/183283. 

## Related issues

Closes https://github.com/elastic/integrations/issues/9886
