### PR TITLE
Update overview dashboard

### DIFF
--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.1"
+  changes:
+    - description: Update overview dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.6.0"
   changes:
     - description: Add saved search to logs dashboard.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update overview dashboard.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10048
 - version: "0.6.0"
   changes:
     - description: Add saved search to logs dashboard.

--- a/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
+++ b/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"cf6d906b-55d7-441d-a250-81b059e08d5b\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"cf6d906b-55d7-441d-a250-81b059e08d5b\",\"fieldName\":\"azure.subscription_id\",\"title\":\"Subscription ID\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"a3d4fb4f-fa13-41c5-8461-d8427f83569b\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"a3d4fb4f-fa13-41c5-8461-d8427f83569b\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"88471060-ec8f-4239-998e-cf862ad7d9d3\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"88471060-ec8f-4239-998e-cf862ad7d9d3\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"03e555a2-a4c9-4c40-91ad-4d6ac4c311a1\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"03e555a2-a4c9-4c40-91ad-4d6ac4c311a1\",\"fieldName\":\"azure.subscription_id\",\"title\":\"subscriptions\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"35b8df02-a059-4d3c-9ffe-997fdd238dbd\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"35b8df02-a059-4d3c-9ffe-997fdd238dbd\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"31f9e786-40a6-40b3-b94f-684dea5214a3\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"31f9e786-40a6-40b3-b94f-684dea5214a3\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"da84f012-cb31-49f6-bb7b-6604ac6166b1\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"da84f012-cb31-49f6-bb7b-6604ac6166b1\",\"fieldName\":\"azure.dimensions.model_deployment_name\",\"title\":\"Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"55b9712c-fea2-47c0-b383-445965b18a6c\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"55b9712c-fea2-47c0-b383-445965b18a6c\",\"fieldName\":\"azure.dimensions.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"cb900441-4026-40c9-9e2a-5e6752e25d5e\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"cb900441-4026-40c9-9e2a-5e6752e25d5e\",\"fieldName\":\"azure.dimensions.api_name\",\"title\":\"API Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -54,12 +54,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "af153277-d840-4bdd-aadd-16393a1b81c8",
+                    "i": "4ee2d205-f2e7-4bbf-9a77-cf7a8e83b286",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "af153277-d840-4bdd-aadd-16393a1b81c8",
+                "panelIndex": "4ee2d205-f2e7-4bbf-9a77-cf7a8e83b286",
                 "title": "",
                 "type": "visualization"
             },
@@ -68,8 +68,8 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                "name": "indexpattern-datasource-layer-639167a0-f975-4e24-89f5-894eb1d51ce6",
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
                                 "type": "index-pattern"
                             }
                         ],
