### PR TITLE
[SSI integrations] Set `response.split.ignore_empty_value: true`

### DIFF
--- a/packages/1password/changelog.yml
+++ b/packages/1password/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.27.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/1password/data_stream/audit_events/agent/stream/httpjson.yml.hbs
+++ b/packages/1password/data_stream/audit_events/agent/stream/httpjson.yml.hbs
@@ -38,6 +38,7 @@ cursor:
 response.decode_as: application/json
 response.split:
   target: body.items
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: body.cursor

--- a/packages/1password/data_stream/item_usages/agent/stream/httpjson.yml.hbs
+++ b/packages/1password/data_stream/item_usages/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
 response.decode_as: application/json
 response.split:
   target: body.items
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: body.cursor

--- a/packages/1password/data_stream/signin_attempts/agent/stream/httpjson.yml.hbs
+++ b/packages/1password/data_stream/signin_attempts/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
 response.decode_as: application/json
 response.split:
   target: body.items
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: body.cursor

--- a/packages/1password/manifest.yml
+++ b/packages/1password/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: 1password
 title: "1Password"
-version: "1.27.0"
+version: "1.28.0"
 description: Collect logs from 1Password with Elastic Agent.
 type: integration
 categories:

--- a/packages/atlassian_jira/changelog.yml
+++ b/packages/atlassian_jira/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.24.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/atlassian_jira/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -82,6 +82,7 @@ cursor:
       value: '[[formatDate now]]'
 response.split:
   target: body.entities
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: url.value

--- a/packages/atlassian_jira/manifest.yml
+++ b/packages/atlassian_jira/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: atlassian_jira
 title: Atlassian Jira
-version: "1.24.0"
+version: "1.25.0"
 description: Collect logs from Atlassian Jira with Elastic Agent.
 type: integration
 categories:

--- a/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
@@ -51,6 +51,7 @@ cursor:
     value: '[[if (ne (len .last_response.body.findings) 100)]][[.last_event.lastObservedAt]][[end]]'
 response.split:
   target: body.findings
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
+++ b/packages/aws/data_stream/inspector/agent/stream/httpjson.yml.hbs
@@ -51,7 +51,6 @@ cursor:
     value: '[[if (ne (len .last_response.body.findings) 100)]][[.last_event.lastObservedAt]][[end]]'
 response.split:
   target: body.findings
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/changelog.yml
+++ b/packages/bitwarden/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.12.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.11.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/bitwarden/data_stream/collection/agent/stream/httpjson.yml.hbs
+++ b/packages/bitwarden/data_stream/collection/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/data_stream/event/agent/stream/httpjson.yml.hbs
+++ b/packages/bitwarden/data_stream/event/agent/stream/httpjson.yml.hbs
@@ -51,6 +51,7 @@ cursor:
     value: '[[if (eq .last_response.body.continuationToken nil)]][[.first_event.date]][[end]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/data_stream/group/agent/stream/httpjson.yml.hbs
+++ b/packages/bitwarden/data_stream/group/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/data_stream/member/agent/stream/httpjson.yml.hbs
+++ b/packages/bitwarden/data_stream/member/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/data_stream/policy/agent/stream/httpjson.yml.hbs
+++ b/packages/bitwarden/data_stream/policy/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/bitwarden/manifest.yml
+++ b/packages/bitwarden/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: bitwarden
 title: Bitwarden
-version: "1.11.0"
+version: "1.12.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Bitwarden with Elastic Agent.

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "2.0.0"
   changes:
     - description: Added v7 alert data stream with dashboards along with new CEL input type for all http data streams.

--- a/packages/carbon_black_cloud/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ cursor:
     value: '[[.last_event.last_update_time]]'
 response.split:
   target: body.results
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/httpjson.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/httpjson.yml.hbs
@@ -35,6 +35,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.results
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -20,6 +20,7 @@ request.transforms:
       value: {{api_secret_key}}/{{api_id}}
 response.split:
   target: body.notifications
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.0.0"
+version: "2.1.0"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:

--- a/packages/ceph/data_stream/osd_pool_stats/agent/stream/httpjson.yml.hbs
+++ b/packages/ceph/data_stream/osd_pool_stats/agent/stream/httpjson.yml.hbs
@@ -24,6 +24,7 @@ request.transforms:
       value: "json"
 response.split:
   target: body.finished
+  ignore_empty_value: true
   transforms:
     - set:
         target: body.outb

--- a/packages/ceph/data_stream/osd_pool_stats/agent/stream/httpjson.yml.hbs
+++ b/packages/ceph/data_stream/osd_pool_stats/agent/stream/httpjson.yml.hbs
@@ -24,7 +24,6 @@ request.transforms:
       value: "json"
 response.split:
   target: body.finished
-  ignore_empty_value: true
   transforms:
     - set:
         target: body.outb

--- a/packages/cisa_kevs/changelog.yml
+++ b/packages/cisa_kevs/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.0.1"
   changes:
     - description: Update logo to align w/ Elastic Integrations page, fix description wording 

--- a/packages/cisa_kevs/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/cisa_kevs/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -25,6 +25,7 @@ request.transforms:
 
 response.split:
   target: body.vulnerabilities
+  ignore_empty_value: true
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/cisa_kevs/manifest.yml
+++ b/packages/cisa_kevs/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: cisa_kevs
 title: "CISA Known Exploited Vulnerabilities"
