### PR TITLE
Replicated `never_install` functionality for `with_vlans`

### DIFF
--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
-- version: "1.30.2"
+- version: "1.31.0"
   changes:
-    - description: Expose `with_vlans`
+    - description: Expose `with_vlans` and `ignore_outgoing`
       type: enhancement
       link: https://github.com/elastic/integrations/issues/10059
 - version: "1.30.1"

--- a/packages/network_traffic/changelog.yml
+++ b/packages/network_traffic/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.30.2"
+  changes:
+    - description: Expose `with_vlans`
+      type: enhancement
+      link: https://github.com/elastic/integrations/issues/10059
 - version: "1.30.1"
   changes:
     - description: capture root requirement

--- a/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
+++ b/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
@@ -67,3 +67,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
+++ b/packages/network_traffic/data_stream/amqp/agent/stream/amqp.yml.hbs
@@ -63,3 +63,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
+++ b/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
@@ -67,3 +67,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
+++ b/packages/network_traffic/data_stream/cassandra/agent/stream/cassandra.yml.hbs
@@ -63,3 +63,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
+++ b/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
@@ -46,3 +46,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
+++ b/packages/network_traffic/data_stream/dhcpv4/agent/stream/dhcpv4.yml.hbs
@@ -42,3 +42,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
+++ b/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
@@ -61,3 +61,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
+++ b/packages/network_traffic/data_stream/dns/agent/stream/dns.yml.hbs
@@ -57,3 +57,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -43,3 +43,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
+++ b/packages/network_traffic/data_stream/flow/agent/stream/flow.yml.hbs
@@ -39,3 +39,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
@@ -102,3 +102,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
+++ b/packages/network_traffic/data_stream/http/agent/stream/http.yml.hbs
@@ -106,3 +106,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -40,3 +40,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
+++ b/packages/network_traffic/data_stream/icmp/agent/stream/icmp.yml.hbs
@@ -36,3 +36,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
+++ b/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
@@ -67,3 +67,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
+++ b/packages/network_traffic/data_stream/memcached/agent/stream/memcached.yml.hbs
@@ -63,3 +63,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
+++ b/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
@@ -61,3 +61,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
+++ b/packages/network_traffic/data_stream/mongodb/agent/stream/mongodb.yml.hbs
@@ -57,3 +57,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
+++ b/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
@@ -51,3 +51,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
+++ b/packages/network_traffic/data_stream/mysql/agent/stream/mysql.yml.hbs
@@ -55,3 +55,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
+++ b/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
@@ -51,3 +51,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
+++ b/packages/network_traffic/data_stream/nfs/agent/stream/nfs.yml.hbs
@@ -55,3 +55,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
+++ b/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
@@ -51,3 +51,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
+++ b/packages/network_traffic/data_stream/pgsql/agent/stream/pgsql.yml.hbs
@@ -55,3 +55,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
+++ b/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
@@ -61,3 +61,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
+++ b/packages/network_traffic/data_stream/redis/agent/stream/redis.yml.hbs
@@ -57,3 +57,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
+++ b/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
@@ -51,3 +51,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
+++ b/packages/network_traffic/data_stream/sip/agent/stream/sip.yml.hbs
@@ -55,3 +55,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
+++ b/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
@@ -82,3 +82,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
+++ b/packages/network_traffic/data_stream/thrift/agent/stream/thrift.yml.hbs
@@ -78,3 +78,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
+++ b/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
@@ -58,3 +58,6 @@ npcap:
 interfaces:
   with_vlans: true
 {{/if}}
+{{#if ignore_outgoing}}
+ignore_outgoing: true
+{{/if}}

--- a/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
+++ b/packages/network_traffic/data_stream/tls/agent/stream/tls.yml.hbs
@@ -54,3 +54,7 @@ interface:
 npcap:
   never_install: true
 {{/if}}
+{{#if with_vlans}}
+interfaces:
+  with_vlans: true
+{{/if}}

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -44,11 +44,19 @@ policy_templates:
             type: bool
             title: Configure BPF to account for VLAN tags
             description: |-
-              Packetbeat automatically generates a BPF for capturing only the traffic on ports where it expects to find known protocols.
+              Packetbeat automatically generates a BPF program for capturing only the traffic on ports where it expects to find known protocols.
               For example, if you have configured port 80 for HTTP and port 3306 for MySQL, Packetbeat generates the following BPF filter: "port 80 or port 3306".
 
               However, if the traffic contains VLAN tags, the filter that Packetbeat generates is ineffective because the offset is moved by four bytes.
               To fix this, you can enable the with_vlans option, which generates a BPF filter that looks like this: "port 80 or port 3306 or (vlan and (port 80 or port 3306))".
+            required: false
+            show_user: true
+            default: false
+          - name: ignore_outgoing
+            type: bool
+            title: Ignore network transactions initiated locally
+            description: |-
+              If the ignore_outgoing option is enabled, Packetbeat ignores all the transactions initiated from the server running Packetbeat.
             required: false
             show_user: true
             default: false

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -40,6 +40,18 @@ policy_templates:
             required: false
             show_user: false
             default: false
+          - name: with_vlans
+            type: bool
+            title: Configure BPF to account for VLAN tags
+            description: |-
+              Packetbeat automatically generates a BPF for capturing only the traffic on ports where it expects to find known protocols.
+              For example, if you have configured port 80 for HTTP and port 3306 for MySQL, Packetbeat generates the following BPF filter: "port 80 or port 3306".
+
+              However, if the traffic contains VLAN tags, the filter that Packetbeat generates is ineffective because the offset is moved by four bytes.
+              To fix this, you can enable the with_vlans option, which generates a BPF filter that looks like this: "port 80 or port 3306 or (vlan and (port 80 or port 3306))".
+            required: false
+            show_user: true
+            default: false
 agent:
   privileges:
     root: true

--- a/packages/network_traffic/manifest.yml
+++ b/packages/network_traffic/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: network_traffic
 title: Network Packet Capture
-version: "1.30.1"
+version: "1.31.0"
 description: Capture and analyze network traffic from a host with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

This creates a configuration option for `with_vlans` in the manifest that gets propagated to all data streams that packetbeat can use in fleet managed mode instead of the CLI flag.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10059

