### PR TITLE
[Azure OpenAI] Add saved search to the Logs dashboard.

### DIFF
--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.0"
+  changes:
+    - description: Add saved search to logs dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.5.1"
   changes:
     - description: Update overview dashboard and navigation panel.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add saved search to logs dashboard.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10039
 - version: "0.5.1"
   changes:
     - description: Update overview dashboard and navigation panel.

--- a/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
+++ b/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"35dec3e9-d88a-4d28-bbd2-560c53153705\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"35dec3e9-d88a-4d28-bbd2-560c53153705\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription ID\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"4605e45a-ad77-411c-8b73-9386ad0b2767\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"4605e45a-ad77-411c-8b73-9386ad0b2767\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"6d0e6057-e2be-430f-a773-a24b9f09abfc\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"6d0e6057-e2be-430f-a773-a24b9f09abfc\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"cf6d906b-55d7-441d-a250-81b059e08d5b\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"cf6d906b-55d7-441d-a250-81b059e08d5b\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription ID\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"a3d4fb4f-fa13-41c5-8461-d8427f83569b\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"a3d4fb4f-fa13-41c5-8461-d8427f83569b\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"88471060-ec8f-4239-998e-cf862ad7d9d3\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"88471060-ec8f-4239-998e-cf862ad7d9d3\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -26,7 +26,9 @@
         "panelsJSON": [
             {
                 "embeddableConfig": {
+                    "description": "",
                     "enhancements": {},
+                    "hidePanelTitles": true,
                     "savedVis": {
                         "data": {
                             "aggs": [],
@@ -52,12 +54,13 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "4b82f69d-19ee-4376-99b6-72a3774b5038",
+                    "i": "af153277-d840-4bdd-aadd-16393a1b81c8",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "4b82f69d-19ee-4376-99b6-72a3774b5038",
+                "panelIndex": "af153277-d840-4bdd-aadd-16393a1b81c8",
+                "title": "",
                 "type": "visualization"
             },
             {
@@ -188,12 +191,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "308b660d-b9eb-432b-81b4-69f370daf43a",
+                    "i": "a5ca3e3b-6667-40b3-af64-25943e30e040",
                     "w": 16,
                     "x": 0,
                     "y": 5
                 },
-                "panelIndex": "308b660d-b9eb-432b-81b4-69f370daf43a",
+                "panelIndex": "a5ca3e3b-6667-40b3-af64-25943e30e040",
                 "title": "Total Documents",
                 "type": "lens"
             },
@@ -371,12 +374,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "e8bd0970-e6ea-406f-90e2-4cbc3aa1b2cb",
+                    "i": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1",
                     "w": 32,
                     "x": 16,
                     "y": 5
                 },
-                "panelIndex": "e8bd0970-e6ea-406f-90e2-4cbc3aa1b2cb",
+                "panelIndex": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1",
                 "title": "Documents Over Time",
                 "type": "lens"
             },
@@ -408,7 +411,6 @@
                             },
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
                                     "layers": {
                                         "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
                                             "columnOrder": [
@@ -421,7 +423,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Subscription ID",
+                                                    "label": "Subscriptions",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -484,20 +486,13 @@
                                                     "sourceField": "data_stream.dataset"
                                                 }
                                             },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1"
+                                            "incompleteColumns": {}
                                         }
                                     }
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [
-                                {
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                    "type": "index-pattern"
-                                }
-                            ],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -576,12 +571,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "876fb0e5-ff3c-4736-93c0-ff39c8dbeaf4",
+                    "i": "9562d7a5-d988-4a39-9041-0eb8569a4174",
                     "w": 16,
                     "x": 0,
                     "y": 20
                 },
-                "panelIndex": "876fb0e5-ff3c-4736-93c0-ff39c8dbeaf4",
+                "panelIndex": "9562d7a5-d988-4a39-9041-0eb8569a4174",
                 "title": "Subscriptions By Dataset",
                 "type": "lens"
             },
