### PR TITLE
[crowdstrike] Fix handling of empty responses in CEL

### DIFF
--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.34.3"
+  changes:
+    - description: Fix handling of empty responses in CEL.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9972
 - version: "1.34.2"
   changes:
     - description: Resolved ignore_malformed issues with fields.

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -50,7 +50,7 @@ program: |
         )
     ).do_request().as(get_resp, get_resp.StatusCode == 200 ?
       bytes(get_resp.Body).decode_json().as(body, {
-        "resources": has(body.resources) && body.resources.size() > 0 ? body.resources : "",
+        ?"resources": has(body.resources) && body.resources.size() > 0 ? optional.of(body.resources) : optional.none(),
         "want_more": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total),
         "offset": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total) ?
           int(state.offset) + body.resources.size()
@@ -59,18 +59,18 @@ program: |
       })
     :
       {
-        "events": {
+        "events": [{
           "error": {
             "code": string(get_resp.StatusCode),
             "id": string(get_resp.Status),
-            "message": string(get_resp.Body)
+            "message": "GET:"+string(get_resp.Body)
           },
-        },
+        }],
         "want_more": false,
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? state : // Exit early due to GET failure.
+    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url.trim_right("/") + "/alerts/entities/alerts/v2",
         "application/json",
@@ -97,13 +97,13 @@ program: |
         })
       :
         {
-          "events": {
+          "events": [{
             "error": {
               "code": string(post_resp.StatusCode),
               "id": string(post_resp.Status),
-              "message": string(post_resp.Body)
+              "message": "POST:"string(post_resp.Body)
             },
-          },
+          }],
           "want_more": false,
         }
       )

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -101,7 +101,7 @@ program: |
             "error": {
               "code": string(post_resp.StatusCode),
               "id": string(post_resp.Status),
-              "message": "POST:"string(post_resp.Body)
+              "message": "POST:"+string(post_resp.Body)
             },
           }],
           "want_more": false,

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -50,7 +50,7 @@ program: |
         )
     ).do_request().as(get_resp, get_resp.StatusCode == 200 ?
       bytes(get_resp.Body).decode_json().as(body, {
-        "resources": has(body.resources) && body.resources.size() > 0 ? body.resources : "",
+        ?"resources": has(body.resources) && body.resources.size() > 0 ? optional.of(body.resources) : optional.none(),
         "want_more": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total),
         "offset": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total) ?
           int(state.offset) + body.resources.size()
@@ -59,18 +59,18 @@ program: |
       })
     :
       {
-        "events": {
+        "events": [{
           "error": {
             "code": string(get_resp.StatusCode),
             "id": string(get_resp.Status),
-            "message": string(get_resp.Body)
+            "message": "GET:"+string(get_resp.Body)
           },
-        },
+        }],
         "want_more": false,
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? state : // Exit early due to GET failure.
+    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url + "/devices/entities/devices/v2",
         "application/json",
@@ -97,13 +97,13 @@ program: |
         })
       :
         {
-          "events": {
+          "events": [{
             "error": {
               "code": string(post_resp.StatusCode),
               "id": string(post_resp.Status),
-              "message": string(post_resp.Body)
+              "message": "POST:"+string(post_resp.Body)
             },
-          },
+          }],
           "want_more": false,
         }
       )

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.34.2"
+version: "1.34.3"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

```
[crowdstrike] Fix handling of empty responses in CEL (#)

This fixes a bug in which a GET request that returns no resources is
mistakenly followed by a POST request for no resources, which seem
to have been met with 400s from the server.

Additional improvements:
- Label error messages as resulting from either a GET or a POST request.
- Ensure the value of "errors" is an array, even for the error cases.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).