### PR TITLE
Add cluster UUID to the Logstash node datastream.

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.7"
+  changes:
+    - description: Add the cluster UUID to the node datastream
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9971
 - version: "2.4.6"
   changes:
     - description: Fix support for conditions in Logstash cel inputs

--- a/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
@@ -1,6 +1,6 @@
 config_version: "2"
 interval: {{period}}
-resource.url: "{{url}}/_node/stats?graph=true"
+resource.url: "{{url}}/_node/stats?graph=true&vertices=true"
 {{#if resource_ssl}}
 resource.ssl:
   {{resource_ssl}}

--- a/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
@@ -25,14 +25,15 @@ program: |
   .decode_json().as(body,
     {
       "logstash":{
-        "elasticsearch": has(body.pipelines)
-          ? body.pipelines
-            .map(pipeline_name, pipeline_name != ".monitoring-logstash", {
-              "cluster": has(body.pipelines[pipeline_name].vertices)
-              ? {"id": body.pipelines[pipeline_name].vertices.map(vertex, has(vertex.cluster_uuid), vertex.cluster_uuid) }
-              : {}
-            })
-          : [],
+        "elasticsearch": has(body.pipelines) 
+        ? {
+            "cluster":{
+              "id":body.pipelines.map(pipeline_name, pipeline_name != ".monitoring-logstash", has(body.pipelines[pipeline_name].vertices)
+                ? body.pipelines[pipeline_name].vertices.map(vertex, has(vertex.cluster_uuid), vertex.cluster_uuid) 
+                : []).flatten(),
+             }
+          }
+        : {},
         "node":{
           "stats":{
              "events":body.events,

--- a/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/node_cel/agent/stream/cel.yml.hbs
@@ -23,7 +23,18 @@ program: |
   get(state.url)
   .as(resp, bytes(resp.Body)
   .decode_json().as(body,
-    {"logstash":{"node":{"stats":{
+    {
+      "logstash":{
+        "elasticsearch": has(body.pipelines)
+          ? body.pipelines
+            .map(pipeline_name, pipeline_name != ".monitoring-logstash", {
+              "cluster": has(body.pipelines[pipeline_name].vertices)
+              ? {"id": body.pipelines[pipeline_name].vertices.map(vertex, has(vertex.cluster_uuid), vertex.cluster_uuid) }
+              : {}
+            })
+          : [],
+        "node":{
+          "stats":{
              "events":body.events,
              "jvm":{
                 "uptime_in_millis":body.jvm.uptime_in_millis,

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.6
+version: 2.4.7
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message
Logstash monitoring with metricbeat and self include `cluster_uuid` which will be used during the queries (example telemetry collection). However, with agent driven monitoring we are losing the cluster UUID. This change fixes the explained bug.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally
Use the Logstash integration, install the agent and copy the change script into the policy. We can see the cluster UUID will be reflected in `.ds-metrics-logstash.node*` indices. Also query against `cluster_uuid` (which is an alias for `logstash.elasticsearch.cluster.id`) also works as expected.
```
// example query
GET .ds-metrics-logstash.node*/_search
{
  "query": {
    "bool": {
      "filter": [
        {
          "terms": {
            "cluster_uuid": [
              "wjK4bDWFQxKggvldnpKeng"
            ]
          }
        },
        {
          "bool": {
            "should": [
              {
                "term": {
                  "type": "logstash_stats"
                }
              },
              {
                "term": {
                  "metricset.name": "node_stats"
                }
              },
              {
                "term": {
                  "data_stream.dataset": "logstash.node"
                }
              }
            ]
          }
        },
        {
          "range": {
            "@timestamp": {
              "format": "epoch_millis",
              "gte": 0,
              "lte": 2816489716793
            }
          }
        }
      ]
    }
  },
  "collapse": {
    "field": "host.id"
  },
  "sort": [
    {
      "@timestamp": {
        "order": "desc",
        "unmapped_type": "long"
      }
    }
  ],
  "from": 0,
  "size": 10000
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
