### PR TITLE
[Logstash] Add pipeline info to pipeline screen

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.10"
+  changes:
+    - description: Add Pipeline information to Pipelines View page
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10164
 - version: "2.4.9"
   changes:
     - description: Add pipeline level worker utilization graphs, and remove incorrect flow metrics information

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -1,6 +1,6 @@
 config_version: "2"
 interval: {{period}}
-resource.url: "{{url}}/_node/stats?graph=true&vertices=true"
+resource.url: "{{url}}/_node"
 {{#if resource_ssl}}
 resource.ssl:
   {{resource_ssl}}
@@ -21,9 +21,17 @@ redact:
 
 
 program: |
-  get(state.url).as(resp, bytes(resp.Body).decode_json().as(body,
+  get(state.url + "/stats?graph=true&vertices=true").as(resp, bytes(resp.Body).decode_json().as(body,
     body.pipelines.map(pipeline_name, pipeline_name != ".monitoring-logstash", {
       "name": pipeline_name,
+      "info": get(state.url + "/pipelines/" + pipeline_name).as(resp,
+        bytes(resp.Body).decode_json().as(pipes,
+          has(pipes.pipeline) && has (pipes.pipelines) ?
+            pipes.pipelines[pipeline_name]
+          :
+            []
+        )
+      ),
       "elasticsearch.cluster.id": has(body.pipelines[pipeline_name].vertices) ?
         body.pipelines[pipeline_name].vertices.map(vertex, has(vertex.cluster_uuid), vertex.cluster_uuid)
       :

--- a/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
+++ b/packages/logstash/data_stream/pipeline/agent/stream/cel.yml.hbs
@@ -26,7 +26,7 @@ program: |
       "name": pipeline_name,
       "info": get(state.url + "/pipelines/" + pipeline_name).as(resp,
         bytes(resp.Body).decode_json().as(pipes,
-          has(pipes.pipeline) && has (pipes.pipelines) ?
+          has(pipes.pipelines) ?
             pipes.pipelines[pipeline_name]
           :
             []

--- a/packages/logstash/data_stream/pipeline/fields/fields.yml
+++ b/packages/logstash/data_stream/pipeline/fields/fields.yml
@@ -8,6 +8,23 @@
     - name: elasticsearch.cluster.id
       type: keyword
       description: Elasticsearch clusters this Logstash pipeline is attached to
+    - name: info
+      description: Information about a Logstash Pipeline
+      type: group
+      fields:
+        - name: batch_size
+          type: long
+          description: Batch size for the running pipeline
+        - name: batch_delay
+          type: long
+          description: Batch delay for the running pipeline
+        - name: workers
+          type: long
+          description: Number of workers for the running pipeline
+        - name: ephemeral_id
+          type: keyword
+          dimension: true
+          description: Ephemeral Id for the running pipeline
     - name: host
       description: Information about the host running the pipeline
       type: group

--- a/packages/logstash/docs/README.md
+++ b/packages/logstash/docs/README.md
@@ -881,6 +881,10 @@ This is the `pipeline` dataset, which drives the Pipeline dashboard pages.
 | logstash.pipeline.elasticsearch.cluster.id | Elasticsearch clusters this Logstash pipeline is attached to | keyword |  |  |
 | logstash.pipeline.host.address | address hosting this instance of logstash | keyword |  |  |
 | logstash.pipeline.host.name | Host name of the node running logstash | keyword |  |  |
+| logstash.pipeline.info.batch_delay | Batch delay for the running pipeline | long |  |  |
+| logstash.pipeline.info.batch_size | Batch size for the running pipeline | long |  |  |
+| logstash.pipeline.info.ephemeral_id | Ephemeral Id for the running pipeline | keyword |  |  |
+| logstash.pipeline.info.workers | Number of workers for the running pipeline | long |  |  |
 | logstash.pipeline.name | Logstash Pipeline id/name | keyword |  |  |
 | logstash.pipeline.total.events.filtered | Number of events filtered by the pipeline | long |  | counter |
 | logstash.pipeline.total.events.in | Number of events received by the pipeline | long |  | counter |

--- a/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
+++ b/packages/logstash/kibana/dashboard/logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5.json
@@ -1761,7 +1761,7 @@
     "coreMigrationVersion": "8.8.0",
     "created_at": "2024-06-05T19:53:56.470Z",
     "id": "logstash-a42d7060-45e6-11ee-957b-3720c0b0fbc5",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
+++ b/packages/logstash/kibana/dashboard/logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc.json
@@ -50,7 +50,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 183,
+                    "h": 195,
                     "i": "1b7d4c91-b582-4639-a771-7853e72a94b6",
                     "w": 8,
                     "x": 0,
@@ -6997,7 +6997,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-12T18:52:56.240Z",
+    "created_at": "2024-06-13T20:58:43.098Z",
     "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
     "managed": true,
     "references": [

--- a/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
+++ b/packages/logstash/kibana/dashboard/logstash-c0594170-526a-11ee-9ecc-31444cb79548.json
@@ -50,7 +50,7 @@
                     }
                 },
                 "gridData": {
-                    "h": 46,
+                    "h": 53,
                     "i": "3edb2e9f-2807-4e65-9adc-259c15debce9",
                     "w": 8,
                     "x": 0,
@@ -445,6 +445,242 @@
                 },
                 "panelIndex": "8199ac33-4d5b-46e0-b3cd-3683204cc65c",
                 "title": "[Metrics Logstash] Total Events Emitted viz",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "description": "",
+                        "references": [
+                            {
+                                "id": "logstash-sm-metrics",
+                                "name": "indexpattern-datasource-layer-af02f11d-c2e6-46a1-87fc-76139bbe0998",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "logstash-sm-metrics",
+                                    "layers": {
+                                        "af02f11d-c2e6-46a1-87fc-76139bbe0998": {
+                                            "columnOrder": [
+                                                "2b095037-5d7d-4cb4-a265-afb041616816",
+                                                "aebb5ff5-0a64-4ab9-9eb1-d62a05caa84b",
+                                                "e473562a-74f9-4f25-b1b3-c3af641bc4a9",
+                                                "c7ebb950-07b9-434c-b257-6d9e8fbc7feb",
+                                                "86a537af-27a7-487e-bc70-bba77171e65c",
+                                                "ad2e68ef-89fe-401f-b470-341b6f720797"
+                                            ],
+                                            "columns": {
+                                                "2b095037-5d7d-4cb4-a265-afb041616816": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Pipeline name",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "columnId": "aebb5ff5-0a64-4ab9-9eb1-d62a05caa84b",
+                                                            "type": "column"
+                                                        },
+                                                        "orderDirection": "desc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 1000
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.name"
+                                                },
+                                                "86a537af-27a7-487e-bc70-bba77171e65c": {
+                                                    "customLabel": true,
+                                                    "dataType": "string",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.total.queues.type\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Queue Type",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "logstash.pipeline.total.queues.type"
+                                                },
+                                                "ad2e68ef-89fe-401f-b470-341b6f720797": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.total.queues.type\": \"persisted\" "
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Queue Size",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.total.queues.current_size.bytes"
+                                                },
+                                                "aebb5ff5-0a64-4ab9-9eb1-d62a05caa84b": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.info.workers\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Workers",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.info.workers"
+                                                },
+                                                "c7ebb950-07b9-434c-b257-6d9e8fbc7feb": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.info.batch_delay\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Batch Delay",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.info.batch_delay"
+                                                },
+                                                "e473562a-74f9-4f25-b1b3-c3af641bc4a9": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"logstash.pipeline.info.batch_size\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Batch Size",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "logstash.pipeline.info.batch_size"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "logstash-sm-metrics",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "columns": [
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "2b095037-5d7d-4cb4-a265-afb041616816",
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "aebb5ff5-0a64-4ab9-9eb1-d62a05caa84b",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "e473562a-74f9-4f25-b1b3-c3af641bc4a9",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "c7ebb950-07b9-434c-b257-6d9e8fbc7feb",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "86a537af-27a7-487e-bc70-bba77171e65c",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    },
+                                    {
+                                        "alignment": "center",
+                                        "columnId": "ad2e68ef-89fe-401f-b470-341b6f720797",
+                                        "isMetric": true,
+                                        "isTransposed": false
+                                    }
+                                ],
+                                "layerId": "af02f11d-c2e6-46a1-87fc-76139bbe0998",
+                                "layerType": "data"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsDatatable"
+                    },
+                    "enhancements": {
+                        "dynamicActions": {
+                            "events": [
+                                {
+                                    "action": {
+                                        "config": {
+                                            "openInNewTab": true,
+                                            "useCurrentDateRange": true,
+                                            "useCurrentFilters": true
+                                        },
+                                        "factoryId": "DASHBOARD_TO_DASHBOARD_DRILLDOWN",
+                                        "name": "Go to Dashboard"
+                                    },
+                                    "eventId": "ace863df-5d1f-415c-a5d0-cecc3e9beedd",
+                                    "triggers": [
+                                        "FILTER_TRIGGER"
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 7,
+                    "i": "1e868693-305b-40f1-bbbc-28d249bba95a",
+                    "w": 40,
+                    "x": 8,
+                    "y": 5
+                },
+                "panelIndex": "1e868693-305b-40f1-bbbc-28d249bba95a",
+                "title": "Pipelines Info",
                 "type": "lens"
             },
             {
@@ -1018,7 +1254,7 @@
                     "i": "7f8d9886-3037-425d-bcb4-ae92a2b0d16e",
                     "w": 40,
                     "x": 8,
-                    "y": 5
+                    "y": 12
                 },
                 "panelIndex": "7f8d9886-3037-425d-bcb4-ae92a2b0d16e",
                 "title": "Pipelines",
@@ -1265,7 +1501,7 @@
                     "i": "6609ea37-a262-4072-ac19-90aabff49e12",
                     "w": 40,
                     "x": 8,
-                    "y": 12
+                    "y": 19
                 },
                 "panelIndex": "6609ea37-a262-4072-ac19-90aabff49e12",
                 "title": "Average Time processed per event (ms)",
@@ -1437,7 +1673,7 @@
                     "i": "ea9af11b-6332-4b3c-bbe4-c6d8e9833985",
                     "w": 40,
                     "x": 8,
-                    "y": 21
+                    "y": 28
                 },
                 "panelIndex": "ea9af11b-6332-4b3c-bbe4-c6d8e9833985",
                 "title": "Worker Utilization (%)",
@@ -1586,7 +1822,7 @@
                     "i": "1a42a8c2-9823-4178-90ae-f3a403b63711",
                     "w": 20,
                     "x": 8,
-                    "y": 30
+                    "y": 37
                 },
                 "panelIndex": "1a42a8c2-9823-4178-90ae-f3a403b63711",
                 "title": "Events received per second",
@@ -1836,7 +2072,7 @@
                     "i": "d290b2f1-1769-41f4-9d29-41755eef8871",
                     "w": 20,
                     "x": 28,
-                    "y": 30
+                    "y": 37
                 },
                 "panelIndex": "d290b2f1-1769-41f4-9d29-41755eef8871",
                 "title": "Persistent Queue utilization (%)",
@@ -2003,7 +2239,7 @@
                     "i": "09177cfd-5361-4e91-b7c3-64eeb7837ce8",
                     "w": 20,
                     "x": 8,
-                    "y": 38
+                    "y": 45
                 },
                 "panelIndex": "09177cfd-5361-4e91-b7c3-64eeb7837ce8",
                 "title": "Events emitted per second",
@@ -2151,7 +2387,7 @@
                     "i": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
                     "w": 20,
                     "x": 28,
-                    "y": 38
+                    "y": 45
                 },
                 "panelIndex": "4017b8f5-f8f2-46b9-86fe-501f46d551c3",
                 "title": "Persistent Queue size (events)",
@@ -2163,7 +2399,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-05T20:51:12.261Z",
+    "created_at": "2024-06-13T18:58:36.595Z",
     "id": "logstash-c0594170-526a-11ee-9ecc-31444cb79548",
     "managed": false,
     "references": [
@@ -2186,6 +2422,16 @@
             "id": "logstash-sm-metrics",
             "name": "8199ac33-4d5b-46e0-b3cd-3683204cc65c:indexpattern-datasource-layer-69a27ae4-5987-429d-89e1-84e7fb1b8af8",
             "type": "index-pattern"
+        },
+        {
+            "id": "logstash-sm-metrics",
+            "name": "1e868693-305b-40f1-bbbc-28d249bba95a:indexpattern-datasource-layer-af02f11d-c2e6-46a1-87fc-76139bbe0998",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logstash-bc1a8050-5ee1-11ee-8e78-bf6865bc3ffc",
+            "name": "1e868693-305b-40f1-bbbc-28d249bba95a:drilldown:DASHBOARD_TO_DASHBOARD_DRILLDOWN:ace863df-5d1f-415c-a5d0-cecc3e9beedd:dashboardId",
+            "type": "dashboard"
         },
         {
             "id": "logstash-sm-metrics",

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.9
+version: 2.4.10
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION

## Proposed commit message

This commit adds pipeline information to the Pipelines View. This involves retrieving the `info` object from the `pipelines` view to retrieve `ephemeral_id`, `workers`, `batch_size` and `batch_delay` for each pipeline. 

Additionally, this commit adds a table to the Pipelines View to show `workers`, `batch_size`, `batch_delay`, the type of queue being used, and the current size of the queue if it is a persistent queue

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

Install the integration, and point to a recent version of Logstash. Verify that the Pipelines View shows the correct data for each pipeline


## Screenshots

<img width="1325" alt="Screenshot 2024-06-13 at 12 55 23 PM" src="https://github.com/elastic/integrations/assets/4061337/bbbe6b69-81c9-45ff-aeb6-49bee6118776">