@@ -782,12 +777,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "e8dd040c-f54a-43a4-8158-c44ee4a0a904",
+                    "i": "3e30954e-2294-47ed-9507-5e85222b82bb",
                     "w": 16,
                     "x": 16,
                     "y": 20
                 },
-                "panelIndex": "e8dd040c-f54a-43a4-8158-c44ee4a0a904",
+                "panelIndex": "3e30954e-2294-47ed-9507-5e85222b82bb",
                 "title": "Resource Groups By Dataset",
                 "type": "lens"
             },
@@ -819,7 +814,6 @@
                             },
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
                                     "layers": {
                                         "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
                                             "columnOrder": [
@@ -832,7 +826,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Subscription ID",
+                                                    "label": "Resources",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -896,20 +890,13 @@
                                                     "sourceField": "data_stream.dataset"
                                                 }
                                             },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1"
+                                            "incompleteColumns": {}
                                         }
                                     }
                                 }
                             },
                             "filters": [],
-                            "internalReferences": [
-                                {
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                    "type": "index-pattern"
-                                }
-                            ],
+                            "internalReferences": [],
                             "query": {
                                 "language": "kuery",
                                 "query": ""
@@ -988,12 +975,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "1f63aebc-cb64-42d6-8945-0eab06536b77",
+                    "i": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b",
                     "w": 16,
                     "x": 32,
                     "y": 20
                 },
-                "panelIndex": "1f63aebc-cb64-42d6-8945-0eab06536b77",
+                "panelIndex": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b",
                 "title": "Resources By Dataset",
                 "type": "lens"
             }
