### PR TITLE
[cisco_asa] Add additional log types

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.35.0"
+  changes:
+    - description: Add additional log types.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.34.1"
   changes:
     - description: Add support for spaces in group and user names.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add additional log types.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10067
 - version: "2.34.1"
   changes:
     - description: Add support for spaces in group and user names.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -118,3 +118,35 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <139>Oct 06 2023 11:12:20 myAsaHostname : %ASA-3-106010: Deny inbound protocol 103 src inside:172.31.98.44 dst inside:192.168.2.2
 <166>Oct 06 2023 09:46:34 myAsaHostname : %ASA-6-106015: Deny TCP (no connection) from myComputer1.myDomain.se/11946 to myComputer2.myDomain.se/389 flags FIN ACK  on interface inside
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106023: Deny udp src outside:172.31.98.44/0 dst myInterfaceName:192.168.2.2/80 by access-group "outside" [0x24c36bb3, 0x0]
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106012: Deny IP from 10.1.2.1 to 172.31.98.44, IP options: "Router Alert"
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113008: AAA transaction status ACCEPT: user = USER_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113009: AAA retrieved default group policy GROUP_POLICY_1 for user USER_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-302010: 12 in use, 10 most used
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.1 on interface inside for user USER_1 disconnected by SSH server, reason: Out of memory
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721016: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been created.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721018: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been deleted.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722028: Group <GROUP 1> User <USER 1> IP <10.20.0.1> Stale SVC connection closed.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722028: Group GROUP_1 User USER_1 IP 10.20.0.1 Stale SVC connection closed.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722032: Group <GROUP 1> User <USER 1> IP <10.20.0.1> New SVC connection replacing old connection.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722032: Group GROUP_1 User USER_1 IP 10.20.0.1 New SVC connection replacing old connection.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 for TLSv1.2 session.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725002: Device completed SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725007: SSL session with client inside:172.16.0.1/1133 to 10.20.0.1/443 terminated.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725016: Device selects trust-point TRUSTPOINT_1 for client inside:172.16.0.1/1133 to 10.20.0.1/443
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737003: IPAA: Session=0x1122334455667788, DHCP configured, no viable servers found for tunnel-group TUNNEL_GROUP_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737003: IPAA: DHCP configured, no viable servers found for tunnel-group TUNNEL_GROUP_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737006: IPAA: Session=0x1122334455667788, Local pool request succeeded for tunnel-group TUNNEL_GROUP_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737006: IPAA: Local pool request succeeded for tunnel-group TUNNEL_GROUP_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737016: IPAA: Session=0x1122334455667788, Freeing local pool POOL_1 address 172.16.0.1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737016: IPAA: Freeing local pool POOL_1 address 172.16.0.1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737026: IPAA: Session=0x1122334455667788, Client assigned 172.16.0.1 from local pool POOL_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737026: IPAA: Client assigned 172.16.0.1 from local pool POOL_1
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737034: IPAA: Session=0x1122334455667788, IPv4 address: Error explanation.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737034: IPAA: IPv4 address: Error explanation.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716003: Group GROUP_1 User USER_1 IP 172.16.0.1 WebVPN access GRANTED: "https://google.com"
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716003: Group GROUP_1 User USER_1 IP 172.16.0.1 WebVPN access GRANTED: https://google.com
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716058: Group <GROUP 1> User <USER 1> IP <10.20.0.1> AnyConnect session lost connection. Waiting to resume.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716058: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session lost connection. Waiting to resume.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group <GROUP 1> User <USER 1> IP <10.20.0.1> AnyConnect session resumed. Connection from 172.16.0.1.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session resumed. Connection from 172.16.0.1.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -4995,6 +4995,7 @@
                 "kind": "event",
                 "original": "Apr 27 02:03:03 dev01: %ASA-4-722051: Group <VPN5Policy> User <john> IP <192.168.50.3> IPv4 Address <192.168.50.5> IPv6 address <::> assigned to session",
                 "outcome": "success",
