### PR TITLE
[Logstash] Add pipeline level worker utilization

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "2.4.9"
   changes:
-    - description: Rework worker utilization
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/9971
+    - description: Add pipeline level worker utilization graphs, and remove incorrect flow metrics information
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10107
 - version: "2.4.8"
   changes:
     - description: Add guard against empty graph returned by Logstash API

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.9"
+  changes:
+    - description: Rework worker utilization
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9971
 - version: "2.4.8"
   changes:
     - description: Add guard against empty graph returned by Logstash API

--- a/packages/logstash/data_stream/pipeline/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/logstash/data_stream/pipeline/elasticsearch/ingest_pipeline/default.yml
@@ -96,6 +96,26 @@ processors:
       field: logstash.pipeline.total.flow.worker_concurrency.last_24_hours
   - remove:
       ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_concurrency.current
+      if: ctx.logstash?.pipeline?.total?.flow?.worker_concurrency?.current == "Infinity"
+  - remove:
+      ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_utilization.last_1_minute
+      if: ctx.logstash?.pipeline?.total?.flow?.worker_utilization?.last_1_minute == "Infinity"
+  - remove:
+      ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_utilization.last_5_minutes
+  - remove:
+      ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_utilization.last_15_minutes
+  - remove:
+      ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_utilization.last_1_hour
+  - remove:
+      ignore_missing: true
+      field: logstash.pipeline.total.flow.worker_utilization.last_24_hours
+  - remove:
+      ignore_missing: true
       field: logstash.pipeline.total.flow.filter_throughput.lifetime
   - remove:
       ignore_missing: true

--- a/packages/logstash/data_stream/pipeline/fields/fields.yml
+++ b/packages/logstash/data_stream/pipeline/fields/fields.yml
@@ -76,7 +76,15 @@
             - name: worker_concurrency.current
               type: scaled_float
               metric_type: gauge
+              description: last 1 minute value of the worker utilization flow metric
+            - name: worker_utilization.last_1_minute
+              metric_type: gauge
+              type: scaled_float
               description: current value of the worker concurrency flow metric
+            - name: worker_utilization.current
+              type: scaled_float
+              metric_type: gauge
+              description: last 1 minute value of the worker concurrency flow metric
             - name: worker_concurrency.last_1_minute
               metric_type: gauge
               type: scaled_float

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -897,8 +897,10 @@ This is the `pipeline` dataset, which drives the Pipeline dashboard pages.
 | logstash.pipeline.total.flow.queue_persisted_growth_bytes.last_1_minute | current value of the queue persisted growth bytes flow metric | scaled_float |  | gauge |
 | logstash.pipeline.total.flow.queue_persisted_growth_events.current | current value of the queue persisted growth events flow metric | scaled_float |  | gauge |
 | logstash.pipeline.total.flow.queue_persisted_growth_events.last_1_minute | current value of the queue persisted growth events flow metric | scaled_float |  | gauge |
-| logstash.pipeline.total.flow.worker_concurrency.current | current value of the worker concurrency flow metric | scaled_float |  | gauge |
+| logstash.pipeline.total.flow.worker_concurrency.current | last 1 minute value of the worker utilization flow metric | scaled_float |  | gauge |
 | logstash.pipeline.total.flow.worker_concurrency.last_1_minute | current value of the worker concurrency flow metric | scaled_float |  | gauge |
+| logstash.pipeline.total.flow.worker_utilization.current | last 1 minute value of the worker concurrency flow metric | scaled_float |  | gauge |
+| logstash.pipeline.total.flow.worker_utilization.last_1_minute | current value of the worker concurrency flow metric | scaled_float |  | gauge |
 | logstash.pipeline.total.queues.current_size.bytes | Current size of the PQ | long | byte | gauge |
 | logstash.pipeline.total.queues.events | Number of events in the PQ for this pipeline | long |  | counter |
 | logstash.pipeline.total.queues.max_size.bytes | Maximum possible size of the PQ | long |  | gauge |

--- a/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
@@ -1543,7 +1543,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-4bbf4a50-6ece-11ee-910d-eb0006359086",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
@@ -1541,9 +1541,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:55:53.257Z",
+    "created_at": "2024-06-05T19:47:07.258Z",
     "id": "logstash-4bbf4a50-6ece-11ee-910d-eb0006359086",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
@@ -1541,7 +1541,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:55:53.257Z",
     "id": "logstash-4bbf4a50-6ece-11ee-910d-eb0006359086",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-4bbf4a50-6ece-11ee-910d-eb0006359086.json
@@ -1541,7 +1541,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:47:07.258Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-4bbf4a50-6ece-11ee-910d-eb0006359086",
     "managed": true,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
@@ -894,7 +894,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:55:54.264Z",
+    "created_at": "2024-06-05T19:53:50.055Z",
     "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
@@ -896,7 +896,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
@@ -894,9 +894,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:53:50.055Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975.json
@@ -894,7 +894,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:55:54.264Z",
     "id": "logstash-4f60a1e0-6eab-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-79270240-48ee-11ee-8cb5-99927777c522.json
+++ b/packages/logstash/kibana/dashboard/logstash-79270240-48ee-11ee-8cb5-99927777c522.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"5c0bd4d8-47ca-4a2f-a1ff-d9f4b55dfad0\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"5c0bd4d8-47ca-4a2f-a1ff-d9f4b55dfad0\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}},\"c5cca387-507e-44a6-883f-0ab948c24319\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"c5cca387-507e-44a6-883f-0ab948c24319\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"5c0bd4d8-47ca-4a2f-a1ff-d9f4b55dfad0\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"5c0bd4d8-47ca-4a2f-a1ff-d9f4b55dfad0\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -59,8 +59,7 @@
                     "y": 0
                 },
                 "panelIndex": "67c48168-cf30-4dcb-a96e-8e0a38e6049d",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -129,8 +128,7 @@
                 },
                 "panelIndex": "0c5d0dc4-28b0-4875-a024-63fb45db1c37",
                 "title": "Node Count",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -322,8 +320,7 @@
                 },
                 "panelIndex": "c38da400-a6af-4225-9e21-6ba4da521b43",
                 "title": "Total JVM Heap Used",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -427,8 +424,7 @@
                 },
                 "panelIndex": "944396f6-413e-439e-9226-5fcf76247442",
                 "title": "Total Events Received",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -532,8 +528,7 @@
                 },
                 "panelIndex": "22f8be07-6626-4fc6-a741-e095030bf543",
                 "title": "Total Events Emitted",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -712,8 +707,7 @@
                 },
                 "panelIndex": "3df9851c-7ac3-4bed-ade1-7e3ee0509971",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -892,8 +886,7 @@
                 },
                 "panelIndex": "a66223a5-9fdb-4335-8012-4ae2748928ac",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1147,8 +1140,7 @@
                 },
                 "panelIndex": "272e809f-0867-4ef2-aef3-626e954008c9",
                 "title": "Events Latency (ms) average",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -1156,9 +1148,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:53:51.399Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-79270240-48ee-11ee-8cb5-99927777c522",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",
@@ -1203,11 +1195,6 @@
         {
             "id": "logstash-sm-metrics",
             "name": "controlGroup_5c0bd4d8-47ca-4a2f-a1ff-d9f4b55dfad0:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logstash-sm-metrics",
-            "name": "controlGroup_c5cca387-507e-44a6-883f-0ab948c24319:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/logstash/kibana/dashboard/logstash-79270240-48ee-11ee-8cb5-99927777c522.json
+++ b/packages/logstash/kibana/dashboard/logstash-79270240-48ee-11ee-8cb5-99927777c522.json
@@ -1156,7 +1156,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:16:10.413Z",
+    "created_at": "2024-06-05T19:53:51.399Z",
     "id": "logstash-79270240-48ee-11ee-8cb5-99927777c522",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
@@ -697,9 +697,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:53:50.393Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
@@ -699,7 +699,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
@@ -697,7 +697,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:55:56.289Z",
+    "created_at": "2024-06-05T19:53:50.393Z",
     "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975.json
@@ -697,7 +697,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:55:56.289Z",
     "id": "logstash-8f8c78a0-6e9e-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
+++ b/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
@@ -43,7 +43,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n**[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)**  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)  \n[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)\n\nOverview\n\nThis Dashboard gives a view of the overall performance of a single Logstash Node. Should be used in conjunction with the node name\nfilter",
+                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n**[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)**  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)  \n[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)\n\nOverview\n\nThis Dashboard gives a view of the overall performance of a single Logstash Node. Should be used in conjunction with the node name filter",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -1553,7 +1553,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:27:39.018Z",
+    "created_at": "2024-06-05T20:50:52.440Z",
     "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
