### PR TITLE
Migrate elastic_agent integration to package spec v3

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,5 +1,6 @@
 # newer versions go on top
 - version: "2.0.0"
+  changes:
     - description: Update package spec to 3.1.4
       type: enhancement
       link: "foo"

--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,8 @@
 # newer versions go on top
+- version: "2.0.0"
+    - description: Update package spec to 3.1.4
+      type: enhancement
+      link: "foo"
 - version: "1.20.0"
   changes:
     - description: Change aggregations on elastic agent dashboards

--- a/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/apm_server_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/auditbeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -2,8 +2,10 @@
   type: text
 - name: input
   type: object
+  object_type: object
 - name: result
   type: object
+  object_type: object
 - name: elastic_agent
   type: group
   fields:

--- a/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloud_defend_logs/fields/fields.yml
@@ -1,11 +1,8 @@
 - name: decision_id
   type: text
-- name: input
-  type: object
-  object_type: object
-- name: result
-  type: object
-  object_type: object
+- name: input.type
+  description: "Input type"
+  type: keyword
 - name: elastic_agent
   type: group
   fields:

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -1,8 +1,8 @@
 - name: decision_id
   type: text
-- name: input
-  type: object
-  object_type: object
+- name: input.type
+  description: "Input type"
+  type: keyword
 - name: result
   type: object
   object_type: object

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -5,7 +5,7 @@
   type: keyword
 - name: result
   type: object
-  object_type: object
+  object_type: keyword
 - name: elastic_agent
   type: group
   fields:

--- a/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_logs/fields/fields.yml
@@ -2,8 +2,10 @@
   type: text
 - name: input
   type: object
+  object_type: object
 - name: result
   type: object
+  object_type: object
 - name: elastic_agent
   type: group
   fields:

--- a/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/cloudbeat_metrics/fields/fields.yml
@@ -177,7 +177,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -421,19 +421,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/elastic_agent_metrics/fields/fields.yml
@@ -181,7 +181,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -425,19 +425,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -183,7 +183,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: object
-              object_type: object
+              object_type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/endpoint_security_metrics/fields/fields.yml
@@ -183,6 +183,7 @@
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
               type: object
+              object_type: object
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_input_metrics/fields/fields.yml
@@ -50,19 +50,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/filebeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/fleet_server_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory

--- a/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/heartbeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/metricbeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/osquerybeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
+++ b/packages/elastic_agent/data_stream/packetbeat_metrics/fields/fields.yml
@@ -182,7 +182,7 @@
               unit: nanos
               description: CPU time consumed by tasks in user (kernel) mode.
             - name: percpu
-              type: object
+              type: long
               description: |
                 CPU time (in nanoseconds) consumed on each CPU by all tasks in this cgroup.
         - name: memory
@@ -426,19 +426,8 @@
 - name: component
   type: group
   fields:
-    - name: id
-      type: keyword
-      ignore_above: 1024
-      description: Component id
     - name: binary
       type: keyword
       ignore_above: 1024
       description: The binary that exeuctes the component
       example: filebeat
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: Metricset name
-      example: stats

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -818,22 +818,6 @@
                 "panelIndex": "5848c519-791c-45e2-b350-0740a12c3ace",
                 "title": "[Elastic Agent] Agents with Errors",
                 "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "rowHeight": -1
-                },
-                "gridData": {
-                    "h": 21,
-                    "i": "9604578e-7da2-4575-923e-f15e51bca436",
-                    "w": 40,
-                    "x": 8,
-                    "y": 28
-                },
-                "panelIndex": "9604578e-7da2-4575-923e-f15e51bca436",
-                "panelRefName": "panel_9604578e-7da2-4575-923e-f15e51bca436",
-                "type": "search"
             }
         ],
         "timeRestore": false,

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -47,7 +47,8 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 }
-            }
+            },
+            "showApplySelections": false
         },
         "description": "",
         "kibanaSavedObjectMeta": {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -902,5 +902,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -47,8 +47,7 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 }
-            },
-            "showApplySelections": false
+            }
         },
         "description": "",
         "kibanaSavedObjectMeta": {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -843,11 +843,6 @@
             "type": "index-pattern"
         },
         {
-            "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
-            "name": "9604578e-7da2-4575-923e-f15e51bca436:panel_9604578e-7da2-4575-923e-f15e51bca436",
-            "type": "search"
-        },
-        {
             "id": "logs-*",
             "name": "controlGroup_280071dd-16c7-4610-bae7-bc8f07cc6a1b:optionsListDataView",
             "type": "index-pattern"

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -3,8 +3,51 @@
         "controlGroupInput": {
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"280071dd-16c7-4610-bae7-bc8f07cc6a1b\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent Hostname\",\"id\":\"280071dd-16c7-4610-bae7-bc8f07cc6a1b\",\"selectedOptions\":[],\"enhancements\":{}}},\"66670886-33b8-4cf9-95f3-fe4bff859fe9\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"data_stream.dataset\",\"title\":\"Integration Name\",\"id\":\"66670886-33b8-4cf9-95f3-fe4bff859fe9\",\"enhancements\":{}}},\"d6bc511d-a0f0-450c-b023-4d0295729dca\":{\"order\":2,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.version\",\"title\":\"Agent Version\",\"id\":\"d6bc511d-a0f0-450c-b023-4d0295729dca\",\"enhancements\":{}}}}"
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "280071dd-16c7-4610-bae7-bc8f07cc6a1b": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "agent.name",
+                        "id": "280071dd-16c7-4610-bae7-bc8f07cc6a1b",
+                        "selectedOptions": [],
+                        "title": "Agent Hostname"
+                    },
+                    "grow": true,
+                    "order": 0,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "66670886-33b8-4cf9-95f3-fe4bff859fe9": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "data_stream.dataset",
+                        "id": "66670886-33b8-4cf9-95f3-fe4bff859fe9",
+                        "title": "Integration Name"
+                    },
+                    "grow": true,
+                    "order": 1,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "d6bc511d-a0f0-450c-b023-4d0295729dca": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "agent.version",
+                        "id": "d6bc511d-a0f0-450c-b023-4d0295729dca",
+                        "title": "Agent Version"
+                    },
+                    "grow": true,
+                    "order": 2,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                }
+            }
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -798,7 +841,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-12-11T11:37:02.295Z",
+    "created_at": "2024-07-01T19:40:41.314Z",
     "id": "elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824",
     "managed": true,
     "references": [
@@ -859,5 +902,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "8.9.0"
+    "typeMigrationVersion": "10.2.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -3,39 +3,8 @@
         "controlGroupInput": {
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": {
-                "ignoreFilters": false,
-                "ignoreQuery": false,
-                "ignoreTimerange": false,
-                "ignoreValidations": false
-            },
-            "panelsJSON": {
-                "4a765eb5-fe8e-4ef3-9930-ef8f832a6832": {
-                    "explicitInput": {
-                        "enhancements": {},
-                        "fieldName": "data_stream.dataset",
-                        "id": "4a765eb5-fe8e-4ef3-9930-ef8f832a6832",
-                        "selectedOptions": [],
-                        "title": "Integration Name"
-                    },
-                    "grow": true,
-                    "order": 0,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                },
-                "d5126805-1e20-4c32-8c7b-a9c0afee3215": {
-                    "explicitInput": {
-                        "enhancements": {},
-                        "fieldName": "agent.name",
-                        "id": "d5126805-1e20-4c32-8c7b-a9c0afee3215",
-                        "title": "Agent Name"
-                    },
-                    "grow": true,
-                    "order": 1,
-                    "type": "optionsListControl",
-                    "width": "medium"
-                }
-            }
+            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
+            "panelsJSON": "{\"4a765eb5-fe8e-4ef3-9930-ef8f832a6832\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"data_stream.dataset\",\"title\":\"Integration Name\",\"id\":\"4a765eb5-fe8e-4ef3-9930-ef8f832a6832\",\"enhancements\":{},\"selectedOptions\":[]}},\"d5126805-1e20-4c32-8c7b-a9c0afee3215\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent Name\",\"id\":\"d5126805-1e20-4c32-8c7b-a9c0afee3215\",\"enhancements\":{}}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -482,14 +451,7 @@
                         "hideChart": true,
                         "isTextBasedQuery": false,
                         "kibanaSavedObjectMeta": {
-                            "searchSourceJSON": {
-                                "filter": [],
-                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
-                                "query": {
-                                    "language": "kuery",
-                                    "query": "event.kind: pipeline_error and error.message : * "
-                                }
-                            }
+                            "searchSourceJSON": "{\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"event.kind: pipeline_error and error.message : * \"}}"
                         },
                         "references": [
                             {
@@ -526,7 +488,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-07-01T19:40:41.314Z",
+    "created_at": "2023-12-11T11:37:02.295Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "managed": true,
     "references": [
@@ -567,5 +529,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824.json
@@ -3,8 +3,39 @@
         "controlGroupInput": {
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"4a765eb5-fe8e-4ef3-9930-ef8f832a6832\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"data_stream.dataset\",\"title\":\"Integration Name\",\"id\":\"4a765eb5-fe8e-4ef3-9930-ef8f832a6832\",\"enhancements\":{},\"selectedOptions\":[]}},\"d5126805-1e20-4c32-8c7b-a9c0afee3215\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent Name\",\"id\":\"d5126805-1e20-4c32-8c7b-a9c0afee3215\",\"enhancements\":{}}}}"
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "4a765eb5-fe8e-4ef3-9930-ef8f832a6832": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "data_stream.dataset",
+                        "id": "4a765eb5-fe8e-4ef3-9930-ef8f832a6832",
+                        "selectedOptions": [],
+                        "title": "Integration Name"
+                    },
+                    "grow": true,
+                    "order": 0,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                },
+                "d5126805-1e20-4c32-8c7b-a9c0afee3215": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "agent.name",
+                        "id": "d5126805-1e20-4c32-8c7b-a9c0afee3215",
+                        "title": "Agent Name"
+                    },
+                    "grow": true,
+                    "order": 1,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                }
+            }
         },
         "description": "",
         "kibanaSavedObjectMeta": {
@@ -451,7 +482,14 @@
                         "hideChart": true,
                         "isTextBasedQuery": false,
                         "kibanaSavedObjectMeta": {
-                            "searchSourceJSON": "{\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\",\"query\":{\"language\":\"kuery\",\"query\":\"event.kind: pipeline_error and error.message : * \"}}"
+                            "searchSourceJSON": {
+                                "filter": [],
+                                "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
+                                "query": {
+                                    "language": "kuery",
+                                    "query": "event.kind: pipeline_error and error.message : * "
+                                }
+                            }
                         },
                         "references": [
                             {
@@ -488,7 +526,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2023-12-11T11:37:02.295Z",
+    "created_at": "2024-07-01T19:40:41.314Z",
     "id": "elastic_agent-1a4e7280-6b5e-11ed-98de-67bdecd21824",
     "managed": true,
     "references": [
@@ -529,5 +567,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "8.9.0"
+    "typeMigrationVersion": "10.2.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -3789,9 +3789,9 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-27T21:06:04.956Z",
+    "created_at": "2024-06-28T16:08:23.865Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "metrics-*",

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -213,6 +213,590 @@
                         "references": [
                             {
                                 "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8": {
+                                            "columnOrder": [
+                                                "135cfae0-7159-4211-b7c5-af814a29fd9e",
+                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X5"
+                                            ],
+                                            "columns": {
+                                                "135cfae0-7159-4211-b7c5-af814a29fd9e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of elastic_agent.process",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "elastic_agent.process"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 2,
+                                                                "suffix": ""
+                                                            }
+                                                        },
+                                                        "formula": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X5"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"system.process.cpu.total.value\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.value"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"system.process.cpu.total.value\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.value"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "overall_sum",
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X3"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X5": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4"
+                                                            ],
+                                                            "location": {
+                                                                "max": 124,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X4"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "system.process.cpu.total.ticks",
+                                        "index": "a8bc4aba-aa4d-47c8-8687-31f3e2bdab87",
+                                        "key": "system.process.cpu.total.ticks",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "system.process.cpu.total.ticks"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "75b0be50-24a3-4528-8b08-74c3c072b355"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "135cfae0-7159-4211-b7c5-af814a29fd9e",
+                                        "xAccessor": "7f8f777a-bb98-4d2b-83ab-ec1983847e67"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "22432173-7e06-4fa1-b9df-03cdd7f287e9",
+                    "w": 40,
+                    "x": 8,
+                    "y": 21
+                },
+                "panelIndex": "22432173-7e06-4fa1-b9df-03cdd7f287e9",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8": {
+                                            "columnOrder": [
+                                                "135cfae0-7159-4211-b7c5-af814a29fd9e",
+                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2",
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3"
+                                            ],
+                                            "columns": {
+                                                "135cfae0-7159-4211-b7c5-af814a29fd9e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of elastic_agent.process",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "secondaryFields": [],
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "elastic_agent.process"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355": {
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "compact": true,
+                                                                "decimals": 2,
+                                                                "suffix": ""
+                                                            }
+                                                        },
+                                                        "formula": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X3"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"system.process.cpu.total.time.ms\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.time.ms"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "operationType": "interval",
+                                                    "references": [],
+                                                    "scale": "ratio"
+                                                },
+                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                {
+                                                                    "args": [
+                                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
+                                                                    ],
+                                                                    "location": {
+                                                                        "max": 69,
+                                                                        "min": 1
+                                                                    },
+                                                                    "name": "divide",
+                                                                    "text": "differences(last_value(system.process.cpu.total.time.ms))/interval()",
+                                                                    "type": "function"
+                                                                },
+                                                                100
+                                                            ],
+                                                            "location": {
+                                                                "max": 74,
+                                                                "min": 0
+                                                            },
+                                                            "name": "multiply",
+                                                            "text": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
+                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
+                                                        "interval": "auto"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "system.process.cpu.total.ticks",
+                                        "index": "a8bc4aba-aa4d-47c8-8687-31f3e2bdab87",
+                                        "key": "system.process.cpu.total.ticks",
+                                        "negate": false,
+                                        "type": "exists",
+                                        "value": "exists"
+                                    },
+                                    "query": {
+                                        "exists": {
+                                            "field": "system.process.cpu.total.ticks"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "75b0be50-24a3-4528-8b08-74c3c072b355"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "line",
+                                        "showGridlines": false,
+                                        "splitAccessor": "135cfae0-7159-4211-b7c5-af814a29fd9e",
+                                        "xAccessor": "7f8f777a-bb98-4d2b-83ab-ec1983847e67"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "bar_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8",
+                    "w": 40,
+                    "x": 8,
+                    "y": 9
+                },
+                "panelIndex": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8",
+                "title": "This seems to work:  CPU %",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
                                 "name": "indexpattern-datasource-layer-c8958799-403d-41b6-9b7a-836c6de65bb6",
                                 "type": "index-pattern"
                             }
@@ -371,7 +955,7 @@
                     "i": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                     "w": 40,
                     "x": 8,
-                    "y": 9
+                    "y": 33
                 },
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
@@ -512,7 +1096,7 @@
                     "i": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                     "w": 40,
                     "x": 8,
