### PR TITLE
Fix formatting of filesystem ignore types

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.58.2"
+  changes:
+    - description: Fix filesystem ignore_types
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/9771
 - version: "1.58.1"
   changes:
     - description: Fix metrics overview dashboard.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix filesystem ignore_types
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/9771
+      link: https://github.com/elastic/integrations/pull/10180
 - version: "1.58.1"
   changes:
     - description: Fix metrics overview dashboard.

--- a/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
+++ b/packages/system/data_stream/filesystem/agent/stream/stream.yml.hbs
@@ -2,7 +2,10 @@ metricsets: ["filesystem"]
 period: {{period}}
 processors: {{processors}}
 {{#if filesystem.ignore_types}}
-filesystem.ignore_types: {{filesystem.ignore_types}}
+filesystem.ignore_types: 
+{{#each filesystem.ignore_types as |type i|}}
+- {{type}}
+{{/each}}
 {{/if}}
 {{#if system.hostfs}}
 system.hostfs: {{system.hostfs}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: 1.58.1
+version: 1.58.2
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

closes https://github.com/elastic/integrations/issues/7703

This fixes an issue where the `filesystem.ignore_types:` field in the integration wasn't formatting the YAML list correctly.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

