### PR TITLE
[Azure OpenAI] Update overall latency to the overview dashboard

### DIFF
--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add overall request latency to the overview dashboard.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10050
 - version: "0.6.1"
   changes:
     - description: Update overview dashboard.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.2"
+  changes:
+    - description: Add overall request latency to the overview dashboard.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.6.1"
   changes:
     - description: Update overview dashboard.

--- a/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
+++ b/packages/azure_openai/kibana/dashboard/azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"e3f33d29-c2a9-474d-bea3-d817db57634d\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"e3f33d29-c2a9-474d-bea3-d817db57634d\",\"fieldName\":\"azure.subscription_id\",\"title\":\"subscriptions\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"424f8e18-f9e1-48fd-937f-f46c3c16c62a\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"424f8e18-f9e1-48fd-937f-f46c3c16c62a\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"bcf4c5af-d14f-4097-aa6a-ede7a5765ff6\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"bcf4c5af-d14f-4097-aa6a-ede7a5765ff6\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"c0755312-01ac-4ade-a13a-e44c6bd5ed7b\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"c0755312-01ac-4ade-a13a-e44c6bd5ed7b\",\"fieldName\":\"azure.dimensions.model_deployment_name\",\"title\":\"Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"7b82b735-59d4-4494-a85b-4ad3fb8703f1\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"7b82b735-59d4-4494-a85b-4ad3fb8703f1\",\"fieldName\":\"azure.dimensions.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"c5a4edc4-3a59-406d-8e04-7c86701d3563\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"c5a4edc4-3a59-406d-8e04-7c86701d3563\",\"fieldName\":\"azure.dimensions.api_name\",\"title\":\"API Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"61ac52a9-220b-43e9-b358-003ba7c178bd\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"61ac52a9-220b-43e9-b358-003ba7c178bd\",\"fieldName\":\"azure.subscription_id\",\"title\":\"subscriptions\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"cbbd51d0-e1b2-4c05-8285-ef0cc5269244\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"cbbd51d0-e1b2-4c05-8285-ef0cc5269244\",\"fieldName\":\"azure.resource.group\",\"title\":\"Resource Group\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"10a58470-a823-4262-a3af-814b2af3fc0e\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"10a58470-a823-4262-a3af-814b2af3fc0e\",\"fieldName\":\"azure.resource.name\",\"title\":\"Resource Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"663529b0-69cb-4ae7-9215-31048016aad3\":{\"type\":\"optionsListControl\",\"order\":3,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"663529b0-69cb-4ae7-9215-31048016aad3\",\"fieldName\":\"azure.dimensions.model_deployment_name\",\"title\":\"Deployment Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"49824f45-eba8-4a8f-b0c2-b9ab3e59135d\":{\"type\":\"optionsListControl\",\"order\":4,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"49824f45-eba8-4a8f-b0c2-b9ab3e59135d\",\"fieldName\":\"azure.dimensions.model_version\",\"title\":\"Model Version\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}},\"6c2490d8-52a0-44c5-aadc-eb845ce3cee6\":{\"type\":\"optionsListControl\",\"order\":5,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"6c2490d8-52a0-44c5-aadc-eb845ce3cee6\",\"fieldName\":\"azure.dimensions.api_name\",\"title\":\"API Name\",\"grow\":true,\"width\":\"medium\",\"searchTechnique\":\"prefix\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -54,12 +54,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "0d1b9e11-2cf3-4569-bae2-f6d1250c9dac",
+                    "i": "a62208a4-59ac-4f5d-bbbb-389ed8414226",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "0d1b9e11-2cf3-4569-bae2-f6d1250c9dac",
+                "panelIndex": "a62208a4-59ac-4f5d-bbbb-389ed8414226",
                 "title": "",
                 "type": "visualization"
             },
@@ -144,12 +144,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67",
+                    "i": "30e79d91-42a3-40f7-8804-c34281838b3a",
                     "w": 9,
                     "x": 0,
                     "y": 5
                 },
-                "panelIndex": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67",
+                "panelIndex": "30e79d91-42a3-40f7-8804-c34281838b3a",
                 "title": "",
                 "type": "lens"
             },