-                    "y": 18
+                    "y": 42
                 },
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
@@ -702,7 +1286,7 @@
                     "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                     "w": 24,
                     "x": 0,
-                    "y": 27
+                    "y": 51
                 },
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
@@ -900,7 +1484,7 @@
                     "i": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                     "w": 24,
                     "x": 24,
-                    "y": 27
+                    "y": 51
                 },
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
@@ -1091,7 +1675,7 @@
                     "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                     "w": 24,
                     "x": 0,
-                    "y": 36
+                    "y": 60
                 },
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
@@ -1281,7 +1865,7 @@
                     "i": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                     "w": 24,
                     "x": 24,
-                    "y": 36
+                    "y": 60
                 },
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
@@ -1473,7 +2057,7 @@
                     "i": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                     "w": 24,
                     "x": 0,
-                    "y": 45
+                    "y": 69
                 },
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
@@ -1654,7 +2238,7 @@
                     "i": "d004044a-99f4-44fa-964a-361accd1810d",
                     "w": 24,
                     "x": 24,
-                    "y": 45
+                    "y": 69
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
@@ -1847,7 +2431,7 @@
                     "i": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                     "w": 24,
                     "x": 0,
-                    "y": 54
+                    "y": 78
                 },
                 "panelIndex": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                 "title": "[Elastic Agent] Events dropped rate /s",
@@ -2037,7 +2621,7 @@
                     "i": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                     "w": 24,
                     "x": 24,
-                    "y": 54
+                    "y": 78
                 },
                 "panelIndex": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                 "title": "[Elastic Agent] Events duplicate rate /s",
@@ -2227,7 +2811,7 @@
                     "i": "ce5bea64-4178-4290-997b-a59455991f3d",
                     "w": 24,
                     "x": 0,
-                    "y": 63
+                    "y": 87
                 },
                 "panelIndex": "ce5bea64-4178-4290-997b-a59455991f3d",
                 "title": "[Elastic Agent] Events failed rate /s",
@@ -2417,7 +3001,7 @@
                     "i": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                     "w": 24,
                     "x": 24,
-                    "y": 63
+                    "y": 87
                 },
                 "panelIndex": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                 "title": "[Elastic Agent] Events TooMany rate /s",
@@ -2572,7 +3156,7 @@
                     "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                     "w": 24,
                     "x": 0,
-                    "y": 72
+                    "y": 96
                 },
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
@@ -2583,8 +3167,13 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "logs-*",
-                                "name": "indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
                                 "type": "index-pattern"
                             }
                         ],
@@ -2592,19 +3181,42 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
+                                    "currentIndexPatternId": "metrics-*",
                                     "layers": {
-                                        "38cd2447-deab-49b7-9d84-400f2ba12511": {
+                                        "c7cc9cd8-585a-4078-a86f-8b0213c874fd": {
                                             "columnOrder": [
-                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
-                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b",
-                                                "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                                "ba13a1db-763d-4a12-88c2-a5247a612c66"
                                             ],
                                             "columns": {
-                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94": {
+                                                "ba13a1db-763d-4a12-88c2-a5247a612c66": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Container Limit",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cgroup.memory.mem.limit.bytes"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        },
+                                        "fa212775-2294-4cb0-a671-eb76e6856d14": {
+                                            "columnOrder": [
+                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
+                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae",
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69"
+                                            ],
+                                            "columns": {
+                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 10 values of component.id",
+                                                    "label": "Top 10 values of elastic_agent.process",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -2613,80 +3225,62 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "c37367a6-4c26-4f3f-86eb-10db67933171",
+                                                            "columnId": "90bc620d-c329-4607-90d4-5245a7cc7e69",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
-                                                        "otherBucket": true,
+                                                        "otherBucket": false,
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
                                                         "size": 10
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "component.id"
+                                                    "sourceField": "elastic_agent.process"
                                                 },
-                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b": {
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true,
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        }
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cgroup.memory.mem.usage.bytes"
+                                                },
+                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae": {
                                                     "dataType": "date",
                                                     "isBucketed": true,
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
                                                         "interval": "m"
                                                     },
                                                     "scale": "interval",
                                                     "sourceField": "@timestamp"
-                                                },
-                                                "c37367a6-4c26-4f3f-86eb-10db67933171": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": ""
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "monitoring.metrics.libbeat.pipeline.events.active"
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logs-*",
-                                            "linkToLayers": [],
+                                            "indexPatternId": "metrics-*",
                                             "sampling": 1
                                         }
                                     }
+                                },
+                                "textBased": {
+                                    "layers": {}
                                 }
                             },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "index": "97ad75be-db47-4cb4-bb1e-0c0320d04edd",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.*"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.*"
-                                        }
-                                    }
-                                }
-                            ],
+                            "filters": [],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -2696,54 +3290,60 @@
                                 "axisTitlesVisibilitySettings": {
                                     "x": false,
                                     "yLeft": false,
-                                    "yRight": true
+                                    "yRight": false
                                 },
-                                "fittingFunction": "None",
                                 "gridlinesVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
+                                    "yRight": false
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "c37367a6-4c26-4f3f-86eb-10db67933171"
+                                            "90bc620d-c329-4607-90d4-5245a7cc7e69"
                                         ],
-                                        "layerId": "38cd2447-deab-49b7-9d84-400f2ba12511",
+                                        "layerId": "fa212775-2294-4cb0-a671-eb76e6856d14",
                                         "layerType": "data",
+                                        "position": "top",
                                         "seriesType": "area_stacked",
-                                        "splitAccessor": "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
-                                        "xAccessor": "6093c949-5f5d-4c72-baba-5a84ce2f1a9b"
+                                        "showGridlines": false,
+                                        "splitAccessor": "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
+                                        "xAccessor": "a084070f-a15a-473c-abf4-d2e52e84c6ae"
+                                    },
+                                    {
+                                        "accessors": [
+                                            "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                        ],
+                                        "layerId": "c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+                                        "layerType": "referenceLine",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "forAccessor": "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                            }
+                                        ]
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
                                     "legendSize": "large",
                                     "position": "right",
+                                    "shouldTruncate": true,
                                     "showSingleSeries": true
                                 },
-                                "preferredSeriesType": "line",
+                                "preferredSeriesType": "area_stacked",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
-                                    "yRight": true
+                                    "yRight": false
                                 },
+                                "title": "Empty XY chart",
                                 "valueLabels": "hide",
                                 "valuesInLegend": true,
-                                "yLeftExtent": {
-                                    "mode": "full"
-                                },
-                                "yRightExtent": {
-                                    "mode": "full"
-                                }
+                                "yRightTitle": ""
                             }
                         },