-version: 1.0.1
+version: 1.1.0
 description: "This package allows the ingest of known exploited vulnerabilities according to the Cybersecurity and Infrastructure Security Agency of the United States of America. This information could be used to enrich or track exisiting vulnerabilities that are known to be exploited in the wild."
 type: integration
 categories:

--- a/packages/citrix_adc/data_stream/interface/agent/stream/httpjson.yml.hbs
+++ b/packages/citrix_adc/data_stream/interface/agent/stream/httpjson.yml.hbs
@@ -17,7 +17,6 @@ request.method: GET
 request.url: {{hostname}}/nitro/v1/stat/Interface
 response.split:
   target: body.Interface
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/citrix_adc/data_stream/interface/agent/stream/httpjson.yml.hbs
+++ b/packages/citrix_adc/data_stream/interface/agent/stream/httpjson.yml.hbs
@@ -17,6 +17,7 @@ request.method: GET
 request.url: {{hostname}}/nitro/v1/stat/Interface
 response.split:
   target: body.Interface
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/citrix_adc/data_stream/lbvserver/agent/stream/httpjson.yml.hbs
+++ b/packages/citrix_adc/data_stream/lbvserver/agent/stream/httpjson.yml.hbs
@@ -17,7 +17,6 @@ request.method: GET
 request.url: {{hostname}}/nitro/v1/stat/lbvserver
 response.split:
   target: body.lbvserver
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/citrix_adc/data_stream/lbvserver/agent/stream/httpjson.yml.hbs
+++ b/packages/citrix_adc/data_stream/lbvserver/agent/stream/httpjson.yml.hbs
@@ -17,6 +17,7 @@ request.method: GET
 request.url: {{hostname}}/nitro/v1/stat/lbvserver
 response.split:
   target: body.lbvserver
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/citrix_adc/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/citrix_adc/data_stream/service/agent/stream/stream.yml.hbs
@@ -10,6 +10,7 @@ auth.basic.password: {{password}}
 {{/if}}
 response.split:
   target: body.service
