### PR TITLE
[Apache Tomcat] Add JDBC Connection Pool's `maxActive` in the ingest pipeline

### DIFF
--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.5.2"
+- version: "1.6.0"
   changes:
     - description: Add JDBC Connection Pool maxActive on Ingest pipeline.
       type: enhancement

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.6.0"
   changes:
-    - description: Add JDBC Connection Pool maxActive on Ingest pipeline.
+    - description: Add JDBC Connection Pool's `maxActive` in ingest pipeline.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10069
 - version: "1.5.1"

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.6.0"
   changes:
-    - description: Add JDBC Connection Pool's `maxActive` in ingest pipeline.
+    - description: Add JDBC Connection Pool's `maxActive` in the ingest pipeline.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10069
 - version: "1.5.1"

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.5.2"
   changes:
-    - description: Add JDBC Connection Pool field maxActive on Ingest pipeline.
+    - description: Add JDBC Connection Pool maxActive on Ingest pipeline.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/xxxx
+      link: https://github.com/elastic/integrations/pull/10069
 - version: "1.5.1"
   changes:
     - description: Fix "Harvester Limit" and "File Handle Closure duration" configuration parameters.

--- a/packages/apache_tomcat/changelog.yml
+++ b/packages/apache_tomcat/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.5.2"
+  changes:
+    - description: Add JDBC Connection Pool field maxActive on Ingest pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/xxxx
 - version: "1.5.1"
   changes:
     - description: Fix "Harvester Limit" and "File Handle Closure duration" configuration parameters.

--- a/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json
@@ -42,7 +42,7 @@
                     "Catalina_DataSource_clearStatementPoolOnReturn": 0,
                     "Catalina_DataSource_lifo": 1,
                     "Catalina_DataSource_maxTotal": 8,
-                    "Catalina_DataSource_maxActive": 8,
+                    "Catalina_DataSource_maxActive": 100,
                     "Catalina_DataSource_poolPreparedStatements": 0,
                     "Catalina_DataSource_testOnBorrow": 1,
                     "Catalina_DataSource_testOnCreate": 0

--- a/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json
@@ -42,6 +42,7 @@
                     "Catalina_DataSource_clearStatementPoolOnReturn": 0,
                     "Catalina_DataSource_lifo": 1,
                     "Catalina_DataSource_maxTotal": 8,
+                    "Catalina_DataSource_maxActive": 8,
                     "Catalina_DataSource_poolPreparedStatements": 0,
                     "Catalina_DataSource_testOnBorrow": 1,
                     "Catalina_DataSource_testOnCreate": 0

--- a/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
@@ -71,7 +71,7 @@
                     "lifo": true,
                     "max": {
                         "total": 8,
-                        "active": 8
+                        "active": 100
                     },
                     "prepared_statements": false,
                     "test_on_borrow": true,

--- a/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
@@ -70,8 +70,8 @@
                     },
                     "lifo": true,
                     "max": {
-                        "total": 8,
-                        "active": 100
+                        "active": 100,
+                        "total": 8
                     },
                     "prepared_statements": false,
                     "test_on_borrow": true,

--- a/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/_dev/test/pipeline/test-conection-pool-metrics.json-expected.json
@@ -70,7 +70,8 @@
                     },
                     "lifo": true,
                     "max": {
-                        "total": 8
+                        "total": 8,
+                        "active": 8
                     },
                     "prepared_statements": false,
                     "test_on_borrow": true,

--- a/packages/apache_tomcat/data_stream/connection_pool/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/elasticsearch/ingest_pipeline/default.yml
@@ -208,6 +208,10 @@ processors:
       field: prometheus.metrics.Catalina_DataSource_maxTotal
       target_field: apache_tomcat.connection_pool.max.total
       ignore_missing: true
+  - rename:
+      field: prometheus.metrics.Catalina_DataSource_maxActive
+      target_field: apache_tomcat.connection_pool.max.active
+      ignore_missing: true
   - set:
       field: apache_tomcat.connection_pool.prepared_statements
       value: true

--- a/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
+++ b/packages/apache_tomcat/data_stream/connection_pool/fields/fields.yml
@@ -179,7 +179,11 @@
           fields:
             - name: total
               type: double
-              description: Maximum total of connection pool.
+              description: The maximum number of database connections in pool.
+              metric_type: gauge
+            - name: active
+              type: double
+              description: The maximum number of active connections that can be allocated from a pool at the same time.
               metric_type: gauge
         - name: prepared_statements
           type: boolean

