### PR TITLE
Use all process metrics values for endpoint

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add all process values to endpoint metrics
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9765
+      link: https://github.com/elastic/integrations/pull/10054
 - version: "1.19.1"
   changes:
     - description: component values to endpoint metrics

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.2"
+  changes:
+    - description: Add all process values to endpoint metrics
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9765
 - version: "1.19.1"
   changes:
     - description: component values to endpoint metrics

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -21,6 +21,408 @@
       ignore_above: 1024
       description: Elastic agent version.
       example: 7.11.0
+- name: system.process
+  type: group
+  fields:
+    - name: cpu
+      type: group
+      fields:
+        - name: user.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in user space.
+        - name: total.value
+          type: long
+          metric_type: counter
+          description: |
+            The value of CPU usage since starting the process.
+        - name: system.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in kernel space.
+        - name: total.ticks
+          type: long
+          metric_type: counter
+          description: |
+            The total CPU time spent by the process.
+        - name: total.time.ms
+          type: long
+          metric_type: counter
+          description: |
+            The total CPU time spent by the process.
+        - name: user.time.ms
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in user space.
+        - name: system.time.ms
+          type: long
+          metric_type: counter
+          description: |
+            The amount of CPU time the process spent in kernel space.
+    - name: memory
+      type: group
+      fields:
+        - name: size
+          type: long
+          format: bytes
+          unit: byte
+          metric_type: gauge
+          description: |
+            The total virtual memory the process has. On Windows this represents the Commit Charge (the total amount of memory that the memory manager has committed for a running process) value in bytes for this process.
+    - name: fd
+      type: group
+      fields:
+        - name: open
+          type: long
+          metric_type: gauge
+          description: The number of file descriptors open by the process.
+        - name: limit.soft
+          type: long
+          metric_type: gauge
+          description: |
+            The soft limit on the number of file descriptors opened by the process. The soft limit can be changed by the process at any time.
+        - name: limit.hard
+          type: long
+          metric_type: gauge
+          description: |
+            The hard limit on the number of file descriptors opened by the process. The hard limit can only be raised by root.
+    - name: cgroup
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          description: |
+            The ID common to all cgroups associated with this task. If there isn't a common ID used by all cgroups this field will be absent.
+        - name: path
+          type: keyword
+          description: |
+            The path to the cgroup relative to the cgroup subsystem's mountpoint. If there isn't a common path used by all cgroups this field will be absent.
+        - name: cpu
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: cfs.period.us
+              type: long
+              unit: micros
+              metric_type: gauge
+              description: |
+                Period of time in microseconds for how regularly a cgroup's access to CPU resources should be reallocated.
+            - name: cfs.quota.us
+              type: long
+              unit: micros
+              metric_type: gauge
+              description: |
+                Total amount of time in microseconds for which all tasks in a cgroup can run during one period (as defined by cfs.period.us).
+            - name: cfs.shares
+              type: long
+              metric_type: gauge
+              description: |
+                An integer value that specifies a relative share of CPU time available to the tasks in a cgroup. The value specified in the cpu.shares file must be 2 or higher.
+            - name: rt.period.us
+              type: long
+              unit: micros
+              metric_type: gauge
+              description: |
+                Period of time in microseconds for how regularly a cgroup's access to CPU resources is reallocated.
+            - name: rt.runtime.us
+              type: long
+              unit: micros
+              metric_type: gauge
+              description: |
+                Period of time in microseconds for the longest continuous period in which the tasks in a cgroup have access to CPU resources.
+            - name: stats.periods
+              type: long
+              metric_type: counter
+              description: |
+                Number of period intervals (as specified in cpu.cfs.period.us) that have elapsed.
+            - name: stats.throttled.periods
+              type: long
+              metric_type: counter
+              description: |
+                Number of times tasks in a cgroup have been throttled (that is, not allowed to run because they have exhausted all of the available time as specified by their quota).
+            - name: stats.throttled.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: |
+                The total time duration (in nanoseconds) for which tasks in a cgroup have been throttled.
+        - name: cpuacct
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: total.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: |
+                Total CPU time in nanoseconds consumed by all tasks in the cgroup.
+            - name: stats.user.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: CPU time consumed by tasks in user mode.
+            - name: stats.system.ns
+              type: long
+              metric_type: counter
+              unit: nanos
+              description: CPU time consumed by tasks in user (kernel) mode.
+            - name: percpu
+              type: object
+              description: |
+                CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
+        - name: memory
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystem's mountpoint.
+            - name: mem.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total memory usage by processes in the cgroup (in bytes).
+            - name: mem.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum memory used by processes in the cgroup (in bytes).
+            - name: mem.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of user memory in bytes (including file cache) that tasks in the cgroup are allowed to use.
+            - name: mem.failures
+              type: long
+              description: |
+                The number of times that the memory limit (mem.limit.bytes) was reached.
+            - name: memsw.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The sum of current memory usage plus swap space used by processes in the cgroup (in bytes).
+            - name: memsw.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of memory and swap space used by processes in the cgroup (in bytes).
+            - name: memsw.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount for the sum of memory and swap usage that tasks in the cgroup are allowed to use.
+            - name: memsw.failures
+              type: long
+              unit: byte
+              metric_type: gauge
+              description: |
+                The number of times that the memory plus swap space limit (memsw.limit.bytes) was reached.
+            - name: kmem.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total kernel memory usage by processes in the cgroup (in bytes).
+            - name: kmem.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum kernel memory used by processes in the cgroup (in bytes).
+            - name: kmem.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of kernel memory that tasks in the cgroup are allowed to use.
+            - name: kmem.failures
+              type: long
+              metric_type: counter
+              description: |
+                The number of times that the memory limit (kmem.limit.bytes) was reached.
+            - name: kmem_tcp.usage.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total memory usage for TCP buffers in bytes.
+            - name: kmem_tcp.usage.max.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum memory used for TCP buffers by processes in the cgroup (in bytes).
+            - name: kmem_tcp.limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                The maximum amount of memory for TCP buffers that tasks in the cgroup are allowed to use.
+            - name: kmem_tcp.failures
+              type: long
+              metric_type: counter
+              description: |
+                The number of times that the memory limit (kmem_tcp.limit.bytes) was reached.
+            - name: stats.active_anon.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs (shmem), in bytes.
+            - name: stats.active_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: File-backed memory on active LRU list, in bytes.
+            - name: stats.cache.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: Page cache, including tmpfs (shmem), in bytes.
+            - name: stats.hierarchical_memory_limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory limit for the hierarchy that contains the memory cgroup, in bytes.
+            - name: stats.hierarchical_memsw_limit.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory plus swap limit for the hierarchy that contains the memory cgroup, in bytes.
+            - name: stats.inactive_anon.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache on inactive LRU list, including tmpfs (shmem), in bytes
+            - name: stats.inactive_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                File-backed memory on inactive LRU list, in bytes.
+            - name: stats.mapped_file.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Size of memory-mapped mapped files, including tmpfs (shmem), in bytes.
+            - name: stats.page_faults
+              type: long
+              metric_type: counter
+              description: |
+                Number of times that a process in the cgroup triggered a page fault.
+            - name: stats.major_page_faults
+              type: long
+              metric_type: counter
+              description: |
+                Number of times that a process in the cgroup triggered a major fault. "Major" faults happen when the kernel actually has to read the data from disk.
+            - name: stats.pages_in
+              type: long
+              metric_type: counter
+              description: |
+                Number of pages paged into memory. This is a counter.
+            - name: stats.pages_out
+              type: long
+              metric_type: counter
+              description: |
+                Number of pages paged out of memory. This is a counter.
+            - name: stats.rss.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Anonymous and swap cache (includes transparent hugepages), not including tmpfs (shmem), in bytes.
+            - name: stats.rss_huge.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Number of bytes of anonymous transparent hugepages.
+            - name: stats.swap.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Swap usage, in bytes.
+            - name: stats.unevictable.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Memory that cannot be reclaimed, in bytes.
+        - name: blkio
+          type: group
+          fields:
+            - name: id
+              type: keyword
+              description: ID of the cgroup.
+            - name: path
+              type: keyword
+              description: |
+                Path to the cgroup relative to the cgroup subsystems mountpoint.
+            - name: total.bytes
+              type: long
+              format: bytes
+              unit: byte
+              metric_type: gauge
+              description: |
+                Total number of bytes transferred to and from all block devices by processes in the cgroup.
+            - name: total.ios
+              type: long
+              metric_type: counter
+              description: |
+                Total number of I/O operations performed on all devices by processes in the cgroup as seen by the throttling policy.
 - name: component
   type: group
   fields:

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.19.1
+version: 1.19.2
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 1.0.0


### PR DESCRIPTION
## Proposed commit message

I realized that with https://github.com/elastic/elastic-agent/pull/4789, endpoint actually needs _all_ of the process metrics previously used by only metricbeat and filebeat. This just copies the process definitions into endpoint.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

