### PR TITLE
Promote packages to GA

### DIFF
--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release package as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXX
+      link: https://github.com/elastic/integrations/pull/9977
 - version: "0.6.0"
   changes:
     - description: Update manifest format version to v3.0.3.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release package as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "0.6.0"
   changes:
     - description: Update manifest format version to v3.0.3.

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "0.6.0"
+version: "1.0.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release package as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/XXXX
 - version: "0.6.1"
   changes:
     - description: Fix name canonicalization routines.

--- a/packages/ti_threatconnect/changelog.yml
+++ b/packages/ti_threatconnect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release package as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/XXXX
+      link: https://github.com/elastic/integrations/pull/9977
 - version: "0.6.1"
   changes:
     - description: Fix name canonicalization routines.

--- a/packages/ti_threatconnect/manifest.yml
+++ b/packages/ti_threatconnect/manifest.yml
@@ -2,7 +2,7 @@
 format_version: 3.0.3
 name: ti_threatconnect
 title: ThreatConnect
-version: 0.6.1
+version: 1.0.0
 description: Collects Indicators from ThreatConnect using the Elastic Agent and saves them as logs inside Elastic
 type: integration
 categories:
@@ -70,4 +70,4 @@ policy_templates:
             show_user: false
 owner:
   github: elastic/security-service-integrations
-  type: elastic
+  type: partner


### PR DESCRIPTION
## Proposed commit message

```
Promote packages to GA (#)

Promote the following packages to GA:
- jamf_protect
- ti_threatconnect

Both are partner supported.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #9954
- Closes #9961