+  ignore_empty_value: true
 {{#if ssl}}
 request.ssl: {{ssl}}
 {{/if}}

--- a/packages/citrix_adc/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/citrix_adc/data_stream/service/agent/stream/stream.yml.hbs
@@ -10,7 +10,6 @@ auth.basic.password: {{password}}
 {{/if}}
 response.split:
   target: body.service
-  ignore_empty_value: true
 {{#if ssl}}
 request.ssl: {{ssl}}
 {{/if}}

--- a/packages/cloudflare/changelog.yml
+++ b/packages/cloudflare/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.26.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "2.25.0"
   changes:
     - description: Allow user configuration of results per page.

--- a/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/cloudflare/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -34,6 +34,7 @@ request.transforms:
 
 response.split:
   target: body.result
+  ignore_empty_value: true
 response.pagination:
 - set:
     target: url.params.page

--- a/packages/cloudflare/manifest.yml
+++ b/packages/cloudflare/manifest.yml
@@ -1,6 +1,6 @@
 name: cloudflare
 title: Cloudflare
-version: "2.25.0"
+version: "2.26.0"
 description: Collect logs from Cloudflare with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/couchbase/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/couchbase/data_stream/node/agent/stream/stream.yml.hbs
@@ -11,7 +11,6 @@ request.ssl: {{ssl_couchbase}}
 {{/if}}
 response.split:
   target: body.nodes
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/couchbase/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/couchbase/data_stream/node/agent/stream/stream.yml.hbs
@@ -11,6 +11,7 @@ request.ssl: {{ssl_couchbase}}
 {{/if}}
 response.split:
   target: body.nodes
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/forgerock/changelog.yml
+++ b/packages/forgerock/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.15.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/forgerock/data_stream/am_access/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/am_access/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/am_activity/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/am_activity/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/am_authentication/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/am_authentication/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/am_config/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/am_config/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/am_core/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/am_core/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_access/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_access/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_activity/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_activity/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_authentication/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_authentication/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_config/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_config/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_core/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_core/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/data_stream/idm_sync/agent/stream/httpjson.yml.hbs
+++ b/packages/forgerock/data_stream/idm_sync/agent/stream/httpjson.yml.hbs
@@ -39,8 +39,9 @@ request.transforms:
       target: url.params.endTime
       value: '[[formatDate (now) "2006-01-02T15:04:05-07:00"]]'
 
-response.split: 
+response.split:
   target: body.result
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/forgerock/manifest.yml
+++ b/packages/forgerock/manifest.yml
@@ -1,6 +1,6 @@
 name: forgerock
 title: "ForgeRock"
-version: "1.15.0"
+version: "1.16.0"
 description: Collect audit logs from ForgeRock with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/google_scc/changelog.yml
+++ b/packages/google_scc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.2.1"
   changes:
     - description: Fix name canonicalization routines.

--- a/packages/google_scc/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/google_scc/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -41,6 +41,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.assets
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_scc/data_stream/finding/agent/stream/httpjson.yml.hbs
+++ b/packages/google_scc/data_stream/finding/agent/stream/httpjson.yml.hbs
@@ -45,6 +45,7 @@ cursor:
     value: '[[.last_event.finding.eventTime]]'
 response.split:
   target: body.listFindingsResults
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_scc/data_stream/source/agent/stream/httpjson.yml.hbs
+++ b/packages/google_scc/data_stream/source/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.sources
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_scc/manifest.yml
+++ b/packages/google_scc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: google_scc
 title: Google Security Command Center
-version: "1.2.1"
+version: "1.3.0"
 description: Collect logs from Google Security Command Center with Elastic Agent.
 type: integration
 categories:

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.22.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "2.21.0"
   changes:
     - description: Update manifest format version to v3.0.3.

--- a/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/access_transparency/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/admin/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -44,7 +44,8 @@ cursor:
   last_create_time:
     value: '[[.last_event.createTime]]'
 response.split:
-    target: body.alerts
+  target: body.alerts
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/context_aware_access/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/device/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/drive/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/gcp/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/group_enterprise/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/groups/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/login/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/rules/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/saml/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/token/agent/stream/httpjson.yml.hbs
@@ -37,6 +37,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
+++ b/packages/google_workspace/data_stream/user_accounts/agent/stream/httpjson.yml.hbs
@@ -31,6 +31,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.21.0"
+version: "2.22.0"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.

--- a/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
+++ b/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
@@ -26,4 +26,3 @@ processors:
 {{/if}}
 response.split:
   target: body.apps.app
-  ignore_empty_value: true

--- a/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
+++ b/packages/hadoop/data_stream/application/agent/stream/stream.yml.hbs
@@ -26,3 +26,4 @@ processors:
 {{/if}}
 response.split:
   target: body.apps.app
+  ignore_empty_value: true

--- a/packages/infoblox_bloxone_ddi/changelog.yml
+++ b/packages/infoblox_bloxone_ddi/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.17.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.16.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/infoblox_bloxone_ddi/data_stream/dhcp_lease/agent/stream/httpjson.yml.hbs
+++ b/packages/infoblox_bloxone_ddi/data_stream/dhcp_lease/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ cursor:
     value: '[[.last_event.last_updated]]'
 response.split:
   target: body.results
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/infoblox_bloxone_ddi/data_stream/dns_config/agent/stream/httpjson.yml.hbs
+++ b/packages/infoblox_bloxone_ddi/data_stream/dns_config/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ cursor:
     value: '[[.last_event.updated_at]]'
 response.split:
   target: body.results
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/infoblox_bloxone_ddi/data_stream/dns_data/agent/stream/httpjson.yml.hbs
+++ b/packages/infoblox_bloxone_ddi/data_stream/dns_data/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ cursor:
     value: '[[.last_event.updated_at]]'
 response.split:
   target: body.results
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/infoblox_bloxone_ddi/manifest.yml
+++ b/packages/infoblox_bloxone_ddi/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: infoblox_bloxone_ddi
 title: Infoblox BloxOne DDI
-version: "1.16.0"
+version: "1.17.0"
 description: Collect logs from Infoblox BloxOne DDI with Elastic Agent.
 type: integration
 categories:

--- a/packages/lumos/changelog.yml
+++ b/packages/lumos/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/lumos/data_stream/activity_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/lumos/data_stream/activity_logs/agent/stream/httpjson.yml.hbs
@@ -20,6 +20,7 @@ response.pagination:
 
 response.split:
   target: body.items
+  ignore_empty_value: true
 
 cursor:
   since:

--- a/packages/lumos/manifest.yml
+++ b/packages/lumos/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: lumos
 title: "Lumos"
-version: 1.0.0
+version: 1.1.0
 description: "An integration with Lumos to ship your Activity logs to your Elastic instance."
 type: integration
 categories:

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.10.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "2.9.1"
   changes:
     - description: Drop last page events in the alerts datastream.

--- a/packages/m365_defender/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/m365_defender/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -43,6 +43,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.value
+  ignore_empty_value: true
 cursor:
   last_update_time:
     value: '[[.last_event.lastUpdateDateTime]]'

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.9.1"
+version: "2.10.0"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.19.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -56,6 +56,7 @@ publisher_pipeline.disable_host: true
 {{/contains}}
 response.split:
   target: body.value
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: url.params.$filter

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.19.0"
+version: "1.20.0"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:

--- a/packages/mimecast/changelog.yml
+++ b/packages/mimecast/changelog.yml
@@ -1,3 +1,9 @@
+# newer versions go on top
+- version: "1.25.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.24.0"
   changes:
     - description: Log processing stage and improve document fingerprinting.

--- a/packages/mimecast/data_stream/siem_logs/agent/stream/httpjson.yml.hbs
+++ b/packages/mimecast/data_stream/siem_logs/agent/stream/httpjson.yml.hbs
@@ -30,11 +30,12 @@ request.transforms:
       value: '*/*'
 response.decode_as: application/zip
 response.split:
-   transforms:
-   - set:
+  transforms:
+  - set:
       target: body.Content-Disposition
       value: '[[.last_response.header.Get "Content-Disposition"]]'
-   target: body.data
+  target: body.data
+  ignore_empty_value: true
 cursor:
    next_token:
       value: '[[.last_response.header.Get "mc-siem-token"]]'

--- a/packages/mimecast/manifest.yml
+++ b/packages/mimecast/manifest.yml
@@ -1,8 +1,7 @@
-#
 format_version: "3.0.2"
 name: mimecast
 title: "Mimecast"
-version: "1.24.0"
+version: "1.25.0"
 description: Collect logs from Mimecast with Elastic Agent.
 type: integration
 categories: ["security", "email_security"]

--- a/packages/panw_cortex_xdr/changelog.yml
+++ b/packages/panw_cortex_xdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.25.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/panw_cortex_xdr/data_stream/alerts/agent/stream/httpjson.yml.hbs
@@ -64,6 +64,7 @@ request.transforms:
     value_type: json
 response.split:
   target: body.reply.alerts
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/panw_cortex_xdr/data_stream/incidents/agent/stream/httpjson.yml.hbs
+++ b/packages/panw_cortex_xdr/data_stream/incidents/agent/stream/httpjson.yml.hbs
@@ -64,6 +64,7 @@ request.transforms:
     value_type: json
 response.split:
   target: body.reply.incidents
+  ignore_empty_value: true
   split:
     target: body.events
     keep_parent: true

--- a/packages/panw_cortex_xdr/manifest.yml
+++ b/packages/panw_cortex_xdr/manifest.yml
@@ -1,6 +1,6 @@
 name: panw_cortex_xdr
 title: Palo Alto Cortex XDR
-version: "1.25.0"
+version: "1.26.0"
 description: Collect logs from Palo Alto Cortex XDR with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ping_one/changelog.yml
+++ b/packages/ping_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.14.1"
   changes:
     - description: Update setup documentation.

--- a/packages/ping_one/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/ping_one/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[if (eq .last_response.page 1)]][[.first_event.recordedAt]][[end]]'
 response.split:
   target: body._embedded.activities
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ping_one/manifest.yml
+++ b/packages/ping_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ping_one
 title: PingOne
-version: "1.14.1"
+version: "1.15.0"
 description: Collect logs from PingOne with Elastic-Agent.
 type: integration
 categories:

--- a/packages/proofpoint_tap/changelog.yml
+++ b/packages/proofpoint_tap/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.19.0"
   changes:
     - description: Set @timestamp based on the event trigger which is either the messageTime/clickTime or the threatTime.

--- a/packages/proofpoint_tap/data_stream/clicks_blocked/agent/stream/httpjson.yml.hbs
+++ b/packages/proofpoint_tap/data_stream/clicks_blocked/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ cursor:
     value: '[[.last_response.body.queryEndTime]]'
 response.split:
   target: body.clicksBlocked
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/proofpoint_tap/data_stream/clicks_permitted/agent/stream/httpjson.yml.hbs
+++ b/packages/proofpoint_tap/data_stream/clicks_permitted/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ cursor:
     value: '[[.last_response.body.queryEndTime]]'
 response.split:
   target: body.clicksPermitted
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/proofpoint_tap/data_stream/message_blocked/agent/stream/httpjson.yml.hbs
+++ b/packages/proofpoint_tap/data_stream/message_blocked/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ cursor:
     value: '[[.last_response.body.queryEndTime]]'
 response.split:
   target: body.messagesBlocked
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/proofpoint_tap/data_stream/message_delivered/agent/stream/httpjson.yml.hbs
+++ b/packages/proofpoint_tap/data_stream/message_delivered/agent/stream/httpjson.yml.hbs
@@ -32,6 +32,7 @@ cursor:
     value: '[[.last_response.body.queryEndTime]]'
 response.split:
   target: body.messagesDelivered
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/proofpoint_tap/manifest.yml
+++ b/packages/proofpoint_tap/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: proofpoint_tap
 title: Proofpoint TAP
-version: "1.19.0"
+version: "1.20.0"
 description: Collect logs from Proofpoint TAP with Elastic Agent.
 type: integration
 categories:

--- a/packages/rapid7_insightvm/changelog.yml
+++ b/packages/rapid7_insightvm/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.10.0"
   changes:
     - description: Canonicalize `host.name` to lower case and map subdomain to `host.hostname`.

--- a/packages/rapid7_insightvm/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/rapid7_insightvm/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/rapid7_insightvm/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/rapid7_insightvm/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -36,6 +36,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.data
+  ignore_empty_value: true
 cursor:
   last_update_time:
     value: '[[.last_event.modified]]'

--- a/packages/rapid7_insightvm/manifest.yml
+++ b/packages/rapid7_insightvm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: rapid7_insightvm
 title: Rapid7 InsightVM
-version: "1.10.0"
+version: "1.11.0"
 source:
   license: "Elastic-2.0"
 description: Collect logs from Rapid7 InsightVM with Elastic Agent.

--- a/packages/salesforce/data_stream/setupaudittrail/agent/stream/httpjson.yml.hbs
+++ b/packages/salesforce/data_stream/setupaudittrail/agent/stream/httpjson.yml.hbs
@@ -23,6 +23,7 @@ request.transforms:
       default: "SELECT Action,CreatedByContext,CreatedById,CreatedByIssuer,CreatedDate,DelegateUser,Display,Id,Section FROM SetupAuditTrail ORDER BY CreatedDate ASC NULLS FIRST"
 response.split:
   target: body.records
+  ignore_empty_value: true
 response.pagination:
 - set:
     target: url.value

--- a/packages/salesforce/data_stream/setupaudittrail/agent/stream/httpjson.yml.hbs
+++ b/packages/salesforce/data_stream/setupaudittrail/agent/stream/httpjson.yml.hbs
@@ -23,7 +23,6 @@ request.transforms:
       default: "SELECT Action,CreatedByContext,CreatedById,CreatedByIssuer,CreatedDate,DelegateUser,Display,Id,Section FROM SetupAuditTrail ORDER BY CreatedDate ASC NULLS FIRST"
 response.split:
   target: body.records
-  ignore_empty_value: true
 response.pagination:
 - set:
     target: url.value

--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.20.0"
   changes:
     - description: Set sensitive values as secret and fix incorrect mappings.

--- a/packages/sentinel_one/data_stream/activity/agent/stream/httpjson.yml.hbs
+++ b/packages/sentinel_one/data_stream/activity/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[.last_event.createdAt]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sentinel_one/data_stream/agent/agent/stream/httpjson.yml.hbs
+++ b/packages/sentinel_one/data_stream/agent/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[.last_event.updatedAt]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sentinel_one/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/sentinel_one/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[.last_event.alertInfo.createdAt]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sentinel_one/data_stream/group/agent/stream/httpjson.yml.hbs
+++ b/packages/sentinel_one/data_stream/group/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[.last_event.updatedAt]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sentinel_one/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/sentinel_one/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -39,6 +39,7 @@ cursor:
     value: '[[.last_event.threatInfo.updatedAt]]'
 response.split:
   target: body.data
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one
 title: SentinelOne
-version: "1.20.0"
+version: "1.21.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:

--- a/packages/slack/changelog.yml
+++ b/packages/slack/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.20.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.19.0"
   changes:
     - description: Map md5 hash detail for files.

--- a/packages/slack/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/slack/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -41,6 +41,7 @@ request.rate_limit.remaining: '0' # hardcoded to 0 since slack doesn't return re
 
 response.split:
   target: body.entries
+  ignore_empty_value: true
 
 response.pagination:
   - set:

--- a/packages/slack/manifest.yml
+++ b/packages/slack/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: slack
 title: "Slack Logs"
-version: "1.19.0"
+version: "1.20.0"
 description: "Slack Logs Integration"
 type: integration
 categories:

--- a/packages/snyk/changelog.yml
+++ b/packages/snyk/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.21.0"
   changes:
     - description: Add support for new Snyk API

--- a/packages/snyk/data_stream/vulnerabilities/agent/stream/httpjson.yml.hbs
+++ b/packages/snyk/data_stream/vulnerabilities/agent/stream/httpjson.yml.hbs
@@ -78,6 +78,7 @@ response.pagination:
 
 response.split:
   target: body.results
+  ignore_empty_value: true
 
 
 tags:

--- a/packages/snyk/manifest.yml
+++ b/packages/snyk/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: snyk
 title: "Snyk"
-version: "1.21.0"
+version: "1.22.0"
 description: Collect logs from Snyk with Elastic Agent.
 type: integration
 categories:

--- a/packages/spring_boot/data_stream/audit_events/agent/stream/stream.yml.hbs
+++ b/packages/spring_boot/data_stream/audit_events/agent/stream/stream.yml.hbs
@@ -14,6 +14,7 @@ request.ssl: {{ssl}}
 {{/if}}
 response.split:
   target: body.events
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/spring_boot/data_stream/audit_events/agent/stream/stream.yml.hbs
+++ b/packages/spring_boot/data_stream/audit_events/agent/stream/stream.yml.hbs
@@ -14,7 +14,6 @@ request.ssl: {{ssl}}
 {{/if}}
 response.split:
   target: body.events
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/spring_boot/data_stream/http_trace/agent/stream/stream.yml.hbs
+++ b/packages/spring_boot/data_stream/http_trace/agent/stream/stream.yml.hbs
@@ -14,6 +14,7 @@ request.proxy_url: {{proxy_url}}
 {{/if}}
 response.split:
   target: body.traces
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/spring_boot/data_stream/http_trace/agent/stream/stream.yml.hbs
+++ b/packages/spring_boot/data_stream/http_trace/agent/stream/stream.yml.hbs
@@ -14,7 +14,6 @@ request.proxy_url: {{proxy_url}}
 {{/if}}
 response.split:
   target: body.traces
-  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/tenable_sc/changelog.yml
+++ b/packages/tenable_sc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.21.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -20,7 +20,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.22.0)"]]'
   - set:
       target: body.query.tool
       value: 'sumip'

--- a/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/asset/agent/stream/httpjson.yml.hbs
@@ -59,6 +59,7 @@ request.transforms:
       value: 'accesskey={{access_key}}; secretkey={{secret_key}}'
 response.split:
   target: body.response.results
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: body.startOffset

--- a/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
@@ -20,7 +20,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.22.0)"]]'
   - set:
       target: url.params.fields
       value: id,name,description,family,type,copyright,version,sourceFile,dependencies,requiredPorts,requiredUDPPorts,cpe,srcPort,dstPort,protocol,riskFactor,solution,seeAlso,synopsis,checkType,exploitEase,exploitAvailable,exploitFrameworks,cvssVector,cvssVectorBF,baseScore,temporalScore,cvssV3Vector,cvssV3VectorBF,cvssV3BaseScore,cvssV3TemporalScore,vprScore,vprContext,stigSeverity,pluginPubDate,pluginModDate,patchPubDate,patchModDate,vulnPubDate,modifiedTime,md5,xrefs

--- a/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/plugin/agent/stream/httpjson.yml.hbs
@@ -60,6 +60,7 @@ response.pagination:
       fail_on_template_error: true
 response.split:
   target: body.response
+  ignore_empty_value: true
 cursor:
   last_event_ts:
     value: '[[if (lt (len .last_response.body.response) {{batch_size}})]][[.last_event.pluginModDate]][[end]]'

--- a/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -65,6 +65,7 @@ request.transforms:
       value: 'accesskey={{access_key}}; secretkey={{secret_key}}'
 response.split:
   target: body.response.results
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: body.startOffset

--- a/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/tenable_sc/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -20,7 +20,7 @@ request.transforms:
       # Follow Tenable's format: https://developer.tenable.com/docs/user-agent-header
       # NOTE: The "Build" version must be kept in sync with this package's version.
       target: header.User-Agent
-      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.13.0)"]]'
+      value: '[[userAgent "Integration/1.0 (Elastic; Tenable.sc; Build/1.22.0)"]]'
   - set:
       target: body.query.tool
       value: 'vulndetails'