@@ -77,57 +77,236 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
                                     "layers": {
-                                        "639167a0-f975-4e24-89f5-894eb1d51ce6": {
+                                        "a99ea77a-00e0-4dc9-899e-1708680face0": {
                                             "columnOrder": [
-                                                "8f0aa5d9-d334-4b58-91d2-8ba2744b7e76",
-                                                "133078e7-6151-4740-a4f2-baebd27b2bd2"
+                                                "b5f945ae-fdd4-4309-9813-66adca521ded",
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0"
                                             ],
                                             "columns": {
-                                                "133078e7-6151-4740-a4f2-baebd27b2bd2": {
+                                                "b5f945ae-fdd4-4309-9813-66adca521ded": {
+                                                    "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
+                                                    "label": "Total Requests",
+                                                    "operationType": "formula",
                                                     "params": {
-                                                        "emptyAsNull": true
+                                                        "formula": "sum(azure.open_ai.requests.total)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of sum(azure.open_ai.requests.total)",
+                                                    "operationType": "sum",
+                                                    "params": {
+                                                        "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "8f0aa5d9-d334-4b58-91d2-8ba2744b7e76": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of data_stream.dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "azure_openai.logs",
-                                                            "azure.open_ai"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "133078e7-6151-4740-a4f2-baebd27b2bd2",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
+                                                    "sourceField": "azure.open_ai.requests.total"
                                                 }
                                             },
-                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "a99ea77a-00e0-4dc9-899e-1708680face0",
+                                "layerType": "data",
+                                "metricAccessor": "b5f945ae-fdd4-4309-9813-66adca521ded"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": true
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "96286bd1-f8a8-4164-a1b1-c78c55769412",
+                    "w": 9,
+                    "x": 0,
+                    "y": 5
+                },
+                "panelIndex": "96286bd1-f8a8-4164-a1b1-c78c55769412",
+                "title": "",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "a99ea77a-00e0-4dc9-899e-1708680face0": {
+                                            "columnOrder": [
+                                                "b5f945ae-fdd4-4309-9813-66adca521ded",
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0"
+                                            ],
+                                            "columns": {
+                                                "b5f945ae-fdd4-4309-9813-66adca521ded": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average Response Time",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "average(azure.open_ai.provisioned_managed_utilization_v2.avg)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Total Requests",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.open_ai.provisioned_managed_utilization_v2.avg"
+                                                }
+                                            },
+                                            "incompleteColumns": {}
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layerId": "a99ea77a-00e0-4dc9-899e-1708680face0",
+                                "layerType": "data",
+                                "metricAccessor": "b5f945ae-fdd4-4309-9813-66adca521ded"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsMetric"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": true
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "d9480b4d-208e-4760-bd37-9b66c86563e2",
+                    "w": 9,
+                    "x": 9,
+                    "y": 5
+                },
+                "panelIndex": "d9480b4d-208e-4760-bd37-9b66c86563e2",
+                "title": "",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "b89abbbb-c146-4674-9275-33e9e64f4b41": {
+                                            "columnOrder": [
+                                                "2fb20ea6-fdf4-4c6d-b975-006bc2cfcbcf",
+                                                "733f775d-b17e-48a1-b438-2c661823800d",
+                                                "733f775d-b17e-48a1-b438-2c661823800dX0"
+                                            ],
+                                            "columns": {
+                                                "2fb20ea6-fdf4-4c6d-b975-006bc2cfcbcf": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "733f775d-b17e-48a1-b438-2c661823800d": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Average Tokens",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "average(azure.open_ai.token_transaction.total)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "733f775d-b17e-48a1-b438-2c661823800dX0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "733f775d-b17e-48a1-b438-2c661823800dX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Token Usage",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.open_ai.token_transaction.total"
+                                                }
+                                            },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
                                             "sampling": 1
                                         }
                                     }
@@ -146,9 +325,27 @@
                                 "query": ""
                             },
                             "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
                                 "layers": [
                                     {
-                                        "categoryDisplay": "default",
+                                        "accessors": [
+                                            "733f775d-b17e-48a1-b438-2c661823800d"
+                                        ],
                                         "colorMapping": {
                                             "assignments": [],
                                             "colorMode": {
@@ -167,822 +364,92 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "639167a0-f975-4e24-89f5-894eb1d51ce6",
+                                        "layerId": "b89abbbb-c146-4674-9275-33e9e64f4b41",
                                         "layerType": "data",
-                                        "legendDisplay": "default",
-                                        "metrics": [
-                                            "133078e7-6151-4740-a4f2-baebd27b2bd2"
-                                        ],
-                                        "nestedLegend": false,
-                                        "numberDisplay": "percent",
-                                        "primaryGroups": [
-                                            "8f0aa5d9-d334-4b58-91d2-8ba2744b7e76"
-                                        ]
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "xAccessor": "2fb20ea6-fdf4-4c6d-b975-006bc2cfcbcf"
                                     }
                                 ],
-                                "shape": "pie"
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
                             }
                         },
                         "title": "",
                         "type": "lens",
-                        "visualizationType": "lnsPie"
+                        "visualizationType": "lnsXY"
                     },
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 15,
-                    "i": "a5ca3e3b-6667-40b3-af64-25943e30e040",
-                    "w": 16,
-                    "x": 0,
+                    "h": 12,
+                    "i": "ed8c3985-1d1e-4a02-99dc-4f193165fd07",
+                    "w": 30,
+                    "x": 18,
                     "y": 5
                 },
