### PR TITLE
[sentinel_one] Add agent.id to all agent related data

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Add agent.id to all agent related data.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10102
 - version: "1.21.1"
   changes:
     - description: Fix Ingest Pipline Error in SentinelOne Package with k8s Elastic Agent.

--- a/packages/sentinel_one/data_stream/agent/_dev/test/pipeline/test-pipeline-agent.log-expected.json
+++ b/packages/sentinel_one/data_stream/agent/_dev/test/pipeline/test-pipeline-agent.log-expected.json
@@ -67,6 +67,9 @@
                         "name": "Account Name"
                     },
                     "active_threats_count": 7,
+                    "agent": {
+                        "id": "13491234512345"
+                    },
                     "allow_remote_shell": true,
                     "apps_vulnerability_status": "not_applicable",
                     "console_migration_status": "N/A",

--- a/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/agent/elasticsearch/ingest_pipeline/default.yml
@@ -249,8 +249,12 @@ processors:
             value: '{{{_ingest.on_failure_message}}}'
   - rename:
       field: json.id
-      target_field: host.id
+      target_field: sentinel_one.agent.agent.id
       ignore_missing: true
+  - set:
+      field: host.id
+      copy_from: sentinel_one.agent.agent.id
+      if: ctx.sentinel_one?.agent?.agent?.id != null
   - convert:
       field: json.infected
       target_field: sentinel_one.agent.infected

--- a/packages/sentinel_one/data_stream/agent/fields/fields.yml
+++ b/packages/sentinel_one/data_stream/agent/fields/fields.yml
@@ -43,6 +43,12 @@
     - name: active_threats_count
       type: long
       description: Current number of active threats.
+    - name: agent
+      type: group
+      fields:
+        - name: id
+          type: keyword
+          description: Related agent (if applicable).
     - name: allow_remote_shell
       type: boolean
       description: Agent is capable and policy enabled for remote shell.

--- a/packages/sentinel_one/data_stream/threat/_dev/test/pipeline/test-pipeline-threat.log-expected.json
+++ b/packages/sentinel_one/data_stream/threat/_dev/test/pipeline/test-pipeline-threat.log-expected.json
@@ -76,6 +76,7 @@
                             "id": "1234567890123456789",
                             "name": "Default Group"
                         },
+                        "id": "1234567890123456789",
                         "infected": true,
                         "is_active": true,
                         "is_decommissioned": false,
@@ -320,6 +321,7 @@
                             "id": "1234567890123456789",
                             "name": "Default Group"
                         },
+                        "id": "1234567890123456789",
                         "infected": true,
                         "is_active": true,
                         "is_decommissioned": false,
@@ -609,6 +611,7 @@
                             "id": "1234567890123456789",
                             "name": "Default Group"
                         },
+                        "id": "1234567890123456789",
                         "infected": true,
                         "is_active": true,
                         "is_decommissioned": false,
@@ -898,6 +901,7 @@
                             "id": "1234567890123456789",
                             "name": "Default Group"
                         },
+                        "id": "1234567890123456789",
                         "infected": true,
                         "is_active": true,
                         "is_decommissioned": false,
@@ -1187,6 +1191,7 @@
                             "id": "1234567890123456789",
                             "name": "Default Group"
                         },
+                        "id": "1234567890123456789",
                         "infected": true,
                         "is_active": true,
                         "is_decommissioned": false,

--- a/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/sentinel_one/data_stream/threat/elasticsearch/ingest_pipeline/default.yml
@@ -257,8 +257,12 @@ processors:
       ignore_missing: true
   - rename:
       field: json.agentRealtimeInfo.agentId
-      target_field: host.id
+      target_field: sentinel_one.threat.agent.id
       ignore_missing: true
+  - set:
+      field: host.id
+      copy_from: sentinel_one.threat.agent.id
+      if: ctx.sentinel_one?.threat?.agent?.id != null
   - convert:
       field: json.agentRealtimeInfo.agentInfected
       target_field: sentinel_one.threat.agent.infected

--- a/packages/sentinel_one/data_stream/threat/fields/fields.yml
+++ b/packages/sentinel_one/data_stream/threat/fields/fields.yml
@@ -28,6 +28,9 @@
             - name: name
               type: keyword
               description: Group name.
+        - name: id
+          type: keyword
+          description: Related agent (if applicable).
         - name: infected
           type: boolean
           description: Agent infected.

--- a/packages/sentinel_one/docs/README.md
+++ b/packages/sentinel_one/docs/README.md
@@ -516,6 +516,7 @@ An example event for `agent` looks as following:
 | sentinel_one.agent.active_directory.mail | Mail. | keyword |
 | sentinel_one.agent.active_directory.user.principal_name | User principal name. | keyword |
 | sentinel_one.agent.active_threats_count | Current number of active threats. | long |
+| sentinel_one.agent.agent.id | Related agent (if applicable). | keyword |
 | sentinel_one.agent.allow_remote_shell | Agent is capable and policy enabled for remote shell. | boolean |
 | sentinel_one.agent.apps_vulnerability_status | Apps vulnerability status. | keyword |
 | sentinel_one.agent.cloud_provider | Cloud providers for this agent. | flattened |
@@ -1550,6 +1551,7 @@ An example event for `threat` looks as following:
 | sentinel_one.threat.agent.decommissioned_at | Decommissioned at. | boolean |
 | sentinel_one.threat.agent.group.id | Group id. | keyword |
 | sentinel_one.threat.agent.group.name | Group name. | keyword |
+| sentinel_one.threat.agent.id | Related agent (if applicable). | keyword |
 | sentinel_one.threat.agent.infected | Agent infected. | boolean |
 | sentinel_one.threat.agent.is_active | Is active. | boolean |
 | sentinel_one.threat.agent.is_decommissioned | Is decommissioned. | boolean |

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one
 title: SentinelOne
-version: "1.21.1"
+version: "1.22.0"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[sentinel_one] Add agent.id to all agent related data (#)

If the data is associated with a SentinelOne agent, include the agent's
ID in the final document, as `sentinel_one.<source_type>.agent.id`.

For the `agent` and `threat` data streams, the value was already stored
in `host.id`, but it was added to `sentinel_one.<source_type>.agent.id`.

For the `activity` data stream, this was already done.

For the `alert` data stream, no agent ID is available. There is a field
`agentDetectionInfo.uuid`, described in the documentation as the
"UUID of the agent", which seems to be a different value, and was
already stored in `observer.serial_number`.

For the `group` data stream there is no field that identifies an agent.
```

It's was already done in the `activity` data stream [here](https://github.com/elastic/integrations/blob/736b1f57a92a6ec421621493840759f45b2c5295/packages/sentinel_one/data_stream/activity/elasticsearch/ingest_pipeline/default.yml#L143-L146).

I checked the SentinelOne API documentation to confirm that for each endpoint there weren't additional relevant fields in responses.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #9879