@@ -158,7 +158,7 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metrics-*",
+                                "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
                                 "type": "index-pattern"
                             }
@@ -167,11 +167,14 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "a99ea77a-00e0-4dc9-899e-1708680face0": {
                                             "columnOrder": [
                                                 "b5f945ae-fdd4-4309-9813-66adca521ded",
-                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0"
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0",
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX1",
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX2"
                                             ],
                                             "columns": {
                                                 "b5f945ae-fdd4-4309-9813-66adca521ded": {
@@ -181,11 +184,20 @@
                                                     "label": "Average Response Time",
                                                     "operationType": "formula",
                                                     "params": {
-                                                        "formula": "average(azure.open_ai.provisioned_managed_utilization_v2.avg)",
+                                                        "format": {
+                                                            "id": "duration",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 0,
+                                                                "fromUnit": "nanoseconds",
+                                                                "toUnit": "humanizePrecise"
+                                                            }
+                                                        },
+                                                        "formula": "average(azure.open_ai.properties.response_time) - average(azure.open_ai.properties.request_time)",
                                                         "isFormulaBroken": false
                                                     },
                                                     "references": [
-                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX0"
+                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX2"
                                                     ],
                                                     "scale": "ratio"
                                                 },
@@ -193,16 +205,56 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of Total Requests",
+                                                    "label": "Part of Average Response Time",
                                                     "operationType": "average",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "azure.open_ai.provisioned_managed_utilization_v2.avg"
+                                                    "sourceField": "azure.open_ai.properties.response_time"
+                                                },
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Average Response Time",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "azure.open_ai.properties.request_time"
+                                                },
+                                                "b5f945ae-fdd4-4309-9813-66adca521dedX2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Average Response Time",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "b5f945ae-fdd4-4309-9813-66adca521dedX0",
+                                                                "b5f945ae-fdd4-4309-9813-66adca521dedX1"
+                                                            ],
+                                                            "location": {
+                                                                "max": 96,
+                                                                "min": 0
+                                                            },
+                                                            "name": "subtract",
+                                                            "text": "average(azure.open_ai.properties.response_time) - average(azure.open_ai.properties.request_time)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX0",
+                                                        "b5f945ae-fdd4-4309-9813-66adca521dedX1"
+                                                    ],
+                                                    "scale": "ratio"
                                                 }
                                             },
-                                            "incompleteColumns": {}
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logs-*"
                                         }
                                     }
                                 },
@@ -222,7 +274,51 @@
                             "visualization": {
                                 "layerId": "a99ea77a-00e0-4dc9-899e-1708680face0",
                                 "layerType": "data",
-                                "metricAccessor": "b5f945ae-fdd4-4309-9813-66adca521ded"
+                                "metricAccessor": "b5f945ae-fdd4-4309-9813-66adca521ded",
+                                "palette": {
+                                    "name": "custom",
+                                    "params": {
+                                        "colorStops": [
+                                            {
+                                                "color": "#209280",
+                                                "stop": 0
+                                            },
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": 10000000
+                                            },
+                                            {
+                                                "color": "#d6bf57",
+                                                "stop": 100000000
+                                            }
+                                        ],
+                                        "continuity": "above",
+                                        "maxSteps": 5,
+                                        "name": "custom",
+                                        "progression": "fixed",
+                                        "rangeMax": null,
+                                        "rangeMin": 0,
+                                        "rangeType": "number",
+                                        "reverse": false,
+                                        "steps": 3,
+                                        "stops": [
+                                            {
+                                                "color": "#209280",
+                                                "stop": 10000000
+                                            },
+                                            {
+                                                "color": "#cc5642",
+                                                "stop": 100000000
+                                            },
+                                            {
+                                                "color": "#d6bf57",
+                                                "stop": 100000001
+                                            }
+                                        ]
+                                    },
+                                    "type": "palette"
+                                },
+                                "showBar": false
                             }
                         },
                         "title": "",
