### PR TITLE
Update azure network watcher packages docker scenario

### DIFF
--- a/packages/azure_network_watcher_nsg/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_network_watcher_nsg/_dev/deploy/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command:
       - log
       - --retry=30
-      - --addr=elastic-package-service-azure-network-watcher-nsg-log-1
+      - --addr=azure-network-watcher-nsg-log
       - -p=azureblobstorage
       - --azure-blob-storage-port=10000
       - --azure-blob-storage-container=azure-container1

--- a/packages/azure_network_watcher_vnet/_dev/deploy/docker/docker-compose.yml
+++ b/packages/azure_network_watcher_vnet/_dev/deploy/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command:
       - log
       - --retry=30
-      - --addr=elastic-package-service-azure-network-watcher-vnet-log-1
+      - --addr=azure-network-watcher-vnet-log
       - -p=azureblobstorage
       - --azure-blob-storage-port=10000
       - --azure-blob-storage-container=azure-container1


### PR DESCRIPTION
## Proposed commit message

Update docker scenario for these packages to not use the full service name. Those containers can access the required service just with the service name in the same compose.

This will also help us to update how elastic-package manages these compose scenarios in the context of https://github.com/elastic/elastic-package/issues/787


## How to test this PR locally

Run system tests in both packages:
```shell
elastic-package stack up -v -d

# test both packages
cd /path/package
elastic-package test system -v

elastic-package stack down
```


## Related issues

- https://github.com/elastic/elastic-package/issues/787