+++ b/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
@@ -1564,7 +1564,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
+++ b/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"94cc8a2a-a81e-451b-891b-407075069331\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"94cc8a2a-a81e-451b-891b-407075069331\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -1553,9 +1553,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T20:50:52.440Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",
@@ -1601,11 +1601,6 @@
             "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
             "name": "87bc08bb-a0ca-4f82-8943-a141aaef3248:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:32da855b-5a16-4271-8e06-938568d20659:dashboardId",
             "type": "dashboard"
-        },
-        {
-            "id": "logstash-sm-metrics",
-            "name": "controlGroup_94cc8a2a-a81e-451b-891b-407075069331:optionsListDataView",
-            "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
+++ b/packages/logstash/kibana/dashboard/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"f8e0eae3-62e0-4539-87d6-523e89a8213e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"f8e0eae3-62e0-4539-87d6-523e89a8213e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"25b6ddfd-e372-4344-827b-c81461088031\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"25b6ddfd-e372-4344-827b-c81461088031\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"94cc8a2a-a81e-451b-891b-407075069331\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"94cc8a2a-a81e-451b-891b-407075069331\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -59,8 +59,7 @@
                     "y": 0
                 },
                 "panelIndex": "c2c433cf-50ce-4530-86e5-f82a240c57b8",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -347,8 +346,7 @@
                 },
                 "panelIndex": "73a755c6-89a3-4f34-8daf-83feef5caa28",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -505,8 +503,7 @@
                 },
                 "panelIndex": "63747092-edb6-4864-a9ad-27e5bdce2ad2",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -675,8 +672,7 @@
                 },
                 "panelIndex": "9ea7a32a-ee7e-45d4-b0cf-273278e52cae",
                 "title": "JVM Heap (MB)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -833,8 +829,7 @@
                 },
                 "panelIndex": "bac81244-9c35-4cf9-8ed4-3c7082a255ae",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -973,8 +968,7 @@
                 },
                 "panelIndex": "5a43f153-bec9-4420-96f8-0c2d4b032a43",
                 "title": "Process CPU Utilization (%)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1205,8 +1199,7 @@
                 },
                 "panelIndex": "5af28ec8-a9f0-49cb-9627-e13c0ac5ca1d",
                 "title": "Events Latency (ms)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1345,8 +1338,7 @@
                 },
                 "panelIndex": "c6fb1dc0-c51d-4c00-903c-d90ad3b77ce1",
                 "title": "System Load",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1553,8 +1545,7 @@
                 },
                 "panelIndex": "87bc08bb-a0ca-4f82-8943-a141aaef3248",
                 "title": "Running Pipelines",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -1562,7 +1553,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T19:27:39.018Z",
     "id": "logstash-9d450b10-4680-11ee-9ddc-919f87fe352d",
     "managed": false,
     "references": [
@@ -1613,12 +1604,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "controlGroup_f8e0eae3-62e0-4539-87d6-523e89a8213e:optionsListDataView",
+            "name": "controlGroup_94cc8a2a-a81e-451b-891b-407075069331:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "controlGroup_25b6ddfd-e372-4344-827b-c81461088031:optionsListDataView",
+            "name": "controlGroup_73fdfb3a-3e86-499a-93f1-993479254e4e:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
+++ b/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
@@ -1759,7 +1759,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:56:02.391Z",
+    "created_at": "2024-06-05T19:53:56.470Z",
     "id": "logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
+++ b/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
@@ -1759,7 +1759,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:51:18.875Z",
+    "created_at": "2024-06-05T18:56:02.391Z",
     "id": "logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
+++ b/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
@@ -1220,7 +1220,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-b516a470-71ea-11ee-aadf-e577130ac888",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
+++ b/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
@@ -1218,7 +1218,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:55:52.997Z",
     "id": "logstash-b516a470-71ea-11ee-aadf-e577130ac888",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
+++ b/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
@@ -1218,7 +1218,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:47:07.258Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-b516a470-71ea-11ee-aadf-e577130ac888",
     "managed": true,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
+++ b/packages/logstash/kibana/dashboard/logstash-b516a470-71ea-11ee-aadf-e577130ac888.json
@@ -1218,9 +1218,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:55:52.997Z",
+    "created_at": "2024-06-05T19:47:07.258Z",
     "id": "logstash-b516a470-71ea-11ee-aadf-e577130ac888",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
@@ -1218,7 +1218,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:55:55.278Z",
     "id": "logstash-b5234e70-6f54-11ee-910d-eb0006359086",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
@@ -1218,7 +1218,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:47:07.258Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-b5234e70-6f54-11ee-910d-eb0006359086",
     "managed": true,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
@@ -1220,7 +1220,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-b5234e70-6f54-11ee-910d-eb0006359086",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
+++ b/packages/logstash/kibana/dashboard/logstash-b5234e70-6f54-11ee-910d-eb0006359086.json
@@ -1218,9 +1218,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:55:55.278Z",
+    "created_at": "2024-06-05T19:47:07.258Z",
     "id": "logstash-b5234e70-6f54-11ee-910d-eb0006359086",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -7138,7 +7138,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"429cdb8b-f9d9-45b0-bf04-2fca76ad3cd8\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"429cdb8b-f9d9-45b0-bf04-2fca76ad3cd8\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"selectedOptions\":[],\"enhancements\":{},\"existsSelected\":false}},\"497f4765-376b-4a02-9982-0e8bf9a0b1ef\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"497f4765-376b-4a02-9982-0e8bf9a0b1ef\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[],\"existsSelected\":false}}}"
+            "panelsJSON": "{\"94cc8a2a-a81e-451b-891b-407075069331\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"94cc8a2a-a81e-451b-891b-407075069331\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -58,8 +58,7 @@
                 },
                 "panelIndex": "1b7d4c91-b582-4639-a771-7853e72a94b6",
                 "title": "Logstash Nav Panel",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -184,8 +183,7 @@
                     "y": 0
                 },
                 "panelIndex": "9a756479-5952-441e-beff-e0896500ca39",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -294,8 +292,7 @@
                     "y": 0
                 },
                 "panelIndex": "b48c9b95-bcc4-4bde-b41d-630a4f31b26e",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -404,8 +401,7 @@
                     "y": 0
                 },
                 "panelIndex": "6da9466a-ede0-44b6-a2e7-d704065bb90b",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -655,8 +651,7 @@
                 },
                 "panelIndex": "7d85767a-5dbb-4704-8716-1d4c30a5f675",
                 "title": "Average Time processed per event (ms)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -818,8 +813,7 @@
                 },
                 "panelIndex": "f03395de-a163-4204-ac82-83c0ea542eeb",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1061,8 +1055,7 @@
                 },
                 "panelIndex": "5171ef08-d301-4a9c-832b-40f41c9ad24d",
                 "title": "Persistent Queue utilization (%)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1224,8 +1217,7 @@
                 },
                 "panelIndex": "4fad1f03-99d3-4834-a6c4-bea283178567",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1392,8 +1384,7 @@
                 },
                 "panelIndex": "a3444242-6e3e-4959-8815-43e65b3e8d69",
                 "title": "Persistent Queue size (events)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1429,8 +1420,7 @@
                 },
                 "panelIndex": "681d5f97-e2f4-4a74-9710-7e75bb73fea8",
                 "title": "Plugins",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -1447,6 +1437,7 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
                                         "df79554f-08e3-4f7f-b438-80bc81e14637": {
                                             "columnOrder": [
@@ -1457,7 +1448,6 @@
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbe",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820c",
                                                 "8db4855c-0536-4cf8-84bd-eb8af3b72829",
-                                                "a175cdde-215b-441e-84d6-ceab03b1495d",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX0",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX1",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820cX0",
@@ -1484,10 +1474,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "a175cdde-215b-441e-84d6-ceab03b1495d",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -1510,10 +1500,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "a175cdde-215b-441e-84d6-ceab03b1495d",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -1595,10 +1585,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "a175cdde-215b-441e-84d6-ceab03b1495d",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -1727,28 +1717,6 @@
                                                     ],
                                                     "scale": "ratio"
                                                 },
-                                                "a175cdde-215b-441e-84d6-ceab03b1495d": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"logstash.pipeline.plugin.input.flow.throughput.last_1_minute\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Throughput flow",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 3
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.plugin.input.flow.throughput.last_1_minute"
-                                                },
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbe": {
                                                     "customLabel": true,
                                                     "dataType": "number",
