### PR TITLE
Add field 'event.ingested' to transform

### DIFF
--- a/packages/beaconing/changelog.yml
+++ b/packages/beaconing/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add field 'event.ingested' to transform, resolving detection rule backup timestamp
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9791
+      link: https://github.com/elastic/integrations/pull/9947
 - version: "1.2.1"
   changes:
     - description: Improve package installation documentation

--- a/packages/beaconing/changelog.yml
+++ b/packages/beaconing/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.2.2"
+  changes:
+    - description: Add field 'event.ingested' to transform, resolving detection rule backup timestamp
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9791
 - version: "1.2.1"
   changes:
     - description: Improve package installation documentation

--- a/packages/beaconing/elasticsearch/transform/pivot_transform/fields/fields.yml
+++ b/packages/beaconing/elasticsearch/transform/pivot_transform/fields/fields.yml
@@ -44,3 +44,5 @@
   type: float
 - name: '@timestamp'
   type: date
+- name: 'event.ingested'
+  type: date

--- a/packages/beaconing/elasticsearch/transform/pivot_transform/transform.yml
+++ b/packages/beaconing/elasticsearch/transform/pivot_transform/transform.yml
@@ -1,6 +1,6 @@
 dest:
-  index: ml_beaconing-1.2.1
-  pipeline: 1.2.1-ml_beaconing_ingest_pipeline
+  index: ml_beaconing-1.2.2
+  pipeline: 1.2.2-ml_beaconing_ingest_pipeline
   aliases:
     - alias: ml_beaconing.latest
       move_on_creation: true
@@ -13,6 +13,9 @@ pivot:
     "@timestamp":
       max:
         field: "@timestamp"
+    event.ingested:
+      max:
+        field: event.ingested
     beacon_stats:
       scripted_metric:
         combine_script: return state
@@ -382,5 +385,5 @@ sync:
     delay: 120s
     field: "@timestamp"
 _meta:
-  fleet_transform_version: 1.2.1
+  fleet_transform_version: 1.2.2
   run_as_kibana_system: false

--- a/packages/beaconing/manifest.yml
+++ b/packages/beaconing/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: beaconing
 title: "Network Beaconing Identification"
-version: 1.2.1
+version: 1.2.2
 source:
   license: "Elastic-2.0"
 description: "Package to identify beaconing activity in your network events."


### PR DESCRIPTION
## Proposed commit message

The backup timestamp field `event.ingested` must be generated by the Beaconing integration package in order for the associated detection rules to not generate an error message.

`event.ingested` was added to the pivot aggregation as a backup timestamp. The operation of the pivot was verified on a test dataset with and without the field `event.ingested`.

Related SDH:
* https://github.com/elastic/detection-rules/issues/3703

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] ~I have verified that all data streams collect metrics or logs.~ This package does not collect metrics or logs. I verified the package works with a test generation notebook.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [ ] Test and ensure that the error in the related issue is no longer present 

## How to test this PR locally

Test with `elastic-package build`, see integration package [testing instructions](https://github.com/elastic/integrations/blob/main/docs/testing_and_validation.md).

## Related issues

* https://github.com/elastic/detection-rules/issues/3703