### PR TITLE
Update MSSQL doc for version requirements

### DIFF
--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -38,7 +38,7 @@ If you browse Microsoft Developer Network (MSDN) for the following tables, you w
 1. `transaction_log`:
     - [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
     - [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
-    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)
+    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)  (Only collected on MSSQL 2016 or later)
 2. `performance`:
     - [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 

--- a/packages/microsoft_sqlserver/_dev/build/docs/README.md
+++ b/packages/microsoft_sqlserver/_dev/build/docs/README.md
@@ -38,7 +38,7 @@ If you browse Microsoft Developer Network (MSDN) for the following tables, you w
 1. `transaction_log`:
     - [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
     - [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
-    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)  (Only collected on MSSQL 2016 or later)
+    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16) (Available on SQL Server (MSSQL) 2016 (13.x) SP 2 and later)
 2. `performance`:
     - [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 2.5.1
+  changes:
+    - description: Update documentation for `transaction_logs` metric collection limits.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10025
 - version: 2.5.0
   changes:
     - description: Enable 'secret' for the sensitive fields.

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -38,7 +38,7 @@ If you browse Microsoft Developer Network (MSDN) for the following tables, you w
 1. `transaction_log`:
     - [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
     - [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
-    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16) (Only collected on MSSQL 2016 or later)
+    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)  (Only collected on MSSQL 2016 or later)
 2. `performance`:
     - [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -20,7 +20,7 @@ Find more details in [Logs](#logs).
 Metric data streams collected by the integration include:
 
 * `performance` metrics gather the list of performance objects available on that server. Each server will have a different list of performance objects depending on the installed software.
-* `transaction_log` metrics collect all usage stats and the total space usage. Microsoft SQL Server 2016 or later is required to collect these metrics.
+* `transaction_log` metrics collect all usage stats and the total space usage.
 
 Find more details in [Metrics](#metrics).
 
@@ -38,7 +38,7 @@ If you browse Microsoft Developer Network (MSDN) for the following tables, you w
 1. `transaction_log`:
     - [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
     - [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
-    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)
+    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16) (Only collected on MSSQL 2016 or later)
 2. `performance`:
     - [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -38,7 +38,7 @@ If you browse Microsoft Developer Network (MSDN) for the following tables, you w
 1. `transaction_log`:
     - [sys.databases](https://learn.microsoft.com/en-us/sql/relational-databases/system-compatibility-views/sys-sysdatabases-transact-sql?view=sql-server-ver16)
     - [sys.dm_db_log_space_usage](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-space-usage-transact-sql?view=sql-server-ver16)
-    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16)  (Only collected on MSSQL 2016 or later)
+    - [sys.dm_db_log_stats (DB_ID)](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16) (Available on SQL Server (MSSQL) 2016 (13.x) SP 2 and later)
 2. `performance`:
     - [sys.dm_os_performance_counters](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-os-performance-counters-transact-sql?view=sql-server-ver16)
 

--- a/packages/microsoft_sqlserver/docs/README.md
+++ b/packages/microsoft_sqlserver/docs/README.md
@@ -20,7 +20,7 @@ Find more details in [Logs](#logs).
 Metric data streams collected by the integration include:
 
 * `performance` metrics gather the list of performance objects available on that server. Each server will have a different list of performance objects depending on the installed software.
-* `transaction_log` metrics collect all usage stats and the total space usage.
+* `transaction_log` metrics collect all usage stats and the total space usage. Microsoft SQL Server 2016 or later is required to collect these metrics.
 
 Find more details in [Metrics](#metrics).
 

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "2.5.0"
+version: "2.5.1"
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
 categories:


### PR DESCRIPTION
## Update Microsoft SQL Server docs

This is an update to the MSSQL integration docs to indicate that the `transaction_logs` metrics requires version 2016 or later.  Per [MS documentation](https://learn.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-db-log-stats-transact-sql?view=sql-server-ver16) the collection requires a table that was not present in earlier server versions.

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

![image](https://github.com/elastic/integrations/assets/124054599/f551bf1b-1056-42f6-935a-91da69eaca1b)




## Related issues

Closes https://github.com/elastic/integrations/issues/10024