+                "reason": "IPv4 Address <192.168.50.5> IPv6 address <::> assigned to session",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -8513,6 +8514,2103 @@
                 "address": "172.31.98.44",
                 "ip": "172.31.98.44",
                 "port": 0
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "destination": {
+                "address": "172.31.98.44",
+                "ip": "172.31.98.44"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "firewall-rule",
+                "category": [
+                    "network"
+                ],
+                "code": "106012",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106012: Deny IP from 10.1.2.1 to 172.31.98.44, IP options: \"Router Alert\"",
+                "outcome": "success",
+                "reason": "IP options: \"Router Alert\"",
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "denied"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.1.2.1",
+                    "172.31.98.44"
+                ]
+            },
+            "source": {
+                "address": "10.1.2.1",
+                "ip": "10.1.2.1"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113008",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113008: AAA transaction status ACCEPT: user = USER_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "group_policy": "GROUP_POLICY_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113009",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113009: AAA retrieved default group policy GROUP_POLICY_1 for user USER_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "connections_in_use": 12,
+                    "connections_most_used": 10
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "302010",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-302010: 12 in use, 10 most used",
+                "severity": 6,
+                "timezone": "UTC"
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "source_interface": "inside"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "ssh-session-ended",
+                "category": [
+                    "network"
+                ],
+                "code": "315011",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.1 on interface inside for user USER_1 disconnected by SSH server, reason: Out of memory",
+                "reason": "Out of memory",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.1.2.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "ip": "10.1.2.1",
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "device_type": "DEVICE_1"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-connected",
+                "category": [
+                    "network"
+                ],
+                "code": "721016",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721016: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been created.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "device_type": "DEVICE_1"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-disconnected",
+                "category": [
+                    "network"
+                ],
+                "code": "721018",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-721018: (DEVICE_1) WebVPN session for client user USER_1, IP 10.20.0.1 has been deleted.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722028",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722028: Group <GROUP 1> User <USER 1> IP <10.20.0.1> Stale SVC connection closed.",
+                "outcome": "success",
+                "reason": "Stale SVC connection closed.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER 1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP 1"
+                    },
+                    "name": "USER 1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722028",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722028: Group GROUP_1 User USER_1 IP 10.20.0.1 Stale SVC connection closed.",
+                "outcome": "success",
+                "reason": "Stale SVC connection closed.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP_1"
+                    },
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722032",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722032: Group <GROUP 1> User <USER 1> IP <10.20.0.1> New SVC connection replacing old connection.",
+                "outcome": "success",
+                "reason": "New SVC connection replacing old connection.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER 1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP 1"
+                    },
+                    "name": "USER 1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722032",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722032: Group GROUP_1 User USER_1 IP 10.20.0.1 New SVC connection replacing old connection.",
+                "outcome": "success",
+                "reason": "New SVC connection replacing old connection.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP_1"
+                    },
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725001",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ]
+            },
+            "source": {
+                "ip": "172.16.0.1",
+                "port": 1133
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "tls": {
+                "version": "1.2",
+                "version_protocol": "tls"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "inside"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725001",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 for TLSv1.2 session.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1"
+                ]
+            },
+            "source": {
+                "ip": "172.16.0.1",
+                "port": 1133
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "tls": {
+                "version": "1.2",
+                "version_protocol": "tls"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725002",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725002: Device completed SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ]
+            },
+            "source": {
+                "ip": "172.16.0.1",
+                "port": 1133
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "tls": {
+                "version": "1.2",
+                "version_protocol": "tls"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "inside"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725007",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725007: SSL session with client inside:172.16.0.1/1133 to 10.20.0.1/443 terminated.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ]
+            },
+            "source": {
+                "ip": "172.16.0.1",
+                "port": 1133
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "inside",
+                    "trustpoint": "TRUSTPOINT_1"
+                }
+            },
+            "destination": {
+                "ip": "10.20.0.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725016",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725016: Device selects trust-point TRUSTPOINT_1 for client inside:172.16.0.1/1133 to 10.20.0.1/443",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "ingress": {
+                    "interface": {
+                        "name": "inside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ]
+            },
+            "source": {
+                "ip": "172.16.0.1",
+                "port": 1133
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "session_id": "0x1122334455667788",
+                    "tunnel_group": "TUNNEL_GROUP_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737003",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737003: IPAA: Session=0x1122334455667788, DHCP configured, no viable servers found for tunnel-group TUNNEL_GROUP_1",
+                "outcome": "failure",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "tunnel_group": "TUNNEL_GROUP_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737003",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737003: IPAA: DHCP configured, no viable servers found for tunnel-group TUNNEL_GROUP_1",
+                "outcome": "failure",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "session_id": "0x1122334455667788",
+                    "tunnel_group": "TUNNEL_GROUP_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737006",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737006: IPAA: Session=0x1122334455667788, Local pool request succeeded for tunnel-group TUNNEL_GROUP_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "tunnel_group": "TUNNEL_GROUP_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737006",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737006: IPAA: Local pool request succeeded for tunnel-group TUNNEL_GROUP_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "pool_address": "172.16.0.1",
+                    "pool_name": "POOL_1",
+                    "session_id": "0x1122334455667788"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737016",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737016: IPAA: Session=0x1122334455667788, Freeing local pool POOL_1 address 172.16.0.1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "pool_address": "172.16.0.1",
+                    "pool_name": "POOL_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737016",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737016: IPAA: Freeing local pool POOL_1 address 172.16.0.1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "pool_address": "172.16.0.1",
+                    "pool_name": "POOL_1",
+                    "session_id": "0x1122334455667788"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737026",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737026: IPAA: Session=0x1122334455667788, Client assigned 172.16.0.1 from local pool POOL_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "pool_address": "172.16.0.1",
+                    "pool_name": "POOL_1"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737026",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-737026: IPAA: Client assigned 172.16.0.1 from local pool POOL_1",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "session_id": "0x1122334455667788"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737034",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737034: IPAA: Session=0x1122334455667788, IPv4 address: Error explanation.",
+                "outcome": "failure",
+                "reason": "IPv4 address: Error explanation.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "737034",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-737034: IPAA: IPv4 address: Error explanation.",
+                "outcome": "failure",
+                "reason": "IPv4 address: Error explanation.",
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP_1"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "716003",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716003: Group GROUP_1 User USER_1 IP 172.16.0.1 WebVPN access GRANTED: \"https://google.com\"",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.1",
+                "ip": "172.16.0.1",
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "google.com",
+                "original": "https://google.com",
+                "path": "",
+                "scheme": "https"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP_1"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "716003",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716003: Group GROUP_1 User USER_1 IP 172.16.0.1 WebVPN access GRANTED: https://google.com",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.1",
+                "ip": "172.16.0.1",
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "url": {
+                "domain": "google.com",
+                "original": "https://google.com",
+                "path": "",
+                "scheme": "https"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP 1"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-disconnected",
+                "category": [
+                    "network"
+                ],
+                "code": "716058",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716058: Group <GROUP 1> User <USER 1> IP <10.20.0.1> AnyConnect session lost connection. Waiting to resume.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER 1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "name": "USER 1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP_1"
+                    }
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-disconnected",
+                "category": [
+                    "network"
+                ],
+                "code": "716058",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716058: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session lost connection. Waiting to resume.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "end"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP 1"
+                    }
+                }
+            },
+            "destination": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-resumed",
+                "category": [
+                    "network"
+                ],
+                "code": "716059",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group <GROUP 1> User <USER 1> IP <10.20.0.1> AnyConnect session resumed. Connection from 172.16.0.1.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER 1"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.1",
+                "ip": "172.16.0.1",
+                "user": {
+                    "name": "USER 1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "cisco": {
+                "asa": {
+                    "webvpn": {
+                        "group_name": "GROUP_1"
+                    }
+                }
+            },
+            "destination": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-resumed",
+                "category": [
+                    "network"
+                ],
+                "code": "716059",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session resumed. Connection from 172.16.0.1.",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "172.16.0.1",
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "172.16.0.1",
+                "ip": "172.16.0.1",
+                "user": {
+                    "name": "USER_1"
+                }
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-asa-missing-groups.log-expected.json
@@ -164,7 +164,7 @@
                 "code": "722037",
                 "kind": "event",
                 "original": "Oct 20 2019 15:42:54: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Paul> IP <81.2.69.142> SVC closing connection: DPD failure.",