-                "panelIndex": "a5ca3e3b-6667-40b3-af64-25943e30e040",
-                "title": "Total Documents",
+                "panelIndex": "ed8c3985-1d1e-4a02-99dc-4f193165fd07",
+                "title": "Token Usage",
                 "type": "lens"
             },
             {
                 "embeddableConfig": {
                     "attributes": {
-                        "description": "",
+                        "columns": [
+                            "azure.open_ai.generated_tokens.total",
+                            "azure.open_ai.processed_prompt_tokens.total",
+                            "azure.open_ai.requests.total",
+                            "azure.open_ai.token_transaction.total",
+                            "azure.dimensions.model_deployment_name",
+                            "azure.dimensions.model_name",
+                            "azure.dimensions.model_version",
+                            "azure.dimensions.api_name",
+                            "azure.dimensions.status_code",
+                            "azure.dimensions.stream_type"
+                        ],
+                        "grid": {},
+                        "hideChart": false,
+                        "isTextBasedQuery": false,
+                        "kibanaSavedObjectMeta": {
+                            "searchSourceJSON": "{\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"data_stream.dataset :\\\"azure.open_ai\\\" \"}}"
+                        },
                         "references": [
                             {
-                                "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+                                "id": "metrics-*",
+                                "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
                                 "type": "index-pattern"
                             }
                         ],
-                        "state": {
-                            "adHocDataViews": {
-                                "add3e5b6-18cd-45f2-b47a-406dd1a1e38b": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "logs-*, metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*,metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
-                                            "columnOrder": [
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796",
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                            ],
-                                            "columns": {
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of data_stream.dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "azure.open_ai",
-                                                            "azure_openai.logs"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                        "layerType": "data",
-                                        "seriesType": "bar_stacked",
-                                        "splitAccessor": "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                        "xAccessor": "09dfcf53-a700-4c42-a8ac-10e1550fa796"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "",
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1",
-                    "w": 32,
-                    "x": 16,
-                    "y": 5
-                },
-                "panelIndex": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1",
-                "title": "Documents Over Time",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                "type": "index-pattern"
-                            }
+                        "sort": [
+                            [
+                                "@timestamp",
+                                "desc"
+                            ]
                         ],
-                        "state": {
-                            "adHocDataViews": {
-                                "add3e5b6-18cd-45f2-b47a-406dd1a1e38b": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "logs-*, metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*,metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
-                                            "columnOrder": [
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796",
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                            ],
-                                            "columns": {
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Subscriptions",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.subscription_id"
-                                                },
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "azure.open_ai",
-                                                            "azure_openai.logs"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "splitAccessor": "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                        "xAccessor": "09dfcf53-a700-4c42-a8ac-10e1550fa796"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
+                        "timeRestore": false,
+                        "usesAdHocDataView": false
                     },
-                    "description": "",
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
+                    "enhancements": {}
                 },
                 "gridData": {
-                    "h": 15,
-                    "i": "9562d7a5-d988-4a39-9041-0eb8569a4174",
-                    "w": 16,
+                    "h": 18,
+                    "i": "bbd09f60-fc6b-434c-884b-e29acf9d4859",
+                    "w": 48,
                     "x": 0,
-                    "y": 20
+                    "y": 17
                 },
-                "panelIndex": "9562d7a5-d988-4a39-9041-0eb8569a4174",
-                "title": "Subscriptions By Dataset",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {
-                                "add3e5b6-18cd-45f2-b47a-406dd1a1e38b": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "logs-*, metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*,metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                    "layers": {
-                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
-                                            "columnOrder": [
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796",
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                            ],
-                                            "columns": {
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Resource Group",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.resource.group"
-                                                },
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "azure.open_ai",
-                                                            "azure_openai.logs"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1"
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [
-                                {
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                    "type": "index-pattern"
-                                }
-                            ],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "splitAccessor": "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                        "xAccessor": "09dfcf53-a700-4c42-a8ac-10e1550fa796"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "",
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "3e30954e-2294-47ed-9507-5e85222b82bb",
-                    "w": 16,
-                    "x": 16,
-                    "y": 20
-                },
-                "panelIndex": "3e30954e-2294-47ed-9507-5e85222b82bb",
-                "title": "Resource Groups By Dataset",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-                                "name": "indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {
-                                "add3e5b6-18cd-45f2-b47a-406dd1a1e38b": {
-                                    "allowHidden": false,
-                                    "allowNoIndex": false,
-                                    "fieldAttrs": {},
-                                    "fieldFormats": {},
-                                    "id": "add3e5b6-18cd-45f2-b47a-406dd1a1e38b",
-                                    "name": "logs-*, metrics-*",
-                                    "runtimeFieldMap": {},
-                                    "sourceFilters": [],
-                                    "timeFieldName": "@timestamp",
-                                    "title": "logs-*,metrics-*"
-                                }
-                            },
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "06e5675e-d8f9-45b5-ba57-bae75a6eab02": {
-                                            "columnOrder": [
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796",
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                            ],
-                                            "columns": {
-                                                "09dfcf53-a700-4c42-a8ac-10e1550fa796": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Resources",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "azure.resource.name"
-                                                },
-                                                "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Count of records",
-                                                    "operationType": "count",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "___records___"
-                                                },
-                                                "f271703e-ed89-4233-88f1-bea10ab56b3a": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Dataset",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [
-                                                            "azure.open_ai",
-                                                            "azure_openai.logs"
-                                                        ],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "data_stream.dataset"
-                                                }
-                                            },
-                                            "incompleteColumns": {}
-                                        }
-                                    }
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "49a1a6af-5e02-4aa7-98f1-1cdca13b41d9"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "06e5675e-d8f9-45b5-ba57-bae75a6eab02",
-                                        "layerType": "data",
-                                        "seriesType": "bar_horizontal",
-                                        "splitAccessor": "f271703e-ed89-4233-88f1-bea10ab56b3a",
-                                        "xAccessor": "09dfcf53-a700-4c42-a8ac-10e1550fa796"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_horizontal",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "description": "",
-                    "enhancements": {
-                        "dynamicActions": {
-                            "events": []
-                        }
-                    },
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 15,
-                    "i": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b",
-                    "w": 16,
-                    "x": 32,
-                    "y": 20
-                },
-                "panelIndex": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b",
-                "title": "Resources By Dataset",
-                "type": "lens"
+                "panelIndex": "bbd09f60-fc6b-434c-884b-e29acf9d4859",
+                "type": "search"
             }
         ],
         "refreshInterval": {
@@ -996,48 +463,58 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-05-31T06:04:09.365Z",
+    "created_at": "2024-06-03T10:34:13.268Z",
     "id": "azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3",
     "managed": false,
     "references": [
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "a5ca3e3b-6667-40b3-af64-25943e30e040:indexpattern-datasource-layer-639167a0-f975-4e24-89f5-894eb1d51ce6",
+            "id": "metrics-*",
+            "name": "96286bd1-f8a8-4164-a1b1-c78c55769412:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "f2f54b20-0568-42ea-b4ba-8d7d84197ab1:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "id": "metrics-*",
+            "name": "d9480b4d-208e-4760-bd37-9b66c86563e2:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "9562d7a5-d988-4a39-9041-0eb8569a4174:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "id": "metrics-*",
+            "name": "ed8c3985-1d1e-4a02-99dc-4f193165fd07:indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "3e30954e-2294-47ed-9507-5e85222b82bb:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "id": "metrics-*",
+            "name": "bbd09f60-fc6b-434c-884b-e29acf9d4859:kibanaSavedObjectMeta.searchSourceJSON.index",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "9ea6b09c-5f00-4501-8449-0b804d6a2f7b:indexpattern-datasource-layer-06e5675e-d8f9-45b5-ba57-bae75a6eab02",
+            "id": "metrics-*",
+            "name": "controlGroup_03e555a2-a4c9-4c40-91ad-4d6ac4c311a1:optionsListDataView",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_cf6d906b-55d7-441d-a250-81b059e08d5b:optionsListDataView",
+            "id": "metrics-*",
+            "name": "controlGroup_35b8df02-a059-4d3c-9ffe-997fdd238dbd:optionsListDataView",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_a3d4fb4f-fa13-41c5-8461-d8427f83569b:optionsListDataView",
+            "id": "metrics-*",
+            "name": "controlGroup_31f9e786-40a6-40b3-b94f-684dea5214a3:optionsListDataView",
             "type": "index-pattern"
         },
         {
-            "id": "713624b0-5d1c-4c3a-a3a8-4a8a76c1d3b1",
-            "name": "controlGroup_88471060-ec8f-4239-998e-cf862ad7d9d3:optionsListDataView",
+            "id": "metrics-*",
+            "name": "controlGroup_da84f012-cb31-49f6-bb7b-6604ac6166b1:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_55b9712c-fea2-47c0-b383-445965b18a6c:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_cb900441-4026-40c9-9e2a-5e6752e25d5e:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
+++ b/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"03e555a2-a4c9-4c40-91ad-4d6ac4c311a1\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"03e555a2-a4c9-4c40-91ad-4d6ac4c311a1\",\"fieldName\":\"azure.subscription_id\",\"title\":\"subscriptions\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"35b8df02-a059-4d3c-9ffe-997fdd238dbd\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"35b8df02-a059-4d3c-9ffe-997fdd238dbd\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"31f9e786-40a6-40b3-b94f-684dea5214a3\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"31f9e786-40a6-40b3-b94f-684dea5214a3\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"da84f012-cb31-49f6-bb7b-6604ac6166b1\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"da84f012-cb31-49f6-bb7b-6604ac6166b1\",\"fieldName\":\"azure.dimensions.model_deployment_name\",\"title\":\"Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"55b9712c-fea2-47c0-b383-445965b18a6c\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"55b9712c-fea2-47c0-b383-445965b18a6c\",\"fieldName\":\"azure.dimensions.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"cb900441-4026-40c9-9e2a-5e6752e25d5e\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"cb900441-4026-40c9-9e2a-5e6752e25d5e\",\"fieldName\":\"azure.dimensions.api_name\",\"title\":\"API Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"e3f33d29-c2a9-474d-bea3-d817db57634d\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"e3f33d29-c2a9-474d-bea3-d817db57634d\",\"fieldName\":\"azure.subscription_id\",\"title\":\"subscriptions\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"424f8e18-f9e1-48fd-937f-f46c3c16c62a\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"424f8e18-f9e1-48fd-937f-f46c3c16c62a\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"bcf4c5af-d14f-4097-aa6a-ede7a5765ff6\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"bcf4c5af-d14f-4097-aa6a-ede7a5765ff6\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"c0755312-01ac-4ade-a13a-e44c6bd5ed7b\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"c0755312-01ac-4ade-a13a-e44c6bd5ed7b\",\"fieldName\":\"azure.dimensions.model_deployment_name\",\"title\":\"Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"7b82b735-59d4-4494-a85b-4ad3fb8703f1\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"7b82b735-59d4-4494-a85b-4ad3fb8703f1\",\"fieldName\":\"azure.dimensions.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"c5a4edc4-3a59-406d-8e04-7c86701d3563\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"c5a4edc4-3a59-406d-8e04-7c86701d3563\",\"fieldName\":\"azure.dimensions.api_name\",\"title\":\"API Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -54,12 +54,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "4ee2d205-f2e7-4bbf-9a77-cf7a8e83b286",
+                    "i": "0d1b9e11-2cf3-4569-bae2-f6d1250c9dac",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "4ee2d205-f2e7-4bbf-9a77-cf7a8e83b286",
+                "panelIndex": "0d1b9e11-2cf3-4569-bae2-f6d1250c9dac",
                 "title": "",
                 "type": "visualization"
             },
@@ -144,12 +144,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "96286bd1-f8a8-4164-a1b1-c78c55769412",
+                    "i": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67",
                     "w": 9,
                     "x": 0,
                     "y": 5
                 },
