### PR TITLE
[sentinel_one] Change default interval to 30s for all data streams

### DIFF
--- a/packages/sentinel_one/changelog.yml
+++ b/packages/sentinel_one/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.23.2"
+  changes:
+    - description: Change default interval to 30s for all data streams.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10103
 - version: "1.23.1"
   changes:
     - description: Fix sample event.

--- a/packages/sentinel_one/data_stream/activity/manifest.yml
+++ b/packages/sentinel_one/data_stream/activity/manifest.yml
@@ -18,7 +18,7 @@ streams:
         type: text
         title: Interval
         description: "Duration between requests to the SentinelOne API. NOTE: Supported units for this parameter are h/m/s."
-        default: 1m
+        default: 30s
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/data_stream/agent/manifest.yml
+++ b/packages/sentinel_one/data_stream/agent/manifest.yml
@@ -18,7 +18,7 @@ streams:
         type: text
         title: Interval
         description: "Duration between requests to the SentinelOne API. NOTE: Supported units for this parameter are h/m/s."
-        default: 5m
+        default: 30s
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/data_stream/alert/manifest.yml
+++ b/packages/sentinel_one/data_stream/alert/manifest.yml
@@ -18,7 +18,7 @@ streams:
         type: text
         title: Interval
         description: "Duration between requests to the SentinelOne API. NOTE: Supported units for this parameter are h/m/s."
-        default: 5m
+        default: 30s
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/data_stream/group/manifest.yml
+++ b/packages/sentinel_one/data_stream/group/manifest.yml
@@ -18,7 +18,7 @@ streams:
         type: text
         title: Interval
         description: "Duration between requests to the SentinelOne API. NOTE: Supported units for this parameter are h/m/s."
-        default: 5m
+        default: 30s
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/data_stream/threat/manifest.yml
+++ b/packages/sentinel_one/data_stream/threat/manifest.yml
@@ -18,7 +18,7 @@ streams:
         type: text
         title: Interval
         description: "Duration between requests to the SentinelOne API. NOTE: Supported units for this parameter are h/m/s."
-        default: 5m
+        default: 30s
         multi: false
         required: true
         show_user: true

--- a/packages/sentinel_one/manifest.yml
+++ b/packages/sentinel_one/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one
 title: SentinelOne
-version: "1.23.1"
+version: "1.23.2"
 description: Collect logs from SentinelOne with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[sentinel_one] Change default interval to 30s for all data streams
```

Merge #10102 first, then with this #9879 will be closed.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10102
- Closes #9879