-                        "title": "[Elastic Agent] Queue depth",
+                        "title": "",
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
@@ -2752,13 +3352,13 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
+                    "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
                     "x": 24,
-                    "y": 81
+                    "y": 96
                 },
-                "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
-                "title": "[Elastic Agent] Queue depth",
+                "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
+                "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens"
             },
             {
@@ -2987,7 +3587,7 @@
                     "i": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                     "w": 24,
                     "x": 0,
-                    "y": 81
+                    "y": 105
                 },
                 "panelIndex": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                 "title": "[Elastic Agent] Queue Usage",
@@ -2998,13 +3598,8 @@
                     "attributes": {
                         "references": [
                             {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
+                                "id": "logs-*",
+                                "name": "indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
                                 "type": "index-pattern"
                             }
                         ],
@@ -3012,42 +3607,19 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
+                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
-                                        "c7cc9cd8-585a-4078-a86f-8b0213c874fd": {
+                                        "38cd2447-deab-49b7-9d84-400f2ba12511": {
                                             "columnOrder": [
-                                                "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b",
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171"
                                             ],
                                             "columns": {
-                                                "ba13a1db-763d-4a12-88c2-a5247a612c66": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Container Limit",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cgroup.memory.mem.limit.bytes"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
-                                            "linkToLayers": [],
-                                            "sampling": 1
-                                        },
-                                        "fa212775-2294-4cb0-a671-eb76e6856d14": {
-                                            "columnOrder": [
-                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
-                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae",
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69"
-                                            ],
-                                            "columns": {
-                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e": {
+                                                "0a3d2e1f-e2f5-4001-b02b-927904b0ab94": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 10 values of elastic_agent.process",
+                                                    "label": "Top 10 values of component.id",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -3056,62 +3628,80 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "90bc620d-c329-4607-90d4-5245a7cc7e69",
+                                                            "columnId": "c37367a6-4c26-4f3f-86eb-10db67933171",
                                                             "type": "column"
                                                         },
                                                         "orderDirection": "desc",
-                                                        "otherBucket": false,
+                                                        "otherBucket": true,
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
                                                         "size": 10
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
+                                                    "sourceField": "component.id"
                                                 },
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true,
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        }
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cgroup.memory.mem.usage.bytes"
-                                                },
-                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae": {
+                                                "6093c949-5f5d-4c72-baba-5a84ce2f1a9b": {
                                                     "dataType": "date",
                                                     "isBucketed": true,
                                                     "label": "@timestamp",
                                                     "operationType": "date_histogram",
                                                     "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": false,
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": true,
                                                         "interval": "m"
                                                     },
                                                     "scale": "interval",
                                                     "sourceField": "@timestamp"
+                                                },
+                                                "c37367a6-4c26-4f3f-86eb-10db67933171": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": ""
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "monitoring.metrics.libbeat.pipeline.events.active"
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
+                                            "indexPatternId": "logs-*",
+                                            "linkToLayers": [],
                                             "sampling": 1
                                         }
                                     }
-                                },
-                                "textBased": {
-                                    "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "index": "97ad75be-db47-4cb4-bb1e-0c0320d04edd",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.*"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.*"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -3121,60 +3711,54 @@
                                 "axisTitlesVisibilitySettings": {
                                     "x": false,
                                     "yLeft": false,
-                                    "yRight": false
+                                    "yRight": true
                                 },
+                                "fittingFunction": "None",
                                 "gridlinesVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
-                                    "yRight": false
+                                    "yRight": true
+                                },
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
                                 },
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "90bc620d-c329-4607-90d4-5245a7cc7e69"
+                                            "c37367a6-4c26-4f3f-86eb-10db67933171"
                                         ],
-                                        "layerId": "fa212775-2294-4cb0-a671-eb76e6856d14",
+                                        "layerId": "38cd2447-deab-49b7-9d84-400f2ba12511",
                                         "layerType": "data",
-                                        "position": "top",
                                         "seriesType": "area_stacked",
-                                        "showGridlines": false,
-                                        "splitAccessor": "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
-                                        "xAccessor": "a084070f-a15a-473c-abf4-d2e52e84c6ae"
-                                    },
-                                    {
-                                        "accessors": [
-                                            "ba13a1db-763d-4a12-88c2-a5247a612c66"
-                                        ],
-                                        "layerId": "c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-                                        "layerType": "referenceLine",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "forAccessor": "ba13a1db-763d-4a12-88c2-a5247a612c66"
-                                            }
-                                        ]
+                                        "splitAccessor": "0a3d2e1f-e2f5-4001-b02b-927904b0ab94",
+                                        "xAccessor": "6093c949-5f5d-4c72-baba-5a84ce2f1a9b"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
                                     "legendSize": "large",
                                     "position": "right",
-                                    "shouldTruncate": true,
                                     "showSingleSeries": true
                                 },
-                                "preferredSeriesType": "area_stacked",
+                                "preferredSeriesType": "line",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
-                                    "yRight": false
+                                    "yRight": true
                                 },
-                                "title": "Empty XY chart",
                                 "valueLabels": "hide",
                                 "valuesInLegend": true,
-                                "yRightTitle": ""
+                                "yLeftExtent": {
+                                    "mode": "full"
+                                },
+                                "yRightExtent": {
+                                    "mode": "full"
+                                }
                             }
                         },
-                        "title": "",
+                        "title": "[Elastic Agent] Queue depth",
                         "type": "lens",
                         "visualizationType": "lnsXY"
                     },
@@ -3183,13 +3767,13 @@
                 },
                 "gridData": {
                     "h": 9,
-                    "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
+                    "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                     "w": 24,
                     "x": 24,
-                    "y": 72
+                    "y": 105
                 },
-                "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
-                "title": "[Elastic Agent] Cgroup Memory Usage",
+                "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
+                "title": "[Elastic Agent] Queue depth",
                 "type": "lens"
             }
         ],
@@ -3198,7 +3782,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-21T18:35:47.766Z",
+    "created_at": "2024-06-21T22:02:16.263Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [
@@ -3210,6 +3794,16 @@
         {
             "id": "metrics-*",
             "name": "6b8f954e-e930-4830-b13d-7df1466ad92f:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "22432173-7e06-4fa1-b9df-03cdd7f287e9:indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8:indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
             "type": "index-pattern"
         },
         {
@@ -3283,8 +3877,13 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
-            "name": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
+            "id": "metrics-*",
+            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
             "type": "index-pattern"
         },
         {
@@ -3293,13 +3892,8 @@
             "type": "index-pattern"
         },
         {
-            "id": "metrics-*",
-            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "e651fb9f-763d-4c9d-80d7-7c56adb98883:indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
+            "id": "logs-*",
+            "name": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -3,8 +3,28 @@
         "controlGroupInput": {
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
-            "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"2678bf39-3def-453e-9f30-2904bc88efe9\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"agent.name\",\"title\":\"Agent Hostname\",\"id\":\"2678bf39-3def-453e-9f30-2904bc88efe9\",\"enhancements\":{},\"selectedOptions\":[]}}}"
+            "ignoreParentSettingsJSON": {
+                "ignoreFilters": false,
+                "ignoreQuery": false,
+                "ignoreTimerange": false,
+                "ignoreValidations": false
+            },
+            "panelsJSON": {
+                "2678bf39-3def-453e-9f30-2904bc88efe9": {
+                    "explicitInput": {
+                        "enhancements": {},
+                        "fieldName": "agent.name",
+                        "id": "2678bf39-3def-453e-9f30-2904bc88efe9",
+                        "selectedOptions": [],
+                        "title": "Agent Hostname"
+                    },
+                    "grow": true,
+                    "order": 0,
+                    "type": "optionsListControl",
+                    "width": "medium"
+                }
+            },
+            "showApplySelections": false
         },
         "description": "Elastic Agent metrics dashboard",
         "kibanaSavedObjectMeta": {
@@ -213,7 +233,7 @@
                         "references": [
                             {
                                 "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                "name": "indexpattern-datasource-layer-99f20cec-1684-4175-b773-02c3638f2a32",
                                 "type": "index-pattern"
                             }
                         ],
@@ -223,18 +243,559 @@
                                 "formBased": {
                                     "currentIndexPatternId": "metrics-*",
                                     "layers": {
-                                        "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8": {
+                                        "99f20cec-1684-4175-b773-02c3638f2a32": {
                                             "columnOrder": [
-                                                "135cfae0-7159-4211-b7c5-af814a29fd9e",
-                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3"
+                                                "7bec9e2e-5d9c-4ca9-a665-5017478e1ede",
+                                                "d86c0f7c-06a1-43fa-8110-e3aaec11b5ce",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X0",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X2",
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
                                             ],
                                             "columns": {
-                                                "135cfae0-7159-4211-b7c5-af814a29fd9e": {
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "differences(max(system.process.cpu.total.time.ms))/interval()",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X3"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.time.ms"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "differences",
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X2": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "interval",
+                                                    "references": [],
+                                                    "scale": "ratio"
+                                                },
+                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X3": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
+                                                                "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                            ],
+                                                            "location": {
+                                                                "max": 61,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "differences(max(system.process.cpu.total.time.ms))/interval()",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X1",
+                                                        "36f3abb0-7261-43e6-bc2f-7ad492094054X2"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "7bec9e2e-5d9c-4ca9-a665-5017478e1ede": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 5 values of component.id",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 5
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "component.id"
+                                                },
+                                                "d86c0f7c-06a1-43fa-8110-e3aaec11b5ce": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "ignoreGlobalFilters": false,
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "a56d2368-a048-4c48-a261-e878eb2690c8",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.elastic_agent"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.elastic_agent"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "36f3abb0-7261-43e6-bc2f-7ad492094054"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "99f20cec-1684-4175-b773-02c3638f2a32",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area",
+                                        "showGridlines": false,
+                                        "splitAccessor": "7bec9e2e-5d9c-4ca9-a665-5017478e1ede",
+                                        "xAccessor": "d86c0f7c-06a1-43fa-8110-e3aaec11b5ce"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area",
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "description": "",
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 13,
+                    "i": "a9091abd-f59f-44ff-92f2-6415fd64282c",
+                    "w": 40,
+                    "x": 8,
+                    "y": 9
+                },
+                "panelIndex": "a9091abd-f59f-44ff-92f2-6415fd64282c",
+                "title": "[Elastic Agent] CPU Usage",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6": {
+                                            "columnOrder": [
+                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a",
+                                                "f551a168-2820-4eaa-a238-e93f13648137",
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516",
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0",
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X1"
+                                            ],
+                                            "columns": {
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "percent",
+                                                            "params": {
+                                                                "compact": false,
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "(last_value(system.process.cpu.total.time.ms)/60000)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X1"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"system.process.cpu.total.time.ms\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.time.ms"
+                                                },
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X1": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "math",
+                                                    "params": {
+                                                        "tinymathAst": {
+                                                            "args": [
+                                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0",
+                                                                60000
+                                                            ],
+                                                            "location": {
+                                                                "max": 52,
+                                                                "min": 0
+                                                            },
+                                                            "name": "divide",
+                                                            "text": "(last_value(system.process.cpu.total.time.ms)/60000)",
+                                                            "type": "function"
+                                                        }
+                                                    },
+                                                    "references": [
+                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "f551a168-2820-4eaa-a238-e93f13648137": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top values of elastic_agent.process + 1 other",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": true,
+                                                        "parentFormat": {
+                                                            "id": "multi_terms"
+                                                        },
+                                                        "secondaryFields": [
+                                                            "component.id"
+                                                        ],
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "elastic_agent.process"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*",
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "indexpattern": {
+                                    "layers": {}
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "data_stream.dataset",
+                                        "index": "7f1fb915-a1b3-478f-a616-afac831a31f5",
+                                        "key": "data_stream.dataset",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "elastic_agent.elastic_agent"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.elastic_agent"
+                                        }
+                                    }
+                                }
+                            ],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "fittingFunction": "None",
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "hideEndzones": false,
+                                "labelsOrientation": {
+                                    "x": 0,
+                                    "yLeft": 0,
+                                    "yRight": 0
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "a454c1c1-ed93-466b-bf87-873ea34d8516"
+                                        ],
+                                        "colorMapping": {
+                                            "assignments": [],
+                                            "colorMode": {
+                                                "type": "categorical"
+                                            },
+                                            "paletteId": "eui_amsterdam_color_blind",
+                                            "specialAssignments": [
+                                                {
+                                                    "color": {
+                                                        "type": "loop"
+                                                    },
+                                                    "rule": {
+                                                        "type": "other"
+                                                    },
+                                                    "touched": false
+                                                }
+                                            ]
+                                        },
+                                        "layerId": "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
+                                        "layerType": "data",
+                                        "seriesType": "area",
+                                        "splitAccessor": "fe07d658-4596-451d-b76e-5e5659f0ca7a",
+                                        "xAccessor": "f551a168-2820-4eaa-a238-e93f13648137"
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "position": "right"
+                                },
+                                "preferredSeriesType": "area",
+                                "showCurrentTimeMarker": false,
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": true
+                                },
+                                "valueLabels": "hide"
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {}
+                },
+                "gridData": {
+                    "h": 12,
+                    "i": "d357e079-defd-4739-ab22-05234afcda91",
+                    "w": 40,
+                    "x": 8,
+                    "y": 22
+                },
+                "panelIndex": "d357e079-defd-4739-ab22-05234afcda91",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "currentIndexPatternId": "metrics-*",
+                                    "layers": {
+                                        "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6": {
+                                            "columnOrder": [
+                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a",
+                                                "f551a168-2820-4eaa-a238-e93f13648137",
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516",
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
+                                            ],
+                                            "columns": {
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "formula": "(last_value(system.process.cpu.total.time.ms))",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "filter": {
+                                                        "language": "kuery",
+                                                        "query": "\"system.process.cpu.total.time.ms\": *"
+                                                    },
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "last_value",
+                                                    "params": {
+                                                        "sortField": "@timestamp"
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cpu.total.time.ms"
+                                                },
+                                                "f551a168-2820-4eaa-a238-e93f13648137": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": false,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "s"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                },
+                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
                                                     "label": "Top 5 values of elastic_agent.process",
@@ -259,117 +820,6 @@
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "elastic_agent.process"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2,
-                                                                "suffix": ""
-                                                            }
-                                                        },
-                                                        "formula": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X3"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.time.ms\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.time.ms"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "differences",
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "interval",
-                                                    "references": [],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                {
-                                                                    "args": [
-                                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
-                                                                    ],
-                                                                    "location": {
-                                                                        "max": 69,
-                                                                        "min": 1
-                                                                    },
-                                                                    "name": "divide",
-                                                                    "text": "differences(last_value(system.process.cpu.total.time.ms))/interval()",
-                                                                    "type": "function"
-                                                                },
-                                                                100
-                                                            ],
-                                                            "location": {
-                                                                "max": 74,
-                                                                "min": 0
-                                                            },
-                                                            "name": "multiply",
-                                                            "text": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
                                                 }
                                             },
                                             "incompleteColumns": {},