-                "panelIndex": "96286bd1-f8a8-4164-a1b1-c78c55769412",
+                "panelIndex": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67",
                 "title": "",
                 "type": "lens"
             },
@@ -234,12 +234,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "d9480b4d-208e-4760-bd37-9b66c86563e2",
+                    "i": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0",
                     "w": 9,
                     "x": 9,
                     "y": 5
                 },
-                "panelIndex": "d9480b4d-208e-4760-bd37-9b66c86563e2",
+                "panelIndex": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0",
                 "title": "",
                 "type": "lens"
             },
@@ -393,62 +393,28 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "ed8c3985-1d1e-4a02-99dc-4f193165fd07",
+                    "i": "f11ea77f-c3ce-483d-a967-746d931e94fa",
                     "w": 30,
                     "x": 18,
                     "y": 5
                 },
-                "panelIndex": "ed8c3985-1d1e-4a02-99dc-4f193165fd07",
+                "panelIndex": "f11ea77f-c3ce-483d-a967-746d931e94fa",
                 "title": "Token Usage",
                 "type": "lens"
             },
             {
                 "embeddableConfig": {
-                    "attributes": {
-                        "columns": [
-                            "azure.open_ai.generated_tokens.total",
-                            "azure.open_ai.processed_prompt_tokens.total",
-                            "azure.open_ai.requests.total",
-                            "azure.open_ai.token_transaction.total",
-                            "azure.dimensions.model_deployment_name",
-                            "azure.dimensions.model_name",
-                            "azure.dimensions.model_version",
-                            "azure.dimensions.api_name",
-                            "azure.dimensions.status_code",
-                            "azure.dimensions.stream_type"
-                        ],
-                        "grid": {},
-                        "hideChart": false,
-                        "isTextBasedQuery": false,
-                        "kibanaSavedObjectMeta": {
-                            "searchSourceJSON": "{\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"data_stream.dataset :\\\"azure.open_ai\\\" \"}}"
-                        },
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "sort": [
-                            [
-                                "@timestamp",
-                                "desc"
-                            ]
-                        ],
-                        "timeRestore": false,
-                        "usesAdHocDataView": false
-                    },
                     "enhancements": {}
                 },
                 "gridData": {
-                    "h": 18,
-                    "i": "bbd09f60-fc6b-434c-884b-e29acf9d4859",
+                    "h": 17,
+                    "i": "7d006617-1024-419b-87e2-331ff8467273",
                     "w": 48,
                     "x": 0,
                     "y": 17
                 },
-                "panelIndex": "bbd09f60-fc6b-434c-884b-e29acf9d4859",
+                "panelIndex": "7d006617-1024-419b-87e2-331ff8467273",
+                "panelRefName": "panel_7d006617-1024-419b-87e2-331ff8467273",
                 "type": "search"
             }
         ],