@@ -1790,6 +1758,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
@@ -1898,40 +1867,6 @@
                                     },
                                     {
                                         "alignment": "center",
-                                        "colorMode": "cell",
-                                        "columnId": "a175cdde-215b-441e-84d6-ceab03b1495d",
-                                        "isTransposed": false,
-                                        "palette": {
-                                            "name": "positive",
-                                            "params": {
-                                                "stops": [
-                                                    {
-                                                        "color": "#d6e9e4",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#aed3ca",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#85bdb1",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#5aa898",
-                                                        "stop": 80
-                                                    },
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 100
-                                                    }
-                                                ]
-                                            },
-                                            "type": "palette"
-                                        }
-                                    },
-                                    {
-                                        "alignment": "center",
                                         "columnId": "245e3126-537a-4644-b6b3-9a33800dfb91",
                                         "isTransposed": false
                                     },
@@ -2015,8 +1950,7 @@
                     "y": 39
                 },
                 "panelIndex": "9a34af7e-5f12-49b4-86e0-5577203711eb",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2220,8 +2154,7 @@
                 },
                 "panelIndex": "f94ee279-63d8-45de-bfa0-9c93416b9752",
                 "title": "Time spent pushing to queues",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2429,8 +2362,7 @@
                 },
                 "panelIndex": "1eabaf75-95dd-4cae-95d5-f00efe978872",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2600,8 +2532,7 @@
                 },
                 "panelIndex": "3470dd76-7ebd-4b19-a3de-fa0082a72ee5",
                 "title": "Input Flow",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -2638,8 +2569,7 @@
                 },
                 "panelIndex": "7f5bcb0f-394c-4bbd-b17a-c163a28a9315",
                 "title": "Plugins",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -2656,6 +2586,7 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
                                         "df79554f-08e3-4f7f-b438-80bc81e14637": {
                                             "columnOrder": [
@@ -2667,8 +2598,6 @@
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbe",
                                                 "56e40393-65fa-403e-b757-05ae1fc04063",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820c",
-                                                "5f2a9ea0-38a8-403a-bf56-5792745b0b7a",
-                                                "6fdcaadf-6c83-43f1-9f65-b148037b7aab",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX0",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX1",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820cX0",
@@ -2736,10 +2665,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "5f2a9ea0-38a8-403a-bf56-5792745b0b7a",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -2927,28 +2856,6 @@
                                                     ],
                                                     "scale": "ratio"
                                                 },
-                                                "5f2a9ea0-38a8-403a-bf56-5792745b0b7a": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"logstash.pipeline.plugin.filter.flow.worker_millis_per_event.last_1_minute\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Worker millis per event",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.plugin.filter.flow.worker_millis_per_event.last_1_minute"
-                                                },
                                                 "65ca78d2-d895-4db6-bec3-7e110bd0030b": {
                                                     "customLabel": true,
                                                     "dataType": "string",
@@ -2988,28 +2895,6 @@
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "logstash.pipeline.plugin.filter.name"
-                                                },
-                                                "6fdcaadf-6c83-43f1-9f65-b148037b7aab": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"logstash.pipeline.plugin.filter.flow.worker_utilization.last_1_minute\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Worker utilization",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "number",
-                                                            "params": {
-                                                                "decimals": 3
-                                                            }
-                                                        },
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.plugin.filter.flow.worker_utilization.last_1_minute"
                                                 },
                                                 "8914109f-497d-4293-8692-dbdddffbf42f": {
                                                     "customLabel": true,
@@ -3074,6 +2959,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
@@ -3240,107 +3126,6 @@
                                     {
                                         "alignment": "center",
                                         "colorMode": "cell",
-                                        "columnId": "5f2a9ea0-38a8-403a-bf56-5792745b0b7a",
-                                        "isTransposed": false,
-                                        "palette": {
-                                            "name": "custom",
-                                            "params": {
-                                                "colorStops": [
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#54b399",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#d6bf57",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#e7664c",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#cc5642",
-                                                        "stop": 80
-                                                    }
-                                                ],
-                                                "continuity": "above",
-                                                "name": "custom",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "reverse": false,
-                                                "steps": 5,
-                                                "stops": [
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#54b399",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#d6bf57",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#e7664c",
-                                                        "stop": 80
-                                                    },
-                                                    {
-                                                        "color": "#cc5642",
-                                                        "stop": 100
-                                                    }
-                                                ]
-                                            },
-                                            "type": "palette"
-                                        }
-                                    },
-                                    {
-                                        "alignment": "center",
-                                        "colorMode": "cell",
-                                        "columnId": "6fdcaadf-6c83-43f1-9f65-b148037b7aab",
-                                        "isTransposed": false,
-                                        "palette": {
-                                            "name": "status",
-                                            "params": {
-                                                "continuity": "above",
-                                                "name": "status",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "reverse": false,
-                                                "stops": [
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#54b399",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#d6bf57",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#e7664c",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#cc5642",
-                                                        "stop": 80
-                                                    }
-                                                ]
-                                            },
-                                            "type": "palette"
-                                        }
-                                    },
-                                    {
-                                        "alignment": "center",
-                                        "colorMode": "cell",
                                         "columnId": "56e40393-65fa-403e-b757-05ae1fc04063",
                                         "isTransposed": false,
                                         "palette": {
@@ -3407,11 +3192,7 @@
                                     }
                                 ],
                                 "layerId": "df79554f-08e3-4f7f-b438-80bc81e14637",
-                                "layerType": "data",
-                                "sorting": {
-                                    "columnId": "6fdcaadf-6c83-43f1-9f65-b148037b7aab",
-                                    "direction": "desc"
-                                }
+                                "layerType": "data"
                             }
                         },
                         "title": "",
@@ -3479,8 +3260,7 @@
                     "y": 68
                 },
                 "panelIndex": "97bcb728-f0e5-4047-aade-2ef56bd33c22",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -3766,8 +3546,7 @@
                 },
                 "panelIndex": "f8033492-7353-4564-83d5-6715e387f9ac",
                 "title": "Average time spent processing each event",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -3975,8 +3754,7 @@
                 },
                 "panelIndex": "d6db9db8-7da0-435c-8118-9d0c36d2573d",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -4181,8 +3959,7 @@
                 },
                 "panelIndex": "03d92828-8549-4cd9-a7ea-12f25502cef1",
                 "title": "Worker utilization",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -4390,8 +4167,7 @@
                 },
                 "panelIndex": "55b1238e-1f8e-4b73-8dfc-906aa2eecbb6",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -4580,8 +4356,7 @@
                 },
                 "panelIndex": "48f64446-f5ca-451d-8a59-bb12b4807381",
                 "title": "Worker milliseconds per event",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -4618,8 +4393,7 @@
                 },
                 "panelIndex": "cfd22405-6008-4373-ad69-94e70427e259",
                 "title": "Plugins",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -4636,6 +4410,7 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
                                     "layers": {
                                         "df79554f-08e3-4f7f-b438-80bc81e14637": {
                                             "columnOrder": [
@@ -4647,8 +4422,6 @@
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbe",
                                                 "e0728321-e2b4-44c6-b07b-a89f632f02e1",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820c",
-                                                "a7134cf0-c941-41e8-b346-40bc893c2514",
-                                                "8cb013fb-a55f-4c6d-88e1-6ce798c8db07",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX0",
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbeX1",
                                                 "3bdc4103-5313-4e00-a407-de5b7fde820cX0",
@@ -4815,10 +4588,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "8cb013fb-a55f-4c6d-88e1-6ce798c8db07",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -4841,10 +4614,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "a7134cf0-c941-41e8-b346-40bc893c2514",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -4853,38 +4626,6 @@
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "logstash.pipeline.plugin.output.name"
-                                                },
-                                                "8cb013fb-a55f-4c6d-88e1-6ce798c8db07": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"logstash.pipeline.plugin.output.flow.worker_utilization.last_1_minute\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Worker utilization",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.plugin.output.flow.worker_utilization.last_1_minute"
-                                                },
-                                                "a7134cf0-c941-41e8-b346-40bc893c2514": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"logstash.pipeline.plugin.output.flow.worker_millis_per_event.last_1_minute\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Worker millis per event",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.plugin.output.flow.worker_millis_per_event.last_1_minute"
                                                 },
                                                 "d172976a-5c43-46b7-9d96-44ac40134cbe": {
                                                     "customLabel": true,
@@ -5046,6 +4787,7 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
                                             "sampling": 1
                                         }
                                     }
@@ -5117,84 +4859,6 @@
                                         "alignment": "center",
                                         "colorMode": "cell",
                                         "columnId": "3bdc4103-5313-4e00-a407-de5b7fde820c",
