### PR TITLE
[fortinet_fortiproxy] Add security solution tags and expand categories.

### DIFF
--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI. Expanded categories.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.1"
   changes:
     - description: update documentation

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
-- version: "0.1.2"
+- version: "0.2.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI. Expanded categories.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10105
 - version: "0.1.1"
   changes:
     - description: update documentation

--- a/packages/fortinet_fortiproxy/kibana/tags.yml
+++ b/packages/fortinet_fortiproxy/kibana/tags.yml
@@ -1,0 +1,4 @@
+- text: Security Solution
+  asset_types:
+    - dashboard
+    - search

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 0.1.2
+version: 0.2.0
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,10 +1,12 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 0.1.1
+version: 0.1.2
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:
+  - network
+  - proxy_security
   - security
   - web
 conditions:


### PR DESCRIPTION
## Proposed commit message

- Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI.
- Expanded categories

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
