### PR TITLE
[Prometheus Collector]Set ssl verification mode none and default username to empty

### DIFF
--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Adding ssl verfication mode and removing default username for collector
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/7914
+      link: https://github.com/elastic/integrations/pull/10088
 - version: "1.15.2"
   changes:
     - description: Fix typo - Replace "darastream" with "datastream"

--- a/packages/prometheus/changelog.yml
+++ b/packages/prometheus/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.15.3"
+  changes:
+    - description: Adding ssl verfication mode and removing default username for collector
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/7914
 - version: "1.15.2"
   changes:
     - description: Fix typo - Replace "darastream" with "datastream"

--- a/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
+++ b/packages/prometheus/data_stream/collector/agent/stream/stream.yml.hbs
@@ -16,6 +16,7 @@ period: {{period}}
 rate_counters: {{rate_counters}}
 {{#if bearer_token_file}}
 bearer_token_file: {{bearer_token_file}}
+ssl.verification_mode: {{ssl.verification_mode}}
 {{/if}}
 {{#if ssl.certificate_authorities}}
 ssl.certificate_authorities:

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -69,7 +69,8 @@ streams:
         title: SSL Verification Mode
         multi: false
         required: false
-        show_user: true
+        show_user: false
+        default: none
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities

--- a/packages/prometheus/data_stream/collector/manifest.yml
+++ b/packages/prometheus/data_stream/collector/manifest.yml
@@ -64,6 +64,12 @@ streams:
         secret: false
         required: false
         show_user: false
+      - name: ssl.verification_mode
+        type: text
+        title: SSL Verification Mode
+        multi: false
+        required: false
+        show_user: true
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities
@@ -91,7 +97,6 @@ streams:
         multi: false
         required: false
         show_user: false
-        default: user
       - name: password
         type: password
         secret: true

--- a/packages/prometheus/manifest.yml
+++ b/packages/prometheus/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.10.0
 name: prometheus
 title: Prometheus
-version: 1.15.2
+version: 1.15.3
 description: Collect metrics from Prometheus servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement


## Proposed commit message

- WHAT: Introduced ssl.verificatin_mode none and removing default password for collector metrciset
- WHY

## Checklist

- [X] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [X] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [X] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

1. Clone this repo
2. Navigate to `integrations/packages/prometheus` 
3. `elastic-pacakge build`
4. elastic-package stack up -d -v --version=8.14.0
5. Install prometheus integration with following parameters
![Screenshot 2024-06-06 at 1 14 27 PM](https://github.com/elastic/integrations/assets/1685415/54bddc2b-2167-42c7-a08c-d1dc039550a6)


![Screenshot 2024-06-06 at 1 10 55 PM](https://github.com/elastic/integrations/assets/1685415/59b87681-b2dc-4173-8e16-d7b2c00d651c)

6. Set `SSL Verification mode `: not


## Related issues

- Relates #https://github.com/elastic/integrations/issues/9307


## Screenshots

![Screenshot 2024-06-06 at 10 33 08 AM](https://github.com/elastic/integrations/assets/1685415/f99c23d8-ecd8-470e-887f-7cc8689ccb42)