-                                        "isTransposed": false,
-                                        "palette": {
-                                            "name": "status",
-                                            "params": {
-                                                "continuity": "above",
-                                                "name": "status",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "reverse": false,
-                                                "stops": [
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#54b399",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#d6bf57",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#e7664c",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#cc5642",
-                                                        "stop": 80
-                                                    }
-                                                ]
-                                            },
-                                            "type": "palette"
-                                        }
-                                    },
-                                    {
-                                        "alignment": "center",
-                                        "colorMode": "cell",
-                                        "columnId": "a7134cf0-c941-41e8-b346-40bc893c2514",
-                                        "isTransposed": false,
-                                        "palette": {
-                                            "name": "status",
-                                            "params": {
-                                                "continuity": "above",
-                                                "name": "status",
-                                                "rangeMax": null,
-                                                "rangeMin": 0,
-                                                "reverse": false,
-                                                "stops": [
-                                                    {
-                                                        "color": "#209280",
-                                                        "stop": 0
-                                                    },
-                                                    {
-                                                        "color": "#54b399",
-                                                        "stop": 20
-                                                    },
-                                                    {
-                                                        "color": "#d6bf57",
-                                                        "stop": 40
-                                                    },
-                                                    {
-                                                        "color": "#e7664c",
-                                                        "stop": 60
-                                                    },
-                                                    {
-                                                        "color": "#cc5642",
-                                                        "stop": 80
-                                                    }
-                                                ]
-                                            },
-                                            "type": "palette"
-                                        }
-                                    },
-                                    {
-                                        "alignment": "center",
-                                        "colorMode": "cell",
-                                        "columnId": "8cb013fb-a55f-4c6d-88e1-6ce798c8db07",
                                         "isTransposed": false,
                                         "palette": {
                                             "name": "status",
@@ -5386,8 +5050,7 @@
                     "y": 118
                 },
                 "panelIndex": "5ea51e10-bede-40f6-9842-f840617bcc8b",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -5672,8 +5335,7 @@
                 },
                 "panelIndex": "bb1876b7-7faa-4c37-a8af-c79a70149922",
                 "title": "Average time spent processing event (ms)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -5881,8 +5543,7 @@
                 },
                 "panelIndex": "c49e6ec7-e4a6-4938-b39b-d0c49b1ae114",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -6087,8 +5748,7 @@
                 },
                 "panelIndex": "1c17de77-a7e5-4265-ada5-a7aaf0b6c972",
                 "title": "Worker utilization",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -6296,8 +5956,7 @@
                 },
                 "panelIndex": "231824a2-a183-439f-8e08-e1bad6c5e9db",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -6502,8 +6161,7 @@
                 },
                 "panelIndex": "09cd3d58-f4a5-4033-a011-15002b6649e7",
                 "title": "Worker millseconds per event",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -6541,8 +6199,7 @@
                 },
                 "panelIndex": "31278c59-d923-4beb-800b-a8107e9064c5",
                 "title": "Plugins",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -7127,8 +6784,7 @@
                     "y": 171
                 },
                 "panelIndex": "46fbd106-9dba-4c2c-b359-fd04c22e1314",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -7136,7 +6792,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T19:27:03.795Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "managed": false,
     "references": [
@@ -7302,12 +6958,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "controlGroup_429cdb8b-f9d9-45b0-bf04-2fca76ad3cd8:optionsListDataView",
+            "name": "controlGroup_94cc8a2a-a81e-451b-891b-407075069331:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "controlGroup_497f4765-376b-4a02-9982-0e8bf9a0b1ef:optionsListDataView",
+            "name": "controlGroup_73fdfb3a-3e86-499a-93f1-993479254e4e:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -41,7 +41,7 @@
                         "description": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)  \n**[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)**  \n\n\nOverview\n\nThis Dashboard gives a detailed view of a Logstash pipeline.  \n   \nUse the filters to drill down on individual nodes and pipelines.\n  \nPlugin drilldowns are available by clicking on the plugin in the table views for inputs, filters and outputs.    \n\nSpecialized drilldowns are available for the dissect and grok filters, and the elasticsearch output.  \n\n",
+                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)  \n**[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)**  \n\n\nOverview\n\nThis Dashboard gives a detailed view of a Logstash pipeline.\n   \nUse the filters to drill down on individual nodes and pipelines. This view works best when focused on a single pipeline.\n  \nPlugin drilldowns are available by clicking on the plugin in the table views for inputs, filters and outputs.    \n\nSpecialized drilldowns are available for the dissect and grok filters, and the elasticsearch output.  \n\n",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -418,6 +418,211 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
+                                    "layers": {
+                                        "4d13c1a7-6b92-47fe-8baf-7ca505bd9fda": {
+                                            "columnOrder": [
+                                                "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3",
+                                                "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5",
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececf",
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0",
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX1"
+                                            ],
+                                            "columns": {
+                                                "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Pipeline Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderAgg": {
+                                                            "dataType": "number",
+                                                            "filter": {
+                                                                "language": "kuery",
+                                                                "query": "\"logstash.pipeline.total.flow.worker_utilization.last_1_minute\": *"
+                                                            },
+                                                            "isBucketed": false,
+                                                            "label": "Last value of logstash.pipeline.total.flow.worker_utilization.last_1_minute",
+                                                            "operationType": "last_value",
+                                                            "params": {
+                                                                "sortField": "@timestamp"
+                                                            },
+                                                            "scale": "ratio",
+                                                            "sourceField": "logstash.pipeline.total.flow.worker_utilization.last_1_minute"
+                                                        },
+                                                        "orderBy": {
+                                                            "type": "custom"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.host.name"
+                                                },
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Worker Utilization",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "last_value(logstash.pipeline.total.flow.worker_utilization.last_1_minute)/100",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.total.flow.worker_utilization.last_1_minute\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Worker Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.total.flow.worker_utilization.last_1_minute"
+                                                },
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of Worker Utilization",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0",
+                                                                100
+                                                            ],
+                                                            "location": {
+                                                                "max": 77,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "last_value(logstash.pipeline.total.flow.worker_utilization.last_1_minute)/100",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "d9cd1ee6-586c-41b4-9d5f-976cd8eececf"
+                                        ],
+                                        "layerId": "4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3",
+                                        "xAccessor": "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "Average Time processed per event (ms)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "6f7df80f-6315-417a-8b95-bbcdc938e4df",
+                    "w": 40,
+                    "x": 8,
+                    "y": 5
+                },
+                "panelIndex": "6f7df80f-6315-417a-8b95-bbcdc938e4df",
+                "title": "Worker Utilization (%)",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
                                     "layers": {
                                         "4d13c1a7-6b92-47fe-8baf-7ca505bd9fda": {
                                             "columnOrder": [
@@ -647,7 +852,7 @@
                     "i": "7d85767a-5dbb-4704-8716-1d4c30a5f675",
                     "w": 40,
                     "x": 8,
-                    "y": 5
+                    "y": 17
                 },
                 "panelIndex": "7d85767a-5dbb-4704-8716-1d4c30a5f675",
                 "title": "Average Time processed per event (ms)",
@@ -809,7 +1014,7 @@
                     "i": "f03395de-a163-4204-ac82-83c0ea542eeb",
                     "w": 20,
                     "x": 8,
-                    "y": 17
+                    "y": 29
                 },
                 "panelIndex": "f03395de-a163-4204-ac82-83c0ea542eeb",
                 "title": "Events received per second",
@@ -1051,7 +1256,7 @@
                     "i": "5171ef08-d301-4a9c-832b-40f41c9ad24d",
                     "w": 20,
                     "x": 28,
-                    "y": 17
+                    "y": 29
                 },
                 "panelIndex": "5171ef08-d301-4a9c-832b-40f41c9ad24d",
                 "title": "Persistent Queue utilization (%)",
@@ -1213,7 +1418,7 @@
                     "i": "4fad1f03-99d3-4834-a6c4-bea283178567",
                     "w": 20,
                     "x": 8,
-                    "y": 26
+                    "y": 38
                 },
                 "panelIndex": "4fad1f03-99d3-4834-a6c4-bea283178567",
                 "title": "Events emitted per second",
@@ -1380,7 +1585,7 @@
                     "i": "a3444242-6e3e-4959-8815-43e65b3e8d69",
                     "w": 20,
                     "x": 28,
-                    "y": 26
+                    "y": 38
                 },
                 "panelIndex": "a3444242-6e3e-4959-8815-43e65b3e8d69",
                 "title": "Persistent Queue size (events)",
@@ -1416,7 +1621,7 @@
                     "i": "681d5f97-e2f4-4a74-9710-7e75bb73fea8",
                     "w": 24,
                     "x": 16,
-                    "y": 35
+                    "y": 47
                 },
                 "panelIndex": "681d5f97-e2f4-4a74-9710-7e75bb73fea8",
                 "title": "Plugins",