--- a/packages/tenable_sc/manifest.yml
+++ b/packages/tenable_sc/manifest.yml
@@ -1,8 +1,8 @@
 format_version: "3.0.2"
 name: tenable_sc
 title: Tenable.sc
-# The version must be updated in the pipeline as well. Until elastic/kibana#121310 is implemented we will have to manually sync these.
-version: "1.21.0"
+# The version must be updated in the input configuration templates as well, in order to set the correct User-Agent header. Until elastic/kibana#121310 is implemented we will have to manually sync these.
+version: "1.22.0"
 description: |
   Collect logs from Tenable.sc with Elastic Agent.
 type: integration

--- a/packages/ti_cif3/changelog.yml
+++ b/packages/ti_cif3/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.12.0"
   changes:
     - description: Support for IOC expiration

--- a/packages/ti_cif3/data_stream/feed/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_cif3/data_stream/feed/agent/stream/httpjson.yml.hbs
@@ -70,6 +70,7 @@ request.transforms:
 
 response.split:
   target: body.data
+  ignore_empty_value: true
 
 cursor:
   last_requested_at:

--- a/packages/ti_cif3/manifest.yml
+++ b/packages/ti_cif3/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_cif3
 title: "Collective Intelligence Framework v3"
-version: "1.12.0"
+version: "1.13.0"
 description: "Ingest threat indicators from a Collective Intelligence Framework v3 instance with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_cybersixgill/changelog.yml