@@ -393,15 +843,18 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "field": "system.process.cpu.total.ticks",
-                                        "index": "a8bc4aba-aa4d-47c8-8687-31f3e2bdab87",
-                                        "key": "system.process.cpu.total.ticks",
+                                        "field": "data_stream.dataset",
+                                        "index": "7f1fb915-a1b3-478f-a616-afac831a31f5",
+                                        "key": "data_stream.dataset",
                                         "negate": false,
-                                        "type": "exists"
+                                        "params": {
+                                            "query": "elastic_agent.elastic_agent"
+                                        },
+                                        "type": "phrase"
                                     },
                                     "query": {
-                                        "exists": {
-                                            "field": "system.process.cpu.total.ticks"
+                                        "match_phrase": {
+                                            "data_stream.dataset": "elastic_agent.elastic_agent"
                                         }
                                     }
                                 }
@@ -431,7 +884,7 @@
                                 "layers": [
                                     {
                                         "accessors": [
-                                            "75b0be50-24a3-4528-8b08-74c3c072b355"
+                                            "a454c1c1-ed93-466b-bf87-873ea34d8516"
                                         ],
                                         "colorMapping": {
                                             "assignments": [],
@@ -451,20 +904,18 @@
                                                 }
                                             ]
                                         },
-                                        "layerId": "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+                                        "layerId": "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
                                         "layerType": "data",
-                                        "position": "top",
                                         "seriesType": "area",
-                                        "showGridlines": false,
-                                        "splitAccessor": "135cfae0-7159-4211-b7c5-af814a29fd9e",
-                                        "xAccessor": "7f8f777a-bb98-4d2b-83ab-ec1983847e67"
+                                        "splitAccessor": "fe07d658-4596-451d-b76e-5e5659f0ca7a",
+                                        "xAccessor": "f551a168-2820-4eaa-a238-e93f13648137"
                                     }
                                 ],
                                 "legend": {
                                     "isVisible": true,
                                     "position": "right"
                                 },
-                                "preferredSeriesType": "bar_stacked",
+                                "preferredSeriesType": "area",
                                 "tickLabelsVisibilitySettings": {
                                     "x": true,
                                     "yLeft": true,
@@ -481,13 +932,12 @@
                 },
                 "gridData": {
                     "h": 12,
-                    "i": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8",
+                    "i": "606bbab6-43df-49ac-899e-d102e0905fa9",
                     "w": 40,
                     "x": 8,
-                    "y": 9
+                    "y": 34
                 },
-                "panelIndex": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8",
-                "title": "[Elastic Agent] CPU Usage",
+                "panelIndex": "606bbab6-43df-49ac-899e-d102e0905fa9",
                 "type": "lens"
             },
             {
@@ -654,7 +1104,7 @@
                     "i": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                     "w": 40,
                     "x": 8,
-                    "y": 21
+                    "y": 46
                 },
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
@@ -795,7 +1245,7 @@
                     "i": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                     "w": 40,
                     "x": 8,
-                    "y": 30
+                    "y": 55
                 },
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
@@ -985,7 +1435,7 @@
                     "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                     "w": 24,
                     "x": 0,
-                    "y": 39
+                    "y": 64
                 },
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
@@ -1183,7 +1633,7 @@
                     "i": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                     "w": 24,
                     "x": 24,
-                    "y": 39
+                    "y": 64
                 },
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
@@ -1374,7 +1824,7 @@
                     "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                     "w": 24,
                     "x": 0,
-                    "y": 48
+                    "y": 73
                 },
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
@@ -1564,7 +2014,7 @@
                     "i": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                     "w": 24,
                     "x": 24,
-                    "y": 48
+                    "y": 73
                 },
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
@@ -1756,7 +2206,7 @@
                     "i": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                     "w": 24,
                     "x": 0,
-                    "y": 57
+                    "y": 82
                 },
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
@@ -1937,7 +2387,7 @@
                     "i": "d004044a-99f4-44fa-964a-361accd1810d",
                     "w": 24,
                     "x": 24,
-                    "y": 57
+                    "y": 82
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
@@ -2130,7 +2580,7 @@
                     "i": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                     "w": 24,
                     "x": 0,
-                    "y": 66
+                    "y": 91
                 },
                 "panelIndex": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                 "title": "[Elastic Agent] Events dropped rate /s",
@@ -2320,7 +2770,7 @@
                     "i": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                     "w": 24,
                     "x": 24,
-                    "y": 66
+                    "y": 91
                 },
                 "panelIndex": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                 "title": "[Elastic Agent] Events duplicate rate /s",
@@ -2510,7 +2960,7 @@
                     "i": "ce5bea64-4178-4290-997b-a59455991f3d",
                     "w": 24,
                     "x": 0,
-                    "y": 75
+                    "y": 100
                 },
                 "panelIndex": "ce5bea64-4178-4290-997b-a59455991f3d",
                 "title": "[Elastic Agent] Events failed rate /s",
@@ -2700,377 +3150,10 @@
                     "i": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                     "w": 24,
                     "x": 24,
-                    "y": 75
+                    "y": 100
                 },
                 "panelIndex": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                 "title": "[Elastic Agent] Events TooMany rate /s",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "data_stream.dataset",