@@ -1947,7 +2152,7 @@
                     "i": "9a34af7e-5f12-49b4-86e0-5577203711eb",
                     "w": 40,
                     "x": 8,
-                    "y": 39
+                    "y": 51
                 },
                 "panelIndex": "9a34af7e-5f12-49b4-86e0-5577203711eb",
                 "type": "lens"
@@ -2150,7 +2355,7 @@
                     "i": "f94ee279-63d8-45de-bfa0-9c93416b9752",
                     "w": 40,
                     "x": 8,
-                    "y": 46
+                    "y": 58
                 },
                 "panelIndex": "f94ee279-63d8-45de-bfa0-9c93416b9752",
                 "title": "Time spent pushing to queues",
@@ -2358,7 +2563,7 @@
                     "i": "1eabaf75-95dd-4cae-95d5-f00efe978872",
                     "w": 20,
                     "x": 8,
-                    "y": 55
+                    "y": 67
                 },
                 "panelIndex": "1eabaf75-95dd-4cae-95d5-f00efe978872",
                 "title": "Events emitted per second",
@@ -2528,7 +2733,7 @@
                     "i": "3470dd76-7ebd-4b19-a3de-fa0082a72ee5",
                     "w": 20,
                     "x": 28,
-                    "y": 55
+                    "y": 67
                 },
                 "panelIndex": "3470dd76-7ebd-4b19-a3de-fa0082a72ee5",
                 "title": "Input Flow",
@@ -2565,7 +2770,7 @@
                     "i": "7f5bcb0f-394c-4bbd-b17a-c163a28a9315",
                     "w": 24,
                     "x": 16,
-                    "y": 64
+                    "y": 76
                 },
                 "panelIndex": "7f5bcb0f-394c-4bbd-b17a-c163a28a9315",
                 "title": "Plugins",
@@ -3257,7 +3462,7 @@
                     "i": "97bcb728-f0e5-4047-aade-2ef56bd33c22",
                     "w": 40,
                     "x": 8,
-                    "y": 68
+                    "y": 80
                 },
                 "panelIndex": "97bcb728-f0e5-4047-aade-2ef56bd33c22",
                 "type": "lens"
@@ -3542,7 +3747,7 @@
                     "i": "f8033492-7353-4564-83d5-6715e387f9ac",
                     "w": 40,
                     "x": 8,
-                    "y": 82
+                    "y": 94
                 },
                 "panelIndex": "f8033492-7353-4564-83d5-6715e387f9ac",
                 "title": "Average time spent processing each event",
@@ -3750,7 +3955,7 @@
                     "i": "d6db9db8-7da0-435c-8118-9d0c36d2573d",
                     "w": 20,
                     "x": 8,
-                    "y": 92
+                    "y": 104
                 },
                 "panelIndex": "d6db9db8-7da0-435c-8118-9d0c36d2573d",
                 "title": "Events received per second",
@@ -3955,7 +4160,7 @@
                     "i": "03d92828-8549-4cd9-a7ea-12f25502cef1",
                     "w": 20,
                     "x": 28,
-                    "y": 92
+                    "y": 104
                 },
                 "panelIndex": "03d92828-8549-4cd9-a7ea-12f25502cef1",
                 "title": "Worker utilization",
@@ -4163,7 +4368,7 @@
                     "i": "55b1238e-1f8e-4b73-8dfc-906aa2eecbb6",
                     "w": 20,
                     "x": 8,
-                    "y": 103
+                    "y": 115
                 },
                 "panelIndex": "55b1238e-1f8e-4b73-8dfc-906aa2eecbb6",
                 "title": "Events emitted per second",
@@ -4352,7 +4557,7 @@
                     "i": "48f64446-f5ca-451d-8a59-bb12b4807381",
                     "w": 20,
                     "x": 28,
-                    "y": 103
+                    "y": 115
                 },
                 "panelIndex": "48f64446-f5ca-451d-8a59-bb12b4807381",
                 "title": "Worker milliseconds per event",
@@ -4389,7 +4594,7 @@
                     "i": "cfd22405-6008-4373-ad69-94e70427e259",
                     "w": 24,
                     "x": 17,
-                    "y": 114
+                    "y": 126
                 },
                 "panelIndex": "cfd22405-6008-4373-ad69-94e70427e259",
                 "title": "Plugins",
@@ -5047,7 +5252,7 @@
                     "i": "5ea51e10-bede-40f6-9842-f840617bcc8b",
                     "w": 40,
                     "x": 8,
-                    "y": 118
+                    "y": 130
                 },
                 "panelIndex": "5ea51e10-bede-40f6-9842-f840617bcc8b",
                 "type": "lens"
@@ -5331,7 +5536,7 @@
                     "i": "bb1876b7-7faa-4c37-a8af-c79a70149922",
                     "w": 40,
                     "x": 8,
-                    "y": 134
+                    "y": 146
                 },
                 "panelIndex": "bb1876b7-7faa-4c37-a8af-c79a70149922",
                 "title": "Average time spent processing event (ms)",
@@ -5539,7 +5744,7 @@
                     "i": "c49e6ec7-e4a6-4938-b39b-d0c49b1ae114",
                     "w": 20,
                     "x": 8,
-                    "y": 145
+                    "y": 157
                 },
                 "panelIndex": "c49e6ec7-e4a6-4938-b39b-d0c49b1ae114",
                 "title": "Events received per second",
@@ -5744,7 +5949,7 @@
                     "i": "1c17de77-a7e5-4265-ada5-a7aaf0b6c972",
                     "w": 20,
                     "x": 28,
-                    "y": 145
+                    "y": 157
                 },
                 "panelIndex": "1c17de77-a7e5-4265-ada5-a7aaf0b6c972",
                 "title": "Worker utilization",
@@ -5952,7 +6157,7 @@
                     "i": "231824a2-a183-439f-8e08-e1bad6c5e9db",
                     "w": 20,
                     "x": 8,
-                    "y": 156
+                    "y": 168
                 },
                 "panelIndex": "231824a2-a183-439f-8e08-e1bad6c5e9db",
                 "title": "Events emitted per second",
@@ -6157,7 +6362,7 @@
                     "i": "09cd3d58-f4a5-4033-a011-15002b6649e7",
                     "w": 20,
                     "x": 28,
-                    "y": 156
+                    "y": 168
                 },
                 "panelIndex": "09cd3d58-f4a5-4033-a011-15002b6649e7",
                 "title": "Worker millseconds per event",
@@ -6195,7 +6400,7 @@
                     "i": "31278c59-d923-4beb-800b-a8107e9064c5",
                     "w": 24,
                     "x": 16,
-                    "y": 167
+                    "y": 179
                 },
                 "panelIndex": "31278c59-d923-4beb-800b-a8107e9064c5",
                 "title": "Plugins",
@@ -6781,7 +6986,7 @@
                     "i": "46fbd106-9dba-4c2c-b359-fd04c22e1314",
                     "w": 40,
                     "x": 8,
-                    "y": 171
+                    "y": 183
                 },
                 "panelIndex": "46fbd106-9dba-4c2c-b359-fd04c22e1314",
                 "type": "lens"
@@ -6792,7 +6997,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:27:03.795Z",
+    "created_at": "2024-06-05T20:40:13.197Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "managed": false,
     "references": [
@@ -6814,6 +7019,11 @@
         {
             "id": "logstash-sm-metrics",
             "name": "6da9466a-ede0-44b6-a2e7-d704065bb90b:indexpattern-datasource-layer-d6fe4fea-e92e-4042-9c92-0663b598a523",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "6f7df80f-6315-417a-8b95-bbcdc938e4df:indexpattern-datasource-layer-4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
             "type": "index-pattern"
         },
         {

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -6997,9 +6997,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T20:40:13.197Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
+++ b/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"94cc8a2a-a81e-451b-891b-407075069331\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"94cc8a2a-a81e-451b-891b-407075069331\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"94cc8a2a-a81e-451b-891b-407075069331\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"94cc8a2a-a81e-451b-891b-407075069331\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}},\"73fdfb3a-3e86-499a-93f1-993479254e4e\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"73fdfb3a-3e86-499a-93f1-993479254e4e\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{},\"selectedOptions\":[]}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -41,7 +41,7 @@
                         "description": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n**[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)**  \n[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)\n\n\nOverview\n\nThis Dashboard gives an overall view of pipelines running on dashboards.  \n  \nClick on a pipeline in the table view to get more details on the running pipeline, and the plugins in that pipeline.",
