### PR TITLE
ti_abusech: Adjust field mappings for transform

### DIFF
--- a/packages/ti_abusech/changelog.yml
+++ b/packages/ti_abusech/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.1"
+  changes:
+    - description: Adjust field mappings for transform destination index.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10049
 - version: "2.0.0"
   changes:
     - description: Support IoC expiration

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/base-fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/base-fields.yml
@@ -7,22 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: event.module
-  type: constant_keyword
-  description: Event module
-  value: ti_abusech
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset
-  value: ti_abusech.malware
-- name: threat.feed.name
-  type: constant_keyword
-  description: Display friendly feed name
-  value: AbuseCH Malware
-- name: threat.feed.dashboard_id
-  type: constant_keyword
-  description: Dashboard ID used for Kibana CTI UI
-  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6
 - name: "@timestamp"
   type: date
   description: Event timestamp.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/ecs.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/fields/ecs.yml
@@ -45,3 +45,21 @@
   external: ecs
 - name: labels
   external: ecs
+# Below fields to be moved into base-fields.yml after kibana.version changed to >= 8.14 
+# Related to fix: https://github.com/elastic/kibana/pull/177608
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: ti_abusech
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: ti_abusech.malware
+- name: threat.feed.name
+  type: constant_keyword
+  description: Display friendly feed name
+  value: AbuseCH Malware
+- name: threat.feed.dashboard_id
+  type: constant_keyword
+  description: Dashboard ID used for Kibana CTI UI
+  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6

--- a/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malware/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_malware-1"
+  index: "logs-ti_abusech_latest.dest_malware-2"
   aliases:
     - alias: "logs-ti_abusech_latest.malware"
       move_on_creation: true
@@ -24,7 +24,7 @@ latest:
     - threat.indicator.file.hash.md5
     - threat.indicator.file.hash.sha256
   sort: "@timestamp"
-description: Latest Abuse CH Malware Bazaar indicators
+description: Latest Abuse CH Malware Bazaar indicators.
 frequency: 30s
 sync:
   time:
@@ -38,4 +38,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/base-fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/base-fields.yml
@@ -7,22 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: event.module
-  type: constant_keyword
-  description: Event module
-  value: ti_abusech
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset
-  value: ti_abusech.malwarebazaar
-- name: threat.feed.name
-  type: constant_keyword
-  description: Display friendly feed name
-  value: AbuseCH MalwareBazaar
-- name: threat.feed.dashboard_id
-  type: constant_keyword
-  description: Dashboard ID used for Kibana CTI UI
-  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6
 - name: "@timestamp"
   type: date
   description: Event timestamp.

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/ecs.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/fields/ecs.yml
@@ -76,3 +76,21 @@
   external: ecs
 - name: labels
   external: ecs
+# Below fields to be moved into base-fields.yml after kibana.version changed to >= 8.14 
+# Related to fix: https://github.com/elastic/kibana/pull/177608
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: ti_abusech
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: ti_abusech.malwarebazaar
+- name: threat.feed.name
+  type: constant_keyword
+  description: Display friendly feed name
+  value: AbuseCH MalwareBazaar
+- name: threat.feed.dashboard_id
+  type: constant_keyword
+  description: Dashboard ID used for Kibana CTI UI
+  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6

--- a/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_malwarebazaar/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_malwarebazaar-1"
+  index: "logs-ti_abusech_latest.dest_malwarebazaar-2"
   aliases:
     - alias: "logs-ti_abusech_latest.malwarebazaar"
       move_on_creation: true
@@ -24,7 +24,7 @@ latest:
     - threat.indicator.file.hash.md5
     - threat.indicator.file.hash.sha256
   sort: "@timestamp"
-description: Latest Abuse CH Malware Bazaar indicators
+description: Latest Abuse CH Malware Bazaar indicators.
 frequency: 30s
 sync:
   time:
@@ -38,4 +38,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/base-fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/base-fields.yml
@@ -7,22 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: event.module
-  type: constant_keyword
-  description: Event module
-  value: ti_abusech
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset
-  value: ti_abusech.threatfox
-- name: threat.feed.name
-  type: constant_keyword
-  description: Display friendly feed name
-  value: AbuseCH Threat Fox
-- name: threat.feed.dashboard_id
-  type: constant_keyword
-  description: Dashboard ID used for Kibana CTI UI
-  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6
 - name: "@timestamp"
   type: date
   description: Event timestamp.

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/ecs.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/fields/ecs.yml
@@ -86,3 +86,21 @@
   name: threat.indicator.name
 - external: ecs
   name: labels