-                                            "negate": false,
-                                            "params": {
-                                                "query": "elastic_agent.elastic_agent"
-                                            },
-                                            "type": "phrase"
-                                        },
-                                        "query": {
-                                            "match_phrase": {
-                                                "data_stream.dataset": "elastic_agent.elastic_agent"
-                                            }
-                                        }
-                                    }
-                                ],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 0,
-                            "filter": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "id": "f0383b91-4a09-4b03-a013-f5938add6bfa",
-                            "index_pattern_ref_name": "metrics_42ec7297-eb0f-492b-bb18-d1301fa1ead7_0_index_pattern",
-                            "interval": "\u003e=1m",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "number",
-                                    "id": "a35c4256-5cee-4b6a-ae21-bdd0f0f6d4a2",
-                                    "label": "Cgroup CPU usage",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "field": "system.process.cgroup.cpuacct.total.ns",
-                                            "id": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
-                                            "type": "max"
-                                        },
-                                        {
-                                            "field": "system.process.cgroup.cpu.cfs.quota.us",
-                                            "id": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
-                                            "type": "min"
-                                        },
-                                        {
-                                            "field": "458710e3-e78d-4ebf-b9c7-3b1ca8bfc55a",
-                                            "id": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
-                                            "type": "derivative",
-                                            "unit": "1s"
-                                        },
-                                        {
-                                            "field": "90f31960-fc31-11eb-9d3e-9d72967e3395",
-                                            "id": "4661f000-fc32-11eb-9d3e-9d72967e3395",
-                                            "type": "derivative",
-                                            "unit": "1s"
-                                        },
-                                        {
-                                            "field": "system.process.cgroup.cpu.stats.periods",
-                                            "id": "90f31960-fc31-11eb-9d3e-9d72967e3395",
-                                            "type": "max"
-                                        },
-                                        {
-                                            "id": "5c737680-fc31-11eb-9d3e-9d72967e3395",
-                                            "script": "\n      if (params.deltaUsageDerivNormalizedValue \u003e 0 \u0026\u0026 params.periodsDerivNormalizedValue \u003e0  \u0026\u0026 params.quota \u003e 0) {\n        // if throttling is configured\n        double  factor = params.deltaUsageDerivNormalizedValue / (params.periodsDerivNormalizedValue * params.quota * 1000); \n\n        return factor * 100; \n      }\n\n      return null;",
-                                            "type": "calculation",
-                                            "variables": [
-                                                {
-                                                    "field": "391dc9f0-fc32-11eb-9d3e-9d72967e3395",
-                                                    "id": "60300950-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "deltaUsageDerivNormalizedValue"
-                                                },
-                                                {
-                                                    "field": "4661f000-fc32-11eb-9d3e-9d72967e3395",
-                                                    "id": "d6060d50-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "periodsDerivNormalizedValue"
-                                                },
-                                                {
-                                                    "field": "5a08b810-fc31-11eb-9d3e-9d72967e3395",
-                                                    "id": "e3368450-fc31-11eb-9d3e-9d72967e3395",
-                                                    "name": "quota"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "palette": {
-                                        "name": "default",
-                                        "type": "palette"
-                                    },
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "split_mode": "terms",
-                                    "stacked": "stacked",
-                                    "terms_field": "elastic_agent.process",
-                                    "time_range_mode": "entire_time_range",
-                                    "type": "timeseries",
-                                    "value_template": "{{value}}%"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": true
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
-                    "w": 24,
-                    "x": 0,
-                    "y": 84
-                },
-                "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
-                "title": "[Elastic Agent] CGroup CPU Usage",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-                                "type": "index-pattern"
-                            },
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "layers": {
-                                        "c7cc9cd8-585a-4078-a86f-8b0213c874fd": {
-                                            "columnOrder": [
-                                                "ba13a1db-763d-4a12-88c2-a5247a612c66"
-                                            ],
-                                            "columns": {
-                                                "ba13a1db-763d-4a12-88c2-a5247a612c66": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Container Limit",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": true
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cgroup.memory.mem.limit.bytes"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "linkToLayers": [],
-                                            "sampling": 1
-                                        },
-                                        "fa212775-2294-4cb0-a671-eb76e6856d14": {
-                                            "columnOrder": [
-                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
-                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae",
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69",
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
-                                            ],
-                                            "columns": {
-                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 10 values of elastic_agent.process",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": false,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
-                                                },
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "bytes",
-                                                            "params": {
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "formula": "max(system.process.cgroup.memory.mem.usage.bytes)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "max",
-                                                    "params": {
-                                                        "emptyAsNull": false
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cgroup.memory.mem.usage.bytes"
-                                                },
-                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": true,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "m"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": false,
-                                    "yLeft": false,
-                                    "yRight": false
-                                },
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": false
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "90bc620d-c329-4607-90d4-5245a7cc7e69"
-                                        ],
-                                        "layerId": "fa212775-2294-4cb0-a671-eb76e6856d14",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "area_stacked",
-                                        "showGridlines": false,
-                                        "splitAccessor": "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
-                                        "xAccessor": "a084070f-a15a-473c-abf4-d2e52e84c6ae"
-                                    },
-                                    {
-                                        "accessors": [
-                                            "ba13a1db-763d-4a12-88c2-a5247a612c66"
-                                        ],
-                                        "layerId": "c7cc9cd8-585a-4078-a86f-8b0213c874fd",
-                                        "layerType": "referenceLine",
-                                        "yConfig": [
-                                            {
-                                                "axisMode": "left",
-                                                "forAccessor": "ba13a1db-763d-4a12-88c2-a5247a612c66"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "legendSize": "large",
-                                    "position": "right",
-                                    "shouldTruncate": true,
-                                    "showSingleSeries": true
-                                },
-                                "preferredSeriesType": "area_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": false
-                                },
-                                "title": "Empty XY chart",
-                                "valueLabels": "hide",
-                                "valuesInLegend": true,
-                                "yRightTitle": ""
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {},
-                    "hidePanelTitles": false
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
-                    "w": 24,
-                    "x": 24,
-                    "y": 84
-                },
-                "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
-                "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens"
             },
             {
@@ -3299,10 +3382,222 @@
                     "i": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                     "w": 24,
                     "x": 0,
-                    "y": 93
+                    "y": 109
                 },
                 "panelIndex": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                 "title": "[Elastic Agent] Queue Usage",
+                "type": "lens"
+            },
+            {
+                "embeddableConfig": {
+                    "attributes": {
+                        "references": [
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "metrics-*",
+                                "name": "indexpattern-datasource-layer-fa212775-2294-4cb0-a671-eb76e6856d14",
+                                "type": "index-pattern"
+                            }
+                        ],
+                        "state": {
+                            "adHocDataViews": {},
+                            "datasourceStates": {
+                                "formBased": {
+                                    "layers": {
+                                        "c7cc9cd8-585a-4078-a86f-8b0213c874fd": {
+                                            "columnOrder": [
+                                                "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                            ],
+                                            "columns": {
+                                                "ba13a1db-763d-4a12-88c2-a5247a612c66": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Container Limit",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": true
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cgroup.memory.mem.limit.bytes"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "linkToLayers": [],
+                                            "sampling": 1
+                                        },
+                                        "fa212775-2294-4cb0-a671-eb76e6856d14": {
+                                            "columnOrder": [
+                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
+                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae",
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69",
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
+                                            ],
+                                            "columns": {
+                                                "3495fd36-d74d-4daf-9dae-1e84e63bc31e": {
+                                                    "dataType": "string",
+                                                    "isBucketed": true,
+                                                    "label": "Top 10 values of elastic_agent.process",
+                                                    "operationType": "terms",
+                                                    "params": {
+                                                        "exclude": [],
+                                                        "excludeIsRegex": false,
+                                                        "include": [],
+                                                        "includeIsRegex": false,
+                                                        "missingBucket": false,
+                                                        "orderBy": {
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
+                                                        },
+                                                        "orderDirection": "asc",
+                                                        "otherBucket": false,
+                                                        "parentFormat": {
+                                                            "id": "terms"
+                                                        },
+                                                        "size": 10
+                                                    },
+                                                    "scale": "ordinal",
+                                                    "sourceField": "elastic_agent.process"
+                                                },
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": " ",
+                                                    "operationType": "formula",
+                                                    "params": {
+                                                        "format": {
+                                                            "id": "bytes",
+                                                            "params": {
+                                                                "decimals": 2
+                                                            }
+                                                        },
+                                                        "formula": "max(system.process.cgroup.memory.mem.usage.bytes)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "system.process.cgroup.memory.mem.usage.bytes"
+                                                },
+                                                "a084070f-a15a-473c-abf4-d2e52e84c6ae": {
+                                                    "dataType": "date",
+                                                    "isBucketed": true,
+                                                    "label": "@timestamp",
+                                                    "operationType": "date_histogram",
+                                                    "params": {
+                                                        "dropPartials": true,
+                                                        "includeEmptyRows": false,
+                                                        "interval": "m"
+                                                    },
+                                                    "scale": "interval",
+                                                    "sourceField": "@timestamp"
+                                                }
+                                            },
+                                            "incompleteColumns": {},
+                                            "sampling": 1
+                                        }
+                                    }
+                                },
+                                "textBased": {
+                                    "layers": {}
+                                }
+                            },
+                            "filters": [],
+                            "internalReferences": [],
+                            "query": {
+                                "language": "kuery",
+                                "query": ""
+                            },
+                            "visualization": {
+                                "axisTitlesVisibilitySettings": {
+                                    "x": false,
+                                    "yLeft": false,
+                                    "yRight": false
+                                },
+                                "gridlinesVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "layers": [
+                                    {
+                                        "accessors": [
+                                            "90bc620d-c329-4607-90d4-5245a7cc7e69"
+                                        ],
+                                        "layerId": "fa212775-2294-4cb0-a671-eb76e6856d14",
+                                        "layerType": "data",
+                                        "position": "top",
+                                        "seriesType": "area_stacked",
+                                        "showGridlines": false,
+                                        "splitAccessor": "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
+                                        "xAccessor": "a084070f-a15a-473c-abf4-d2e52e84c6ae"
+                                    },
+                                    {
+                                        "accessors": [
+                                            "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                        ],
+                                        "layerId": "c7cc9cd8-585a-4078-a86f-8b0213c874fd",
+                                        "layerType": "referenceLine",
+                                        "yConfig": [
+                                            {
+                                                "axisMode": "left",
+                                                "forAccessor": "ba13a1db-763d-4a12-88c2-a5247a612c66"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "legend": {
+                                    "isVisible": true,
+                                    "legendSize": "large",
+                                    "position": "right",
+                                    "shouldTruncate": true,
+                                    "showSingleSeries": true
+                                },
+                                "preferredSeriesType": "area_stacked",
+                                "tickLabelsVisibilitySettings": {
+                                    "x": true,
+                                    "yLeft": true,
+                                    "yRight": false
+                                },
+                                "title": "Empty XY chart",
+                                "valueLabels": "hide",
+                                "valuesInLegend": true,
+                                "yRightTitle": ""
+                            }
+                        },
+                        "title": "",
+                        "type": "lens",
+                        "visualizationType": "lnsXY"
+                    },
+                    "enhancements": {},
+                    "hidePanelTitles": false
+                },
+                "gridData": {
+                    "h": 9,
+                    "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
+                    "w": 24,
+                    "x": 24,
+                    "y": 109
+                },
+                "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
+                "title": "[Elastic Agent] Cgroup Memory Usage",
                 "type": "lens"
             },
             {
@@ -3481,8 +3776,8 @@
                     "h": 9,
                     "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                     "w": 24,
-                    "x": 24,
-                    "y": 93
+                    "x": 0,
+                    "y": 118
                 },
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                 "title": "[Elastic Agent] Queue depth",
@@ -3491,10 +3786,10 @@
         ],
         "timeRestore": false,
         "title": "[Elastic Agent] Agent metrics",
-        "version": 1
+        "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-24T20:09:25.192Z",
+    "created_at": "2024-06-27T21:06:04.956Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [
@@ -3510,7 +3805,17 @@
         },
         {
             "id": "metrics-*",
-            "name": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8:indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
+            "name": "a9091abd-f59f-44ff-92f2-6415fd64282c:indexpattern-datasource-layer-99f20cec-1684-4175-b773-02c3638f2a32",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "d357e079-defd-4739-ab22-05234afcda91:indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
+            "type": "index-pattern"
+        },
+        {
+            "id": "metrics-*",
+            "name": "606bbab6-43df-49ac-899e-d102e0905fa9:indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
             "type": "index-pattern"
         },
         {
@@ -3574,13 +3879,8 @@
             "type": "index-pattern"
         },
         {
-            "id": "metrics-*",
-            "name": "42ec7297-eb0f-492b-bb18-d1301fa1ead7:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "42ec7297-eb0f-492b-bb18-d1301fa1ead7:metrics_42ec7297-eb0f-492b-bb18-d1301fa1ead7_0_index_pattern",
+            "id": "logs-*",
+            "name": "bf48fd17-63ec-4d90-8b6a-328bb74b466a:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
             "type": "index-pattern"
         },
         {
@@ -3595,11 +3895,6 @@
         },
         {
             "id": "logs-*",
-            "name": "bf48fd17-63ec-4d90-8b6a-328bb74b466a:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
-            "type": "index-pattern"
-        },
-        {
-            "id": "logs-*",
             "name": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1:indexpattern-datasource-layer-38cd2447-deab-49b7-9d84-400f2ba12511",
             "type": "index-pattern"
         },
@@ -3610,5 +3905,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "8.9.0"
+    "typeMigrationVersion": "10.2.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -107,128 +107,6 @@
             },
             {
                 "embeddableConfig": {
-                    "enhancements": {},
-                    "savedVis": {
-                        "data": {
-                            "aggs": [],
-                            "searchSource": {
-                                "filter": [
-                                    {
-                                        "$state": {
-                                            "store": "appState"
-                                        },
-                                        "meta": {
-                                            "alias": null,
-                                            "disabled": false,
-                                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-                                            "key": "data_stream.dataset",
-                                            "negate": false,
-                                            "params": {
-                                                "query": "elastic_agent.elastic_agent"
-                                            },
-                                            "type": "phrase"
-                                        },
-                                        "query": {
-                                            "match_phrase": {
-                                                "data_stream.dataset": "elastic_agent.elastic_agent"
-                                            }
-                                        }
-                                    }
-                                ],
-                                "query": {
-                                    "language": "kuery",
-                                    "query": ""
-                                }
-                            }
-                        },
-                        "description": "",
-                        "params": {
-                            "axis_formatter": "number",
-                            "axis_position": "left",
-                            "axis_scale": "normal",
-                            "drop_last_bucket": 0,
-                            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
-                            "index_pattern": "metrics-*",
-                            "interval": "\u003e=1m",
-                            "isModelInvalid": false,
-                            "max_lines_legend": 1,
-                            "series": [
-                                {
-                                    "axis_position": "right",
-                                    "chart_type": "line",
-                                    "color": "#68BC00",
-                                    "fill": 0.5,
-                                    "filter": {
-                                        "language": "kuery",
-                                        "query": ""
-                                    },
-                                    "formatter": "percent",
-                                    "id": "61ca57f1-469d-11e7-af02-69e470af7417",
-                                    "label": "CPU usage",
-                                    "line_width": 1,
-                                    "metrics": [
-                                        {
-                                            "field": "system.process.cpu.total.value",
-                                            "id": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "type": "max"
-                                        },
-                                        {
-                                            "field": "61ca57f2-469d-11e7-af02-69e470af7417",
-                                            "id": "42fea6f0-3da7-11eb-a63c-0f13e40aab83",
-                                            "type": "derivative",
-                                            "unit": ""
-                                        },
-                                        {
-                                            "id": "48fd6190-3da7-11eb-a63c-0f13e40aab83",
-                                            "script": "if (params.cpu_total \u003e 0) {\n  return params.cpu_total / params._interval  \n}\n\n",
-                                            "type": "calculation",
-                                            "variables": [
-                                                {
-                                                    "field": "42fea6f0-3da7-11eb-a63c-0f13e40aab83",
-                                                    "id": "4b81c280-3da7-11eb-a63c-0f13e40aab83",
-                                                    "name": "cpu_total"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "point_size": 1,
-                                    "separate_axis": 0,
-                                    "series_index_pattern": "",
-                                    "split_color_mode": "kibana",
-                                    "split_mode": "terms",
-                                    "stacked": "stacked",
-                                    "terms_field": "elastic_agent.process",
-                                    "time_range_mode": "entire_time_range",
-                                    "type": "timeseries"
-                                }
-                            ],
-                            "show_grid": 1,
-                            "show_legend": 1,
-                            "time_field": "@timestamp",
-                            "time_range_mode": "entire_time_range",
-                            "tooltip_mode": "show_all",
-                            "truncate_legend": 1,
-                            "type": "timeseries",
-                            "use_kibana_indexes": false
-                        },
-                        "title": "",
-                        "type": "metrics",
-                        "uiState": {}
-                    }
-                },
-                "gridData": {
-                    "h": 9,
-                    "i": "6b8f954e-e930-4830-b13d-7df1466ad92f",
-                    "w": 40,
-                    "x": 8,
-                    "y": 0
-                },
-                "panelIndex": "6b8f954e-e930-4830-b13d-7df1466ad92f",
-                "title": "[Elastic Agent] CPU Usage",
-                "type": "visualization"
-            },
-            {
-                "embeddableConfig": {
                     "attributes": {
                         "references": [
                             {
@@ -470,474 +348,10 @@
                     "i": "a9091abd-f59f-44ff-92f2-6415fd64282c",
                     "w": 40,
                     "x": 8,
-                    "y": 9
+                    "y": 0
                 },
                 "panelIndex": "a9091abd-f59f-44ff-92f2-6415fd64282c",
                 "title": "[Elastic Agent] CPU Usage",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6": {
-                                            "columnOrder": [
-                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a",
-                                                "f551a168-2820-4eaa-a238-e93f13648137",
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516",
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0",
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X1"
-                                            ],
-                                            "columns": {
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "compact": false,
-                                                                "decimals": 2
-                                                            }
-                                                        },
-                                                        "formula": "(last_value(system.process.cpu.total.time.ms)/60000)",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X1"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.time.ms\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.time.ms"
-                                                },
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0",
-                                                                60000
-                                                            ],
-                                                            "location": {
-                                                                "max": 52,
-                                                                "min": 0
-                                                            },
-                                                            "name": "divide",
-                                                            "text": "(last_value(system.process.cpu.total.time.ms)/60000)",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "f551a168-2820-4eaa-a238-e93f13648137": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top values of elastic_agent.process + 1 other",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "multi_terms"
-                                                        },
-                                                        "secondaryFields": [
-                                                            "component.id"
-                                                        ],
-                                                        "size": 10
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "data_stream.dataset",
-                                        "index": "7f1fb915-a1b3-478f-a616-afac831a31f5",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.elastic_agent"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.elastic_agent"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "hideEndzones": false,
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a454c1c1-ed93-466b-bf87-873ea34d8516"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
-                                        "layerType": "data",
-                                        "seriesType": "area",
-                                        "splitAccessor": "fe07d658-4596-451d-b76e-5e5659f0ca7a",
-                                        "xAccessor": "f551a168-2820-4eaa-a238-e93f13648137"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "showCurrentTimeMarker": false,
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "d357e079-defd-4739-ab22-05234afcda91",
-                    "w": 40,
-                    "x": 8,
-                    "y": 22
-                },
-                "panelIndex": "d357e079-defd-4739-ab22-05234afcda91",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6": {
-                                            "columnOrder": [
-                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a",
-                                                "f551a168-2820-4eaa-a238-e93f13648137",
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516",
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
-                                            ],
-                                            "columns": {
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": " ",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "formula": "(last_value(system.process.cpu.total.time.ms))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "a454c1c1-ed93-466b-bf87-873ea34d8516X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "a454c1c1-ed93-466b-bf87-873ea34d8516X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.time.ms\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of  ",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.time.ms"
-                                                },
-                                                "f551a168-2820-4eaa-a238-e93f13648137": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": false,
-                                                        "interval": "s"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                },
-                                                "fe07d658-4596-451d-b76e-5e5659f0ca7a": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of elastic_agent.process",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "data_stream.dataset",
-                                        "index": "7f1fb915-a1b3-478f-a616-afac831a31f5",
-                                        "key": "data_stream.dataset",
-                                        "negate": false,
-                                        "params": {
-                                            "query": "elastic_agent.elastic_agent"
-                                        },
-                                        "type": "phrase"
-                                    },
-                                    "query": {
-                                        "match_phrase": {
-                                            "data_stream.dataset": "elastic_agent.elastic_agent"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "a454c1c1-ed93-466b-bf87-873ea34d8516"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
-                                        "layerType": "data",
-                                        "seriesType": "area",
-                                        "splitAccessor": "fe07d658-4596-451d-b76e-5e5659f0ca7a",
-                                        "xAccessor": "f551a168-2820-4eaa-a238-e93f13648137"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "area",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "606bbab6-43df-49ac-899e-d102e0905fa9",
-                    "w": 40,
-                    "x": 8,
-                    "y": 34
-                },
-                "panelIndex": "606bbab6-43df-49ac-899e-d102e0905fa9",
                 "type": "lens"
             },
             {
@@ -1104,7 +518,7 @@
                     "i": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                     "w": 40,
                     "x": 8,
-                    "y": 46
+                    "y": 13
                 },
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
@@ -1245,7 +659,7 @@
                     "i": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                     "w": 40,
                     "x": 8,
-                    "y": 55
+                    "y": 22
                 },
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
@@ -1435,7 +849,7 @@
                     "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                     "w": 24,
                     "x": 0,
-                    "y": 64
+                    "y": 31
                 },
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
@@ -1633,7 +1047,7 @@
                     "i": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                     "w": 24,
                     "x": 24,
-                    "y": 64
+                    "y": 31
                 },
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
@@ -1824,7 +1238,7 @@
                     "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                     "w": 24,
                     "x": 0,