+                            "markdown": "**Navigation** \n\n**Logstash Overview**\n\n[Overview](/app/dashboards#/view/logstash-79270240-48ee-11ee-8cb5-99927777c522)  \n[Nodes Overview](/app/dashboards#/view/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a)  \n[Node Overview](/app/dashboards#/view/logstash-9d450b10-4680-11ee-9ddc-919f87fe352d)  \n[Node Overview Advanced View](/app/dashboards#/view/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5)  \n\n**[Pipelines Overview](/app/dashboards#/view/logstash-c0594170-526a-11ee-9ecc-31444cb79548)**  \n[Pipeline Details Overview](/app/dashboards#/view/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc)\n\n\nOverview\n\nThis Dashboard gives an overall view of pipelines running on dashboards.  \n\nUse filters to narrow down on individual nodes\n  \nClick on a pipeline in the table view to get more details on the running pipeline, and the plugins in that pipeline.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -50,7 +50,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 37,
+                    "h": 46,
                     "i": "3edb2e9f-2807-4e65-9adc-259c15debce9",
                     "w": 8,
                     "x": 0,
@@ -1274,6 +1274,178 @@
             {
                 "embeddableConfig": {
                     "attributes": {
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
+                                    "layers": {
+                                        "4d13c1a7-6b92-47fe-8baf-7ca505bd9fda": {
+                                            "columnOrder": [
+                                                "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3",
+                                                "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5",
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececf",
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0"
+                                            ],
+                                            "columns": {
+                                                "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Pipeline Name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.name"
+                                                },
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececf": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Worker Utilization",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "number",
+                                                            "params": {
+                                                                "decimals": 2,
+                                                                "suffix": "%"
+                                                            }
+                                                        },
+                                                        "formula": "last_value(logstash.pipeline.total.flow.worker_utilization.last_1_minute)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "d9cd1ee6-586c-41b4-9d5f-976cd8eececfX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.total.flow.worker_utilization.last_1_minute\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of Worker Utilization",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.total.flow.worker_utilization.last_1_minute"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_STEP_AFTER",
+                                "hideEndzones": true,
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "d9cd1ee6-586c-41b4-9d5f-976cd8eececf"
+                                        ],
+                                        "layerId": "4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "splitAccessor": "31515c2b-a1f2-4da6-a5f7-f6f2ad8bc7d3",
+                                        "xAccessor": "1c9f4a0d-3d6f-4126-afbb-ba4745e565d5"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "showCurrentTimeMarker": false,
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": false,
+                                "yLeftExtent": {
+                                    "mode": "full",
+                                    "niceValues": true
+                                }
+                            }
+                        },
+                        "title": "Worker Utilization(%)",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "ea9af11b-6332-4b3c-bbe4-c6d8e9833985",
+                    "w": 40,
+                    "x": 8,
+                    "y": 21
+                },
+                "panelIndex": "ea9af11b-6332-4b3c-bbe4-c6d8e9833985",
+                "title": "Worker Utilization (%)",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
                         "description": "",
                         "references": [
                             {
@@ -1414,7 +1586,7 @@
                     "i": "1a42a8c2-9823-4178-90ae-f3a403b63711",
                     "w": 20,
                     "x": 8,
-                    "y": 21
+                    "y": 30
                 },
                 "panelIndex": "1a42a8c2-9823-4178-90ae-f3a403b63711",
                 "title": "Events received per second",
@@ -1664,158 +1836,10 @@
                     "i": "d290b2f1-1769-41f4-9d29-41755eef8871",
                     "w": 20,
                     "x": 28,
-                    "y": 21
+                    "y": 30
                 },
                 "panelIndex": "d290b2f1-1769-41f4-9d29-41755eef8871",
                 "title": "Persistent Queue utilization (%)",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "0dc38ed3-eda8-48d3-85d1-454d187be2f1": {
-                                            "columnOrder": [
-                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
-                                                "66ce1290-0494-4de1-b877-e672f10deaf3",
-                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29",
-                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
-                                            ],
-                                            "columns": {
-                                                "66ce1290-0494-4de1-b877-e672f10deaf3": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "logstash.pipeline.total.events.in: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Persistent Queue Event Count",
-                                                    "operationType": "counter_rate",
-                                                    "references": [
-                                                        "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Maximum of logstash.pipeline.total.queues.events",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.total.queues.events"
-                                                },
-                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100 values of logstash.pipeline.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 100
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "logstash.pipeline.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "curveType": "CURVE_MONOTONE_X",
-                                "fittingFunction": "Linear",
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "735d813f-2024-473c-bc2c-69cbcfb5ff29"
-                                        ],
-                                        "layerId": "0dc38ed3-eda8-48d3-85d1-454d187be2f1",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
-                                        "xAccessor": "66ce1290-0494-4de1-b877-e672f10deaf3"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "Empty XY chart",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
-                    "w": 20,
-                    "x": 28,
-                    "y": 29
-                },
-                "panelIndex": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
-                "title": "Persistent Queue size (events)",
                 "type": "lens"
             },
             {
@@ -1979,10 +2003,158 @@
                     "i": "09177cfd-5361-4e91-b7c3-64eeb7837ce8",
                     "w": 20,
                     "x": 8,
-                    "y": 29
+                    "y": 38
                 },
                 "panelIndex": "09177cfd-5361-4e91-b7c3-64eeb7837ce8",
                 "title": "Events emitted per second",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0dc38ed3-eda8-48d3-85d1-454d187be2f1": {
+                                            "columnOrder": [
+                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
+                                                "66ce1290-0494-4de1-b877-e672f10deaf3",
+                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29",
+                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
+                                            ],
+                                            "columns": {
+                                                "66ce1290-0494-4de1-b877-e672f10deaf3": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "logstash.pipeline.total.events.in: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Persistent Queue Event Count",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of logstash.pipeline.total.queues.events",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.total.queues.events"
+                                                },
+                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100 values of logstash.pipeline.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "735d813f-2024-473c-bc2c-69cbcfb5ff29"
+                                        ],
+                                        "layerId": "0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
+                                        "xAccessor": "66ce1290-0494-4de1-b877-e672f10deaf3"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
+                    "w": 20,
+                    "x": 28,
+                    "y": 38
+                },
+                "panelIndex": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
+                "title": "Persistent Queue size (events)",
                 "type": "lens"
             }
         ],
@@ -1991,7 +2163,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:26:54.958Z",
+    "created_at": "2024-06-05T20:51:12.261Z",
     "id": "logstash-c0594170-526a-11ee-9ecc-31444cb79548",
     "managed": false,
     "references": [
@@ -2032,6 +2204,11 @@
         },
         {
             "id": "logstash-sm-metrics",
+            "name": "ea9af11b-6332-4b3c-bbe4-c6d8e9833985:indexpattern-datasource-layer-4d13c1a7-6b92-47fe-8baf-7ca505bd9fda",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
             "name": "1a42a8c2-9823-4178-90ae-f3a403b63711:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
             "type": "index-pattern"
         },
@@ -2047,12 +2224,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "4017b8f5-f8f2-46b9-86fe-501f46d551c3:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+            "name": "09177cfd-5361-4e91-b7c3-64eeb7837ce8:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "09177cfd-5361-4e91-b7c3-64eeb7837ce8:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+            "name": "4017b8f5-f8f2-46b9-86fe-501f46d551c3:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
             "type": "index-pattern"
         },
         {

--- a/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
+++ b/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
@@ -58,8 +58,7 @@
                 },
                 "panelIndex": "3edb2e9f-2807-4e65-9adc-259c15debce9",
                 "title": "Logstash Nav Panel",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -159,8 +158,7 @@
                 },
                 "panelIndex": "5f909278-92f5-4ebc-bb18-8aca8f987733",
                 "title": "",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -235,8 +233,7 @@
                 },
                 "panelIndex": "239e17fa-3741-4bd5-a44c-6488c53c7c2b",
                 "title": "[Metrics Logstash] Nodes running pipelines viz",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -342,8 +339,7 @@
                 },
                 "panelIndex": "0134bb0e-0e1d-49ec-92d4-d775c64c7bdb",
                 "title": "[Metrics Logstash] Total Events Received viz ",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -449,8 +445,7 @@
                 },
                 "panelIndex": "8199ac33-4d5b-46e0-b3cd-3683204cc65c",
                 "title": "[Metrics Logstash] Total Events Emitted viz",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1027,8 +1022,7 @@
                 },
                 "panelIndex": "7f8d9886-3037-425d-bcb4-ae92a2b0d16e",
                 "title": "Pipelines",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1275,8 +1269,7 @@
                 },
                 "panelIndex": "6609ea37-a262-4072-ac19-90aabff49e12",
                 "title": "Average Time processed per event (ms)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1425,8 +1418,7 @@
                 },
                 "panelIndex": "1a42a8c2-9823-4178-90ae-f3a403b63711",
                 "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1672,12 +1664,159 @@
                     "i": "d290b2f1-1769-41f4-9d29-41755eef8871",
                     "w": 20,
                     "x": 28,