@@ -463,58 +429,58 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-03T10:34:13.268Z",
+    "created_at": "2024-06-03T10:54:40.252Z",
     "id": "azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3",
     "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "96286bd1-f8a8-4164-a1b1-c78c55769412:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+            "name": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "d9480b4d-208e-4760-bd37-9b66c86563e2:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+            "name": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "ed8c3985-1d1e-4a02-99dc-4f193165fd07:indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
+            "name": "f11ea77f-c3ce-483d-a967-746d931e94fa:indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
+            "type": "index-pattern"
+        },
+        {
+            "id": "azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0",
+            "name": "7d006617-1024-419b-87e2-331ff8467273:panel_7d006617-1024-419b-87e2-331ff8467273",
+            "type": "search"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_e3f33d29-c2a9-474d-bea3-d817db57634d:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "bbd09f60-fc6b-434c-884b-e29acf9d4859:kibanaSavedObjectMeta.searchSourceJSON.index",
+            "name": "controlGroup_424f8e18-f9e1-48fd-937f-f46c3c16c62a:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_03e555a2-a4c9-4c40-91ad-4d6ac4c311a1:optionsListDataView",
+            "name": "controlGroup_bcf4c5af-d14f-4097-aa6a-ede7a5765ff6:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_35b8df02-a059-4d3c-9ffe-997fdd238dbd:optionsListDataView",
+            "name": "controlGroup_c0755312-01ac-4ade-a13a-e44c6bd5ed7b:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_31f9e786-40a6-40b3-b94f-684dea5214a3:optionsListDataView",
+            "name": "controlGroup_7b82b735-59d4-4494-a85b-4ad3fb8703f1:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_da84f012-cb31-49f6-bb7b-6604ac6166b1:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_55b9712c-fea2-47c0-b383-445965b18a6c:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_cb900441-4026-40c9-9e2a-5e6752e25d5e:optionsListDataView",
+            "name": "controlGroup_c5a4edc4-3a59-406d-8e04-7c86701d3563:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/kibana/search/azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0.json
+++ b/packages/azure_openai/kibana/search/azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0.json
@@ -1,0 +1,52 @@
+{
+    "attributes": {
+        "columns": [
+            "azure.open_ai.generated_tokens.total",
+            "azure.open_ai.processed_prompt_tokens.total",
+            "azure.open_ai.requests.total",
+            "azure.open_ai.token_transaction.total",
+            "azure.dimensions.model_deployment_name",
+            "azure.dimensions.model_name",
+            "azure.dimensions.model_version",
+            "azure.dimensions.api_name",
+            "azure.dimensions.status_code",
+            "azure.dimensions.stream_type"
+        ],
+        "description": "",
+        "grid": {},
+        "hideChart": false,
+        "isTextBasedQuery": false,
+        "kibanaSavedObjectMeta": {
+            "searchSourceJSON": {
+                "filter": [],
+                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                "query": {
+                    "language": "kuery",
+                    "query": "data_stream.dataset :\"azure.open_ai\" "
+                }
+            }
+        },
+        "sort": [
+            [
+                "@timestamp",
+                "desc"
+            ]
+        ],
+        "timeRestore": false,
+        "title": "Discover Metrics",
+        "usesAdHocDataView": false
+    },
+    "coreMigrationVersion": "8.8.0",
+    "created_at": "2024-06-03T10:22:40.881Z",
+    "id": "azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0",
+    "managed": false,
+    "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        }
+    ],
+    "type": "search",
+    "typeMigrationVersion": "10.2.0"
+}

