### PR TITLE
[Buildkite] Update default timeout for pipeline serverless

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -49,7 +49,7 @@ steps:
   - label: "Check integrations in serverless"
     key: "test-integrations-serverless-project"
     command: ".buildkite/scripts/test_integrations_with_serverless.sh"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 240
     env:
       SERVERLESS: true
       FORCE_CHECK_ALL: true


### PR DESCRIPTION
## Proposed commit message

Update default timeout for serverless step up to 4 hours.
The last 2 builds were failing due to hit that timeout
- https://buildkite.com/elastic/integrations-schedule-daily/builds/229
- https://buildkite.com/elastic/integrations-schedule-daily/builds/230
