### PR TITLE
Remove references to Kibana versions from READMEs

### DIFF
--- a/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_nsg/_dev/build/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### To collect data from Azure Network Watcher NSG follow the below steps:

--- a/packages/azure_network_watcher_nsg/changelog.yml
+++ b/packages/azure_network_watcher_nsg/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "0.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/azure_network_watcher_nsg/docs/README.md
+++ b/packages/azure_network_watcher_nsg/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### To collect data from Azure Network Watcher NSG follow the below steps:

--- a/packages/azure_network_watcher_nsg/manifest.yml
+++ b/packages/azure_network_watcher_nsg/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: azure_network_watcher_nsg
 title: Azure Network Watcher NSG
-version: "0.2.0"
+version: "0.2.1"
 description: Collect logs from Azure Network Watcher NSG with Elastic Agent.
 type: integration
 categories:

--- a/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
+++ b/packages/azure_network_watcher_vnet/_dev/build/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### To collect data from Azure Network Watcher VNet follow the below steps:

--- a/packages/azure_network_watcher_vnet/changelog.yml
+++ b/packages/azure_network_watcher_vnet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.2.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "0.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/azure_network_watcher_vnet/docs/README.md
+++ b/packages/azure_network_watcher_vnet/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html#_minimum_requirements).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### To collect data from Azure Network Watcher VNet follow the below steps:

--- a/packages/azure_network_watcher_vnet/manifest.yml
+++ b/packages/azure_network_watcher_vnet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: azure_network_watcher_vnet
 title: Azure Network Watcher VNet
-version: "0.2.0"
+version: "0.2.1"
 description: Collect logs from Azure Network Watcher VNet with Elastic Agent.
 type: integration
 categories:

--- a/packages/eset_protect/_dev/build/docs/README.md
+++ b/packages/eset_protect/_dev/build/docs/README.md
@@ -34,7 +34,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.12.0**.
 This module has been tested against the **ESET PROTECT (version: 5.0.9.1)**.
 
 ## Setup

--- a/packages/eset_protect/changelog.yml
+++ b/packages/eset_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.1.0"
   changes:
     - description: Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/eset_protect/docs/README.md
+++ b/packages/eset_protect/docs/README.md
@@ -34,7 +34,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.12.0**.
 This module has been tested against the **ESET PROTECT (version: 5.0.9.1)**.
 
 ## Setup

--- a/packages/eset_protect/manifest.yml
+++ b/packages/eset_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: eset_protect
 title: ESET PROTECT
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs from ESET PROTECT with Elastic Agent.
 type: integration
 categories:

--- a/packages/imperva_cloud_waf/_dev/build/docs/README.md
+++ b/packages/imperva_cloud_waf/_dev/build/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.10.1**.  
-
 ## Setup
 
 ### Steps to setup Amazon S3 Connection(Push Mode):

--- a/packages/imperva_cloud_waf/changelog.yml
+++ b/packages/imperva_cloud_waf/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.1.0"
   changes:
     - description: Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/imperva_cloud_waf/docs/README.md
+++ b/packages/imperva_cloud_waf/docs/README.md
@@ -30,8 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.10.1**.  
-
 ## Setup
 
 ### Steps to setup Amazon S3 Connection(Push Mode):

--- a/packages/imperva_cloud_waf/manifest.yml
+++ b/packages/imperva_cloud_waf/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: imperva_cloud_waf
 title: Imperva Cloud WAF
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs from Imperva Cloud WAF with Elastic Agent.
 type: integration
 categories:

--- a/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/_dev/build/docs/README.md
@@ -57,8 +57,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.11.0**.
-
 ## Setup
 
 ### To collect data from an AWS S3 bucket, follow the below steps:

--- a/packages/sentinel_one_cloud_funnel/changelog.yml
+++ b/packages/sentinel_one_cloud_funnel/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.2.0"
   changes:
     - description: Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/sentinel_one_cloud_funnel/docs/README.md
+++ b/packages/sentinel_one_cloud_funnel/docs/README.md
@@ -57,8 +57,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.11.0**.
-
 ## Setup
 
 ### To collect data from an AWS S3 bucket, follow the below steps:

--- a/packages/sentinel_one_cloud_funnel/manifest.yml
+++ b/packages/sentinel_one_cloud_funnel/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sentinel_one_cloud_funnel
 title: SentinelOne Cloud Funnel
-version: "1.2.0"
+version: "1.2.1"
 description: Collect logs from SentinelOne Cloud Funnel with Elastic Agent.
 type: integration
 categories: ["security", "edr_xdr"]

--- a/packages/symantec_edr_cloud/_dev/build/docs/README.md
+++ b/packages/symantec_edr_cloud/_dev/build/docs/README.md
@@ -30,7 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.10.1**.  
 This module has been tested against the **Symantec EDR Cloud API Version v1**.
 
 ## Setup

--- a/packages/symantec_edr_cloud/changelog.yml
+++ b/packages/symantec_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/symantec_edr_cloud/docs/README.md
+++ b/packages/symantec_edr_cloud/docs/README.md
@@ -30,7 +30,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.10.1**.  
 This module has been tested against the **Symantec EDR Cloud API Version v1**.
 
 ## Setup

--- a/packages/symantec_edr_cloud/manifest.yml
+++ b/packages/symantec_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: symantec_edr_cloud
 title: Symantec EDR Cloud
-version: "1.2.0"
+version: "1.2.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Symantec EDR Cloud with Elastic Agent.

--- a/packages/ti_crowdstrike/_dev/build/docs/README.md
+++ b/packages/ti_crowdstrike/_dev/build/docs/README.md
@@ -35,7 +35,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.11.0**.
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 
 ## Setup

--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.1.0"
   changes:
     - description: Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ti_crowdstrike/docs/README.md
+++ b/packages/ti_crowdstrike/docs/README.md
@@ -35,7 +35,6 @@ You can run Elastic Agent inside a container, either with Fleet Server or standa
 
 There are some minimum requirements for running Elastic Agent and for more information, refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **kibana.version** required is **8.11.0**.
 This module has been tested against the **CrowdStrike Falcon Intelligence API Version v1**.
 
 ## Setup

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "1.1.0"
+version: "1.1.1"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:

--- a/packages/ti_eset/_dev/build/docs/README.md
+++ b/packages/ti_eset/_dev/build/docs/README.md
@@ -74,8 +74,6 @@ and we provide deployment manifests for running on Kubernetes.
 There are some minimum requirements for running Elastic Agent and for more information,
 refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### Enabling the integration in Elastic:

--- a/packages/ti_eset/changelog.yml
+++ b/packages/ti_eset/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Remove reference to a Kibana version from the README.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10182
 - version: "1.2.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ti_eset/docs/README.md
+++ b/packages/ti_eset/docs/README.md
@@ -74,8 +74,6 @@ and we provide deployment manifests for running on Kubernetes.
 There are some minimum requirements for running Elastic Agent and for more information,
 refer to the link [here](https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation.html).
 
-The minimum **Kibana version** required is **8.12.0**.
-
 ## Setup
 
 ### Enabling the integration in Elastic:

--- a/packages/ti_eset/manifest.yml
+++ b/packages/ti_eset/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eset
 title: "ESET Threat Intelligence"
-version: "1.2.0"
+version: "1.2.1"
 description: "Ingest threat intelligence indicators from ESET Threat Intelligence with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
Remove references to Kibana versions from READMEs (#)

The source of truth for Kibana version constraints is the manifest file.
Hard-coded references in READMEs easily become out of date, so it's
better to not have them.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #9778