### PR TITLE
[Jolokia Input] Add processors option

### DIFF
--- a/packages/jolokia_input/agent/input/input.yml.hbs
+++ b/packages/jolokia_input/agent/input/input.yml.hbs
@@ -10,3 +10,7 @@ http_method: 'GET'
 jmx.mappings: {{jmx.mappings}}
 data_stream:
   dataset: {{data_stream.dataset}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/jolokia_input/changelog.yml
+++ b/packages/jolokia_input/changelog.yml
@@ -1,5 +1,10 @@
 # newer versions go on top
-- version: 0.3.0
+- version: "0.3.1"
+  changes:
+    - description: Update the package format_version to 3.0.0.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
+- version: "0.3.0"
   changes:
     - description: Update the package format_version to 3.0.0.
       type: enhancement

--- a/packages/jolokia_input/changelog.yml
+++ b/packages/jolokia_input/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "0.3.1"
+- version: "0.4.0"
   changes:
     - description: Add processors option.
       type: enhancement

--- a/packages/jolokia_input/changelog.yml
+++ b/packages/jolokia_input/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "0.3.1"
   changes:
-    - description: Update the package format_version to 3.0.0.
+    - description: Add processors option.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/10068
 - version: "0.3.0"
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/jolokia_input/manifest.yml
+++ b/packages/jolokia_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: jolokia
 title: "Jolokia Input"
-version: "0.3.1"
+version: "0.4.0"
 description: "Collects Metrics from Jolokia Agents"
 type: input
 categories:

--- a/packages/jolokia_input/manifest.yml
+++ b/packages/jolokia_input/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: jolokia
 title: "Jolokia Input"
-version: "0.3.0"
+version: "0.3.1"
 description: "Collects Metrics from Jolokia Agents"
 type: input
 categories:
@@ -60,6 +60,14 @@ policy_templates:
                 field: memory.heap_usage
               - attr: NonHeapMemoryUsage
                 field: memory.non_heap_usage
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 owner:
   github: elastic/obs-infraobs-integrations
   type: elastic


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## Proposed commit message

Add the processors option to Jolokia Input integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- Used the kubernetes integration as reference to add the processors option: [data stream apiserver](https://github.com/elastic/integrations/tree/main/packages/kubernetes/data_stream/apiserver).

## How to test this PR locally

1. Install Elastic Agent.
2. Add Jolokia Input integration.
3. Set up a processor.

## Related issues

- Closes #10033 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