+++ b/packages/ti_cybersixgill/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.28.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.27.0"
   changes:
     - description: Add support for IOC expiration.

--- a/packages/ti_cybersixgill/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_cybersixgill/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -45,6 +45,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_cybersixgill/manifest.yml
+++ b/packages/ti_cybersixgill/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_cybersixgill
 title: Cybersixgill
-version: "1.27.0"
+version: "1.28.0"
 description: Ingest threat intelligence indicators from Cybersixgill with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.0.0"
   changes:
     - description: Release package as GA.

--- a/packages/ti_eset/data_stream/apt/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/apt/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/botnet/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/botnet/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/cc/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/cc/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/domains/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/domains/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/files/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/files/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/ip/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/ip/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/data_stream/url/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_eset/data_stream/url/agent/stream/httpjson.yml.hbs
@@ -49,6 +49,7 @@ response.pagination:
 
 response.split:
   target: body.objects
+  ignore_empty_value: true
 
 cursor:
   timestamp:

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: 1.0.0
+version: 1.1.0
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:

--- a/packages/ti_mandiant_advantage/changelog.yml
+++ b/packages/ti_mandiant_advantage/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.1.1"
   changes:
     - description: Remove invalid field definition.

--- a/packages/ti_mandiant_advantage/data_stream/threat_intelligence/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_mandiant_advantage/data_stream/threat_intelligence/agent/stream/httpjson.yml.hbs
@@ -47,6 +47,7 @@ cursor:
 
 response.split:
   target: body.indicators
