### PR TITLE
[ti_opencti] Ignore missing createdBy, improve reg hive name handling

### DIFF
--- a/packages/ti_opencti/changelog.yml
+++ b/packages/ti_opencti/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.1"
+  changes:
+    - description: Ignore missing createdBy, improve registry hive name handling.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10203
 - version: "2.3.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr-createdby-is-null.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr-createdby-is-null.json
@@ -1,0 +1,47 @@
+{
+    "events": [
+        {
+            "confidence": 15,
+            "created": "2022-06-21T07:08:58.222Z",
+            "createdBy": null,
+            "description": "Simple indicator of observable {216.160.83.57}",
+            "externalReferences": {
+                "edges": []
+            },
+            "id": "a1f3e8b3-d1c0-4fca-929b-81d3570a4c3c",
+            "is_inferred": false,
+            "killChainPhases": [],
+            "lang": "en",
+            "modified": "2022-07-21T08:13:19.927Z",
+            "name": "216.160.83.57",
+            "objectLabel": [],
+            "objectMarking": [],
+            "observables": {
+                "edges": [
+                    {
+                        "node": {
+                            "entity_type": "IPv4-Addr",
+                            "id": "25ee0d9d-d68e-49e9-bf5e-ec530baa8604",
+                            "observable_value": "216.160.83.57",
+                            "standard_id": "ipv4-addr--b4c90ba2-9df9-50ca-870c-093d6883fb88",
+                            "value": "216.160.83.57"
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "globalCount": 1
+                }
+            },
+            "pattern": "[ipv4-addr:value = '216.160.83.57']",
+            "pattern_type": "stix",
+            "pattern_version": null,
+            "revoked": true,
+            "standard_id": "indicator--8e4329db-e015-541d-8397-3b3816d7473a",
+            "valid_from": "2022-06-21T08:11:01.786Z",
+            "valid_until": "2022-07-21T08:11:01.785Z",
+            "x_opencti_detection": false,
+            "x_opencti_main_observable_type": "IPv4-Addr",
+            "x_opencti_score": 50
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr-createdby-is-null.json-expected.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-ipv4-addr-createdby-is-null.json-expected.json
@@ -1,0 +1,73 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "threat"
+                ],
+                "created": "2022-06-21T07:08:58.222Z",
+                "id": "a1f3e8b3-d1c0-4fca-929b-81d3570a4c3c",
+                "kind": "enrichment",
+                "type": [
+                    "indicator"
+                ]
+            },
+            "opencti": {
+                "indicator": {
+                    "detection": false,
+                    "invalid_or_revoked_from": "2022-07-21T08:11:01.785Z",
+                    "is_inferred": false,
+                    "lang": "en",
+                    "observables_count": 1,
+                    "pattern": "[ipv4-addr:value = '216.160.83.57']",
+                    "pattern_type": "stix",
+                    "revoked": true,
+                    "score": 50,
+                    "standard_id": "indicator--8e4329db-e015-541d-8397-3b3816d7473a",
+                    "valid_from": "2022-06-21T08:11:01.786Z",
+                    "valid_until": "2022-07-21T08:11:01.785Z"
+                },
+                "observable": {
+                    "ipv4_addr": {
+                        "entity_type": "IPv4-Addr",
+                        "id": "25ee0d9d-d68e-49e9-bf5e-ec530baa8604",
+                        "standard_id": "ipv4-addr--b4c90ba2-9df9-50ca-870c-093d6883fb88",
+                        "value": "216.160.83.57"
+                    }
+                }
+            },
+            "related": {
+                "ip": [
+                    "216.160.83.57"
+                ]
+            },
+            "tags": [
+                "forwarded",
+                "opencti-indicator",
+                "ecs-indicator-detail"
+            ],
+            "threat": {
+                "feed": {
+                    "dashboard_id": "ti_opencti-83b2bef0-591c-11ee-ba5f-49a63bb985cd",
+                    "description": "Indicator data from OpenCTI",
+                    "name": "OpenCTI",
+                    "reference": "https://docs.opencti.io/latest/usage/overview/"
+                },
+                "indicator": {
+                    "confidence": "Low",
+                    "description": "Simple indicator of observable {216.160.83.57}",
+                    "ip": [
+                        "216.160.83.57"
+                    ],
+                    "modified_at": "2022-07-21T08:13:19.927Z",
+                    "name": "216.160.83.57",
+                    "reference": "https://demo.opencti.io/dashboard/observations/indicators/a1f3e8b3-d1c0-4fca-929b-81d3570a4c3c",
+                    "type": "ipv4-addr"
+                }
+            }
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key-no-hive.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key-no-hive.json
@@ -1,0 +1,61 @@
+{
+    "events": [
+        {
+            "id": "e300e111-f6c6-4305-9069-fcb2f5fb2938",
+            "standard_id": "indicator--6cec4cfd-299f-5cd2-ad1a-9259d44331e5",
+            "is_inferred": false,
+            "revoked": true,
+            "confidence": 15,
+            "lang": "en",
+            "created": "2016-10-25T14:13:17.000Z",
+            "modified": "2023-01-17T06:30:13.710Z",
+            "pattern_type": "stix",
+            "pattern_version": "2.1",
+            "pattern": "[windows-registry-key:key = '{59031A47-3F72-44A7-80C5-5595FE6B30EE}']",
+            "name": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}",
+            "description": "Sedreco",
+            "valid_from": "2016-10-25T14:13:17.000Z",
+            "valid_until": "2017-10-25T14:13:17.000Z",
+            "x_opencti_score": 40,
+            "x_opencti_detection": false,
+            "x_opencti_main_observable_type": "Windows-Registry-Key",
+            "createdBy": {
+                "identity_class": "organization",
+                "name": "CIRCL"
+            },
+            "objectMarking": [
+                {
+                    "definition_type": "TLP",
+                    "definition": "TLP:CLEAR"
+                }
+            ],
+            "objectLabel": [
+                {
+                    "value": "technical-report"
+                }
+            ],
+            "killChainPhases": [],
+            "externalReferences": {
+                "edges": []
+            },
+            "observables": {
+                "edges": [
+                    {
+                        "node": {
+                            "id": "12befd29-7fba-46c2-8b17-733878fe8d74",
+                            "standard_id": "windows-registry-key--e4bb86e8-5280-5059-924a-6e8431fc2b78",
+                            "entity_type": "Windows-Registry-Key",
+                            "observable_value": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}",
+                            "attribute_key": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}",
+                            "modified_time": null,
+                            "number_of_subkeys": null
+                        }
+                    }
+                ],
+                "pageInfo": {
+                    "globalCount": 1
+                }
+            }
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key-no-hive.json-expected.json
+++ b/packages/ti_opencti/data_stream/indicator/_dev/test/pipeline/test-windows-registry-key-no-hive.json-expected.json
@@ -1,0 +1,76 @@
+{
+    "expected": [
+        {
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "threat"
+                ],
+                "created": "2016-10-25T14:13:17.000Z",
+                "id": "e300e111-f6c6-4305-9069-fcb2f5fb2938",
+                "kind": "enrichment",
+                "type": [
+                    "indicator"
+                ]
+            },
+            "opencti": {
+                "indicator": {
+                    "creator_identity_class": "organization",
+                    "detection": false,
+                    "invalid_or_revoked_from": "2017-10-25T14:13:17.000Z",
+                    "is_inferred": false,
+                    "lang": "en",
+                    "observables_count": 1,
+                    "pattern": "[windows-registry-key:key = '{59031A47-3F72-44A7-80C5-5595FE6B30EE}']",
+                    "pattern_type": "stix",
+                    "pattern_version": "2.1",
+                    "revoked": true,
+                    "score": 40,
+                    "standard_id": "indicator--6cec4cfd-299f-5cd2-ad1a-9259d44331e5",
+                    "valid_from": "2016-10-25T14:13:17.000Z",
+                    "valid_until": "2017-10-25T14:13:17.000Z"
+                },
+                "observable": {
+                    "windows_registry_key": {
+                        "attribute_key": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}",
+                        "entity_type": "Windows-Registry-Key",
+                        "id": "12befd29-7fba-46c2-8b17-733878fe8d74",
+                        "standard_id": "windows-registry-key--e4bb86e8-5280-5059-924a-6e8431fc2b78",
+                        "value": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}"
+                    }
+                }
+            },
+            "tags": [
+                "forwarded",
+                "opencti-indicator",
+                "technical-report",
+                "ecs-indicator-detail"
+            ],
+            "threat": {
+                "feed": {
+                    "dashboard_id": "ti_opencti-83b2bef0-591c-11ee-ba5f-49a63bb985cd",
+                    "description": "Indicator data from OpenCTI",
+                    "name": "OpenCTI",
+                    "reference": "https://docs.opencti.io/latest/usage/overview/"
+                },
+                "indicator": {
+                    "confidence": "Low",
+                    "description": "Sedreco",
+                    "marking": {
+                        "tlp": "CLEAR"
+                    },
+                    "modified_at": "2023-01-17T06:30:13.710Z",
+                    "name": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}",
+                    "provider": "CIRCL",
+                    "reference": "https://demo.opencti.io/dashboard/observations/indicators/e300e111-f6c6-4305-9069-fcb2f5fb2938",
+                    "registry": {
+                        "key": "{59031A47-3F72-44A7-80C5-5595FE6B30EE}"
+                    },
+                    "type": "windows-registry-key"
+                }
+            }
+        }
+    ]
+}

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/default.yml
@@ -156,9 +156,11 @@ processors:
   - rename:
       field: createdBy.name
       target_field: threat.indicator.provider