@@ -234,12 +330,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0",
+                    "i": "af69ecf7-0dd8-4220-8858-49d7cf7301d5",
                     "w": 9,
                     "x": 9,
                     "y": 5
                 },
-                "panelIndex": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0",
+                "panelIndex": "af69ecf7-0dd8-4220-8858-49d7cf7301d5",
                 "title": "",
                 "type": "lens"
             },
@@ -393,28 +489,67 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "f11ea77f-c3ce-483d-a967-746d931e94fa",
+                    "i": "550bd34a-20b7-497d-a2dd-78ade424a0a5",
                     "w": 30,
                     "x": 18,
                     "y": 5
                 },
-                "panelIndex": "f11ea77f-c3ce-483d-a967-746d931e94fa",
+                "panelIndex": "550bd34a-20b7-497d-a2dd-78ade424a0a5",
                 "title": "Token Usage",
                 "type": "lens"
             },
             {
                 "embeddableConfig": {
+                    "attributes": {
+                        "columns": [
+                            "azure.dimensions.model_deployment_name",
+                            "azure.dimensions.model_name",
+                            "azure.dimensions.api_name",
+                            "azure.open_ai.generated_tokens.total",
+                            "azure.open_ai.processed_prompt_tokens.total",
+                            "azure.open_ai.requests.total",
+                            "azure.open_ai.token_transaction.total",
+                            "azure.dimensions.model_version",
+                            "azure.dimensions.status_code",
+                            "azure.dimensions.stream_type"
+                        ],
+                        "grid": {},
+                        "hideChart": false,
+                        "isTextBasedQuery": false,
+                        "kibanaSavedObjectMeta": {
+                            "searchSourceJSON": "{\"filter\":[{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index\",\"negate\":false,\"params\":[{\"meta\":{\"alias\":null,\"disabled\":false,\"field\":\"azure.open_ai.generated_tokens.total\",\"index\":\"metrics-*\",\"key\":\"azure.open_ai.generated_tokens.total\",\"negate\":false,\"params\":{\"gte\":\"1\"},\"type\":\"range\",\"value\":{\"gte\":\"1\"}},\"query\":{\"range\":{\"azure.open_ai.generated_tokens.total\":{\"gte\":\"1\"}}}},{\"meta\":{\"alias\":null,\"disabled\":false,\"field\":\"azure.open_ai.processed_prompt_tokens.total\",\"index\":\"metrics-*\",\"key\":\"azure.open_ai.processed_prompt_tokens.total\",\"negate\":false,\"params\":{\"gte\":\"1\"},\"type\":\"range\",\"value\":{\"gte\":\"1\"}},\"query\":{\"range\":{\"azure.open_ai.processed_prompt_tokens.total\":{\"gte\":\"1\"}}}},{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"field\":\"azure.open_ai.token_transaction.total\",\"index\":\"metrics-*\",\"key\":\"azure.open_ai.token_transaction.total\",\"negate\":false,\"params\":{\"gte\":\"1\"},\"type\":\"range\",\"value\":{\"gte\":\"1\"}},\"query\":{\"range\":{\"azure.open_ai.token_transaction.total\":{\"gte\":\"1\"}}}},{\"$state\":{\"store\":\"appState\"},\"meta\":{\"alias\":null,\"disabled\":false,\"field\":\"azure.open_ai.requests.total\",\"index\":\"metrics-*\",\"key\":\"azure.open_ai.requests.total\",\"negate\":false,\"params\":{\"gte\":\"1\"},\"type\":\"range\",\"value\":{\"gte\":\"1\"}},\"query\":{\"range\":{\"azure.open_ai.requests.total\":{\"gte\":\"1\"}}}}],\"relation\":\"OR\",\"type\":\"combined\"},\"query\":{}}],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"data_stream.dataset :\\\"azure.open_ai\\\" \"}}"
+                        },
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "sort": [
+                            [
+                                "@timestamp",
+                                "desc"
+                            ]
+                        ],
+                        "timeRestore": false,
+                        "usesAdHocDataView": false
+                    },
                     "enhancements": {}
                 },
                 "gridData": {
                     "h": 17,
-                    "i": "7d006617-1024-419b-87e2-331ff8467273",
+                    "i": "2905b86a-0c97-4b80-842c-104650397b05",
                     "w": 48,
                     "x": 0,
                     "y": 17
                 },
-                "panelIndex": "7d006617-1024-419b-87e2-331ff8467273",
-                "panelRefName": "panel_7d006617-1024-419b-87e2-331ff8467273",
+                "panelIndex": "2905b86a-0c97-4b80-842c-104650397b05",
                 "type": "search"
             }
         ],