+  ignore_empty_value: true
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/ti_mandiant_advantage/manifest.yml
+++ b/packages/ti_mandiant_advantage/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: ti_mandiant_advantage
 title: "Mandiant Advantage"
-version: 1.1.1
+version: 1.2.0
 source:
   license: "Elastic-2.0"
 description: "Collect Threat Intelligence from products within the Mandiant Advantage platform."

--- a/packages/ti_misp/changelog.yml
+++ b/packages/ti_misp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.33.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.32.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_misp/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -55,6 +55,7 @@ request.transforms:
 
 response.split:
   target: body.response
+  ignore_empty_value: true
   split:
     target: body.Event.Attribute
     ignore_empty_value: true

--- a/packages/ti_misp/manifest.yml
+++ b/packages/ti_misp/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_misp
 title: MISP
-version: "1.32.0"
+version: "1.33.0"
 description: Ingest threat intelligence indicators from MISP platform with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/ti_rapid7_threat_command/changelog.yml
+++ b/packages/ti_rapid7_threat_command/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.15.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/ti_rapid7_threat_command/data_stream/ioc/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_rapid7_threat_command/data_stream/ioc/agent/stream/httpjson.yml.hbs
@@ -60,6 +60,7 @@ cursor:
 
 response.split:
   target: body.content