-                    "y": 73
+                    "y": 40
                 },
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
@@ -2014,7 +1428,7 @@
                     "i": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                     "w": 24,
                     "x": 24,
-                    "y": 73
+                    "y": 40
                 },
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
@@ -2206,7 +1620,7 @@
                     "i": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                     "w": 24,
                     "x": 0,
-                    "y": 82
+                    "y": 49
                 },
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
@@ -2387,7 +1801,7 @@
                     "i": "d004044a-99f4-44fa-964a-361accd1810d",
                     "w": 24,
                     "x": 24,
-                    "y": 82
+                    "y": 49
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
@@ -2580,7 +1994,7 @@
                     "i": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                     "w": 24,
                     "x": 0,
-                    "y": 91
+                    "y": 58
                 },
                 "panelIndex": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                 "title": "[Elastic Agent] Events dropped rate /s",
@@ -2770,7 +2184,7 @@
                     "i": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                     "w": 24,
                     "x": 24,
-                    "y": 91
+                    "y": 58
                 },
                 "panelIndex": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                 "title": "[Elastic Agent] Events duplicate rate /s",
@@ -2960,7 +2374,7 @@
                     "i": "ce5bea64-4178-4290-997b-a59455991f3d",
                     "w": 24,
                     "x": 0,
-                    "y": 100
+                    "y": 67
                 },
                 "panelIndex": "ce5bea64-4178-4290-997b-a59455991f3d",
                 "title": "[Elastic Agent] Events failed rate /s",
