### PR TITLE
[cisco_asa] Add support for spaces in group and user names

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.34.1"
+  changes:
+    - description: Add support for spaces in group and user names.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.34.0"
   changes:
     - description: Improve ECS categorizations.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -104,6 +104,7 @@ May  5 19:02:25 dev01: %ASA-6-716039: Authentication: rejected, group = malcorp 
 May  5 19:02:25 dev01: %ASA-6-716039: Authentication: rejected, group = malcorp user = malory , Session Type: WebVPN
 May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp> User <eve> IP <172.31.98.44> Authentication: rejected, Session Type: Admin.
 May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp> User <malory> IP <172.31.98.44> Authentication: rejected, Session Type: WebVPN.
+May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <172.31.98.44> Authentication: rejected, Session Type: WebVPN.
 <190>Mar 03 2023 09:01:16 sac-firewall : %ASA-6-113004: AAA user accounting Successful : server =  192.168.0.8 : user = sample-user
 <190>Mar 03 2023 08:50:32 sac-firewall : %ASA-6-113012: AAA user authentication Successful : local database : user = sample.user
 <190>Mar 03 2023 09:13:09 sac-firewall : %ASA-6-716039: Group <DfltGrpPolicy> User <*****> IP <192.168.0.8> Authentication: rejected, Session Type: WebVPN.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -7374,6 +7374,70 @@
             ]
         },
         {
+            "@timestamp": "2024-05-05T19:02:25.000Z",
+            "cisco": {
+                "asa": {
+                    "session_type": "WebVPN"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "716039",
+                "kind": "event",
+                "original": "May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <172.31.98.44> Authentication: rejected, Session Type: WebVPN.",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "dev01"
+            },
+            "log": {
+                "level": "informational"
+            },
+            "observer": {
+                "hostname": "dev01",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "dev01"
+                ],
+                "ip": [
+                    "172.31.98.44"
+                ],
+                "user": [
+                    "malory"
+                ]
+            },
+            "source": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44",
+                "user": {
+                    "group": {
+                        "name": "malcorp group"
+                    },
+                    "name": "malory"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2023-03-03T09:01:16.000Z",
             "cisco": {
                 "asa": {

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log
@@ -12,3 +12,4 @@ Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-6-113039: Group VPN_USERS Use
 Oct 10 2018 12:34:56 localhost CiscoASA[999]: %ASA-4-113040: Terminating the VPN connection attempt from VPN_USERS. Reason: This connection is group locked to OTHER_VPN_USERS.
 <166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy_Remote-VPN> User <user-1> IP <81.2.69.144> AnyConnect parent session started.
 <166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy_Remote-VPN> User <first.o'last@example.com> IP <81.2.69.144> AnyConnect parent session started.
+<166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy Remote-VPN> User <first.o'last@example.com> IP <81.2.69.144> AnyConnect parent session started.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-anyconnect-messages.log-expected.json
@@ -1002,6 +1002,89 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2022-06-22T13:29:11.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-connected",
+                "category": [
+                    "network",
+                    "session"
+                ],
+                "code": "113039",
+                "kind": "event",
+                "original": "<166>Jun 22 2022 13:29:11 single : %ASA-6-113039: Group <GroupPolicy Remote-VPN> User <first.o'last@example.com> IP <81.2.69.144> AnyConnect parent session started.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "single"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "single",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "single",
+                    "example.com"
+                ],
+                "ip": [
+                    "81.2.69.144"
+                ],
+                "user": [
+                    "first.o'last"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "user": {
+                    "domain": "example.com",
+                    "email": "first.o'last@example.com",
+                    "group": {
+                        "name": "GroupPolicy Remote-VPN"
+                    },
+                    "name": "first.o'last"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log
@@ -3,12 +3,17 @@ Oct 20 2019 15:42:53: %ASA-4-113019: Group = TheBeatles, Username = John, IP = 6
 Oct 20 2019 15:42:54: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Paul> IP <81.2.69.142> SVC closing connection: DPD failure.
 Aug  6 2020 11:01:37: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Brian> IP <234.63.56.32> SVC closing connection: Transport closing.
 Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy_TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session
+Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session
 Oct 20 2021 16:41:52: %ASA-4-722011: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> SVC Message: 17/WARNING: Reconnecting the VPN tunnel..
+Oct 20 2021 16:41:52: %ASA-4-722011: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> SVC Message: 17/WARNING: Reconnecting the VPN tunnel..
 <190>Jan 24 2024 15:24:40 XYZhost1 : %ASA-6-722022: Group <MY-MFA> User <src_user@myorg.com> IP <67.43.156.118> TCP SVC connection established without compression
 <190>Jan 24 2024 15:25:23 XYZhost1 : %ASA-6-722023: Group <MGMT_Tunnel> User <src_user@myorg.com> IP <81.2.69.142> UDP SVC connection terminated without compression
 <190>Feb 21 2024 09:53:46 xxxxxx : %ASA-6-722022: Group MY-MFA User myuser@email.com IP 192.168.0.12 UDP SVC connection established without compression
 <190>Feb 21 2024 09:55:01 xxxxxx: %ASA-6-722023: Group MGMT_Tunnel User my123.org.com IP 192.168.0.228 UDP SVC connection terminated without compression
 Oct 20 2021 16:41:52: %ASA-4-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First UDP SVC connection established for SVC session.
 Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.
+Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.
 Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.
 Oct 20 2021 16:41:52: %ASA-4-722037: Group <GroupPolicy_Employee> User <foo.bar@example.com> IP <192.168.0.1> SVC closing connection: DPD failure.
+Oct 20 2021 16:41:52: %ASA-4-722037: Group <GroupPolicy Employee> User <foo.bar@example.com> IP <192.168.0.1> SVC closing connection: DPD failure.
+Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -333,6 +333,74 @@
             ]
         },
         {
+            "@timestamp": "2020-08-06T11:01:38.000Z",
+            "cisco": {
+                "asa": {
+                    "assigned_ip": "67.43.156.12"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "address-assigned",
+                "category": [
+                    "network"
+                ],
+                "code": "722051",
+                "kind": "event",
+                "original": "Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
+                "outcome": "success",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "67.43.156.12"
+                ],
+                "user": [
+                    "George"
+                ]
+            },
+            "source": {
+                "address": "67.43.156.12",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.12",
+                "user": {
+                    "group": {
+                        "name": "GroupPolicy TheBeatles"
+                    },
+                    "name": "George"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2021-10-20T16:41:52.000Z",
             "ecs": {
                 "version": "8.11.0"
@@ -373,6 +441,55 @@
                 "user": {
                     "group": {
                         "name": "GroupPolicy_Employee"
+                    },
+                    "name": "464_0273"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2021-10-20T16:41:52.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722011",
+                "kind": "event",
+                "original": "Oct 20 2021 16:41:52: %ASA-4-722011: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> SVC Message: 17/WARNING: Reconnecting the VPN tunnel..",
+                "reason": "17/WARNING: Reconnecting the VPN tunnel.",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.1"
+                ],
+                "user": [
+                    "464_0273"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.1",
+                "ip": "192.168.0.1",
+                "user": {
+                    "group": {
+                        "name": "GroupPolicy Employee"
                     },
                     "name": "464_0273"
                 }
@@ -799,6 +916,60 @@
                 "category": [
                     "network"
                 ],
+                "code": "722033",
+                "kind": "event",
+                "original": "Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.",
+                "outcome": "success",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "notification"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.1"
+                ],
+                "user": [
+                    "464_0273"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.1",
+                "ip": "192.168.0.1",
+                "user": {
+                    "group": {
+                        "name": "GroupPolicy Employee"
+                    },
+                    "name": "464_0273"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2021-10-20T16:41:52.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
                 "code": "722034",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.",
@@ -892,6 +1063,114 @@
                         "name": "GroupPolicy_Employee"
                     },
                     "name": "foo.bar"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2021-10-20T16:41:52.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722037",
+                "kind": "event",
+                "original": "Oct 20 2021 16:41:52: %ASA-4-722037: Group <GroupPolicy Employee> User <foo.bar@example.com> IP <192.168.0.1> SVC closing connection: DPD failure.",
+                "reason": "DPD failure",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "log": {
+                "level": "warning"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "example.com"
+                ],
+                "ip": [
+                    "192.168.0.1"
+                ],
+                "user": [
+                    "foo.bar"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.1",
+                "ip": "192.168.0.1",
+                "user": {
+                    "domain": "example.com",
+                    "email": "foo.bar@example.com",
+                    "group": {
+                        "name": "GroupPolicy Employee"
+                    },
+                    "name": "foo.bar"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2021-10-20T16:41:52.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722034",
+                "kind": "event",
+                "original": "Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning"
+            },
+            "network": {
+                "iana_number": "6",
+                "transport": "tcp"
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "192.168.0.1"
+                ],
+                "user": [
+                    "464_0273"
+                ]
+            },
+            "source": {
+                "address": "192.168.0.1",
+                "ip": "192.168.0.1",
+                "user": {
+                    "group": {
+                        "name": "GroupPolicy Employee"
+                    },
+                    "name": "464_0273"
                 }
             },
             "tags": [

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -430,7 +430,7 @@ processors:
       field: "message"
       description: "113029, 113030, 113031, 113032, 113033, 113034, 113035, 113036, 113038, 113039"
       patterns:
-      - "Group <%{NOTSPACE:source.user.group.name}> User <%{CISCO_USER:source.user.name}> IP <%{IP:source.address}>"
+      - "Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}>"
       - "Group %{NOTSPACE:source.user.group.name} User %{CISCO_USER:source.user.name} IP %{IP:source.address}"
       pattern_definitions:
         HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z\\-_]{0,62}))*(\\.?|\\b)"
@@ -865,7 +865,7 @@ processors:
       field: "message"
       description: "716002"
       patterns:
-        - "Group <%{NOTSPACE:_temp_.cisco.webvpn.group_name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> WebVPN session terminated: %{GREEDYDATA:event.reason}."
+        - "Group <%{DATA:_temp_.cisco.webvpn.group_name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> WebVPN session terminated: %{GREEDYDATA:event.reason}."
         - "Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} WebVPN session terminated: %{GREEDYDATA:event.reason}."
   - grok:
       if: "ctx._temp_.cisco.message_id == '722011'"
@@ -873,7 +873,7 @@ processors:
       field: "message"
       description: "722011"
       patterns:
-        - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> SVC Message: %{GREEDYDATA:event.reason}\.'
+        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> SVC Message: %{GREEDYDATA:event.reason}\.'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC Message: %{GREEDYDATA:event.reason}\.'
   - grok:
       if: '["722022", "722023"].contains(ctx._temp_.cisco.message_id)'
@@ -881,7 +881,7 @@ processors:
       field: "message"
       description: "722022, 722023"
       patterns:
-        - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> %{GREEDYDATA:event.reason}'
+        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> %{GREEDYDATA:event.reason}'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} %{GREEDYDATA:event.reason}'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722033'"
@@ -889,7 +889,7 @@ processors:
       field: "message"
       description: "722033"
       patterns:
-        - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
+        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722034'"
@@ -897,7 +897,7 @@ processors:
       field: "message"
       description: "722034"
       patterns:
-        - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
+        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722037'"
@@ -905,7 +905,7 @@ processors:
       field: "message"
       description: "722037"
       patterns:
-        - 'Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> SVC closing connection: %{GREEDYDATA:event.reason}\.'
+        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> SVC closing connection: %{GREEDYDATA:event.reason}\.'
         - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC closing connection: %{GREEDYDATA:event.reason}\.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722051'"
@@ -913,7 +913,7 @@ processors:
       field: "message"
       description: "722051"
       patterns:
-        - "Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> IPv4 Address <%{IP:_temp_.cisco.assigned_ip}> %{GREEDYDATA}"
+        - "Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> IPv4 Address <%{IP:_temp_.cisco.assigned_ip}> %{GREEDYDATA}"
         - "Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} IPv4 Address %{IP:_temp_.cisco.assigned_ip} %{GREEDYDATA}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '733100'"
@@ -992,7 +992,7 @@ processors:
       field: "message"
       patterns:
         - "Authentication: rejected, group = %{NOTSPACE:source.user.group.name} user = %{USER:source.user.name} , Session Type: %{NOTSPACE:_temp_.cisco.session_type}"
-        - "Group <%{NOTSPACE:source.user.group.name}> User <%{NOTSPACE:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
+        - "Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> Authentication: rejected, Session Type: %{NOTSPACE:_temp_.cisco.session_type}\\."
   - dissect:
       if: "ctx._temp_.cisco.message_id == '750003'"
       tag: parse_750003

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.34.0"
+version: "2.34.1"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Add support for spaces in group and user names, but only for patterns that enclose the name in brackets.
- Add test cases

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

- Closes #9929 
