### PR TITLE
[Azure OpenAI] Disable TSDB on metrics datastream

### DIFF
--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.7.2"
+  changes:
+    - description: Disable TSDB on OpenAI metrics.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.7.1"
   changes:
     - description: Enable sanitization by default.

--- a/packages/azure_openai/changelog.yml
+++ b/packages/azure_openai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Disable TSDB on OpenAI metrics.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10076
 - version: "0.7.1"
   changes:
     - description: Enable sanitization by default.

--- a/packages/azure_openai/data_stream/metrics/manifest.yml
+++ b/packages/azure_openai/data_stream/metrics/manifest.yml
@@ -58,8 +58,3 @@ streams:
         show_user: true
     title: Azure OpenAI metrics
     description: Collect openAI metrics
-elasticsearch:
-  # Ensures agents have permissions to write data to `metrics-*-*`
-  dynamic_dataset: true
-  dynamic_namespace: true
-  index_mode: "time_series"

--- a/packages/azure_openai/data_stream/metrics/manifest.yml
+++ b/packages/azure_openai/data_stream/metrics/manifest.yml
@@ -58,3 +58,7 @@ streams:
         show_user: true
     title: Azure OpenAI metrics
     description: Collect openAI metrics
+elasticsearch:
+  # Ensures agents have permissions to write data to `metrics-*-*`
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/packages/azure_openai/manifest.yml
+++ b/packages/azure_openai/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: azure_openai
 title: "Azure OpenAI"
-version: 0.7.1
+version: 0.7.2
 source:
   license: "Elastic-2.0"
 description: "Azure OpenAI Logs and Metrics"


### PR DESCRIPTION
- Bug

This PR disables the TSDB for metrics datastream which is considered for later.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

- Install the integrations with the changes
- Compare pre and post installation the data ingestion rate should be equal to the request rate.
- Also verify the data with the Azure monitor metrics.


## Screenshots

### Before
<img width="1715" alt="before" src="https://github.com/elastic/integrations/assets/101238137/731a525a-f35d-4e8c-93b2-38a1b8275320">

### After
<img width="1723" alt="after" src="https://github.com/elastic/integrations/assets/101238137/8ca85945-75ff-4bd4-9bb4-1c5d28b46db6">



