### PR TITLE
[cisco_ios] Update 'if' case in grok to handle IOSXE log message that was erroring

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.9"
+  changes:
+    - description: Update grok if statement to skip IOSXE messages with no sub-message
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10030
 - version: "1.26.8"
   changes:
     - description: Fix parsing for timezones with abbreviation and offset representation

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog-header.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog-header.log
@@ -15,3 +15,4 @@
 <190>Jul 13 08:23:43 192.168.100.2 585917: Jul 14 2023 08:23:43 UTC: %FOO-6-BAR: Test header format
 Jul 13 08:23:43 192.168.100.2 585917: Jul 14 2023 08:23:43 UTC: %FOO-6-BAR: Test header format
 Jul 13 08:23:43 sw01 1663410: Jul 14 2023 08:23:43 UTC: %FOO-6-BAR: Test header format
+<171>250756222: FNZPRPE11: 328926563: May 8 14:21:40.139 MDT: %IOSXE-3-PLATFORM: R0/0: bcm_switch: SchanTimeOut:soc_schan_op operation timed out

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog-header.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-syslog-header.log-expected.json
@@ -679,6 +679,48 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-05-08T14:21:40.139-06:00",
+            "cisco": {
+                "ios": {
+                    "facility": "IOSXE",
+                    "message_count": 250756222,
+                    "sequence": "328926563"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PLATFORM",
+                "original": "<171>250756222: FNZPRPE11: 328926563: May 8 14:21:40.139 MDT: %IOSXE-3-PLATFORM: R0/0: bcm_switch: SchanTimeOut:soc_schan_op operation timed out",
+                "provider": "firewall",
+                "sequence": 328926563,
+                "severity": 3,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "FNZPRPE11",
+                    "priority": 171
+                }
+            },
+            "message": "SchanTimeOut:soc_schan_op operation timed out",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -147,7 +147,7 @@ processors:
       patterns:
         - '%%{DATA:cisco.ios.facility}-%{POSINT:event.severity}-%{DATA:event.code}:\s+(\w+\d+(/\d+)?\:\s+)?([a-zA-Z0-9_]+\:\s+)?%{GREEDYDATA:message}'
       ignore_missing: true
-      if: ctx.cisco?.ios?.facility == 'IOSXE' && ctx.event?.code == 'PLATFORM'
+      if: "ctx.cisco?.ios?.facility == 'IOSXE' && ctx.event?.code == 'PLATFORM' && ctx.message.indexOf('%') != -1"
   - grok:
       field: message
       tag: grok_audit_details

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.26.8"
+version: "1.26.9"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

 * Update `if` clause for `grok_child_message` entry so it does not try to parse log messages that do not contain submessages that start with `%`.  Added test using log message from SDH that was throwing an error and verified the tests pass.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

```
cd packages/cisco_ios
elastic-package test pipeline
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/sdh-beats/issues/4754

## Screenshots

Log message that triggered the bug:

```
<171>250756222: FNZPRPE11: 328926563: May 8 14:21:40.139 MDT: %IOSXE-3-PLATFORM: R0/0: bcm_switch: SchanTimeOut:soc_schan_op operation timed out
```

Error message that was being created:

```
Processor "conditional" with tag "grok_child_message" in pipeline "logs-cisco_ios.log-1.26.6" failed with message "Provided Grok expressions do not match field value: [SchanTimeOut:soc_schan_op operation timed out]"
```

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