@@ -1009,48 +996,48 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-05-30T10:54:04.168Z",
+    "created_at": "2024-05-31T06:04:09.365Z",
     "id": "azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3",
     "managed": false,
     "references": [
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "308b660d-b9eb-432b-81b4-69f370daf43a:indexpattern-datasource-layer-639167a0-f975-4e24-89f5-894eb1d51ce6",
+            "name": "a5ca3e3b-6667-40b3-af64-25943e30e040:indexpattern-datasource-layer-639167a0-f975-4e24-89f5-894eb1d51ce6",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "e8bd0970-e6ea-406f-90e2-4cbc3aa1b2cb:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "name": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "876fb0e5-ff3c-4736-93c0-ff39c8dbeaf4:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "name": "9562d7a5-d988-4a39-9041-0eb8569a4174:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "e8dd040c-f54a-43a4-8158-c44ee4a0a904:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "name": "3e30954e-2294-47ed-9507-5e85222b82bb:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "1f63aebc-cb64-42d6-8945-0eab06536b77:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "name": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_35dec3e9-d88a-4d28-bbd2-560c53153705:optionsListDataView",
+            "name": "controlGroup_cf6d906b-55d7-441d-a250-81b059e08d5b:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_4605e45a-ad77-411c-8b73-9386ad0b2767:optionsListDataView",
+            "name": "controlGroup_a3d4fb4f-fa13-41c5-8461-d8427f83569b:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_6d0e6057-e2be-430f-a773-a24b9f09abfc:optionsListDataView",
+            "name": "controlGroup_88471060-ec8f-4239-998e-cf862ad7d9d3:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/kibana/dashboard/azure_openai-5b98323b-7e41-408d-8b82-9cc41d4ed747.json
+++ b/packages/azure_openai/kibana/dashboard/azure_openai-5b98323b-7e41-408d-8b82-9cc41d4ed747.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"8f7d94c1-add0-4df6-b677-0cef87a4fac2\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"8f7d94c1-add0-4df6-b677-0cef87a4fac2\",\"fieldName\":\"azure.open_ai.properties.model_name\",\"title\":\"Model Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"5e381b5e-eb14-4af8-800c-d4d32ded0ac6\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"5e381b5e-eb14-4af8-800c-d4d32ded0ac6\",\"fieldName\":\"azure.open_ai.properties.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"0eeb7454-b3a2-476c-b4fe-52936ac0a818\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"0eeb7454-b3a2-476c-b4fe-52936ac0a818\",\"fieldName\":\"azure.open_ai.properties.model_deployment_name\",\"title\":\"Model Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"f2093459-6dac-4f17-8921-fb2330b7e74a\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"f2093459-6dac-4f17-8921-fb2330b7e74a\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription ID\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"d19fa356-c0b3-4490-8062-be43f9425227\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"d19fa356-c0b3-4490-8062-be43f9425227\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"cadf4d8b-6542-4095-a5cb-aa48e93d7db8\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"cadf4d8b-6542-4095-a5cb-aa48e93d7db8\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"a5782f20-ea17-4c98-83dd-76c5eea72996\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"a5782f20-ea17-4c98-83dd-76c5eea72996\",\"fieldName\":\"azure.open_ai.properties.model_name\",\"title\":\"Model Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"7539ae5d-62a1-4935-8e2d-d3c989e9459c\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"7539ae5d-62a1-4935-8e2d-d3c989e9459c\",\"fieldName\":\"azure.open_ai.properties.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"30d882e3-4b70-424f-881c-33f6e3d9bde0\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"30d882e3-4b70-424f-881c-33f6e3d9bde0\",\"fieldName\":\"azure.open_ai.properties.model_deployment_name\",\"title\":\"Model Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"2000b189-afd8-4824-9a69-b34587323392\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"2000b189-afd8-4824-9a69-b34587323392\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription ID\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"582b9906-76be-4b32-87b4-417fcc51ab92\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"582b9906-76be-4b32-87b4-417fcc51ab92\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"1ca21205-a666-4653-818f-92a93d17cb3f\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"1ca21205-a666-4653-818f-92a93d17cb3f\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -75,12 +75,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "26eaeb8c-ecc4-451f-a526-4ad1bc0998e0",
+                    "i": "647ee35b-53c3-46b9-b3d7-4f0eb797e732",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "26eaeb8c-ecc4-451f-a526-4ad1bc0998e0",
+                "panelIndex": "647ee35b-53c3-46b9-b3d7-4f0eb797e732",
                 "type": "visualization"
             },
             {
@@ -172,12 +172,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "2de88fc5-35da-46ab-be7b-252617812d27",
+                    "i": "d2966ed0-2851-47ca-9b62-62b6bbe7f2cc",
                     "w": 8,
                     "x": 0,
                     "y": 5
                 },
-                "panelIndex": "2de88fc5-35da-46ab-be7b-252617812d27",
+                "panelIndex": "d2966ed0-2851-47ca-9b62-62b6bbe7f2cc",
                 "title": "Number of Requests",
                 "type": "lens"
             },
@@ -360,12 +360,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "ad45a576-6069-47e1-abd2-f488a3ce0d7a",
+                    "i": "a34e094c-0fb7-4023-90c6-ba8386b2aab2",
                     "w": 8,
                     "x": 8,
                     "y": 5
                 },
-                "panelIndex": "ad45a576-6069-47e1-abd2-f488a3ce0d7a",
+                "panelIndex": "a34e094c-0fb7-4023-90c6-ba8386b2aab2",
                 "title": "Total Average Latency",
                 "type": "lens"
             },
@@ -495,12 +495,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "c2c09a26-acd3-4820-89a3-f3d96e2bcc4f",
+                    "i": "8b11a8c4-03c4-41c0-a877-7e56bd3dd99a",
                     "w": 8,
                     "x": 16,
                     "y": 5
                 },
-                "panelIndex": "c2c09a26-acd3-4820-89a3-f3d96e2bcc4f",
+                "panelIndex": "8b11a8c4-03c4-41c0-a877-7e56bd3dd99a",
                 "title": "Response Codes",
                 "type": "lens"
             },