-                    "y": 22
+                    "y": 21
                 },
                 "panelIndex": "d290b2f1-1769-41f4-9d29-41755eef8871",
                 "title": "Persistent Queue utilization (%)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "0dc38ed3-eda8-48d3-85d1-454d187be2f1": {
+                                            "columnOrder": [
+                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
+                                                "66ce1290-0494-4de1-b877-e672f10deaf3",
+                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29",
+                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
+                                            ],
+                                            "columns": {
+                                                "66ce1290-0494-4de1-b877-e672f10deaf3": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "logstash.pipeline.total.events.in: *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Persistent Queue Event Count",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of logstash.pipeline.total.queues.events",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.total.queues.events"
+                                                },
+                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 100 values of logstash.pipeline.name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 100
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "curveType": "CURVE_MONOTONE_X",
+                                "fittingFunction": "Linear",
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "735d813f-2024-473c-bc2c-69cbcfb5ff29"
+                                        ],
+                                        "layerId": "0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
+                                        "xAccessor": "66ce1290-0494-4de1-b877-e672f10deaf3"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "line",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 8,
+                    "i": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
+                    "w": 20,
+                    "x": 28,
+                    "y": 29
+                },
+                "panelIndex": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
+                "title": "Persistent Queue size (events)",
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1844,157 +1983,7 @@
                 },
                 "panelIndex": "09177cfd-5361-4e91-b7c3-64eeb7837ce8",
                 "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "0dc38ed3-eda8-48d3-85d1-454d187be2f1": {
-                                            "columnOrder": [
-                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
-                                                "66ce1290-0494-4de1-b877-e672f10deaf3",
-                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29",
-                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
-                                            ],
-                                            "columns": {
-                                                "66ce1290-0494-4de1-b877-e672f10deaf3": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "735d813f-2024-473c-bc2c-69cbcfb5ff29": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "logstash.pipeline.total.events.in: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Persistent Queue Event Count",
-                                                    "operationType": "counter_rate",
-                                                    "references": [
-                                                        "88e7718d-261a-4cf0-8558-ae0bfbe0cae0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "88e7718d-261a-4cf0-8558-ae0bfbe0cae0": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Maximum of logstash.pipeline.total.queues.events",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.pipeline.total.queues.events"
-                                                },
-                                                "c10baf86-fe98-4d07-b5da-cc4c8b0f901e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 100 values of logstash.pipeline.name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 100
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "logstash.pipeline.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "curveType": "CURVE_MONOTONE_X",
-                                "fittingFunction": "Linear",
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "735d813f-2024-473c-bc2c-69cbcfb5ff29"
-                                        ],
-                                        "layerId": "0dc38ed3-eda8-48d3-85d1-454d187be2f1",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "c10baf86-fe98-4d07-b5da-cc4c8b0f901e",
-                                        "xAccessor": "66ce1290-0494-4de1-b877-e672f10deaf3"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "line",
-                                "title": "Empty XY chart",
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 8,
-                    "i": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
-                    "w": 20,
-                    "x": 28,
-                    "y": 28
-                },
-                "panelIndex": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
-                "title": "Persistent Queue size (events)",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -2002,7 +1991,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:15:45.734Z",
+    "created_at": "2024-06-05T19:26:54.958Z",
     "id": "logstash-c0594170-526a-11ee-9ecc-31444cb79548",
     "managed": false,
     "references": [
@@ -2058,12 +2047,12 @@
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "09177cfd-5361-4e91-b7c3-64eeb7837ce8:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+            "name": "4017b8f5-f8f2-46b9-86fe-501f46d551c3:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
-            "name": "4017b8f5-f8f2-46b9-86fe-501f46d551c3:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
+            "name": "09177cfd-5361-4e91-b7c3-64eeb7837ce8:indexpattern-datasource-layer-0dc38ed3-eda8-48d3-85d1-454d187be2f1",
             "type": "index-pattern"
         },
         {

--- a/packages/logstash/kibana/dashboard/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a.json
+++ b/packages/logstash/kibana/dashboard/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"55797c81-115d-42f4-8b92-a90449de3183\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"55797c81-115d-42f4-8b92-a90449de3183\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}},\"ffddbdfd-c666-4a7c-b81d-c66cb20212f4\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"ffddbdfd-c666-4a7c-b81d-c66cb20212f4\",\"fieldName\":\"logstash.pipeline.name\",\"title\":\"Logstash Pipeline Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
+            "panelsJSON": "{\"55797c81-115d-42f4-8b92-a90449de3183\":{\"type\":\"optionsListControl\",\"order\":0,\"grow\":true,\"width\":\"medium\",\"explicitInput\":{\"id\":\"55797c81-115d-42f4-8b92-a90449de3183\",\"fieldName\":\"logstash.host.name\",\"title\":\"Logstash Host Name\",\"grow\":true,\"width\":\"medium\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -1519,9 +1519,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T20:51:50.090Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-ee860840-41ed-11ee-874b-fdb94cc3273a",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",
@@ -1571,11 +1571,6 @@
         {
             "id": "logstash-sm-metrics",
             "name": "controlGroup_55797c81-115d-42f4-8b92-a90449de3183:optionsListDataView",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logstash-sm-metrics",
-            "name": "controlGroup_ffddbdfd-c666-4a7c-b81d-c66cb20212f4:optionsListDataView",
             "type": "index-pattern"
         }
     ],

--- a/packages/logstash/kibana/dashboard/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a.json
+++ b/packages/logstash/kibana/dashboard/logstash-ee860840-41ed-11ee-874b-fdb94cc3273a.json
@@ -58,8 +58,7 @@
                     "y": 0
                 },
                 "panelIndex": "3175d525-4aa7-40b5-bc68-d89d105257de",
-                "type": "visualization",
-                "version": "8.10.1"
+                "type": "visualization"
             },
             {
                 "embeddableConfig": {
@@ -129,8 +128,7 @@
                     "y": 0
                 },
                 "panelIndex": "8302492d-1d16-4955-91cd-c892d7002dbb",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -240,8 +238,7 @@
                 },
                 "panelIndex": "345f1c7e-4b91-4df2-8c09-22d2a8c5d6be",
                 "title": "Total JVM Heap Used",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -347,8 +344,7 @@
                 },
                 "panelIndex": "b1f30ec6-50f8-4fb0-8ebf-c00b1df332ee",
                 "title": "Total Events Received",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -454,8 +450,7 @@
                 },
                 "panelIndex": "5eedee54-06fd-496e-8b1d-b3df3ff80341",
                 "title": "Total Events Emitted",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -897,375 +892,10 @@
                     "i": "4a093412-9812-433a-bf8d-225e4a402339",
                     "w": 40,
                     "x": 8,
-                    "y": 5
+                    "y": 4
                 },
                 "panelIndex": "4a093412-9812-433a-bf8d-225e4a402339",