-                "reason": "DPD failure",
+                "reason": "SVC closing connection: DPD failure.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -226,7 +226,7 @@
                 "code": "722037",
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:37: %ASA-4-722037: Group <GroupPolicy_TheBeatles> User <Brian> IP <234.63.56.32> SVC closing connection: Transport closing.",
-                "reason": "Transport closing",
+                "reason": "SVC closing connection: Transport closing.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -283,6 +283,7 @@
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy_TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
                 "outcome": "success",
+                "reason": "IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -351,6 +352,7 @@
                 "kind": "event",
                 "original": "Aug  6 2020 11:01:38: %ASA-4-722051: Group <GroupPolicy TheBeatles> User <George> IP <67.43.156.12> IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
                 "outcome": "success",
+                "reason": "IPv4 Address <67.43.156.12> IPv6 address <::> assigned to session",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -412,7 +414,7 @@
                 "code": "722011",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722011: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> SVC Message: 17/WARNING: Reconnecting the VPN tunnel..",
-                "reason": "17/WARNING: Reconnecting the VPN tunnel.",
+                "reason": "SVC Message: 17/WARNING: Reconnecting the VPN tunnel..",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -461,7 +463,7 @@
                 "code": "722011",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722011: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> SVC Message: 17/WARNING: Reconnecting the VPN tunnel..",
-                "reason": "17/WARNING: Reconnecting the VPN tunnel.",
+                "reason": "SVC Message: 17/WARNING: Reconnecting the VPN tunnel..",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -812,6 +814,7 @@
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First UDP SVC connection established for SVC session.",
                 "outcome": "success",
+                "reason": "First UDP SVC connection established for SVC session.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -866,6 +869,7 @@
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.",
                 "outcome": "success",
+                "reason": "First TCP SVC connection established for SVC session.",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -920,6 +924,7 @@
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-5-722033: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> First TCP SVC connection established for SVC session.",
                 "outcome": "success",