@@ -668,12 +668,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "f72ec432-eef5-47c5-9e41-adc5c70e396d",
+                    "i": "420df4b7-2af2-475f-adda-85013c856d52",
                     "w": 24,
                     "x": 24,
                     "y": 5
                 },
-                "panelIndex": "f72ec432-eef5-47c5-9e41-adc5c70e396d",
+                "panelIndex": "420df4b7-2af2-475f-adda-85013c856d52",
                 "title": "Response Codes over time",
                 "type": "lens"
             },
@@ -880,12 +880,12 @@
                 },
                 "gridData": {
                     "h": 13,
-                    "i": "63eadaf9-4a41-4ca0-a699-e36649bf660f",
+                    "i": "adfec282-0a6a-4ea7-93cf-4b433a1f57a2",
                     "w": 24,
                     "x": 0,
                     "y": 17
                 },
-                "panelIndex": "63eadaf9-4a41-4ca0-a699-e36649bf660f",
+                "panelIndex": "adfec282-0a6a-4ea7-93cf-4b433a1f57a2",
                 "title": "Average Latency",
                 "type": "lens"
             },
@@ -1040,12 +1040,12 @@
                 },
                 "gridData": {
                     "h": 13,
-                    "i": "596c5aac-e72d-433d-90f4-6e84d123daa9",
+                    "i": "ec9144d1-4baa-4228-afd4-3d2c99c40b0d",
                     "w": 24,
                     "x": 24,
                     "y": 17
                 },
-                "panelIndex": "596c5aac-e72d-433d-90f4-6e84d123daa9",
+                "panelIndex": "ec9144d1-4baa-4228-afd4-3d2c99c40b0d",
                 "title": "Request and Response Length",
                 "type": "lens"
             },
@@ -1213,12 +1213,12 @@
                 },
                 "gridData": {
                     "h": 14,
-                    "i": "6c6f368e-b0f0-45e5-ae7d-5f0dbd7765b9",
+                    "i": "7bb01835-4f88-4eaf-9956-dd7b235a6712",
                     "w": 24,
                     "x": 0,
                     "y": 30
                 },
-                "panelIndex": "6c6f368e-b0f0-45e5-ae7d-5f0dbd7765b9",
+                "panelIndex": "7bb01835-4f88-4eaf-9956-dd7b235a6712",
                 "title": "Top Request Response Operations",
                 "type": "lens"
             },
@@ -1382,14 +1382,35 @@
                 },
                 "gridData": {
                     "h": 14,
-                    "i": "d20f729a-c05a-41bc-a0ae-da81afbadbff",
+                    "i": "e0767d2f-30c6-47d9-ade4-72ddcc51f16f",
                     "w": 24,
                     "x": 24,
                     "y": 30
                 },
-                "panelIndex": "d20f729a-c05a-41bc-a0ae-da81afbadbff",
+                "panelIndex": "e0767d2f-30c6-47d9-ade4-72ddcc51f16f",
                 "title": "Top Audit Operations",
                 "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "enhancements": {},
+                    "sort": [
+                        [
+                            "@timestamp",
+                            "desc"
+                        ]
+                    ]
+                },
+                "gridData": {
+                    "h": 16,
+                    "i": "b2c4e00a-6ea2-4675-8ebd-9c0154655b28",
+                    "w": 48,
+                    "x": 0,
+                    "y": 57
+                },
+                "panelIndex": "b2c4e00a-6ea2-4675-8ebd-9c0154655b28",
+                "panelRefName": "panel_b2c4e00a-6ea2-4675-8ebd-9c0154655b28",
+                "type": "search"
             },
             {
                 "embeddableConfig": {
@@ -1538,12 +1559,12 @@
                 },
                 "gridData": {
                     "h": 13,
-                    "i": "916e1ab6-6ca7-4c59-b84b-3b32ccc91b37",
+                    "i": "d866ba2c-4847-4eaa-9ab3-c0fa3035a876",
                     "w": 24,
                     "x": 0,
                     "y": 44
                 },
-                "panelIndex": "916e1ab6-6ca7-4c59-b84b-3b32ccc91b37",
+                "panelIndex": "d866ba2c-4847-4eaa-9ab3-c0fa3035a876",
                 "title": "Operations by Stream Type",
                 "type": "lens"
             },
