### PR TITLE
lastpass: Add `pagesize` and `pageindex` to `detailed_shared_folder` datastream

### DIFF
--- a/packages/lastpass/_dev/deploy/docker/files/config.yml
+++ b/packages/lastpass/_dev/deploy/docker/files/config.yml
@@ -1,11 +1,18 @@
 rules:
   - path: /
     methods: ['POST']
-    request_body: /^\{"cid":"[0-9]+","cmd":"getdetailedsfdata","data":"all","provhash":"[a-zA-Z]+"\}/
+    request_body: /^\{"cid":"[0-9]+","cmd":"getdetailedsfdata","data":\{"data":"all","pageindex":"0","pagesize":"[0-9]+"\},"provhash":"[a-zA-Z]+"\}/
     responses:
       - status_code: 200
         body: |
-          {"101":{"sharedfoldername":"ThisSFName","score":99,"users":[{"username":"joe.user@lastpass.com","readonly":true,"give":false,"can_administer":true,"sites":["aaa.com","bbb.com"]},{"username":"jane.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["zzz.com"]}]}}
+          {"101":{"sharedfoldername":"ThisSFName","score":99,"users":[{"username":"joe.user@lastpass.com","readonly":true,"give":false,"can_administer":true,"sites":["aaa.com","bbb.com"]},{"username":"jane.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["zzz.com"]},{"username":"john.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["ccc.com"]},{"username":"doe.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["ddd.com"]}]},"102":{"sharedfoldername":"ThatSFName","score":98,"users":[{"username":"john.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["ccc.com"]},{"username":"doe.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["ddd.com"]}]}}
+  - path: /
+    methods: ['POST']
+    request_body: /^\{"cid":"[0-9]+","cmd":"getdetailedsfdata","data":\{"data":"all","pageindex":"1","pagesize":"[0-9]+"\},"provhash":"[a-zA-Z]+"\}/
+    responses:
+      - status_code: 200
+        body: |
+          {"103":{"sharedfoldername":"SampleSFName","score":97,"users":[{"username":"sample.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["sss.com"]},{"username":"sample2.user@lastpass.com","readonly":true,"give":false,"can_administer":false,"sites":["ssss.com"]}]}}
   - path: /
     methods: ['POST']
     request_body: /^\{"cid":"[0-9]+","cmd":"reporting","data":\{[^}]*\},"provhash":"[a-zA-Z]+","user":"allusers"\}/

--- a/packages/lastpass/changelog.yml
+++ b/packages/lastpass/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Add pagesize and pageindex to request.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9988
 - version: "1.15.1"
   changes:
     - description: Fix page index for event reports.

--- a/packages/lastpass/data_stream/detailed_shared_folder/_dev/test/system/test-default-config.yml
+++ b/packages/lastpass/data_stream/detailed_shared_folder/_dev/test/system/test-default-config.yml
@@ -9,3 +9,6 @@ data_stream:
   vars:
     preserve_original_event: true
     preserve_duplicate_custom_fields: true
+    page_size: 2
+assert:
+  hit_count: 8

--- a/packages/lastpass/data_stream/detailed_shared_folder/agent/stream/httpjson.yml.hbs
+++ b/packages/lastpass/data_stream/detailed_shared_folder/agent/stream/httpjson.yml.hbs
@@ -26,13 +26,24 @@ request.transforms:
       target: body.cmd
       value: 'getdetailedsfdata'
   - set:
-      target: body.data
+      target: body.data.data
       value: 'all'
+  - set:
+      target: body.data.pagesize
+      value: '{{page_size}}'
+  - set:
+      target: body.data.pageindex
+      value: 0
 response.transforms:
   - set:
       target: body.data
       value: '[[.last_response.body]]'
       value_type: json
+response.pagination:
+  - set:
+      target: body.data.pageindex
+      value: '[[if (eq (len .last_response.body) (toInt .body.data.pagesize))]][[add .last_response.page 1]][[end]]'
+      fail_on_template_error: true
 response.split:
   target: body.data
   type: map

--- a/packages/lastpass/data_stream/detailed_shared_folder/manifest.yml
+++ b/packages/lastpass/data_stream/detailed_shared_folder/manifest.yml
@@ -6,6 +6,14 @@ streams:
     description: Collect detailed shared folder logs from LastPass.
     template_path: httpjson.yml.hbs
     vars:
+      - name: page_size
+        type: integer
+        multi: false
+        required: false
+        default: "2000"
+        show_user: false
+        title: Page Size
+        description: Limits the maximum number of items listed per page.
       - name: interval
         type: text
         title: Interval

--- a/packages/lastpass/data_stream/detailed_shared_folder/sample_event.json
+++ b/packages/lastpass/data_stream/detailed_shared_folder/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-07-24T13:38:49.667Z",
+    "@timestamp": "2024-05-24T11:28:38.242Z",
     "agent": {
-        "ephemeral_id": "0c9df2f5-7a57-46b5-af86-d72509a29876",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "4a4388c0-12ab-4c2c-910c-c912f6bd4730",
+        "id": "b0183e4b-ecd8-4ee9-8e73-bb43ce3ddcf2",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.12.2"
     },
     "data_stream": {
         "dataset": "lastpass.detailed_shared_folder",
@@ -16,15 +16,15 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "b0183e4b-ecd8-4ee9-8e73-bb43ce3ddcf2",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.12.2"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-07-24T13:38:49.667Z",
+        "created": "2024-05-24T11:28:38.242Z",
         "dataset": "lastpass.detailed_shared_folder",
-        "ingested": "2023-07-24T13:38:52Z",
+        "ingested": "2024-05-24T11:28:50Z",
         "kind": "state",
         "original": "{\"id\":\"101\",\"score\":99,\"sharedfoldername\":\"ThisSFName\",\"users\":{\"can_administer\":true,\"give\":false,\"readonly\":true,\"sites\":[\"aaa.com\",\"bbb.com\"],\"username\":\"joe.user@lastpass.com\"}}",
         "type": [

--- a/packages/lastpass/docs/README.md
+++ b/packages/lastpass/docs/README.md
@@ -52,13 +52,13 @@ An example event for `detailed_shared_folder` looks as following:
 
 ```json
 {
-    "@timestamp": "2023-07-24T13:38:49.667Z",
+    "@timestamp": "2024-05-24T11:28:38.242Z",
     "agent": {
-        "ephemeral_id": "0c9df2f5-7a57-46b5-af86-d72509a29876",
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "ephemeral_id": "4a4388c0-12ab-4c2c-910c-c912f6bd4730",
+        "id": "b0183e4b-ecd8-4ee9-8e73-bb43ce3ddcf2",
         "name": "docker-fleet-agent",
         "type": "filebeat",
-        "version": "8.8.2"
+        "version": "8.12.2"
     },
     "data_stream": {
         "dataset": "lastpass.detailed_shared_folder",
@@ -69,15 +69,15 @@ An example event for `detailed_shared_folder` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "e4c29d91-bbb7-42b8-80fd-85ddb56d2300",
+        "id": "b0183e4b-ecd8-4ee9-8e73-bb43ce3ddcf2",
         "snapshot": false,
-        "version": "8.8.2"
+        "version": "8.12.2"
     },
     "event": {
         "agent_id_status": "verified",
-        "created": "2023-07-24T13:38:49.667Z",
+        "created": "2024-05-24T11:28:38.242Z",
         "dataset": "lastpass.detailed_shared_folder",
-        "ingested": "2023-07-24T13:38:52Z",
+        "ingested": "2024-05-24T11:28:50Z",
         "kind": "state",
         "original": "{\"id\":\"101\",\"score\":99,\"sharedfoldername\":\"ThisSFName\",\"users\":{\"can_administer\":true,\"give\":false,\"readonly\":true,\"sites\":[\"aaa.com\",\"bbb.com\"],\"username\":\"joe.user@lastpass.com\"}}",
         "type": [
@@ -121,7 +121,6 @@ An example event for `detailed_shared_folder` looks as following:
         "email": "joe.user@lastpass.com"
     }
 }
-
 ```
 
 **Exported fields**

--- a/packages/lastpass/manifest.yml
+++ b/packages/lastpass/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: lastpass
 title: LastPass
-version: "1.15.1"
+version: "1.16.0"
 description: Collect logs from LastPass with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Add pagination to `detailed_shared_folder` data.

When `data.pagesize` and `data.pageindex` properties are omitted from the 
request body, by default the API returns all shared folders. Internally, LastPass does 
multiple backend calls which could result in `429 Too Many Requests`. 
To prevent this, add `data.pagesize` and `data.pageindex` to request body.

Other changes:
  - Update request `body.data: all` to `body.data.data: all` as per the API guide.
  - Update system tests to contain pagination request.
  - Add `assert.hit_count` to system test config.
```

Reference - https://support.lastpass.com/s/document-item?language=en_US&bundleId=lastpass&topicId=LastPass/api_shared_folder_detailed_data.html&_LANG=enus

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Check pagination using system tests

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
`elastic-package stack down && elastic-package build && elastic-package stack up -d -v && eval "$(elastic-package stack shellinit)" && elastic-package test system --data-streams=detailed_shared_folder --generate  -v --defer-cleanup 30m `
```
2024/05/24 16:58:38 DEBUG Policy revision assigned to the agent (ID: b0183e4b-ecd8-4ee9-8e73-bb43ce3ddcf2)...
2024/05/24 16:58:38 DEBUG checking for expected data in data stream (10m0s)...
2024/05/24 16:58:38 DEBUG found 0 hits in logs-lastpass.detailed_shared_folder-ep data stream
2024/05/24 16:58:50 DEBUG found 8 hits in logs-lastpass.detailed_shared_folder-ep data stream
2024/05/24 16:58:54 DEBUG found 8 hits in logs-lastpass.detailed_shared_folder-ep data stream
2024/05/24 16:58:54 DEBUG running command: /usr/local/bin/docker compose version --short
2024/05/24 16:58:54 DEBUG Determined Docker Compose version: 2.23.0-desktop.1
2024/05/24 16:58:54 DEBUG running command: /usr/local/bin/docker compose -f /Users/kcreddy/go/src/github.com/kcreddy/integrations/packages/lastpass/_dev/deploy/docker/docker-compose.yml -p elastic-package-service ps -a -q lastpass
2024/05/24 16:58:54 DEBUG output command: /usr/local/bin/docker inspect 033eff719d9a40a408c8fb4f638ffc7d1ed4a4d4afb67076158519f187b1e9ba
2024/05/24 16:58:55 DEBUG check whether or not synthetics is enabled (component template logs-lastpass.detailed_shared_folder@package)...
2024/05/24 16:58:55 DEBUG data stream logs-lastpass.detailed_shared_folder-ep has synthetics enabled: false
2024/05/24 16:58:55 DEBUG Package does not embed ECS mappings
2024/05/24 16:58:55 DEBUG assert hit count expected 8, observed 8
.......
--- Test results for package: lastpass - START ---
╭──────────┬────────────────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE  │ DATA STREAM            │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├──────────┼────────────────────────┼───────────┼───────────┼────────┼───────────────┤
│ lastpass │ detailed_shared_folder │ system    │ default   │ PASS   │ 34.453457458s │
╰──────────┴────────────────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: lastpass - END   ---
Done
```

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