+                "reason": "First TCP SVC connection established for SVC session.",
                 "severity": 5,
                 "timezone": "UTC",
                 "type": [
@@ -973,6 +978,7 @@
                 "code": "722034",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy_Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.",
+                "reason": "New TCP SVC connection, no existing connection.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1026,7 +1032,7 @@
                 "code": "722037",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722037: Group <GroupPolicy_Employee> User <foo.bar@example.com> IP <192.168.0.1> SVC closing connection: DPD failure.",
-                "reason": "DPD failure",
+                "reason": "SVC closing connection: DPD failure.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1081,7 +1087,7 @@
                 "code": "722037",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722037: Group <GroupPolicy Employee> User <foo.bar@example.com> IP <192.168.0.1> SVC closing connection: DPD failure.",
-                "reason": "DPD failure",
+                "reason": "SVC closing connection: DPD failure.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [
@@ -1136,6 +1142,7 @@
                 "code": "722034",
                 "kind": "event",
                 "original": "Oct 20 2021 16:41:52: %ASA-4-722034: Group <GroupPolicy Employee> User <464_0273> IP <192.168.0.1> New TCP SVC connection, no existing connection.",
+                "reason": "New TCP SVC connection, no existing connection.",
                 "severity": 4,
                 "timezone": "UTC",
                 "type": [

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -237,6 +237,12 @@ processors:
       - "Deny %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}/%{POSINT:source.port} (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}/%{POSINT:destination.port}(%{GREEDYDATA})?"
       - "Deny %{NOTSPACE:network.direction} ((protocol %{POSINT:network.iana_number})|%{NOTSPACE:network.transport}) src %{NOTSPACE:_temp_.cisco.source_interface}:%{NOTSPACE:source.address}(/%{POSINT:source.port})? (%{DATA})?dst %{NOTSPACE:_temp_.cisco.destination_interface}:%{NOTSPACE:destination.address}(/%{POSINT:destination.port})?(%{GREEDYDATA})?"
   - dissect:
+      if: "ctx._temp_.cisco.message_id == '106012'"
+      tag: parse_106012
+      field: "message"
+      description: "106012"
+      pattern: "Deny IP from %{source.address} to %{destination.address}, %{event.reason}"
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '106013'"
       tag: parse_106013
       field: "message"
@@ -384,6 +390,30 @@ processors:
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
         IPORNONE: (%{IP:source.address}|None)
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113008'"
+      tag: parse_113008
+      field: message
+      description: "113008"
+      pattern: "AAA transaction status ACCEPT: user = %{source.user.name}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113009'"
+      tag: parse_113009
+      field: message
+      description: "113008"
+      pattern: "AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113008'"
+      tag: parse_113008
+      description: "113008"
+      field: message
+      pattern: "AAA transaction status ACCEPT: user = %{source.user.name}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '113009'"
+      tag: parse_113009
+      description: "113009"
+      field: message
+      pattern: "AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '113012'"
       tag: parse_113012
@@ -437,6 +467,12 @@ processors:
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '302010'"
+      tag: parse_302010
+      field: "message"
+      description: "302010"
+      pattern: "%{_temp_.cisco.connections_in_use} in use, %{_temp_.cisco.connections_most_used} most used"
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
       tag: parse_302013-302015
@@ -594,6 +630,12 @@ processors:
       field: "message"
       description: "313009"
       pattern: "Denied invalid %{network.transport} code %{_temp_.cisco.icmp_code}, for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{_temp_.natsrcip}/%{_temp_.cisco.mapped_source_port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{_temp_.natdstip}/%{_temp_.cisco.mapped_destination_port})%{}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '315011'"
+      tag: parse_315011
+      field: "message"
+      description: "315011"
+      pattern: "SSH session from %{source.ip} on interface %{_temp_.cisco.source_interface} for user %{source.user.name} disconnected by SSH server, reason: %{event.reason}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
       tag: parse_322001
@@ -851,7 +893,7 @@ processors:
       field: "message"
       description: "710005"
       pattern: "%{network.transport} request discarded from %{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
-  - grok: 
+  - grok:
       if: "ctx._temp_.cisco.message_id == '713049'"
       tag: parse_713049
       field: "message"
@@ -868,53 +910,110 @@ processors:
         - "Group <%{DATA:_temp_.cisco.webvpn.group_name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> WebVPN session terminated: %{GREEDYDATA:event.reason}."
         - "Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} WebVPN session terminated: %{GREEDYDATA:event.reason}."
   - grok:
-      if: "ctx._temp_.cisco.message_id == '722011'"
-      tag: parse_722011
+      if: "ctx._temp_.cisco.message_id == '716003'"
+      tag: parse_716003
       field: "message"
-      description: "722011"
+      description: "716003"
       patterns:
-        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> SVC Message: %{GREEDYDATA:event.reason}\.'
-        - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC Message: %{GREEDYDATA:event.reason}\.'
+        - '^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> WebVPN access GRANTED: "?%{DATA:url.original}"?$'
+        - '^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} WebVPN access GRANTED: "?%{DATA:url.original}"?$'
+      pattern_definitions:
+        NOTBRACKET: "[^<>]+"
   - grok:
-      if: '["722022", "722023"].contains(ctx._temp_.cisco.message_id)'
-      tag: parse_722022-722023
+      if: "ctx._temp_.cisco.message_id == '716058'"
+      tag: parse_716058
       field: "message"
-      description: "722022, 722023"
+      description: "716058"
       patterns:
-        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> %{GREEDYDATA:event.reason}'
-        - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} %{GREEDYDATA:event.reason}'
+        - "^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}>"
+        - "^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address}"
+      pattern_definitions:
+        NOTBRACKET: "[^<>]+"
   - grok:
+      if: "ctx._temp_.cisco.message_id == '716059'"
+      tag: parse_716059
+      field: "message"
+      description: "716059"
+      patterns:
+        - "^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:destination.address}> AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\\.$"
+        - "^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:destination.address} AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\\.$"
+      pattern_definitions:
+        NOTBRACKET: "[^<>]+"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '721016'"
+      tag: parse_721016
+      field: message
+      description: "721016"
+      pattern: "(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been created."
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '721018'"
+      tag: parse_721018
+      field: message
+      description: "721018"
+      pattern: "(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been deleted."
+  - grok:
+      if: "['722011', '722022', '722023', '722028', '722032', '722033', '722034', '722037', '722051'].contains(ctx._temp_.cisco.message_id)"
+      tag: parse_svc_message
+      field: "message"
+      description: "svc_message"
+      patterns:
+        - "^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> %{GREEDYDATA:event.reason}$"
+        - "^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} %{GREEDYDATA:event.reason}$"
+      pattern_definitions:
+        NOTBRACKET: "[^<>]+"
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '722033'"
       tag: parse_722033
-      field: "message"
+      field: "event.reason"
       description: "722033"
-      patterns:
-        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
-        - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} First %{NOTSPACE:network.transport} SVC connection established for SVC session\.'
-  - grok:
+      pattern: 'First %{network.transport} SVC connection established for SVC session.'
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '722034'"
       tag: parse_722034
-      field: "message"
+      field: "event.reason"
       description: "722034"
-      patterns:
-        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
-        - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} New %{NOTSPACE:network.transport} SVC connection, no existing connection\.'
-  - grok:
-      if: "ctx._temp_.cisco.message_id == '722037'"
-      tag: parse_722037
-      field: "message"
-      description: "722037"
-      patterns:
-        - 'Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> SVC closing connection: %{GREEDYDATA:event.reason}\.'
-        - 'Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} SVC closing connection: %{GREEDYDATA:event.reason}\.'
-  - grok:
+      pattern: 'New %{network.transport} SVC connection, no existing connection.'
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '722051'"
       tag: parse_722051