+# Below fields to be moved into base-fields.yml after kibana.version changed to >= 8.14 
+# Related to fix: https://github.com/elastic/kibana/pull/177608
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: ti_abusech
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: ti_abusech.threatfox
+- name: threat.feed.name
+  type: constant_keyword
+  description: Display friendly feed name
+  value: AbuseCH Threat Fox
+- name: threat.feed.dashboard_id
+  type: constant_keyword
+  description: Dashboard ID used for Kibana CTI UI
+  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6

--- a/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_threatfox/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_threatfox-1"
+  index: "logs-ti_abusech_latest.dest_threatfox-2"
   aliases:
     - alias: "logs-ti_abusech_latest.threatfox"
       move_on_creation: true
@@ -23,7 +23,7 @@ latest:
     - event.dataset
     - event.id
   sort: "@timestamp"
-description: Latest Abuse CH Threat Fox data
+description: Latest Abuse CH Threat Fox data.
 frequency: 30s
 sync:
   time:
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/fields/base-fields.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/fields/base-fields.yml
@@ -7,22 +7,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
-- name: event.module
-  type: constant_keyword
-  description: Event module
-  value: ti_abusech
-- name: event.dataset
-  type: constant_keyword
-  description: Event dataset
-  value: ti_abusech.url
-- name: threat.feed.name
-  type: constant_keyword
-  description: Display friendly feed name
-  value: AbuseCH URL
-- name: threat.feed.dashboard_id
-  type: constant_keyword
-  description: Dashboard ID used for Kibana CTI UI
-  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6
 - name: "@timestamp"
   type: date
   description: Event timestamp.

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/fields/ecs.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/fields/ecs.yml
@@ -52,3 +52,21 @@
   name: threat.indicator.name
 - external: ecs
   name: labels
+# Below fields to be moved into base-fields.yml after kibana.version changed to >= 8.14 
+# Related to fix: https://github.com/elastic/kibana/pull/177608
+- name: event.module
+  type: constant_keyword
+  description: Event module
+  value: ti_abusech
+- name: event.dataset
+  type: constant_keyword
+  description: Event dataset
+  value: ti_abusech.url
+- name: threat.feed.name
+  type: constant_keyword
+  description: Display friendly feed name
+  value: AbuseCH URL
+- name: threat.feed.dashboard_id
+  type: constant_keyword
+  description: Dashboard ID used for Kibana CTI UI
+  value: ti_abusech-c0d8d1f0-3b20-11ec-ae50-2fdf1e96c6a6

--- a/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
+++ b/packages/ti_abusech/elasticsearch/transform/latest_url/transform.yml
@@ -14,7 +14,7 @@ source:
 # us that ability in order to prevent having duplicate IoC data and prevent query
 # time field type conflicts.
 dest:
-  index: "logs-ti_abusech_latest.dest_url-1"
+  index: "logs-ti_abusech_latest.dest_url-2"
   aliases:
     - alias: "logs-ti_abusech_latest.url"
       move_on_creation: true
@@ -23,7 +23,7 @@ latest:
     - event.dataset
     - threat.indicator.name
   sort: "@timestamp"
-description: Latest Abuse CH URL data
+description: Latest Abuse CH URL data.
 frequency: 30s
 sync:
   time:
@@ -37,4 +37,4 @@ _meta:
   managed: true
   # Bump this version to delete, reinstall, and restart the transform during package.
   # Version bump is needed if there is any code change in transform.
-  fleet_transform_version: 0.1.0
+  fleet_transform_version: 0.2.0

--- a/packages/ti_abusech/manifest.yml
+++ b/packages/ti_abusech/manifest.yml
@@ -1,6 +1,6 @@
 name: ti_abusech
 title: AbuseCH
-version: "2.0.0"
+version: "2.0.1"
 description: Ingest threat intelligence indicators from URL Haus, Malware Bazaar, and Threat Fox feeds with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Adjust field mappings for transform.

Some fields such as event.module were missing from the destination index.
The field mappings are getting overwritten when same prefix exists in 
multiple files. To prevent this, all fields with same prefix are moved into 
single file, in this case ecs.yml. This is only a temporary fix until 
kibana.version is updated to >= 8.14.0, in which the root issue is fixed.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Verify the destination mappings in all AbuseCH datastreams contains the missing fields `event.module`, `event.dataset`, `threat.feed.name`, and `threat.feed.dashboard_id`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/10032
- Relates https://github.com/elastic/kibana/pull/177608

