### PR TITLE
auditd: Fix invalid event.type: stop->end

### DIFF
--- a/packages/auditd/changelog.yml
+++ b/packages/auditd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.19.2"
+  changes:
+    - description: Fix invalid event type.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10090
 - version: "3.19.1"
   changes:
     - description: Changed owners

--- a/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
+++ b/packages/auditd/data_stream/log/_dev/test/pipeline/test-auditd-raw.log-expected.json
@@ -1221,7 +1221,7 @@
                 "original": "type=SERVICE_STOP msg=audit(1481076984.534:16): pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=irqbalance comm=\"systemd\" exe=\"/usr/lib/systemd/systemd\" hostname=? addr=? terminal=? res=success'",
                 "outcome": "success",
                 "type": [
-                    "stop"
+                    "end"
                 ]
             },
             "process": {
@@ -1943,7 +1943,7 @@
                 "original": "type=DAEMON_END msg=audit(1481078697.892:7799): auditd normal halt, sending auid=? pid=? subj=? res=success",
                 "outcome": "success",
                 "type": [
-                    "stop"
+                    "end"
                 ]
             },
             "tags": [

--- a/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/auditd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1299,7 +1299,7 @@ processors:
                 category:
                   - process
                 type:
-                  - stop
+                  - end
           DAEMON_ACCEPT:
             - event:
                 action:
@@ -1334,7 +1334,7 @@ processors:
                 category:
                   - process
                 type:
-                  - stop
+                  - end
           DAEMON_ERR:
             - event:
                 action:
@@ -1610,7 +1610,7 @@ processors:
                 category:
                   - process
                 type:
-                  - stop
+                  - end
           SOFTWARE_UPDATE:
             - event:
                 action:

--- a/packages/auditd/manifest.yml
+++ b/packages/auditd/manifest.yml
@@ -1,6 +1,6 @@
 name: auditd
 title: Auditd Logs
-version: "3.19.1"
+version: "3.19.2"
 description: Collect logs from Linux audit daemon with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

`stop` is not a valid `event.type`, use `end` where applicable.

https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-type.html#ecs-event-type-end

Related to: https://github.com/elastic/sdh-beats/issues/4763

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

I've tested with `elastic-package`, and run the tests for the respective package.

## Related issues

Related to: https://github.com/elastic/sdh-beats/issues/4763

## Screenshots

![Screenshot from 2024-06-06 15-02-43](https://github.com/elastic/integrations/assets/204048/cec5bb7f-6fe4-43be-8aa8-d10394979d9b)

