### PR TITLE
[Apache Tomcat] Fix improperly configured fields `harvester_limit` and `close.on_state_change.inactive`

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.5.1"
   changes:
-    - description: Fix "Harvest Limit" and "File Handle Closure duration" configuration parameters.
+    - description: Fix "Harvester Limit" and "File Handle Closure duration" configuration parameters.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9990
 - version: "1.5.0"

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix harvester_limit parameter in hbs file.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1 #FIX ME
+      link: https://github.com/elastic/integrations/pull/9990
 - version: "1.5.0"
   changes:
     - description: Add the configuration option for harvester_limit

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.5.1"
   changes:
-    - description: Fix harvester_limit parameter in hbs file.
+    - description: Fix "Harvest Limit" and "File Handle Closure duration" configuration parameters.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9990
 - version: "1.5.0"

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.1"
+  changes:
+    - description: Fix harvester_limit parameter in hbs file.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1 #FIX ME
 - version: "1.5.0"
   changes:
     - description: Add the configuration option for harvester_limit

--- a/packages/apache_tomcat/data_stream/access/agent/stream/filestream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/access/agent/stream/filestream.yml.hbs
@@ -18,10 +18,8 @@ processors:
 {{processors}}
 {{/if}}
 {{#if harvester_limit}}
-harvester_limit:
-{{harvester_limit}}
+harvester_limit: {{harvester_limit}}
 {{/if}}
 {{#if close.on_state_change.inactive}}
-close.on_state_change.inactive: 
+close.on_state_change.inactive: {{close.on_state_change.inactive}}
 {{/if}}
-

--- a/packages/apache_tomcat/data_stream/access/manifest.yml
+++ b/packages/apache_tomcat/data_stream/access/manifest.yml
@@ -39,7 +39,7 @@ streams:
       - name: harvester_limit
         type: integer
         title: Harvester Limit
-        description: Limits the number of files that are ingested in parallel.
+        description: Limits the number of files that are ingested in parallel. More details [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#filebeat-input-filestream-harvester-limit).
         required: false
         show_user: false
         default: 0

--- a/packages/apache_tomcat/data_stream/catalina/agent/stream/filestream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/catalina/agent/stream/filestream.yml.hbs
@@ -18,11 +18,10 @@ processors:
 {{processors}}
 {{/if}}
 {{#if harvester_limit}}
-harvester_limit:
-{{harvester_limit}}
+harvester_limit: {{harvester_limit}}
 {{/if}}
 {{#if close.on_state_change.inactive}}
-close.on_state_change.inactive: 
+close.on_state_change.inactive: {{close.on_state_change.inactive}}
 {{/if}}
 {{#if tz_offset}}
 fields_under_root: true

--- a/packages/apache_tomcat/data_stream/catalina/manifest.yml
+++ b/packages/apache_tomcat/data_stream/catalina/manifest.yml
@@ -48,7 +48,7 @@ streams:
       - name: harvester_limit
         type: integer
         title: Harvester Limit
-        description: Limits the number of harvesters that are started in parallel.
+        description: Limits the number of harvesters that are started in parallel. More details [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#filebeat-input-filestream-harvester-limit).
         required: false
         show_user: false
         default: 0 

--- a/packages/apache_tomcat/data_stream/localhost/agent/stream/filestream.yml.hbs
+++ b/packages/apache_tomcat/data_stream/localhost/agent/stream/filestream.yml.hbs
@@ -18,11 +18,10 @@ processors:
 {{processors}}
 {{/if}}
 {{#if harvester_limit}}
-harvester_limit:
-{{harvester_limit}}
+harvester_limit: {{harvester_limit}}
 {{/if}}
 {{#if close.on_state_change.inactive}}
-close.on_state_change.inactive: 
+close.on_state_change.inactive: {{close.on_state_change.inactive}}
 {{/if}}
 {{#if tz_offset}}
 fields_under_root: true

--- a/packages/apache_tomcat/data_stream/localhost/manifest.yml
+++ b/packages/apache_tomcat/data_stream/localhost/manifest.yml
@@ -48,7 +48,7 @@ streams:
       - name: harvester_limit
         type: integer
         title: Harvester Limit
-        description: Limits the number of harvesters that are started in parallel.
+        description: Limits the number of harvesters that are started in parallel. More details [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#filebeat-input-filestream-harvester-limit).
         required: false
         show_user: false
         default: 0 

--- a/packages/apache_tomcat/data_stream/localhost/manifest.yml
+++ b/packages/apache_tomcat/data_stream/localhost/manifest.yml
@@ -59,6 +59,7 @@ streams:
         multi: false
         required: false
         show_user: false
+        default: 5m
       - name: parsers
         type: yaml
         title: Parsers

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.5.0"
+version: "1.5.1"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Description
`harvester_limit` was configured wrongly in `hbs.yml` file which leads to the following error while saving the integration.
![error](https://github.com/elastic/integrations/assets/124254029/0c222e19-dacf-4d4a-a456-f4fbe5105037)

This PR is raised to fix the above issue. After fix we are able to save the integration and agent policy is getting updated properly.

![image](https://github.com/elastic/integrations/assets/124254029/7a9bead3-05ca-45db-9052-9b179f3436e3)

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
- Clone integrations repo.
- Install elastic-package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/apache_tomcat) directory.
- Run the following command to run tests. elastic-package test



## Related issues


- Relates https://github.com/elastic/enhancements/issues/21308