+  ignore_empty_value: true
 
 tags:
 {{#if preserve_original_event}}

--- a/packages/ti_rapid7_threat_command/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_rapid7_threat_command/data_stream/vulnerability/agent/stream/httpjson.yml.hbs
@@ -46,6 +46,7 @@ cursor:
     value: '[[.last_event.updateDate]]'
 response.split:
   target: body.content
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/ti_rapid7_threat_command/manifest.yml
+++ b/packages/ti_rapid7_threat_command/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.2
 name: ti_rapid7_threat_command
 title: Rapid7 Threat Command
 # The version must be updated manually in the transform.yml files and transform APIs mentioned in README.
-version: "1.15.0"
+version: "1.16.0"
 description: Collect threat intelligence from Threat Command API with Elastic Agent.
 type: integration
 categories: ["security", "threat_intel"]

--- a/packages/ti_threatq/changelog.yml
+++ b/packages/ti_threatq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.27.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.26.0"
   changes:
     - description: Support user configurable page size.

--- a/packages/ti_threatq/data_stream/threat/agent/stream/httpjson.yml.hbs
+++ b/packages/ti_threatq/data_stream/threat/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ response.request_body_on_pagination: true
 
 response.split:
   target: body.data
+  ignore_empty_value: true
   fail_on_template_error: true
 
 {{#if ioc_expiration_duration}}

--- a/packages/ti_threatq/manifest.yml
+++ b/packages/ti_threatq/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_threatq
 title: ThreatQuotient
-version: "1.26.0"
+version: "1.27.0"
 description: Ingest threat intelligence indicators from ThreatQuotient with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/trend_micro_vision_one/changelog.yml
+++ b/packages/trend_micro_vision_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.17.0"
   changes:
     - description: Update manifest format version to v3.0.3.

--- a/packages/trend_micro_vision_one/data_stream/alert/agent/stream/httpjson.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/alert/agent/stream/httpjson.yml.hbs
@@ -42,6 +42,7 @@ cursor:
     value: '[[.last_response.url.params.Get "endDateTime"]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/trend_micro_vision_one/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -45,6 +45,7 @@ cursor:
     value: '[[.last_response.url.params.Get "endDateTime"]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/trend_micro_vision_one/data_stream/detection/agent/stream/httpjson.yml.hbs
+++ b/packages/trend_micro_vision_one/data_stream/detection/agent/stream/httpjson.yml.hbs
@@ -45,6 +45,7 @@ cursor:
     value: '[[.last_response.url.params.Get "endDateTime"]]'
 response.split:
   target: body.items
+  ignore_empty_value: true
   split:
     target: body.requests
     ignore_empty_value: true

--- a/packages/trend_micro_vision_one/manifest.yml
+++ b/packages/trend_micro_vision_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: trend_micro_vision_one
 title: Trend Micro Vision One
-version: "1.17.0"
+version: "1.18.0"
 description: Collect logs from Trend Micro Vision One with Elastic Agent.
 type: integration
 categories:

--- a/packages/zerofox/changelog.yml
+++ b/packages/zerofox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.24.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.23.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/zerofox/data_stream/alerts/agent/stream/httpjson.yml.hbs
+++ b/packages/zerofox/data_stream/alerts/agent/stream/httpjson.yml.hbs
@@ -23,6 +23,7 @@ request.transforms:
       default: '[[formatDate (now (parseDuration "-{{initial_interval}}"))]]'
 response.split:
   target: body.alerts
+  ignore_empty_value: true
 response.pagination:
   - set:
       target: url.value

--- a/packages/zerofox/manifest.yml
+++ b/packages/zerofox/manifest.yml
@@ -1,6 +1,6 @@
 name: zerofox
 title: ZeroFox
-version: "1.23.0"
+version: "1.24.0"
 description: Collect logs from ZeroFox with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/zeronetworks/changelog.yml
+++ b/packages/zeronetworks/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Improve handling of empty responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9974
 - version: "1.13.0"
   changes:
     - description: Add dashboard.

--- a/packages/zeronetworks/data_stream/audit/agent/stream/httpjson.yml.hbs
+++ b/packages/zeronetworks/data_stream/audit/agent/stream/httpjson.yml.hbs
@@ -33,6 +33,7 @@ request.transforms:
 
 response.split:
   target: body.items
+  ignore_empty_value: true
 
 response.pagination:
 - set:

--- a/packages/zeronetworks/manifest.yml
+++ b/packages/zeronetworks/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: zeronetworks
 title: "Zero Networks"
-version: "1.13.0"
+version: "1.14.0"
 source:
   license: "Elastic-2.0"
 description: "Zero Networks Logs integration"


### PR DESCRIPTION
## Proposed commit message

```
[SSI integrations] Set `response.split.ignore_empty_value: true` (#)

For integrations that use `response.split` options to split on a list,
don't explicitly set the `ignore_empty_value` option, and don't keep
parent fields, we usually don't want to index a document if the target
list is empty.

However, the default functionality is to index the whole document if
the split target is empty, so this change sets
`ignore_empty_value: true` explicitly.

The [`response.split` documentation][1] says:

> If the split target is empty the parent document will be kept.
> If documents with empty splits should be dropped, the
> `ignore_empty_value` option should be set to `true`.
 
[1]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#response-split
```

## Discussion

The effects of the somewhat counterintuitive default split behavior are sometimes reported by users, as was the case in https://github.com/elastic/integrations/pull/9705.

I used the following Python script to identify and update relevant cases.

<details>
<summary><code>fix.py</code></summary>

```python
#!/usr/bin/env python3

import os
import fnmatch
import re
import yaml


# define functions to generate and transform items

def yml_hbs_files(root=os.getcwd()):
    files = []
    for dirpath, dirnames, filenames in os.walk(root):
        for filename in fnmatch.filter(filenames, "*.yml.hbs"):
            files.append({ "file": os.path.join(dirpath, filename) })
    return files

def add_split_config(item):
    config = []
    with open(item["file"], 'r') as file:
        is_split_config = False
        for line in file.readlines():
            if line.startswith('response.split:'):
                is_split_config = True
                config = [] # one case has two configs and it's the second one that matters
            elif not line.startswith(' ') and not line.startswith('\t'):
                is_split_config = False
            if is_split_config:
                config.append(line)
    result = item.copy()
    result["split_config"] = config
    return result

def add_not_templated(item):
    templated = False
    for line in item["split_config"]:
        if re.match(r".*{{.*}}.*", line):
            templated = True
    result = item.copy()
    result["not_templated"] = not templated
    return result

def add_yaml(item):
    parsed = None
    if len(item["split_config"]) > 0 and item["not_templated"]:
        parsed = yaml.safe_load("".join(item["split_config"]))
    result = item.copy()
    result["yaml"] = parsed
    return result

def add_is_list_type(item):
    is_list_type = False
    if item["yaml"]:
        is_list_type = item["yaml"]["response.split"].get("type", "list") == "list"
    result = item.copy()
    result["is_list_type"] = is_list_type
    return result

def add_no_top_level_ignore_empty_value(item):
    absent = True
    if item["yaml"]:
        absent = not "ignore_empty_value" in item["yaml"]["response.split"]
    result = item.copy()
    result["no_top_level_ignore_empty_value"] = absent
    return result

def add_false_top_level_keep_parent(item):
    is_set = False
    if item["yaml"]:
        is_set = item["yaml"]["response.split"].get("keep_parent", False)
    result = item.copy()
    result["false_top_level_keep_parent"] = not is_set
    return result

def add_new_config_if_suitable(item):
    suitable = \
        len(item["split_config"]) > 0 and \
        item["not_templated"] and \
        item["is_list_type"] and \
        item["no_top_level_ignore_empty_value"] and \
        item["false_top_level_keep_parent"]
    if suitable:
        new_yaml = item["yaml"].copy()
        new_yaml["response.split"] = {}
        for k, v in item["yaml"]["response.split"].items():
            new_yaml["response.split"][k] = v
            if k == "target": # insert after top-level target param
                new_yaml["response.split"]["ignore_empty_value"] = True
        new_config = yaml.dump(new_yaml, sort_keys=False)
        result = item.copy()
        result["new_config"] = new_config
        return result
    else:
        return item


# generate and transform items
items = yml_hbs_files()
items = map(add_split_config, items)
items = map(add_not_templated, items)
items = map(add_yaml, items)
items = map(add_is_list_type, items)
items = map(add_no_top_level_ignore_empty_value, items)
items = map(add_false_top_level_keep_parent, items)
items = map(add_new_config_if_suitable, items)
items = list(items)


# print summary
selected = items.copy()
print("                                      total  selected")
print("                                  --------- ---------")
print("*.yml.hbs                         %9d %9d" % (
    len(items), len(selected)
))
selected = [i for i in selected if len(i["split_config"]) > 0]
print("has split_config:                 %9d %9d" % (
    sum(len(i["split_config"]) > 0 for i in items), len(selected)
))
selected = [i for i in selected if i["not_templated"]]
print("not_templated:                    %9d %9d" % (
    sum(i["not_templated"] for i in items), len(selected)
))
selected = [i for i in selected if i["is_list_type"]]
print("is_list_type:                     %9d %9d" % (
    sum(i["is_list_type"] for i in items), len(selected)
))
selected = [i for i in selected if i["no_top_level_ignore_empty_value"]]
print("no_top_level_ignore_empty_value:  %9d %9d" % (
    sum(i["no_top_level_ignore_empty_value"] for i in items), len(selected)
))
selected = [i for i in selected if i["false_top_level_keep_parent"]]
print("false_top_level_keep_parent:      %9d %9d" % (
    sum(i["false_top_level_keep_parent"] for i in items), len(selected)
))
selected = [i for i in selected if "new_config" in i]
print("new_config:                       %9d %9d" % (
    sum("new_config" in i for i in items), len(selected)
))
print()


# # print details
# for item in items:
#     if (
#         len(item["split_config"]) > 0 and \
#         item["not_templated"] and \
#         item["is_list_type"] and \
#         item["no_top_level_ignore_empty_value"] and \
#         item["false_top_level_keep_parent"] and \
#         "new_config" in item and \
#         True
#     ):
#         print(item["file"])
#         print()
#         print("".join(item["split_config"]))
#         print(item.get("new_config"))
#         print()

# # apply changes
# for item in items:
#     if "new_config" in item:
#         with open(item["file"], 'r', encoding='utf-8') as f:
#             content = f.read()
#         updated_content = content.replace("".join(item["split_config"]), item["new_config"])
#         with open(item["file"], 'w', encoding='utf-8') as f:
#             f.write(updated_content)
#         print("%s updated" % item["file"])
```

</details>

It's summary was:

```
                                      total  selected
                                  --------- ---------
*.yml.hbs                              1061      1061
has split_config:                       186       186
not_templated:                         1060       185
is_list_type:                           133       133
no_top_level_ignore_empty_value:       1032       105
false_top_level_keep_parent:           1057       101
new_config:                             101       101
```

I left out the AWS Security Hub changes already handled in https://github.com/elastic/integrations/pull/9705.

Some minor formatting changes are included.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #9705
- Supersedes #9815
- Closes #9965