### PR TITLE
Replace Azure AD with Microsoft Entra ID

### DIFF
--- a/packages/azure_billing/_dev/build/docs/README.md
+++ b/packages/azure_billing/_dev/build/docs/README.md
@@ -54,7 +54,7 @@ Set up a new app registration in Azure.
 To create the app registration:
 
 1. Sign in to the [Azure Portal](https://portal.azure.com/).
-2. Search for and select **Azure Active Directory**.
+2. Search for and select **Microsoft Entra ID**.
 3. Under **Manage**, select **App registrations** > **New registration**.
 4. Enter a display _Name_ for your application (for example, "elastic-agent").
 5. Specify who can use the application.

--- a/packages/azure_billing/changelog.yml
+++ b/packages/azure_billing/changelog.yml
@@ -1,3 +1,8 @@
+- version: 1.5.1
+  changes:
+    - description: Replace Azure AD with Microsoft Entra ID
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10142
 - version: 1.5.0
   changes:
     - description: Enable secrets for sensitive fields. For more details, refer https://www.elastic.co/guide/en/fleet/current/agent-policy.html#agent-policy-secret-values

--- a/packages/azure_billing/docs/README.md
+++ b/packages/azure_billing/docs/README.md
@@ -54,7 +54,7 @@ Set up a new app registration in Azure.
 To create the app registration:
 
 1. Sign in to the [Azure Portal](https://portal.azure.com/).
-2. Search for and select **Azure Active Directory**.
+2. Search for and select **Microsoft Entra ID**.
 3. Under **Manage**, select **App registrations** > **New registration**.
 4. Enter a display _Name_ for your application (for example, "elastic-agent").
 5. Specify who can use the application.

--- a/packages/azure_billing/manifest.yml
+++ b/packages/azure_billing/manifest.yml
@@ -1,6 +1,6 @@
 name: azure_billing
 title: Azure Billing Metrics
-version: "1.5.0"
+version: "1.5.1"
 description: Collect billing metrics with Elastic Agent.
 type: integration
 icons:

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -107,7 +107,7 @@ To start collecting data with this integration, you need to:
 To create a new app registration:
 
 1. Sign in to the [Azure Portal](https://portal.azure.com/).
-2. Search for and select **Azure Active Directory**.
+2. Search for and select **Microsoft Entra ID**.
 3. Under **Manage**, select **App registrations** > **New registration**.
 4. Enter a display _Name_ for your application (for example, "elastic-agent").
 5. Specify who can use the application.

--- a/packages/azure_functions/changelog.yml
+++ b/packages/azure_functions/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.4.2
+  changes:
+    - description: Replace Azure AD with Microsoft Entra ID.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10142
 - version: 0.4.1
   changes:
     - description: Remove Add Cloud Metadata flag from agent config.

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -214,7 +214,7 @@ To start collecting data with this integration, you need to:
 To create a new app registration:
 
 1. Sign in to the [Azure Portal](https://portal.azure.com/).
-2. Search for and select **Azure Active Directory**.
+2. Search for and select **Microsoft Entra ID**.
 3. Under **Manage**, select **App registrations** > **New registration**.
 4. Enter a display _Name_ for your application (for example, "elastic-agent").
 5. Specify who can use the application.

--- a/packages/azure_functions/manifest.yml
+++ b/packages/azure_functions/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: azure_functions
 title: "Azure Functions"
-version: "0.4.1"
+version: "0.4.2"
 source:
   license: "Elastic-2.0"
 description: "Get metrics and logs from Azure Functions"


### PR DESCRIPTION

This PR replaces `Azure AD` with `Microsoft Entra ID` on the [Azure Billing Metrics](https://www.elastic.co/docs/current/integrations/azure_billing#setup) page.

Relates https://github.com/elastic/integration-docs/issues/438