+      ignore_missing: true
   - rename:
       field: createdBy.identity_class
       target_field: opencti.indicator.creator_identity_class
+      ignore_missing: true
   - remove:
       field: createdBy
       ignore_missing: true

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/ecs_from_windows_registry_key.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/ecs_from_windows_registry_key.yml
@@ -2,9 +2,26 @@
 description: Build ECS fields from an OpenCTI windows registry key observable
 processors:
 
-  - dissect:
+  - grok:
       field: _ingest._value.attribute_key
-      pattern: "%{_tmp_registry.hive}\\%{_tmp_registry.key}"
+      patterns:
+        - "^(%{HIVE_NAMES:_tmp_registry.hive}\\\\)?%{GREEDYDATA:_tmp_registry.key}$"
+      pattern_definitions:
+        HIVE_NAMES: "(?i:HKEY_CLASSES_ROOT|HKCR|HKEY_CURRENT_USER|HKCU|HKEY_LOCAL_MACHINE|HKLM|HKEY_USERS|HKU|HKEY_CURRENT_CONFIG|HKCC)"
+
+  - script:
+      description: Normalize hive names (ECS uses abbreviated names)
+      lang: painless
+      params:
+        HKEY_CLASSES_ROOT: HKCR
+        HKEY_CURRENT_USER: HKCU
+        HKEY_LOCAL_MACHINE: HKLM
+        HKEY_USERS: HKU
+        HKEY_CURRENT_CONFIG: HKCC
+      source: |
+        def name = ctx._tmp_registry.hive.toUpperCase();
+        ctx._tmp_registry.hive = params.getOrDefault(name, name);
+      if: ctx._tmp_registry?.hive != null
 
   # append object
   - append:

