### PR TITLE
Add component values to endpoint metrics

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.1"
+  changes:
+    - description: component values to endpoint metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9765
 - version: "1.19.0"
   changes:
     - description: Add queue full percentage fields

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -21,3 +21,15 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+- name: component
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      ignore_above: 1024
+      description: Component id
+    - name: binary
+      type: keyword
+      ignore_above: 1024
+      description: The binary that exeuctes the component
+      example: filebeat

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.19.0
+version: 1.19.1
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

Needed for https://github.com/elastic/elastic-agent/issues/4083

This adds  `component.*` values used by the agent metrics to monitor the beats. We have these values for all the other beats, but they're missing for endpoint.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
~~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~~