--- a/packages/azure_openai/kibana/search/azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0.json
+++ b/packages/azure_openai/kibana/search/azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0.json
@@ -1,14 +1,14 @@
 {
     "attributes": {
         "columns": [
+            "azure.dimensions.model_deployment_name",
+            "azure.dimensions.model_name",
+            "azure.dimensions.api_name",
             "azure.open_ai.generated_tokens.total",
             "azure.open_ai.processed_prompt_tokens.total",
             "azure.open_ai.requests.total",
             "azure.open_ai.token_transaction.total",
-            "azure.dimensions.model_deployment_name",
-            "azure.dimensions.model_name",
             "azure.dimensions.model_version",
-            "azure.dimensions.api_name",
             "azure.dimensions.status_code",
             "azure.dimensions.stream_type"
         ],
@@ -18,7 +18,126 @@
         "isTextBasedQuery": false,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "negate": false,
+                            "params": [
+                                {
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "azure.open_ai.generated_tokens.total",
+                                        "index": "metrics-*",
+                                        "key": "azure.open_ai.generated_tokens.total",
+                                        "negate": false,
+                                        "params": {
+                                            "gte": "1"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "gte": "1"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "azure.open_ai.generated_tokens.total": {
+                                                "gte": "1"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "azure.open_ai.processed_prompt_tokens.total",
+                                        "index": "metrics-*",
+                                        "key": "azure.open_ai.processed_prompt_tokens.total",
+                                        "negate": false,
+                                        "params": {
+                                            "gte": "1"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "gte": "1"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "azure.open_ai.processed_prompt_tokens.total": {
+                                                "gte": "1"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "azure.open_ai.token_transaction.total",
+                                        "index": "metrics-*",
+                                        "key": "azure.open_ai.token_transaction.total",
+                                        "negate": false,
+                                        "params": {
+                                            "gte": "1"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "gte": "1"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "azure.open_ai.token_transaction.total": {
+                                                "gte": "1"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "azure.open_ai.requests.total",
+                                        "index": "metrics-*",
+                                        "key": "azure.open_ai.requests.total",
+                                        "negate": false,
+                                        "params": {
+                                            "gte": "1"
+                                        },
+                                        "type": "range",
+                                        "value": {
+                                            "gte": "1"
+                                        }
+                                    },
+                                    "query": {
+                                        "range": {
+                                            "azure.open_ai.requests.total": {
+                                                "gte": "1"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "relation": "OR",
+                            "type": "combined"
+                        },
+                        "query": {}
+                    }
+                ],
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
@@ -44,6 +163,11 @@
         {
             "id": "metrics-*",
             "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: azure_openai
 title: "Azure OpenAI"
-version: 0.6.0
+version: 0.6.1
 source:
   license: "Elastic-2.0"
 description: "Azure OpenAI Logs and Metrics"


### PR DESCRIPTION
- Enhancement

- This PR updates the overview dashboard for the Azure OpenAI integrations. Currently the average response time will be empty and this will have data once we have the PTU changes.
- Filter by Model Deployment Name, Model Version and API Names.
- The estimated cost needs more research on how to dynamically fetch the cost for calculations based on token usage. Not considering the cost estimation in this PR.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



## How to test this PR locally

Install the integrations and verify the dashboard loads appropriate data.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
### Before
<img width="1719" alt="Screenshot 2024-06-03 at 4 11 46 PM" src="https://github.com/elastic/integrations/assets/101238137/3478f83a-b66a-488b-b843-a4efd118afe4">

### After
<img width="1717" alt="Screenshot 2024-06-03 at 4 24 28 PM" src="https://github.com/elastic/integrations/assets/101238137/decc0127-4ac2-4cb6-acb6-e5e1a689852a">