@@ -1698,216 +1719,13 @@
                 },
                 "gridData": {
                     "h": 13,
-                    "i": "cc9dd648-1668-4ad3-930b-f137d09b6601",
+                    "i": "3b9b71f6-1296-4898-b4f7-ac201b276cf8",
                     "w": 24,
                     "x": 24,
                     "y": 44
                 },
-                "panelIndex": "cc9dd648-1668-4ad3-930b-f137d09b6601",
+                "panelIndex": "3b9b71f6-1296-4898-b4f7-ac201b276cf8",
                 "title": "Top Error Response Codes by Operations",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-00e65d9d-c39d-4cc4-ba5f-6b8e6b3d3a64",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "00e65d9d-c39d-4cc4-ba5f-6b8e6b3d3a64": {
-                                            "columnOrder": [
-                                                "8ff57a0c-5ce2-4f97-baca-685defc2cf60",
-                                                "cee42f78-3475-46ee-9b88-9f0b36c3cac0",
-                                                "eb8e428b-ac44-48bc-a7ae-523c276f71d1",
-                                                "46fae128-4cfe-4edb-862e-c89d99f3f156",
-                                                "18bfae74-2b07-4c99-9b31-d589f489ae78"
-                                            ],
-                                            "columns": {
-                                                "18bfae74-2b07-4c99-9b31-d589f489ae78": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Number of Events",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "46fae128-4cfe-4edb-862e-c89d99f3f156": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Tenant",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "18bfae74-2b07-4c99-9b31-d589f489ae78",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 3
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.open_ai.tenant"
-                                                },
-                                                "8ff57a0c-5ce2-4f97-baca-685defc2cf60": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Operations",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "18bfae74-2b07-4c99-9b31-d589f489ae78",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.open_ai.operation_name"
-                                                },
-                                                "cee42f78-3475-46ee-9b88-9f0b36c3cac0": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Model Name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "18bfae74-2b07-4c99-9b31-d589f489ae78",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.open_ai.properties.model_name"
-                                                },
-                                                "eb8e428b-ac44-48bc-a7ae-523c276f71d1": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Model Version",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "18bfae74-2b07-4c99-9b31-d589f489ae78",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.open_ai.properties.model_version"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "columns": [
-                                    {
-                                        "columnId": "8ff57a0c-5ce2-4f97-baca-685defc2cf60",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "cee42f78-3475-46ee-9b88-9f0b36c3cac0",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "eb8e428b-ac44-48bc-a7ae-523c276f71d1",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "left",
-                                        "columnId": "46fae128-4cfe-4edb-862e-c89d99f3f156",
-                                        "isTransposed": false
-                                    },
-                                    {
-                                        "alignment": "left",
-                                        "columnId": "18bfae74-2b07-4c99-9b31-d589f489ae78",
-                                        "isTransposed": false,
-                                        "summaryRow": "none"
-                                    }
-                                ],
-                                "layerId": "00e65d9d-c39d-4cc4-ba5f-6b8e6b3d3a64",
-                                "layerType": "data"
-                            }
-                        },
-                        "visualizationType": "lnsDatatable"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 13,
-                    "i": "d49d40cf-b284-468c-abef-16dda02802b1",
-                    "w": 48,
-                    "x": 0,
-                    "y": 57
-                },
-                "panelIndex": "d49d40cf-b284-468c-abef-16dda02802b1",
                 "type": "lens"
             }
         ],
@@ -1915,14 +1733,14 @@
             "pause": true,
             "value": 60000
         },