-      field: "message"
+      field: "event.reason"
       description: "722051"
+      pattern: "IPv4 Address <%{_temp_.cisco.assigned_ip}> %{}"
+  - grok:
+      if: "ctx._temp_.cisco.message_id == '722055'"
+      tag: parse_722055
+      field: "message"
+      description: "722055"
       patterns:
-        - "Group <%{DATA:source.user.group.name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> IPv4 Address <%{IP:_temp_.cisco.assigned_ip}> %{GREEDYDATA}"
-        - "Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} IPv4 Address %{IP:_temp_.cisco.assigned_ip} %{GREEDYDATA}"
+        - "^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> Client Type: %{GREEDYDATA:user_agent}$"
+        - "^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} Client Type: %{GREEDYDATA:user_agent}$"
+      pattern_definitions:
+        NOTBRACKET: "[^<>]+"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '725001'"
+      tag: parse_725001
+      patterns:
+        - "^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
+        - "^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '725002'"
+      tag: parse_725002
+      patterns:
+        - "^Device completed SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '725007'"
+      tag: parse_725007
+      patterns:
+        - "^SSL session with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} terminated.$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '725016'"
+      tag: parse_725016
+      patterns:
+        - "^Device selects trust-point %{DATA:_temp_.cisco.trustpoint} for %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port}$"
   - grok:
       if: "ctx._temp_.cisco.message_id == '733100'"
       tag: parse_733100
@@ -928,6 +1027,41 @@ processors:
       field: "message"
       description: "734001"
       pattern: "DAP: User %{user.email}, Addr %{source.address}, Connection %{_temp_.cisco.connection_type}: The following DAP records were selected for this connection: %{_temp_.cisco.dap_records->}"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '737003'"
+      tag: parse_737003
+      patterns:
+        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+        - "^IPAA: DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '737006'"
+      tag: parse_737006
+      patterns:
+        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+        - "^IPAA: Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '737016'"
+      tag: parse_737016
+      patterns:
+        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$"
+        - "^IPAA: Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '737026'"
+      tag: parse_737026
+      patterns:
+        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$"
+        - "^IPAA: Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$"
+  - grok:
+      field: message
+      if: "ctx._temp_.cisco.message_id == '737034'"
+      tag: parse_737034
+      patterns:
+        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, %{GREEDYDATA:event.reason}$"
+        - "^IPAA: %{GREEDYDATA:event.reason}$"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '805001'"
       tag: parse_805001
@@ -1864,7 +1998,17 @@ processors:
       tag: "convert_sip_to_uri_port"
       type: integer
       ignore_missing: true
-      
+  - convert:
+      field: _temp_.cisco.connections_in_use
+      tag: "convert_connections_in_use"
+      type: long
+      ignore_missing: true
+  - convert:
+      field: _temp_.cisco.connections_most_used
+      tag: "convert_connections_most_used"
+      type: long
+      ignore_missing: true
+
   #
   # Assign ECS .ip fields from .address is a valid IP address is found,
   # otherwise set .domain field.
@@ -2084,6 +2228,21 @@ processors:
       allow_duplicates: false
       if: ctx?._temp_?.url_domain != null
 
+  - grok:
+      field: _temp_.cisco.tls_version
+      if: "ctx._temp_?.cisco?.tls_version != null"
+      tag: parse_tls_version
+      patterns:
+        - "%{PROTO:tls.version_protocol}v%{NUMBER:tls.version}"
+      pattern_definitions:
+        PROTO: "[A-Z]+"
+  - lowercase:
+      field: tls.version_protocol
+      ignore_missing: true
+  - remove:
+      field: _temp_.cisco.tls_version
+      ignore_missing: true
+
   #
   # Populate ECS event.code
   #
@@ -2181,6 +2340,10 @@ processors:
           type: [ connection, denied ]
           outcome: success
           action: firewall-rule
+        "106012":
+          type: [ connection, denied ]
+          outcome: success
+          action: firewall-rule
         "106013":
           type: [ connection, denied ]
           outcome: success
@@ -2253,6 +2416,16 @@ processors:
           type: [ denied, info ]
           outcome: failure
           action: logon-failed
+        "113008":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          outcome: success
+          action: logged-in
+        "113009":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          outcome: success
+          action: logged-in
         "113012":
           category: [ authentication, network ]
           type: [ allowed, info ]
@@ -2428,6 +2601,9 @@ processors:
           type: [ connection, denied ]
           outcome: success
           action: firewall-rule
+        "315011":
+          type: [ connection, end ]
+          action: ssh-session-ended
         "322001":
           type: [ connection, denied ]
           outcome: success
@@ -2590,11 +2766,31 @@ processors:
           type: [ connection, end ]
           outcome: success
           action: client-vpn-disconnected
+        "716003":
+          category: [ authentication, network ]
+          type: [ allowed, info ]
+          outcome: success
         "716039":
           category: [ authentication, network ]
           type: [ denied, info ]
           action: logon-failed
           outcome: failure
+        "716058":
+          type: [ connection, end ]
+          outcome: success
+          action: client-vpn-disconnected
+        "716059":
+          type: [ connection, start ]
+          outcome: success
+          action: client-vpn-resumed
+        "721016":
+          type: [ connection, start ]
+          outcome: success
+          action: client-vpn-connected
+        "721018":
+          type: [ connection, end ]
+          outcome: success
+          action: client-vpn-disconnected
         "722011":
           type: [ info ]
         "722022":
@@ -2602,6 +2798,12 @@ processors:
           outcome: success
         "722023":
           type: [ connection, end ]
