### PR TITLE
[Apache Tomcat] Add JDBC Connection Pool maxActive on Ingestion Pipeline // do not approve

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Add JDBC Connection Pool maxActive on Ingestion Pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10037
 - version: "1.5.1"
   changes:
     - description: Fix "Harvester Limit" and "File Handle Closure duration" configuration parameters.

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add JDBC Connection Pool maxActive on Ingestion Pipeline.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10037
+      link: https://github.com/elastic/integrations/pull/10038
 - version: "1.5.1"
   changes:
     - description: Fix "Harvester Limit" and "File Handle Closure duration" configuration parameters.

--- a/packages/apache_tomcat/data_stream/connection_pool/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/elasticsearch/ingest_pipeline/default.yml
@@ -208,6 +208,10 @@ processors:
       field: prometheus.metrics.Catalina_DataSource_maxTotal
       target_field: apache_tomcat.connection_pool.max.total
       ignore_missing: true
+  - rename:
+      field: prometheus.metrics.Catalina_DataSource_maxActive
+      target_field: apache_tomcat.connection_pool.max.active
+      ignore_missing: true
   - set:
       field: apache_tomcat.connection_pool.prepared_statements
       value: true

--- a/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
@@ -181,6 +181,10 @@
               type: double
               description: Maximum total of connection pool.
               metric_type: gauge
+            - name: active
+              type: double
+              description: Maximum active of connection pool.
+              metric_type: gauge
         - name: prepared_statements
           type: boolean
           description: Validate connections from this pool.

--- a/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
@@ -179,11 +179,11 @@
           fields:
             - name: total
               type: double
-              description: Maximum total of connection pool.
+              description: The maximum number of database connections in pool.
               metric_type: gauge
             - name: active
               type: double
-              description: Maximum active of connection pool.
+              description: The maximum number of active connections that can be allocated from a pool at the same time.
               metric_type: gauge
         - name: prepared_statements
           type: boolean

--- a/packages/apache_tomcat/docs/README.md
+++ b/packages/apache_tomcat/docs/README.md
@@ -841,7 +841,8 @@ An example event for `connection_pool` looks as following:
 | apache_tomcat.connection_pool.connection.time_betwen_eviction_run.time.ms | The total amount of time in milliseconds to sleep between runs of the idle connection validation/cleaner thread. | double | ms | gauge |
 | apache_tomcat.connection_pool.connection.validate | Validate connections from this pool. | double |  | gauge |
 | apache_tomcat.connection_pool.lifo | Last In First Out connections. | boolean |  |  |
-| apache_tomcat.connection_pool.max.total | Maximum total of connection pool. | double |  | gauge |
+| apache_tomcat.connection_pool.max.active | The maximum number of active connections that can be allocated from a pool at the same time. | double |  | gauge |
+| apache_tomcat.connection_pool.max.total | The maximum number of database connections in pool. | double |  | gauge |
 | apache_tomcat.connection_pool.prepared_statements | Validate connections from this pool. | boolean |  |  |
 | apache_tomcat.connection_pool.test_on_borrow | The indication of whether objects will be validated before being borrowed from the pool. | boolean |  |  |
 | apache_tomcat.connection_pool.test_on_create | Property determines whether or not the pool will validate objects immediately after they are created by the pool. | boolean |  |  |

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.5.1"
+version: "1.5.2"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
## Type

- Enhancement

## Proposed commit message

Extract the maxActive field from the Apache Tomcat connection pool using the ingest pipeline.

This data could be used to identify the usage of a JBDC pool.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Tested in a real case adding this change to the default ingest pipeline.

## How to test this PR locally

1. Install elastic-agent
2. Add the Apache Tomcat integration

## Related issues

- Closes #10037

## Screenshots

None