-        "timeFrom": "2024-05-21T12:30:00.000Z",
+        "timeFrom": "now-48h",
         "timeRestore": true,
-        "timeTo": "2024-05-23T13:30:00.000Z",
+        "timeTo": "now",
         "title": "[Logs Azure OpenAI] Overview",
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-05-30T13:27:46.283Z",
+    "created_at": "2024-05-31T06:03:39.160Z",
     "id": "azure_openai-5b98323b-7e41-408d-8b82-9cc41d4ed747",
     "managed": false,
     "references": [
@@ -1933,87 +1751,87 @@
         },
         {
             "id": "logs-*",
-            "name": "2de88fc5-35da-46ab-be7b-252617812d27:indexpattern-datasource-layer-ceb4ecd0-48e5-44df-8577-0c518323b01c",
+            "name": "d2966ed0-2851-47ca-9b62-62b6bbe7f2cc:indexpattern-datasource-layer-ceb4ecd0-48e5-44df-8577-0c518323b01c",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "ad45a576-6069-47e1-abd2-f488a3ce0d7a:indexpattern-datasource-layer-ceb4ecd0-48e5-44df-8577-0c518323b01c",
+            "name": "a34e094c-0fb7-4023-90c6-ba8386b2aab2:indexpattern-datasource-layer-ceb4ecd0-48e5-44df-8577-0c518323b01c",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "c2c09a26-acd3-4820-89a3-f3d96e2bcc4f:indexpattern-datasource-layer-6cdaeaa7-9e07-4c10-97db-8fa17f38c37d",
+            "name": "8b11a8c4-03c4-41c0-a877-7e56bd3dd99a:indexpattern-datasource-layer-6cdaeaa7-9e07-4c10-97db-8fa17f38c37d",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "f72ec432-eef5-47c5-9e41-adc5c70e396d:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
+            "name": "420df4b7-2af2-475f-adda-85013c856d52:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "63eadaf9-4a41-4ca0-a699-e36649bf660f:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
+            "name": "adfec282-0a6a-4ea7-93cf-4b433a1f57a2:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "596c5aac-e72d-433d-90f4-6e84d123daa9:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
+            "name": "ec9144d1-4baa-4228-afd4-3d2c99c40b0d:indexpattern-datasource-layer-694a14a8-c1c3-48ce-9843-1b7eb9be7927",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "6c6f368e-b0f0-45e5-ae7d-5f0dbd7765b9:indexpattern-datasource-layer-163f2cb2-70c3-4eea-9819-362bb6484b6b",
+            "name": "7bb01835-4f88-4eaf-9956-dd7b235a6712:indexpattern-datasource-layer-163f2cb2-70c3-4eea-9819-362bb6484b6b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "d20f729a-c05a-41bc-a0ae-da81afbadbff:indexpattern-datasource-layer-693fbbac-b30e-4436-a696-db3e71c194a1",
+            "name": "e0767d2f-30c6-47d9-ade4-72ddcc51f16f:indexpattern-datasource-layer-693fbbac-b30e-4436-a696-db3e71c194a1",
+            "type": "index-pattern"
+        },
+        {
+            "id": "azure_openai-8bbccfdf-236f-4834-b0ac-fd32a56e05f0",
+            "name": "b2c4e00a-6ea2-4675-8ebd-9c0154655b28:panel_b2c4e00a-6ea2-4675-8ebd-9c0154655b28",
+            "type": "search"
+        },
+        {
+            "id": "logs-*",
+            "name": "d866ba2c-4847-4eaa-9ab3-c0fa3035a876:indexpattern-datasource-layer-feeef037-d053-47eb-b2f9-9cc5ff35b867",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "916e1ab6-6ca7-4c59-b84b-3b32ccc91b37:indexpattern-datasource-layer-feeef037-d053-47eb-b2f9-9cc5ff35b867",
+            "name": "3b9b71f6-1296-4898-b4f7-ac201b276cf8:indexpattern-datasource-layer-f347a5eb-7019-4d9a-96a1-7b7c43f72e80",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "cc9dd648-1668-4ad3-930b-f137d09b6601:indexpattern-datasource-layer-f347a5eb-7019-4d9a-96a1-7b7c43f72e80",
+            "name": "controlGroup_a5782f20-ea17-4c98-83dd-76c5eea72996:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "d49d40cf-b284-468c-abef-16dda02802b1:indexpattern-datasource-layer-00e65d9d-c39d-4cc4-ba5f-6b8e6b3d3a64",
+            "name": "controlGroup_7539ae5d-62a1-4935-8e2d-d3c989e9459c:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_8f7d94c1-add0-4df6-b677-0cef87a4fac2:optionsListDataView",
+            "name": "controlGroup_30d882e3-4b70-424f-881c-33f6e3d9bde0:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_5e381b5e-eb14-4af8-800c-d4d32ded0ac6:optionsListDataView",
+            "name": "controlGroup_2000b189-afd8-4824-9a69-b34587323392:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_0eeb7454-b3a2-476c-b4fe-52936ac0a818:optionsListDataView",
+            "name": "controlGroup_582b9906-76be-4b32-87b4-417fcc51ab92:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_f2093459-6dac-4f17-8921-fb2330b7e74a:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "controlGroup_d19fa356-c0b3-4490-8062-be43f9425227:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
-            "name": "controlGroup_cadf4d8b-6542-4095-a5cb-aa48e93d7db8:optionsListDataView",
+            "name": "controlGroup_1ca21205-a666-4653-818f-92a93d17cb3f:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/kibana/search/azure_openai-8bbccfdf-236f-4834-b0ac-fd32a56e05f0.json
+++ b/packages/azure_openai/kibana/search/azure_openai-8bbccfdf-236f-4834-b0ac-fd32a56e05f0.json
@@ -1,0 +1,52 @@
+{
+    "attributes": {
+        "columns": [
+            "azure.open_ai.caller_ip_address",
+            "azure.open_ai.category",
+            "azure.open_ai.operation_name",
+            "azure.open_ai.properties.model_deployment_name",
+            "azure.open_ai.properties.model_name",
+            "azure.open_ai.properties.model_version",
+            "azure.open_ai.properties.request_length",
+            "azure.open_ai.properties.response_length",
+            "azure.open_ai.result_signature",
+            "azure.open_ai.properties.stream_type"
+        ],
+        "description": "",
+        "grid": {},
+        "hideChart": false,
+        "isTextBasedQuery": false,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
+        },
+        "sort": [
+            [
+                "@timestamp",
+                "desc"
+            ]
+        ],
+        "timeRestore": false,
+        "title": "Discover Logs",
+        "usesAdHocDataView": false
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-05-31T05:23:25.690Z",
+    "id": "azure_openai-8bbccfdf-236f-4834-b0ac-fd32a56e05f0",
+    "managed": false,
+    "references": [
+        {
+            "id": "logs-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "search",
+    "typeMigrationVersion": "10.2.0"
+}

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: azure_openai
 title: "Azure OpenAI"
-version: 0.5.1
+version: 0.6.0
 source:
   license: "Elastic-2.0"
 description: "Azure OpenAI Logs and Metrics"


### PR DESCRIPTION
- Enhancement

- This PR adds the saved search to load the overview of logs in the logs dashboard.
- Rename metrics name in the overview dashboard.
- Removes the LENS which gets duplicated after adding saved search.
- Change the time range to last 48 hours in the logs dashboard.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Install the integration and verify the dashboard loads data properly in all the dashbaords.

## Screenshots

![azure_open_ai_logs png](https://github.com/elastic/integrations/assets/101238137/0aae49bb-1b99-4472-9245-960f4e0cfec8)
![azure_open_ai_overview](https://github.com/elastic/integrations/assets/101238137/c20ba630-7a29-4d3f-a459-a758c04fe78d)

