### PR TITLE
Prevent failure on not encoded url`s

### DIFF
--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Prevent failure on not encoded url`s
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10225
+      link: https://github.com/elastic/integrations/pull/10226
 - version: "2.20.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.20.1"
   changes:
     - description: Prevent failure on not encoded url`s
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/10226
 - version: "2.20.0"
   changes:

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.20.1"
   changes:
-    - description: Prevent failure on not encoded url`s
+    - description: Prevent failure on not encoded URLs.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/10226
 - version: "2.20.0"

--- a/packages/zscaler_zia/changelog.yml
+++ b/packages/zscaler_zia/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.20.1"
+  changes:
+    - description: Prevent failure on not encoded url`s
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10225
 - version: "2.20.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/zscaler_zia/data_stream/web/elasticsearch/ingest_pipeline/default.yml
@@ -204,10 +204,12 @@ processors:
   - urldecode:
       field: url.original
       ignore_missing: true
+      ignore_failure: true
       if: ctx.url?.original != null && ctx.url.original != ''
   - urldecode:
       field: json.eua
       ignore_missing: true
+      ignore_failure: true
       if: ctx.json?.eua != null && ctx.json.eua != ''
   - user_agent:
       field: json.eua

--- a/packages/zscaler_zia/manifest.yml
+++ b/packages/zscaler_zia/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: zscaler_zia
 title: Zscaler Internet Access
-version: "2.20.0"
+version: "2.20.1"
 description: Collect logs from Zscaler Internet Access (ZIA) with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
In some cases, zscaler sents not encoded urls which den causes an parsing failure if the url contains e.g. a %