--- a/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/ecs_from_windows_registry_key.yml
+++ b/packages/ti_opencti/data_stream/indicator/elasticsearch/ingest_pipeline/ecs_from_windows_registry_key.yml
@@ -5,7 +5,7 @@ processors:
   - grok:
       field: _ingest._value.attribute_key
       patterns:
-        - "^(%{HIVE_NAMES:_tmp_registry.hive}\\\\)?%{GREEDYDATA:_tmp_registry.key}$"
+        - '^(%{HIVE_NAMES:_tmp_registry.hive}\\)?%{GREEDYDATA:_tmp_registry.key}$'
       pattern_definitions:
         HIVE_NAMES: "(?i:HKEY_CLASSES_ROOT|HKCR|HKEY_CURRENT_USER|HKCU|HKEY_LOCAL_MACHINE|HKLM|HKEY_USERS|HKU|HKEY_CURRENT_CONFIG|HKCC)"
 

--- a/packages/ti_opencti/manifest.yml
+++ b/packages/ti_opencti/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: ti_opencti
 title: OpenCTI
-version: "2.3.0"
+version: "2.3.1"
 description: "Ingest threat intelligence indicators from OpenCTI with Elastic Agent."
 type: integration
 source:


### PR DESCRIPTION
## Proposed commit message

```
[ti_opencti] Ignore missing createdBy, improve reg hive name handling

- Avoid failing the pipeline if the createdBy field is null or absent.
- Avoid failing if a Windows registry key name doesn't have a path
  separator in it.
- Match and normalize specific Windows registry hive names rather than
  assuming the first part of a path is a hive. The
  `opencti.observable.windows_registry_key.attribute_key` value is
  unchanged, but the ECS field `threat.indicator.registry.hive` is now
  set to the abbreviated name, as expected.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #10195