+          outcome: success
+        "722028":
+          type: [ connection, end ]
+          outcome: success
+        "722032":
+          type: [ connection, start ]
           outcome: success
         "722033":
           type: [ connection, start ]
@@ -2614,6 +2816,20 @@ processors:
           type: [ connection, info ]
           outcome: success
           action: address-assigned
+        "722055":
+          type: [ connection, info ]
+        "725001":
+          type: [ connection, start ]
+          outcome: success
+        "725002":
+          type: [ connection, info ]
+          outcome: success
+        "725007":
+          type: [ connection, end ]
+          outcome: success
+        "725016":
+          type: [ connection, info ]
+          outcome: success
         "733100":
           type: [ info ]
         "734001":
@@ -2621,6 +2837,21 @@ processors:
           type: [ allowed, info ]
           outcome: success
           action: logged-in
+        "737003":
+          type: [ connection, info ]
+          outcome: failure
+        "737006":
+          type: [ connection, info ]
+          outcome: success
+        "737016":
+          type: [ connection, info ]
+          outcome: success
+        "737026":
+          type: [ connection, info ]
+          outcome: success
+        "737034":
+          type: [ connection, info ]
+          outcome: failure
         "750002":
           type: [ connection, start ]
           outcome: success

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -241,7 +241,7 @@ processors:
       tag: parse_106012
       field: "message"
       description: "106012"
-      pattern: "Deny IP from %{source.address} to %{destination.address}, %{event.reason}"
+      pattern: 'Deny IP from %{source.address} to %{destination.address}, %{event.reason}'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '106013'"
       tag: parse_106013
@@ -395,25 +395,13 @@ processors:
       tag: parse_113008
       field: message
       description: "113008"
-      pattern: "AAA transaction status ACCEPT: user = %{source.user.name}"
+      pattern: 'AAA transaction status ACCEPT: user = %{source.user.name}'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113009'"
       tag: parse_113009
       field: message
       description: "113008"
-      pattern: "AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}"
-  - dissect:
-      if: "ctx._temp_.cisco.message_id == '113008'"
-      tag: parse_113008
-      description: "113008"
-      field: message
-      pattern: "AAA transaction status ACCEPT: user = %{source.user.name}"
-  - dissect:
-      if: "ctx._temp_.cisco.message_id == '113009'"
-      tag: parse_113009
-      description: "113009"
-      field: message
-      pattern: "AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}"
+      pattern: 'AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}'
   - grok:
       if: "ctx._temp_.cisco.message_id == '113012'"
       tag: parse_113012
@@ -472,7 +460,7 @@ processors:
       tag: parse_302010
       field: "message"
       description: "302010"
-      pattern: "%{_temp_.cisco.connections_in_use} in use, %{_temp_.cisco.connections_most_used} most used"
+      pattern: '%{_temp_.cisco.connections_in_use} in use, %{_temp_.cisco.connections_most_used} most used'
   - grok:
       if: '["302013", "302015"].contains(ctx._temp_.cisco.message_id)'
       tag: parse_302013-302015
@@ -635,7 +623,7 @@ processors:
       tag: parse_315011
       field: "message"
       description: "315011"
-      pattern: "SSH session from %{source.ip} on interface %{_temp_.cisco.source_interface} for user %{source.user.name} disconnected by SSH server, reason: %{event.reason}"
+      pattern: 'SSH session from %{source.ip} on interface %{_temp_.cisco.source_interface} for user %{source.user.name} disconnected by SSH server, reason: %{event.reason}'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '322001'"
       tag: parse_322001
@@ -907,8 +895,8 @@ processors:
       field: "message"
       description: "716002"
       patterns:
-        - "Group <%{DATA:_temp_.cisco.webvpn.group_name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> WebVPN session terminated: %{GREEDYDATA:event.reason}."
-        - "Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} WebVPN session terminated: %{GREEDYDATA:event.reason}."
+        - 'Group <%{DATA:_temp_.cisco.webvpn.group_name}> User <%{DATA:source.user.name}> IP <%{IP:source.address}> WebVPN session terminated: %{GREEDYDATA:event.reason}.'
+        - 'Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{IP:source.address} WebVPN session terminated: %{GREEDYDATA:event.reason}.'
   - grok:
       if: "ctx._temp_.cisco.message_id == '716003'"
       tag: parse_716003
@@ -925,8 +913,8 @@ processors:
       field: "message"
       description: "716058"
       patterns:
-        - "^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}>"
-        - "^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address}"
+        - '^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}>'
+        - '^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address}'
       pattern_definitions:
         NOTBRACKET: "[^<>]+"
   - grok:
@@ -935,8 +923,8 @@ processors:
       field: "message"
       description: "716059"
       patterns:
-        - "^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:destination.address}> AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\\.$"
-        - "^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:destination.address} AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\\.$"
+        - '^Group <%{NOTBRACKET:_temp_.cisco.webvpn.group_name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:destination.address}> AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\.$'
+        - '^Group %{NOTSPACE:_temp_.cisco.webvpn.group_name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:destination.address} AnyConnect session resumed. Connection from %{NOTSPACE:source.address}\.$'
       pattern_definitions:
         NOTBRACKET: "[^<>]+"
   - dissect:
@@ -944,21 +932,21 @@ processors:
       tag: parse_721016
       field: message
       description: "721016"
-      pattern: "(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been created."
+      pattern: '(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been created.'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '721018'"
       tag: parse_721018
       field: message
       description: "721018"
