### PR TITLE
[microsoft_exchange_online_message_trace] Fix template to not fail without local domains.

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.21.2"
+  changes:
+    - description: Fix template to not fail without local domains.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10172
 - version: "1.21.1"
   changes:
     - description: Fix sample event.

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/httpjson.yml.hbs
@@ -38,12 +38,14 @@ request.transforms:
       target: url.params.$skiptoken
       value: 0
 fields_under_root: true
+{{#if local_domains}}
 fields:
   _conf:
     local_domains:
     {{#each local_domains as |local_domain i|}}
       - {{local_domain}}
     {{/each}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/agent/stream/log.yml.hbs
@@ -4,12 +4,14 @@ paths:
 {{/each}}
 exclude_files: ['\.gz$']
 fields_under_root: true
+{{#if local_domains}}
 fields:
   _conf:
     local_domains:
     {{#each local_domains as |local_domain i|}}
       - {{local_domain}}
     {{/each}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.21.1"
+version: "1.21.2"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Adds a check to the templates to avoid failing when `local_domains` is empty.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