@@ -3150,7 +2564,7 @@
                     "i": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                     "w": 24,
                     "x": 24,
-                    "y": 100
+                    "y": 67
                 },
                 "panelIndex": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                 "title": "[Elastic Agent] Events TooMany rate /s",
@@ -3382,7 +2796,7 @@
                     "i": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                     "w": 24,
                     "x": 0,
-                    "y": 109
+                    "y": 76
                 },
                 "panelIndex": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                 "title": "[Elastic Agent] Queue Usage",
@@ -3594,7 +3008,7 @@
                     "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
                     "x": 24,
-                    "y": 109
+                    "y": 76
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
@@ -3777,7 +3191,7 @@
                     "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                     "w": 24,
                     "x": 0,
-                    "y": 118
+                    "y": 85
                 },
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                 "title": "[Elastic Agent] Queue depth",
@@ -3789,9 +3203,9 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-28T16:08:23.865Z",
+    "created_at": "2024-07-01T19:33:39.601Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": true,
+    "managed": false,
     "references": [
         {
             "id": "metrics-*",
@@ -3800,22 +3214,7 @@
         },
         {
             "id": "metrics-*",
-            "name": "6b8f954e-e930-4830-b13d-7df1466ad92f:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
             "name": "a9091abd-f59f-44ff-92f2-6415fd64282c:indexpattern-datasource-layer-99f20cec-1684-4175-b773-02c3638f2a32",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "d357e079-defd-4739-ab22-05234afcda91:indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "606bbab6-43df-49ac-899e-d102e0905fa9:indexpattern-datasource-layer-c055ce6b-9b69-47a6-ab0f-6c83e079b9d6",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -9,7 +9,30 @@
         "description": "Elastic Agent metrics dashboard",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "data_stream.dataset",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "data_stream.dataset",
+                            "negate": false,
+                            "params": {
+                                "query": "elastic_agent.*"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "data_stream.dataset": "elastic_agent.*"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -3175,10 +3198,15 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-18T13:40:33.056Z",
+    "created_at": "2024-06-21T18:35:47.766Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [
+        {
+            "id": "metrics-*",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+            "type": "index-pattern"
+        },
         {
             "id": "metrics-*",
             "name": "6b8f954e-e930-4830-b13d-7df1466ad92f:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -3304,5 +3304,5 @@
         }
     ],
     "type": "dashboard",
-    "typeMigrationVersion": "10.2.0"
+    "typeMigrationVersion": "8.9.0"
 }

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -231,307 +231,6 @@
                                                 "75b0be50-24a3-4528-8b08-74c3c072b355X0",
                                                 "75b0be50-24a3-4528-8b08-74c3c072b355X1",
                                                 "75b0be50-24a3-4528-8b08-74c3c072b355X2",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X5"
-                                            ],
-                                            "columns": {
-                                                "135cfae0-7159-4211-b7c5-af814a29fd9e": {
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Top 5 values of elastic_agent.process",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "fallback": true,
-                                                            "type": "alphabetical"
-                                                        },
-                                                        "orderDirection": "asc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "secondaryFields": [],
-                                                        "size": 5
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "elastic_agent.process"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355": {
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "formula",
-                                                    "params": {
-                                                        "format": {
-                                                            "id": "percent",
-                                                            "params": {
-                                                                "compact": true,
-                                                                "decimals": 2,
-                                                                "suffix": ""
-                                                            }
-                                                        },
-                                                        "formula": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                        "isFormulaBroken": false
-                                                    },
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X5"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.value\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.value"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "differences",
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X0"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "\"system.process.cpu.total.value\": *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "system.process.cpu.total.value"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X3": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "differences",
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X2"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "overall_sum",
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X3"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X5": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                    "operationType": "math",
-                                                    "params": {
-                                                        "tinymathAst": {
-                                                            "args": [
-                                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                                "75b0be50-24a3-4528-8b08-74c3c072b355X4"
-                                                            ],
-                                                            "location": {
-                                                                "max": 124,
-                                                                "min": 0
-                                                            },
-                                                            "name": "divide",
-                                                            "text": "differences(last_value(system.process.cpu.total.value))/overall_sum(differences(last_value(system.process.cpu.total.value)))",
-                                                            "type": "function"
-                                                        }
-                                                    },
-                                                    "references": [
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                        "75b0be50-24a3-4528-8b08-74c3c072b355X4"
-                                                    ],
-                                                    "scale": "ratio"
-                                                },
-                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67": {
-                                                    "dataType": "date",
-                                                    "isBucketed": true,
-                                                    "label": "@timestamp",
-                                                    "operationType": "date_histogram",
-                                                    "params": {
-                                                        "dropPartials": false,
-                                                        "includeEmptyRows": true,
-                                                        "interval": "auto"
-                                                    },
-                                                    "scale": "interval",
-                                                    "sourceField": "@timestamp"
-                                                }
-                                            },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
-                                            "sampling": 1
-                                        }
-                                    }
-                                },
-                                "indexpattern": {
-                                    "layers": {}
-                                },
-                                "textBased": {
-                                    "layers": {}
-                                }
-                            },
-                            "filters": [
-                                {
-                                    "$state": {
-                                        "store": "appState"
-                                    },
-                                    "meta": {
-                                        "alias": null,
-                                        "disabled": false,
-                                        "field": "system.process.cpu.total.ticks",
-                                        "index": "a8bc4aba-aa4d-47c8-8687-31f3e2bdab87",
-                                        "key": "system.process.cpu.total.ticks",
-                                        "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
-                                    },
-                                    "query": {
-                                        "exists": {
-                                            "field": "system.process.cpu.total.ticks"
-                                        }
-                                    }
-                                }
-                            ],
-                            "internalReferences": [],
-                            "query": {
-                                "language": "kuery",
-                                "query": ""
-                            },
-                            "visualization": {
-                                "axisTitlesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "fittingFunction": "None",
-                                "gridlinesVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "labelsOrientation": {
-                                    "x": 0,
-                                    "yLeft": 0,
-                                    "yRight": 0
-                                },
-                                "layers": [
-                                    {
-                                        "accessors": [
-                                            "75b0be50-24a3-4528-8b08-74c3c072b355"
-                                        ],
-                                        "colorMapping": {
-                                            "assignments": [],
-                                            "colorMode": {
-                                                "type": "categorical"
-                                            },
-                                            "paletteId": "eui_amsterdam_color_blind",
-                                            "specialAssignments": [
-                                                {
-                                                    "color": {
-                                                        "type": "loop"
-                                                    },
-                                                    "rule": {
-                                                        "type": "other"
-                                                    },
-                                                    "touched": false
-                                                }
-                                            ]
-                                        },
-                                        "layerId": "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
-                                        "layerType": "data",
-                                        "position": "top",
-                                        "seriesType": "line",
-                                        "showGridlines": false,
-                                        "splitAccessor": "135cfae0-7159-4211-b7c5-af814a29fd9e",
-                                        "xAccessor": "7f8f777a-bb98-4d2b-83ab-ec1983847e67"
-                                    }
-                                ],
-                                "legend": {
-                                    "isVisible": true,
-                                    "position": "right"
-                                },
-                                "preferredSeriesType": "bar_stacked",
-                                "tickLabelsVisibilitySettings": {
-                                    "x": true,
-                                    "yLeft": true,
-                                    "yRight": true
-                                },
-                                "valueLabels": "hide"
-                            }
-                        },
-                        "title": "",
-                        "type": "lens",
-                        "visualizationType": "lnsXY"
-                    },
-                    "enhancements": {}
-                },
-                "gridData": {
-                    "h": 12,
-                    "i": "22432173-7e06-4fa1-b9df-03cdd7f287e9",
-                    "w": 40,
-                    "x": 8,
-                    "y": 21
-                },
-                "panelIndex": "22432173-7e06-4fa1-b9df-03cdd7f287e9",
-                "type": "lens"
-            },
-            {
-                "embeddableConfig": {
-                    "attributes": {
-                        "references": [
-                            {
-                                "id": "metrics-*",
-                                "name": "indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
-                                "type": "index-pattern"
-                            }
-                        ],
-                        "state": {
-                            "adHocDataViews": {},
-                            "datasourceStates": {
-                                "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
-                                    "layers": {
-                                        "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8": {
-                                            "columnOrder": [
-                                                "135cfae0-7159-4211-b7c5-af814a29fd9e",
-                                                "7f8f777a-bb98-4d2b-83ab-ec1983847e67",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X0",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X1",
-                                                "75b0be50-24a3-4528-8b08-74c3c072b355X2",
                                                 "75b0be50-24a3-4528-8b08-74c3c072b355X3"
                                             ],
                                             "columns": {
@@ -562,9 +261,10 @@
                                                     "sourceField": "elastic_agent.process"
                                                 },
                                                 "75b0be50-24a3-4528-8b08-74c3c072b355": {
+                                                    "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "(differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "label": " ",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
@@ -591,7 +291,7 @@
                                                         "query": "\"system.process.cpu.total.time.ms\": *"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "label": "Part of  ",
                                                     "operationType": "last_value",
                                                     "params": {
                                                         "sortField": "@timestamp"
@@ -603,7 +303,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "label": "Part of  ",
                                                     "operationType": "differences",
                                                     "references": [
                                                         "75b0be50-24a3-4528-8b08-74c3c072b355X0"
@@ -614,7 +314,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "label": "Part of  ",
                                                     "operationType": "interval",
                                                     "references": [],
                                                     "scale": "ratio"
@@ -623,7 +323,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of (differences(last_value(system.process.cpu.total.time.ms))/interval())*100",
+                                                    "label": "Part of  ",
                                                     "operationType": "math",
                                                     "params": {
                                                         "tinymathAst": {
@@ -697,8 +397,7 @@
                                         "index": "a8bc4aba-aa4d-47c8-8687-31f3e2bdab87",
                                         "key": "system.process.cpu.total.ticks",
                                         "negate": false,
-                                        "type": "exists",
-                                        "value": "exists"
+                                        "type": "exists"
                                     },
                                     "query": {
                                         "exists": {
@@ -755,7 +454,7 @@
                                         "layerId": "8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
                                         "layerType": "data",
                                         "position": "top",
-                                        "seriesType": "line",
+                                        "seriesType": "area",
                                         "showGridlines": false,
                                         "splitAccessor": "135cfae0-7159-4211-b7c5-af814a29fd9e",
                                         "xAccessor": "7f8f777a-bb98-4d2b-83ab-ec1983847e67"
@@ -788,7 +487,7 @@
                     "y": 9
                 },
                 "panelIndex": "13d1887a-dc7e-4286-9e99-e17cb92f1ab8",
-                "title": "This seems to work:  CPU %",
+                "title": "[Elastic Agent] CPU Usage",
                 "type": "lens"
             },
             {
@@ -955,7 +654,7 @@
                     "i": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                     "w": 40,
                     "x": 8,
-                    "y": 33
+                    "y": 21
                 },
                 "panelIndex": "59d829a2-c460-450d-b3f1-e24463ca8fbc",
                 "title": "[Elastic Agent] Memory Usage",
@@ -1096,7 +795,7 @@
                     "i": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                     "w": 40,
                     "x": 8,
-                    "y": 42
+                    "y": 30
                 },
                 "panelIndex": "3f8fc111-60c1-4886-bb6d-3b83cdcf88c5",
                 "title": "[Elastic Agent] Open Handles",
@@ -1286,7 +985,7 @@
                     "i": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                     "w": 24,
                     "x": 0,
-                    "y": 51
+                    "y": 39
                 },
                 "panelIndex": "6f1753a7-612d-4e25-a33f-8aa3542d3c39",
                 "title": "[Elastic Agent] Total events rate /s",
@@ -1484,7 +1183,7 @@
                     "i": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                     "w": 24,
                     "x": 24,
-                    "y": 51
+                    "y": 39
                 },
                 "panelIndex": "daff36f6-d0b5-45e8-b0d9-910bace3c15b",
                 "title": "[Elastic Agent] Output write throughput",
@@ -1675,7 +1374,7 @@
                     "i": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                     "w": 24,
                     "x": 0,
-                    "y": 60
+                    "y": 48
                 },
                 "panelIndex": "0165de2d-694a-40f5-95e1-855ce4ebd03e",
                 "title": "[Elastic Agent] Output write errors",
@@ -1865,7 +1564,7 @@
                     "i": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                     "w": 24,
                     "x": 24,
-                    "y": 60
+                    "y": 48
                 },
                 "panelIndex": "b1dcfde7-66f1-41fb-bc7d-d3deef840d4f",
                 "title": "[Elastic Agent] Events acknowledged rate /s",
@@ -2057,7 +1756,7 @@
                     "i": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                     "w": 24,
                     "x": 0,
-                    "y": 69
+                    "y": 57
                 },
                 "panelIndex": "1a30ba18-2c22-4935-b245-6ec8f1a37ced",
                 "title": "[Elastic Agent] Output write batches",
@@ -2238,7 +1937,7 @@
                     "i": "d004044a-99f4-44fa-964a-361accd1810d",
                     "w": 24,
                     "x": 24,
-                    "y": 69
+                    "y": 57
                 },
                 "panelIndex": "d004044a-99f4-44fa-964a-361accd1810d",
                 "title": "[Elastic Agent] Output batch size",
@@ -2431,7 +2130,7 @@
                     "i": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                     "w": 24,
                     "x": 0,
-                    "y": 78
+                    "y": 66
                 },
                 "panelIndex": "ded80e0c-7b32-4022-bee5-1c224e1ec73b",
                 "title": "[Elastic Agent] Events dropped rate /s",
@@ -2621,7 +2320,7 @@
                     "i": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                     "w": 24,
                     "x": 24,
-                    "y": 78
+                    "y": 66
                 },
                 "panelIndex": "08f30154-3b1f-475b-acd2-6a6f6415b9eb",
                 "title": "[Elastic Agent] Events duplicate rate /s",
@@ -2811,7 +2510,7 @@
                     "i": "ce5bea64-4178-4290-997b-a59455991f3d",
                     "w": 24,
                     "x": 0,
-                    "y": 87
+                    "y": 75
                 },
                 "panelIndex": "ce5bea64-4178-4290-997b-a59455991f3d",
                 "title": "[Elastic Agent] Events failed rate /s",
@@ -3001,7 +2700,7 @@
                     "i": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                     "w": 24,
                     "x": 24,
-                    "y": 87
+                    "y": 75
                 },
                 "panelIndex": "d3b72917-b8be-4c96-b10f-cbca8ebf0a68",
                 "title": "[Elastic Agent] Events TooMany rate /s",
@@ -3156,7 +2855,7 @@
                     "i": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                     "w": 24,
                     "x": 0,
-                    "y": 96
+                    "y": 84
                 },
                 "panelIndex": "42ec7297-eb0f-492b-bb18-d1301fa1ead7",
                 "title": "[Elastic Agent] CGroup CPU Usage",
