### PR TITLE
added source/destination port 0 check to community id processor to pr…

### DIFF
--- a/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zeek/data_stream/connection/elasticsearch/ingest_pipeline/default.yml
@@ -127,7 +127,7 @@ processors:
       copy_from: destination.address
       if: ctx.destination?.address != null
   - community_id:
-      if: 'ctx.network?.transport != "icmp"'
+      if: 'ctx.network?.transport != "icmp" && ctx.source?.port != 0 && ctx.destination?.port != 0'
   - community_id:
       icmp_type: zeek.connection.icmp.type
       icmp_code: zeek.connection.icmp.code


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
There are rare cases where a Zeek log has a "network.transport" of "tcp" but the source and destination port values are 0 which breaks the community_id processor as it requires a non zero value in both port fields. This appears to happen when the "zeek.connection.history" is just "R" but otherwise I cannot explain why this happens. Since this pipeline calls the custom Zeek Connection pipeline, failure at this stage means that the custom pipelines are never called.

To fix this I added a check on the community_id processor in the Zeek connection pipeline to ensure source and destination port are not 0. 
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots
![image](https://github.com/elastic/integrations/assets/25185548/d6aabba5-76dc-4840-9b12-f75ccb542bbb)


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->