### PR TITLE
[CISCO AIRONET] Allow failure for LOG-3-Q_IND matching

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.2"
+  changes:
+    - description: Make LOG-3-Q_IND parsing optional.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10166
 - version: "1.13.1"
   changes:
     - description: Fix CLIENT_ORCH_LOG messages.

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -30,3 +30,6 @@
 <132>WLC001: *bcastReceiveTask: Aug 20 14:55:28.577: %BCAST-4-MLD_INVALID_IPV6_PKT: bcastMld.c:2594  Received IPV6 packet which is not a valid MLD packet
 <132>WLC001: *apfReceiveTask: Aug 22 10:24:20.959: %APF-4-MOBILESTATION_NOT_FOUND: apf_ms.c:8467 Could not find the mobile cc:73:14:61:b0:8f in internal database
 <190>201477: Jan 4 17:25:42.866: %CLIENT_ORCH_LOG-6-CLIENT_ADDED_TO_RUN_STATE: Chassis 2 R0/0: wncd: Username entry (00-00-00-00-00-00) joined with ssid (System-110) for device with MAC: 0000.0000.0000
+<132>WLC001: *spamReceiveTask: Dec 17 19:59:10.223: %LOG-3-Q_IND: mm_aplist.c:734 Could not delete an AP from the AP list.
+<132>WLC001: *spamApTask4: Jun 08 04:26:43.773: %LOG-3-Q_IND: spam_lrad.c:11366 Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]
+<132>WLC001: *emWeb: Jan 22 11:42:50.501: %LOG-3-Q_IND: spam_lrad.c:52448 The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1242,6 +1242,108 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-12-17T19:59:10.223Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "Q_IND",
+                "original": "<132>WLC001: *spamReceiveTask: Dec 17 19:59:10.223: %LOG-3-Q_IND: mm_aplist.c:734 Could not delete an AP from the AP list.",
+                "provider": "LOG",
+                "severity": "3"
+            },
+            "host": {
+                "name": "WLC001"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 16
+                    },
+                    "priority": 132,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "message": "Could not delete an AP from the AP list.",
+            "process": {
+                "name": "spamReceiveTask"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-06-08T04:26:43.773Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "Q_IND",
+                "original": "<132>WLC001: *spamApTask4: Jun 08 04:26:43.773: %LOG-3-Q_IND: spam_lrad.c:11366 Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]",
+                "provider": "LOG",
+                "severity": "3"
+            },
+            "host": {
+                "name": "WLC001"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 16
+                    },
+                    "priority": 132,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "message": "Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]",
+            "process": {
+                "name": "spamApTask4"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-22T11:42:50.501Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "Q_IND",
+                "original": "<132>WLC001: *emWeb: Jan 22 11:42:50.501: %LOG-3-Q_IND: spam_lrad.c:52448 The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]",
+                "provider": "LOG",
+                "severity": "3"
+            },
+            "host": {
+                "name": "WLC001"
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "facility": {
+                        "code": 16
+                    },
+                    "priority": 132,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "message": "The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]",
+            "process": {
+                "name": "emWeb"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -191,7 +191,7 @@ processors:
       patterns:
         - "version %{INT:cisco.eapol.version:int}, type %{INT:cisco.eapol.type:int}, descriptor %{INT:cisco.eapol.descriptor:int}, client %{MAC:client.mac}"
         - "client %{MAC:client.mac}"
-      ignore_failure: false
+      ignore_failure: true
   ###
   - grok:
       description: APF-6-USER_NAME_CREATED, APF-6-USER_NAME_DELETED

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.13.1"
+version: "1.13.2"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION

## Proposed commit message

https://github.com/elastic/sdh-beats/issues/4827

The existing grok patterns handling LOG-3-Q_IND for Cisco Aironet do not cover every possible situation. It is better to make parsing optional.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