@@ -3181,7 +2880,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "metrics-*",
                                     "layers": {
                                         "c7cc9cd8-585a-4078-a86f-8b0213c874fd": {
                                             "columnOrder": [
@@ -3202,7 +2900,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
                                             "linkToLayers": [],
                                             "sampling": 1
                                         },
@@ -3210,7 +2907,8 @@
                                             "columnOrder": [
                                                 "3495fd36-d74d-4daf-9dae-1e84e63bc31e",
                                                 "a084070f-a15a-473c-abf4-d2e52e84c6ae",
-                                                "90bc620d-c329-4607-90d4-5245a7cc7e69"
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69",
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
                                             ],
                                             "columns": {
                                                 "3495fd36-d74d-4daf-9dae-1e84e63bc31e": {
@@ -3225,10 +2923,10 @@
                                                         "includeIsRegex": false,
                                                         "missingBucket": false,
                                                         "orderBy": {
-                                                            "columnId": "90bc620d-c329-4607-90d4-5245a7cc7e69",
-                                                            "type": "column"
+                                                            "fallback": true,
+                                                            "type": "alphabetical"
                                                         },
-                                                        "orderDirection": "desc",
+                                                        "orderDirection": "asc",
                                                         "otherBucket": false,
                                                         "parentFormat": {
                                                             "id": "terms"
@@ -3243,15 +2941,30 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": " ",
-                                                    "operationType": "max",
+                                                    "operationType": "formula",
                                                     "params": {
-                                                        "emptyAsNull": true,
                                                         "format": {
                                                             "id": "bytes",
                                                             "params": {
                                                                 "decimals": 2
                                                             }
-                                                        }
+                                                        },
+                                                        "formula": "max(system.process.cgroup.memory.mem.usage.bytes)",
+                                                        "isFormulaBroken": false
+                                                    },
+                                                    "references": [
+                                                        "90bc620d-c329-4607-90d4-5245a7cc7e69X0"
+                                                    ],
+                                                    "scale": "ratio"
+                                                },
+                                                "90bc620d-c329-4607-90d4-5245a7cc7e69X0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of  ",
+                                                    "operationType": "max",
+                                                    "params": {
+                                                        "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
                                                     "sourceField": "system.process.cgroup.memory.mem.usage.bytes"
@@ -3271,7 +2984,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*",
                                             "sampling": 1
                                         }
                                     }
@@ -3355,7 +3067,7 @@
                     "i": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                     "w": 24,
                     "x": 24,
-                    "y": 96
+                    "y": 84
                 },
                 "panelIndex": "e651fb9f-763d-4c9d-80d7-7c56adb98883",
                 "title": "[Elastic Agent] Cgroup Memory Usage",
@@ -3587,7 +3299,7 @@
                     "i": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                     "w": 24,
                     "x": 0,
-                    "y": 105
+                    "y": 93
                 },
                 "panelIndex": "bf48fd17-63ec-4d90-8b6a-328bb74b466a",
                 "title": "[Elastic Agent] Queue Usage",
@@ -3770,7 +3482,7 @@
                     "i": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                     "w": 24,
                     "x": 24,
-                    "y": 105
+                    "y": 93
                 },
                 "panelIndex": "9bbe71b3-01b6-4eb3-bac0-90ea2437d0d1",
                 "title": "[Elastic Agent] Queue depth",
@@ -3782,7 +3494,7 @@
         "version": 1
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-06-21T22:02:16.263Z",
+    "created_at": "2024-06-24T20:09:25.192Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
     "managed": false,
     "references": [
@@ -3794,11 +3506,6 @@
         {
             "id": "metrics-*",
             "name": "6b8f954e-e930-4830-b13d-7df1466ad92f:kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
-            "type": "index-pattern"
-        },
-        {
-            "id": "metrics-*",
-            "name": "22432173-7e06-4fa1-b9df-03cdd7f287e9:indexpattern-datasource-layer-8df1fc7a-29b5-4d2c-9d9e-6cc2091d91f8",
             "type": "index-pattern"
         },
         {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -23,8 +23,7 @@
                     "type": "optionsListControl",
                     "width": "medium"
                 }
-            },
-            "showApplySelections": false
+            }
         },
         "description": "Elastic Agent metrics dashboard",
         "kibanaSavedObjectMeta": {

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395.json
@@ -3203,9 +3203,9 @@
         "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-07-01T19:33:39.601Z",
+    "created_at": "2024-07-01T19:40:41.314Z",
     "id": "elastic_agent-f47f18cc-9c7d-4278-b2ea-a6dee816d395",
-    "managed": false,
+    "managed": true,
     "references": [
         {
             "id": "metrics-*",

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,16 +1,18 @@
 name: elastic_agent
 title: Elastic Agent
-version: 1.20.0
+version: 2.0.0
 description: Collect logs and metrics from Elastic Agents.
 type: integration
-format_version: 1.0.0
-license: basic
+format_version: 3.1.4
 categories: ["elastic_stack"]
 conditions:
   kibana:
     version: "^8.11.2"
+  elastic:
+    subscription: basic
 owner:
   github: elastic/elastic-agent
+  type: elastic
 icons:
   - src: /img/logo_elastic_agent.svg
     title: logo Elastic Agent

--- a/packages/elastic_agent/validation.yml
+++ b/packages/elastic_agent/validation.yml
@@ -1,0 +1,3 @@
+errors:
+  exclude_checks:
+    - SVR00002


### PR DESCRIPTION
## Proposed commit message

Migrate the elastic_agent integration to package spec v3.
 - Mappings were updated as required
 - Missing filters (SVR00002) errors are now ignored because some dashboards cannot have a common filter in all visualistaions.
 
Changes to dashboards:
- [Elastic Agent] Agent Info
  - Removed missing reference

- [Elastic Agent] Agent metrics
  - Visualisations were migrated to lens
  - cgroup CPU percentage was removed from the Elastic-Agent Metrics dashboard because we don't collect those metrics on a default installation with monitoring enabled

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

~~## Author's Checklist~~


## How to test this PR locally

1. Using `elastic-package` build the elastic_agent integration
2. Using `elastic-package` bring up the stack
3. Go to the dashboards:
    - [Elastic Agent] Agent Info
    - [Elastic Agent] Integrations
    - [Elastic Agent] Agent metrics

## Related issues

- Closes https://github.com/elastic/integrations/issues/10275

## Screenshots
Comparison between old and new CPU usage visualisation in the Elastic-Agent dashboard. The CPU usage is now aggregated by `component.id`, effectively aggregating by running process, while the old one aggregated by binary name.

At the top is the old visualisation and the new one is at the bottom.
![2024-07-01_15-32](https://github.com/elastic/integrations/assets/333577/759cb0d3-0397-4586-ad95-893e132d7932)