@@ -422,65 +557,70 @@
             "pause": true,
             "value": 60000
         },
-        "timeFrom": "now-48h",
+        "timeFrom": "now-7d/d",
         "timeRestore": true,
         "timeTo": "now",
         "title": "[Azure OpenAI] Overview",
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-03T10:54:40.252Z",
+    "created_at": "2024-06-03T12:26:30.466Z",
     "id": "azure_openai-21d9a0d0-e6a0-4b34-bc6d-ce6560a1dab3",
     "managed": false,
     "references": [
         {
             "id": "metrics-*",
-            "name": "4e9d10f6-5d36-45c8-99df-4cbf8badcd67:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+            "name": "30e79d91-42a3-40f7-8804-c34281838b3a:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "af69ecf7-0dd8-4220-8858-49d7cf7301d5:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "e2acaad4-5a4e-4dbe-8e57-65d8f6a1abf0:indexpattern-datasource-layer-a99ea77a-00e0-4dc9-899e-1708680face0",
+            "name": "550bd34a-20b7-497d-a2dd-78ade424a0a5:indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "f11ea77f-c3ce-483d-a967-746d931e94fa:indexpattern-datasource-layer-b89abbbb-c146-4674-9275-33e9e64f4b41",
-            "type": "index-pattern"
-        },
-        {
-            "id": "azure_openai-588ff5b1-0b56-4a9d-aadf-9658403870d0",
-            "name": "7d006617-1024-419b-87e2-331ff8467273:panel_7d006617-1024-419b-87e2-331ff8467273",
-            "type": "search"
-        },
-        {
-            "id": "metrics-*",
-            "name": "controlGroup_e3f33d29-c2a9-474d-bea3-d817db57634d:optionsListDataView",
+            "name": "2905b86a-0c97-4b80-842c-104650397b05:kibanaSavedObjectMeta.searchSourceJSON.index",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_424f8e18-f9e1-48fd-937f-f46c3c16c62a:optionsListDataView",
+            "name": "2905b86a-0c97-4b80-842c-104650397b05:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_bcf4c5af-d14f-4097-aa6a-ede7a5765ff6:optionsListDataView",
+            "name": "controlGroup_61ac52a9-220b-43e9-b358-003ba7c178bd:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_c0755312-01ac-4ade-a13a-e44c6bd5ed7b:optionsListDataView",
+            "name": "controlGroup_cbbd51d0-e1b2-4c05-8285-ef0cc5269244:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_7b82b735-59d4-4494-a85b-4ad3fb8703f1:optionsListDataView",
+            "name": "controlGroup_10a58470-a823-4262-a3af-814b2af3fc0e:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "metrics-*",
-            "name": "controlGroup_c5a4edc4-3a59-406d-8e04-7c86701d3563:optionsListDataView",
+            "name": "controlGroup_663529b0-69cb-4ae7-9215-31048016aad3:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_49824f45-eba8-4a8f-b0c2-b9ab3e59135d:optionsListDataView",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "controlGroup_6c2490d8-52a0-44c5-aadc-eb845ce3cee6:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: azure_openai
 title: "Azure OpenAI"
-version: 0.6.1
+version: 0.6.2
 source:
   license: "Elastic-2.0"
 description: "Azure OpenAI Logs and Metrics"


### PR DESCRIPTION
- Enhancement

This PR updates the overall latency in the overview dashboard and the PTU latency will go into the metrics dashboard.


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Verify the average latency loads in the dashboard properly in the overview dashboard.


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