-      pattern: "(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been deleted."
+      pattern: '(%{_temp_.cisco.device_type}) WebVPN session for client user %{source.user.name}, IP %{destination.ip} has been deleted.'
   - grok:
       if: "['722011', '722022', '722023', '722028', '722032', '722033', '722034', '722037', '722051'].contains(ctx._temp_.cisco.message_id)"
       tag: parse_svc_message
       field: "message"
       description: "svc_message"
       patterns:
-        - "^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> %{GREEDYDATA:event.reason}$"
-        - "^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} %{GREEDYDATA:event.reason}$"
+        - '^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> %{GREEDYDATA:event.reason}$'
+        - '^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} %{GREEDYDATA:event.reason}$'
       pattern_definitions:
         NOTBRACKET: "[^<>]+"
   - dissect:
@@ -978,15 +966,15 @@ processors:
       tag: parse_722051
       field: "event.reason"
       description: "722051"
-      pattern: "IPv4 Address <%{_temp_.cisco.assigned_ip}> %{}"
+      pattern: 'IPv4 Address <%{_temp_.cisco.assigned_ip}> %{}'
   - grok:
       if: "ctx._temp_.cisco.message_id == '722055'"
       tag: parse_722055
       field: "message"
       description: "722055"
       patterns:
-        - "^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> Client Type: %{GREEDYDATA:user_agent}$"
-        - "^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} Client Type: %{GREEDYDATA:user_agent}$"
+        - '^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> Client Type: %{GREEDYDATA:user_agent}$'
+        - '^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} Client Type: %{GREEDYDATA:user_agent}$'
       pattern_definitions:
         NOTBRACKET: "[^<>]+"
   - grok:
@@ -994,26 +982,26 @@ processors:
       if: "ctx._temp_.cisco.message_id == '725001'"
       tag: parse_725001
       patterns:
-        - "^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
-        - "^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
+        - '^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$'
+        - '^Starting SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '725002'"
       tag: parse_725002
       patterns:
-        - "^Device completed SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$"
+        - '^Device completed SSL handshake with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} for %{NOTSPACE:_temp_.cisco.tls_version} session.$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '725007'"
       tag: parse_725007
       patterns:
-        - "^SSL session with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} terminated.$"
+        - '^SSL session with %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port} terminated.$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '725016'"
       tag: parse_725016
       patterns:
-        - "^Device selects trust-point %{DATA:_temp_.cisco.trustpoint} for %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port}$"
+        - '^Device selects trust-point %{DATA:_temp_.cisco.trustpoint} for %{NOTSPACE:_temp_.cisco.peer_type} %{DATA:_temp_.cisco.source_interface}:%{NOTSPACE:source.ip}/%{NOTSPACE:source.port} to %{NOTSPACE:destination.ip}/%{NOTSPACE:destination.port}$'
   - grok:
       if: "ctx._temp_.cisco.message_id == '733100'"
       tag: parse_733100
@@ -1032,36 +1020,36 @@ processors:
       if: "ctx._temp_.cisco.message_id == '737003'"
       tag: parse_737003
       patterns:
-        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
-        - "^IPAA: DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$'
+        - '^IPAA: DHCP configured, no viable servers found for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '737006'"
       tag: parse_737006
       patterns:
-        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
-        - "^IPAA: Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$"
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$'
+        - '^IPAA: Local pool request succeeded for tunnel-group %{NOTSPACE:_temp_.cisco.tunnel_group}$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '737016'"
       tag: parse_737016
       patterns:
-        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$"
-        - "^IPAA: Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$"
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$'
+        - '^IPAA: Freeing local pool %{NOTSPACE:_temp_.cisco.pool_name} address %{NOTSPACE:_temp_.cisco.pool_address}$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '737026'"
       tag: parse_737026
       patterns:
-        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$"
-        - "^IPAA: Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$"
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$'
+        - '^IPAA: Client assigned %{NOTSPACE:_temp_.cisco.pool_address} from local pool %{NOTSPACE:_temp_.cisco.pool_name}$'
   - grok:
       field: message
       if: "ctx._temp_.cisco.message_id == '737034'"
       tag: parse_737034
       patterns:
-        - "^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, %{GREEDYDATA:event.reason}$"
-        - "^IPAA: %{GREEDYDATA:event.reason}$"
+        - '^IPAA: Session=%{NOTSPACE:_temp_.cisco.session_id}, %{GREEDYDATA:event.reason}$'
+        - '^IPAA: %{GREEDYDATA:event.reason}$'
   - dissect:
       if: "ctx._temp_.cisco.message_id == '805001'"
       tag: parse_805001

--- a/packages/cisco_asa/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_asa/data_stream/log/fields/ecs.yml
@@ -219,6 +219,10 @@
 - external: ecs
   name: tags
 - external: ecs
+  name: tls.version
+- external: ecs
+  name: tls.version_protocol
+- external: ecs
   name: url.domain
 - external: ecs
   name: url.extension

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -290,3 +290,4 @@
       type: keyword
       description: >
         The tunnel group name.
+

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -241,3 +241,52 @@
       description: >
         IANA Protocol Number of the original IP payload.
 
+    - name: connections_in_use
+      type: long
+      description: >
+        The number of connections in use.
+
+    - name: connections_most_used
+      type: long
+      description: >
+        The number of most used connections.
+
+    - name: device_type
+      type: keyword
+      description: >
+        The device type.
+
+    - name: group_policy
+      type: keyword
+      description: >
+        The number of most used connections.
+
+    - name: peer_type
+      type: keyword
+      description: >
+        The peer type.
+
+    - name: pool_address
+      type: ip
+      description: >
+        The pool address.
+
+    - name: pool_name
+      type: keyword
+      description: >
+        The pool name.
+
+    - name: session_id
+      type: keyword
+      description: >
+        The session id.
+
+    - name: trustpoint
+      type: keyword
+      description: >
+        The trustpoint name.
+
+    - name: tunnel_group
+      type: keyword
+      description: >
+        The tunnel group name.