-                "type": "lens",
-                "version": "8.10.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425": {
-                                            "columnOrder": [
-                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84",
-                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
-                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1",
-                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
-                                            ],
-                                            "columns": {
-                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "logstash.node.stats.events.in : *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Events Received Rate",
-                                                    "operationType": "counter_rate",
-                                                    "references": [
-                                                        "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": "s"
-                                                },
-                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Maximum of logstash.node.stats.events.in",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.node.stats.events.in"
-                                                },
-                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Node name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 1000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "logstash.node.stats.logstash.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "hideEndzones": true,
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0c423bdf-578e-4f0a-bb27-180a24a133e1"
-                                        ],
-                                        "collapseFn": "",
-                                        "layerId": "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ef4e5445-487e-4a0c-ac01-063e8c199a84",
-                                        "xAccessor": "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
-                                        "yConfig": [
-                                            {
-                                                "color": "#ff0000",
-                                                "forAccessor": "0c423bdf-578e-4f0a-bb27-180a24a133e1"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom",
-                                    "shouldTruncate": false,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "yLeftExtent": {
-                                    "mode": "dataBounds"
-                                }
-                            }
-                        },
-                        "title": "Events Received Rate/s",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "fef0f0cc-45df-4389-9c13-78b56790905c",
-                    "w": 20,
-                    "x": 8,
-                    "y": 15
-                },
-                "panelIndex": "fef0f0cc-45df-4389-9c13-78b56790905c",
-                "title": "Events received per second",
-                "type": "lens",
-                "version": "8.10.1"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "description": "",
-                        "references": [
-                            {
-                                "id": "logstash-sm-metrics",
-                                "name": "indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425": {
-                                            "columnOrder": [
-                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84",
-                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
-                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1",
-                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
-                                            ],
-                                            "columns": {
-                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "logstash.node.stats.events.in : *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Events Emitted Rate",
-                                                    "operationType": "counter_rate",
-                                                    "references": [
-                                                        "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": "s"
-                                                },
-                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Maximum of logstash.node.stats.events.out",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "logstash.node.stats.events.out"
-                                                },
-                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Node name",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 1000
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "logstash.node.stats.logstash.name"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "hideEndzones": true,
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "0c423bdf-578e-4f0a-bb27-180a24a133e1"
-                                        ],
-                                        "collapseFn": "",
-                                        "layerId": "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "ef4e5445-487e-4a0c-ac01-063e8c199a84",
-                                        "xAccessor": "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
-                                        "yConfig": [
-                                            {
-                                                "color": "#ff0000",
-                                                "forAccessor": "0c423bdf-578e-4f0a-bb27-180a24a133e1"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "bottom",
-                                    "shouldTruncate": false,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "line",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide",
-                                "yLeftExtent": {
-                                    "mode": "dataBounds"
-                                }
-                            }
-                        },
-                        "title": "Events Emitted Rate/s",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 10,
-                    "i": "acdc425f-0de2-46b6-8d9e-5dccdcb99270",
-                    "w": 20,
-                    "x": 8,
-                    "y": 25
-                },
-                "panelIndex": "acdc425f-0de2-46b6-8d9e-5dccdcb99270",
-                "title": "Events emitted per second",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
             },
             {
                 "embeddableConfig": {
@@ -1515,12 +1145,373 @@
                     "i": "7bfdba6c-bcdc-4c51-be8c-41188c08dc6c",
                     "w": 20,
                     "x": 28,
-                    "y": 9
+                    "y": 14
                 },
                 "panelIndex": "7bfdba6c-bcdc-4c51-be8c-41188c08dc6c",
                 "title": "Events Latency (ms) average",
-                "type": "lens",
-                "version": "8.10.1"
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425": {
+                                            "columnOrder": [
+                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84",
+                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
+                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1",
+                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
+                                            ],
+                                            "columns": {
+                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "logstash.node.stats.events.in : *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Events Received Rate",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of logstash.node.stats.events.in",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.node.stats.events.in"
+                                                },
+                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Node name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 1000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.node.stats.logstash.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "hideEndzones": true,
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0c423bdf-578e-4f0a-bb27-180a24a133e1"
+                                        ],
+                                        "collapseFn": "",
+                                        "layerId": "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "ef4e5445-487e-4a0c-ac01-063e8c199a84",
+                                        "xAccessor": "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
+                                        "yConfig": [
+                                            {
+                                                "color": "#ff0000",
+                                                "forAccessor": "0c423bdf-578e-4f0a-bb27-180a24a133e1"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "bottom",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "dataBounds"
+                                }
+                            }
+                        },
+                        "title": "Events Received Rate/s",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "fef0f0cc-45df-4389-9c13-78b56790905c",
+                    "w": 20,
+                    "x": 8,
+                    "y": 14
+                },
+                "panelIndex": "fef0f0cc-45df-4389-9c13-78b56790905c",
+                "title": "Events received per second",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425": {
+                                            "columnOrder": [
+                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84",
+                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
+                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1",
+                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
+                                            ],
+                                            "columns": {
+                                                "0c423bdf-578e-4f0a-bb27-180a24a133e1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "logstash.node.stats.events.in : *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Events Emitted Rate",
+                                                    "operationType": "counter_rate",
+                                                    "references": [
+                                                        "cd7a8cba-084f-42b4-a4b5-334eee79e32e"
+                                                    ],
+                                                    "scale": "ratio",
+                                                    "timeScale": "s"
+                                                },
+                                                "43c45a77-5bb2-4f66-8bfd-77f3cf386a87": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "cd7a8cba-084f-42b4-a4b5-334eee79e32e": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Maximum of logstash.node.stats.events.out",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.node.stats.events.out"
+                                                },
+                                                "ef4e5445-487e-4a0c-ac01-063e8c199a84": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Node name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 1000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.node.stats.logstash.name"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "hideEndzones": true,
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "0c423bdf-578e-4f0a-bb27-180a24a133e1"
+                                        ],
+                                        "collapseFn": "",
+                                        "layerId": "9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "ef4e5445-487e-4a0c-ac01-063e8c199a84",
+                                        "xAccessor": "43c45a77-5bb2-4f66-8bfd-77f3cf386a87",
+                                        "yConfig": [
+                                            {
+                                                "color": "#ff0000",
+                                                "forAccessor": "0c423bdf-578e-4f0a-bb27-180a24a133e1"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "bottom",
+                                    "shouldTruncate": false,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "line",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide",
+                                "yLeftExtent": {
+                                    "mode": "dataBounds"
+                                }
+                            }
+                        },
+                        "title": "Events Emitted Rate/s",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 10,
+                    "i": "acdc425f-0de2-46b6-8d9e-5dccdcb99270",
+                    "w": 20,
+                    "x": 8,
+                    "y": 24
+                },
+                "panelIndex": "acdc425f-0de2-46b6-8d9e-5dccdcb99270",
+                "title": "Events emitted per second",
+                "type": "lens"
             }
         ],
         "timeRestore": false,
@@ -1528,7 +1519,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:16:38.088Z",
+    "created_at": "2024-06-05T20:51:50.090Z",
     "id": "logstash-ee860840-41ed-11ee-874b-fdb94cc3273a",
     "managed": false,
     "references": [
@@ -1564,17 +1555,17 @@
         },
         {
             "id": "logstash-sm-metrics",
+            "name": "7bfdba6c-bcdc-4c51-be8c-41188c08dc6c:indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
             "name": "fef0f0cc-45df-4389-9c13-78b56790905c:indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
             "type": "index-pattern"
         },
         {
             "id": "logstash-sm-metrics",
             "name": "acdc425f-0de2-46b6-8d9e-5dccdcb99270:indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logstash-sm-metrics",
-            "name": "7bfdba6c-bcdc-4c51-be8c-41188c08dc6c:indexpattern-datasource-layer-9f4942e8-bd51-41fe-9e6b-c6ca7ee81425",
             "type": "index-pattern"
         },
         {

--- a/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
@@ -934,9 +934,9 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T19:53:54.453Z",
+    "created_at": "2024-06-12T18:52:56.240Z",
     "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
@@ -934,7 +934,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T18:56:00.387Z",
+    "created_at": "2024-06-05T19:53:54.453Z",
     "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
@@ -936,7 +936,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2023-10-26T14:38:12.893Z",
     "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
+++ b/packages/logstash/kibana/dashboard/logstash-fe17b800-6eb4-11ee-86f6-d7074508d975.json
@@ -934,7 +934,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-10-26T14:38:12.893Z",
+    "created_at": "2024-06-05T18:56:00.387Z",
     "id": "logstash-fe17b800-6eb4-11ee-86f6-d7074508d975",
     "managed": false,
     "references": [

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.8
+version: 2.4.9
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -9,14 +9,14 @@ icons:
     size: 32x32
     type: image/svg+xml
 format_version: 3.0.0
-categories: ["elastic_stack"]
+categories:
+  - observability
+  - elastic_stack
 conditions:
   kibana:
     version: ^8.10.1
   elastic:
     subscription: basic
-    capabilities:
-      - observability
 owner:
   github: elastic/stack-monitoring
   type: elastic


### PR DESCRIPTION
This commit adds support for pipeline level worker utilization from the Logstash API

This involves

* Adding mapping to the fields for the worker_utilization metrics in the pipeline datastream
* Adding exclusions to the ingest pipeline to tidy up the data coming in
* Adding visualizations to the `pipelines` and `single pipeline view` dashboards

Additionally, this PR removes some incorrect flow metrics from the dashboards - previously, the summary tables in the pipeline details view would show flow metrics _summing_ all data across the picker time period, giving a nonsense value.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Install the integration, and point to a recent version of Logstash. Verify that the `worker_utilization` visualizations are present, and reflect the data from the version of Logstash

## Related issues

Relates #10028  
Closes #10029
 

## Screenshots
Worker Utilization in `Pipelines Overview`
<img width="1206" alt="Screenshot 2024-06-07 at 2 35 59 PM" src="https://github.com/elastic/integrations/assets/4061337/5826e5ac-625b-47c1-9ab9-537fe0c54a19">

Worker Utilization in `Single Pipeline View`
<img width="1201" alt="Screenshot 2024-06-07 at 2 36 13 PM" src="https://github.com/elastic/integrations/assets/4061337/87a64894-d73c-4ace-bc47-e14398647b67">