--- a/packages/apache_tomcat/data_stream/connection_pool/sample_event.json
+++ b/packages/apache_tomcat/data_stream/connection_pool/sample_event.json
@@ -1,11 +1,11 @@
 {
-    "@timestamp": "2023-09-27T19:11:29.922Z",
+    "@timestamp": "2024-06-04T20:30:02.263Z",
     "agent": {
-        "ephemeral_id": "8dcc13af-7670-441d-b51b-826f604c433b",
-        "id": "86a82f91-ff66-4d28-ab7c-eb9350f317ed",
+        "ephemeral_id": "cdb88fd3-51aa-4c86-80ed-f7a18252170c",
+        "id": "e557bc95-45b0-488a-beed-9fe34eb0668a",
         "name": "docker-fleet-agent",
         "type": "metricbeat",
-        "version": "8.10.1"
+        "version": "8.13.2"
     },
     "apache_tomcat": {
         "connection_pool": {
@@ -92,9 +92,9 @@
         "version": "8.7.0"
     },
     "elastic_agent": {
-        "id": "86a82f91-ff66-4d28-ab7c-eb9350f317ed",
+        "id": "e557bc95-45b0-488a-beed-9fe34eb0668a",
         "snapshot": false,
-        "version": "8.10.1"
+        "version": "8.13.2"
     },
     "event": {
         "agent_id_status": "verified",
@@ -102,8 +102,8 @@
             "web"
         ],
         "dataset": "apache_tomcat.connection_pool",
-        "duration": 198881542,
-        "ingested": "2023-09-27T19:11:32Z",
+        "duration": 86530424,
+        "ingested": "2024-06-04T20:30:14Z",
         "kind": "metric",
         "module": "apache_tomcat",
         "type": [
@@ -111,21 +111,21 @@
         ]
     },
     "host": {
-        "architecture": "aarch64",
+        "architecture": "x86_64",
         "containerized": false,
         "hostname": "docker-fleet-agent",
-        "id": "ddbe644fa129402e9d5cf6452db1422d",
+        "id": "b8c773dd25ee40cab70ed671239f33f5",
         "ip": [
-            "172.31.0.7"
+            "172.24.0.7"
         ],
         "mac": [
-            "02-42-AC-1F-00-07"
+            "02-42-AC-18-00-07"
         ],
         "name": "docker-fleet-agent",
         "os": {
             "codename": "focal",
             "family": "debian",
-            "kernel": "5.15.49-linuxkit",
+            "kernel": "6.1.0-20-amd64",
             "name": "Ubuntu",
             "platform": "ubuntu",
             "type": "linux",

--- a/packages/apache_tomcat/docs/README.md
+++ b/packages/apache_tomcat/docs/README.md
@@ -841,7 +841,8 @@ An example event for `connection_pool` looks as following:
 | apache_tomcat.connection_pool.connection.time_betwen_eviction_run.time.ms | The total amount of time in milliseconds to sleep between runs of the idle connection validation/cleaner thread. | double | ms | gauge |
 | apache_tomcat.connection_pool.connection.validate | Validate connections from this pool. | double |  | gauge |
 | apache_tomcat.connection_pool.lifo | Last In First Out connections. | boolean |  |  |
-| apache_tomcat.connection_pool.max.total | Maximum total of connection pool. | double |  | gauge |
+| apache_tomcat.connection_pool.max.active | The maximum number of active connections that can be allocated from a pool at the same time. | double |  | gauge |
+| apache_tomcat.connection_pool.max.total | The maximum number of database connections in pool. | double |  | gauge |
 | apache_tomcat.connection_pool.prepared_statements | Validate connections from this pool. | boolean |  |  |
 | apache_tomcat.connection_pool.test_on_borrow | The indication of whether objects will be validated before being borrowed from the pool. | boolean |  |  |
 | apache_tomcat.connection_pool.test_on_create | Property determines whether or not the pool will validate objects immediately after they are created by the pool. | boolean |  |  |

--- a/packages/apache_tomcat/manifest.yml
+++ b/packages/apache_tomcat/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: apache_tomcat
 title: Apache Tomcat
-version: "1.5.1"
+version: "1.6.0"
 description: Collect and parse logs and metrics from Apache Tomcat servers with Elastic Agent.
 categories: ["web", "observability"]
 type: integration


### PR DESCRIPTION
## Type

- Enhancement

## Proposed commit message

Extract the maxActive field from the Apache Tomcat connection pool using the ingest pipeline.

This data could be used to identify the usage of a JBDC pool.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Tested in a real case adding this change to the default ingest pipeline.

## How to test this PR locally

1. Install elastic-agent
2. Add the Apache Tomcat integration

## Related issues

- Closes #10037

## Screenshots

elastic-package test pipeline -v -g

![image](https://github.com/elastic/integrations/assets/19363015/8b81ddcb-a3d0-49bc-88e8-6da555942780)

elastic-package test system -v -d connection_pool -g

![image](https://github.com/elastic/integrations/assets/19363015/a9df781c-aaca-4b5a-a9ac-c7c2e7c04fc7)
