### PR TITLE
[PANW] Bug - fix grok parser for panw audit logs

### DIFF
--- a/packages/panw/changelog.yml
+++ b/packages/panw/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.26.1"
+  changes:
+    - description: fix grok parser for audit-logs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10140
 - version: "3.26.0"
   changes:
     - description: Improve handling of urls and filenames when parsing anti-virus events.

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log
@@ -1,2 +1,4 @@
 Apr 11 20:06:15 192.168.0.1 01111111111,2024/04/11 20:06:15,audit,2561,gui-op,suser,"<debug><dataplane><packet-diag><show><setting/></show></packet-diag></dataplane></debug>",success
 Apr 18 18:35:20 10.1.1.1 003001000000,2024/04/18 18:35:20,audit,2561,gui-op,Mustang,"<show><config-locks><vsys>all</vsys></config-locks></show>",success
+Apr 18 18:36:20 test-hostname 003001000000,2024/04/18 18:36:20,audit,2561,gui-op,Mustang,"<show><config-locks><vsys>all</vsys></config-locks></show>",success
+Apr 18 18:37:20 test-hostname.test.intra 003001000000,2024/04/18 18:37:20,audit,2561,gui-op,Mustang,"<show><config-locks><vsys>all</vsys></config-locks></show>",success

--- a/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
+++ b/packages/panw/data_stream/panos/_dev/test/pipeline/test-panw-panos-audit-sample.log-expected.json
@@ -16,10 +16,8 @@
                 "timezone": "-04:00"
             },
             "message": "2561,gui-op,suser,\"<debug><dataplane><packet-diag><show><setting/></show></packet-diag></dataplane></debug>\",success",
-            "network": {
-                "type": "ipv4"
-            },
             "observer": {
+                "hostname": "192.168.0.1",
                 "product": "PAN-OS",
                 "serial_number": "01111111111",
                 "type": "firewall",
@@ -34,12 +32,9 @@
                 }
             },
             "related": {
-                "ip": [
+                "hosts": [
                     "192.168.0.1"
                 ]
-            },
-            "source": {
-                "ip": "192.168.0.1"
             },
             "tags": [
                 "preserve_original_event"
@@ -64,10 +59,8 @@
                 "timezone": "-04:00"
             },
             "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
-            "network": {
-                "type": "ipv4"
-            },
             "observer": {
+                "hostname": "10.1.1.1",
                 "product": "PAN-OS",
                 "serial_number": "003001000000",
                 "type": "firewall",
@@ -82,12 +75,95 @@
                 }
             },
             "related": {
-                "ip": [
+                "hosts": [
                     "10.1.1.1"
                 ]
             },
-            "source": {
-                "ip": "10.1.1.1"
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Mustang"
+            }
+        },
+        {
+            "@timestamp": "2024-04-18T18:36:20.000-04:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "configuration"
+                ],
+                "created": "2024-04-18T14:36:20.000-04:00",
+                "kind": "event",
+                "original": "Apr 18 18:36:20 test-hostname 003001000000,2024/04/18 18:36:20,audit,2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
+                "outcome": "success",
+                "timezone": "-04:00"
+            },
+            "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
+            "observer": {
+                "hostname": "test-hostname",
+                "product": "PAN-OS",
+                "serial_number": "003001000000",
+                "type": "firewall",
+                "vendor": "Palo Alto Networks"
+            },
+            "panw": {
+                "panos": {
+                    "cmd": "<show><config-locks><vsys>all</vsys></config-locks></show>",
+                    "cmd_source": "gui-op",
+                    "config_version": "2561",
+                    "type": "AUDIT"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "test-hostname"
+                ]
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user": {
+                "name": "Mustang"
+            }
+        },
+        {
+            "@timestamp": "2024-04-18T18:37:20.000-04:00",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "configuration"
+                ],
+                "created": "2024-04-18T14:37:20.000-04:00",
+                "kind": "event",
+                "original": "Apr 18 18:37:20 test-hostname.test.intra 003001000000,2024/04/18 18:37:20,audit,2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
+                "outcome": "success",
+                "timezone": "-04:00"
+            },
+            "message": "2561,gui-op,Mustang,\"<show><config-locks><vsys>all</vsys></config-locks></show>\",success",
+            "observer": {
+                "hostname": "test-hostname.test.intra",
+                "product": "PAN-OS",
+                "serial_number": "003001000000",
+                "type": "firewall",
+                "vendor": "Palo Alto Networks"
+            },
+            "panw": {
+                "panos": {
+                    "cmd": "<show><config-locks><vsys>all</vsys></config-locks></show>",
+                    "cmd_source": "gui-op",
+                    "config_version": "2561",
+                    "type": "AUDIT"
+                }
+            },
+            "related": {
+                "hosts": [
+                    "test-hostname.test.intra"
+                ]
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/panw/data_stream/panos/elasticsearch/ingest_pipeline/default.yml
@@ -31,7 +31,7 @@ processors:
       field: _temp_.message
       patterns:
         - "^%{DATA},%{TIMESTAMP:event.created},%{FIELD:observer.serial_number},%{FIELD:panw.panos.type},(?:%{FIELD:panw.panos.sub_type})?,%{FIELD:_temp_.config_version},%{TIMESTAMP:_temp_.generated_time},%{GREEDYDATA:message}$"
-        - "^%{SYSLOGTIMESTAMP:_temp_.syslog_time} %{IP:source.ip} %{NOTSPACE:observer.serial_number},%{PANW_DATE:_temp_.generated_time},%{FIELD:panw.panos.type},%{GREEDYDATA:message}$"
+        - "^%{SYSLOGTIMESTAMP:_temp_.syslog_time} %{IPORHOST:observer.hostname} %{NOTSPACE:observer.serial_number},%{PANW_DATE:_temp_.generated_time},%{FIELD:panw.panos.type},%{GREEDYDATA:message}$"
       pattern_definitions:
         TIMESTAMP: "%{PANW_DATE}|%{TIMESTAMP_ISO8601}"
         PANW_DATE: "%{YEAR}/%{MONTHNUM}/%{MONTHDAY} %{TIME}"

--- a/packages/panw/manifest.yml
+++ b/packages/panw/manifest.yml
@@ -1,6 +1,6 @@
 name: panw
 title: Palo Alto Next-Gen Firewall
-version: "3.26.0"
+version: "3.26.1"
 description: Collect logs from Palo Alto next-gen firewalls with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
fix grok parser for panw audit-logs.

The new grok-parser for the panw audit-logs is a bit buggy/not completely correct. there are two problems with using `%{IP:source.ip}` to parse the syslog-senders name/ip:
- this field can be either an ip-address or hostname/fqdn, `%{ip}` can't parse hostnames and ecs-field `source.ip` is of type `ip`
- in this case this field is the `observer` and not the `source`


## Checklist


## Author's Checklist

- [ ] 

## How to test this PR locally
just run the pipelinetest with elastic-package

## Related issues
- Relates #9663

## Screenshots