--- a/packages/cisco_asa/data_stream/log/fields/fields.yml
+++ b/packages/cisco_asa/data_stream/log/fields/fields.yml
@@ -259,7 +259,7 @@
     - name: group_policy
       type: keyword
       description: >
-        The number of most used connections.
+        The group policy name.
 
     - name: peer_type
       type: keyword

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -144,12 +144,16 @@ An example event for `log` looks as following:
 | cisco.asa.command_line_arguments | The command line arguments logged by the local audit log | keyword |
 | cisco.asa.connection_id | Unique identifier for a flow. | keyword |
 | cisco.asa.connection_type | The VPN connection type | keyword |
+| cisco.asa.connections_in_use | The number of connections in use. | long |
+| cisco.asa.connections_most_used | The number of most used connections. | long |
 | cisco.asa.dap_records | The assigned DAP records | keyword |
 | cisco.asa.destination_interface | Destination interface for the flow or event. | keyword |
 | cisco.asa.destination_user_security_group_tag | The Security Group Tag for the destination user. Security Group Tag are 16-bit identifiers used to represent logical group privilege. | long |
 | cisco.asa.destination_user_security_group_tag_name | The name of Security Group Tag for the destination user. | keyword |
 | cisco.asa.destination_username | Name of the user that is the destination for this event. | keyword |
+| cisco.asa.device_type | The device type. | keyword |
 | cisco.asa.full_message | The Cisco log message text. | keyword |
+| cisco.asa.group_policy | The group policy name. | keyword |
 | cisco.asa.icmp_code | ICMP code. | short |
 | cisco.asa.icmp_type | ICMP type. | short |
 | cisco.asa.mapped_destination_host |  | keyword |
@@ -161,11 +165,15 @@ An example event for `log` looks as following:
 | cisco.asa.message | The message associated with SIP and Skinny VoIP events | keyword |
 | cisco.asa.message_id | The Cisco ASA message identifier. | keyword |
 | cisco.asa.original_iana_number | IANA Protocol Number of the original IP payload. | short |
+| cisco.asa.peer_type | The peer type. | keyword |
+| cisco.asa.pool_address | The pool address. | ip |
+| cisco.asa.pool_name | The pool name. | keyword |
 | cisco.asa.privilege.new | When a users privilege is changed this is the new value | keyword |
 | cisco.asa.privilege.old | When a users privilege is changed this is the old value | keyword |
 | cisco.asa.rejection_reason | Reason for an AAA authentication rejection. | keyword |
 | cisco.asa.rule_name | Name of the Access Control List rule that matched this event. | keyword |
 | cisco.asa.security | Cisco FTD security event fields. | flattened |
+| cisco.asa.session_id | The session id. | keyword |
 | cisco.asa.session_type | Session type (for example, IPsec or UDP). | keyword |
 | cisco.asa.source_interface | Source interface for the flow or event. | keyword |
 | cisco.asa.source_user_security_group_tag | The Security Group Tag for the source user. Security Group Tag are 16-bit identifiers used to represent logical group privilege. | long |
@@ -176,6 +184,8 @@ An example event for `log` looks as following:
 | cisco.asa.termination_user | AAA name of user requesting termination | keyword |
 | cisco.asa.threat_category | Category for the malware / botnet traffic. For example: virus, botnet, trojan, etc. | keyword |
 | cisco.asa.threat_level | Threat level for malware / botnet traffic. One of very-low, low, moderate, high or very-high. | keyword |
+| cisco.asa.trustpoint | The trustpoint name. | keyword |
+| cisco.asa.tunnel_group | The tunnel group name. | keyword |
 | cisco.asa.tunnel_type | SA type (remote access or L2L) | keyword |
 | cisco.asa.username |  | keyword |
 | cisco.asa.webvpn.group_name | The WebVPN group name the user belongs to | keyword |
@@ -342,6 +352,8 @@ An example event for `log` looks as following:
 | source.user.name | Short name or login of the user. | keyword |
 | source.user.name.text | Multi-field of `source.user.name`. | match_only_text |
 | tags | List of keywords used to tag each event. | keyword |
+| tls.version | Numeric part of the version parsed from the original string. | keyword |
+| tls.version_protocol | Normalized lowercase protocol name parsed from original string. | keyword |
 | url.domain | Domain of the url, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field. | keyword |
 | url.extension | The field contains the file extension from the original request url, excluding the leading dot. The file extension is only set if it exists, as not every url has a file extension. The leading period must not be included. For example, the value must be "png", not ".png". Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz"). | keyword |
 | url.fragment | Portion of the url after the `#`, such as "top". The `#` is not part of the fragment. | keyword |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.34.1"
+version: "2.35.0"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Add support for the following log types:

106006, 106012, 113008, 113009, 113015, 113039, 302010, 315011, 716002, 716058, 716059, 721016, 721018, 722022, 722023, 722028, 722032, 722033, 722034, 722055, 725001, 725002, 725007, 725016, 737003, 737006, 737016, 737026, 737034, 113019, 113004, 113005, 113008, 113009, 716003, 716039

## Proposed commit message

- Add additional log types to integration
- Add new mappings
- Add test cases

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

- Closes #5256
