### PR TITLE
bitdefender: Update doc with input limitation collecting jsonRPC format.

### DIFF
--- a/packages/bitdefender/_dev/build/docs/README.md
+++ b/packages/bitdefender/_dev/build/docs/README.md
@@ -70,7 +70,7 @@ The BitDefender documentation for how to do this is [here](https://www.bitdefend
 
 You should use the "qradar" format option.
 
-**NOTE**: The "jsonrpc" format that BitDefender's documentation presents as the default and best option, should **NOT** be used, due to limitations in the filebeat "http_endpoint" input and available processors at this point.
+**NOTE**: The `jsonrpc` format that BitDefender's documentation presents as the default and best option, should **NOT** be used, due to limitations in the filebeat "http_endpoint" input and available processors at this point. The [`http_endpoint` input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-http_endpoint.html) can only collect events if the incoming body is either an object or an array of objects at the root. But as `jsonrpc` format sends the array of events bundled inside `params.events` JSON key, the input is currently unable to collect them.
 
 An example using cURL, as the official documentation is unclear at times what to do and how to do it.
 

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update doc with input limitation collecting jsonRPC format.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/10019
 - version: "1.12.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/bitdefender/changelog.yml
+++ b/packages/bitdefender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.0"
+  changes:
+    - description: Update doc with input limitation collecting jsonRPC format.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.12.0"
   changes:
     - description: Set sensitive values as secret.

--- a/packages/bitdefender/data_stream/push_notifications/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/bitdefender/data_stream/push_notifications/elasticsearch/ingest_pipeline/default.yml
@@ -32,10 +32,6 @@ processors:
     field: ecs.version
     value: '8.11.0'
 
-### fix common dumb string/numeric conflicts that we've seen so far, before doing anything else
-### NOTE: given the insanity oozing out of the "defined" BitDefender push notification event type formats,
-### perhaps a script to just convert everything to keyword/string and we do convert when necessary instead of hoping they will send a consistent format?
-
 - convert:
     field: bitdefender.event.status
     type: string
@@ -65,9 +61,6 @@ processors:
     field: bitdefender.event.taskType
     type: string
     ignore_missing: true
-
-### fix timestamps because BitDefender is too inept to format them properly or provide them consistently
-### we do not use any of these for @timestamp due to the lack of consistency with respect to BitDefender providing any of them.
 
 - date:
     if: ctx.bitdefender?.event?.lastAdReportDate != null && ctx.bitdefender?.event?.lastAdReportDate != ""
@@ -179,7 +172,9 @@ processors:
       - ISO8601
       - UNIX
 
-### attempt to parse this pile of garbage to ECS
+################
+## ECS fields ##
+################
 
 ### organization fields
 
@@ -352,7 +347,7 @@ processors:
         ctx.event.type = schema;
       }
 
-# translate module code to a usefule description
+# translate module code to a useful description
 - script:
     lang: painless
     params:
@@ -446,7 +441,7 @@ processors:
     ignore_empty_value: true
     if: ctx.event?.severity == null
 
-### try to determine the action taken by BitDefender from the miriad of fields they use to say the same thing...
+### Determine event.action
 
 - set:
     copy_from: bitdefender.event.final_status
@@ -755,7 +750,7 @@ processors:
     target_field: destination.port
     ignore_missing: true
 
-### user related fields from the quagmire that is the BitDefender fields.
+### user related fields.
 
 - set:
     copy_from: bitdefender.event.user.id
@@ -1042,7 +1037,7 @@ processors:
     ignore_empty_value: true
     if: ctx.threat?.software?.name == null
 
-### MITRE ATT&CK stuff - dubious value given the quality of BitDefender.
+### attack fields
 
 - set:
     copy_from: bitdefender.event.attack_types
@@ -1097,7 +1092,7 @@ processors:
     allow_duplicates: false
 
 
-### message - create something useful if BitDefender didn't give us something useful (hint: they did not.)
+### Create message if it doesn't exist.
 
 - set:
     field: message

--- a/packages/bitdefender/docs/README.md
+++ b/packages/bitdefender/docs/README.md
@@ -70,7 +70,7 @@ The BitDefender documentation for how to do this is [here](https://www.bitdefend
 
 You should use the "qradar" format option.
 
-**NOTE**: The "jsonrpc" format that BitDefender's documentation presents as the default and best option, should **NOT** be used, due to limitations in the filebeat "http_endpoint" input and available processors at this point.
+**NOTE**: The `jsonrpc` format that BitDefender's documentation presents as the default and best option, should **NOT** be used, due to limitations in the filebeat "http_endpoint" input and available processors at this point. The [`http_endpoint` input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-http_endpoint.html) can only collect events if the incoming body is either an object or an array of objects at the root. But as `jsonrpc` format sends the array of events bundled inside `params.events` JSON key, the input is currently unable to collect them.
 
 An example using cURL, as the official documentation is unclear at times what to do and how to do it.
 

--- a/packages/bitdefender/manifest.yml
+++ b/packages/bitdefender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: bitdefender
 title: "BitDefender"
-version: "1.12.0"
+version: "1.13.0"
 source:
   license: "Elastic-2.0"
 description: "Ingest BitDefender GravityZone logs and data"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Update doc with input limitations.

The http_endpoint input limitation on jsonRPC format 
is not properly explained inside the doc, which is confusing to users. 
Update the doc explaining the input limitation on jsonRPC format.

Other changes:
  - Remove comments from pipeline definition.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
Before:
<img width="929" alt="Screenshot 2024-05-30 at 12 36 18 PM" src="https://github.com/elastic/integrations/assets/11301409/3ad37285-2015-436b-8dc8-7e0f89d5c69f">

After:
<img width="929" alt="Screenshot 2024-05-30 at 12 35 48 PM" src="https://github.com/elastic/integrations/assets/11301409/37be340b-c377-49ac-9267-b2958758f1cb">

