### PR TITLE
[cisco_asa] Extract user agent from 722055 logs to correct field

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.35.1"
   changes:
     - description: Extract user agent from 722055 logs to correct field.
-      type: enhancement
+      type: bugfix
       link: https://github.com/elastic/integrations/pull/10229
 - version: "2.35.0"
   changes:

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Extract user agent from 722055 logs to correct field.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10229
 - version: "2.35.0"
   changes:
     - description: Add additional log types.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.35.1"
+  changes:
+    - description: Extract user agent from 722055 logs to correct field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.35.0"
   changes:
     - description: Add additional log types.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -150,3 +150,5 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716058: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session lost connection. Waiting to resume.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group <GROUP 1> User <USER 1> IP <10.20.0.1> AnyConnect session resumed. Connection from 172.16.0.1.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-716059: Group GROUP_1 User USER_1 IP 10.20.0.1 AnyConnect session resumed. Connection from 172.16.0.1.
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-722055: Group <GROUP 1> User <USER 1> IP <10.20.0.1> Client Type: user-agent
+<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-722055: Group GROUP_1 User USER_1 IP 10.20.0.1 Client Type: user-agent

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -10615,6 +10615,142 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722055",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-722055: Group <GROUP 1> User <USER 1> IP <10.20.0.1> Client Type: user-agent",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER 1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP 1"
+                    },
+                    "name": "USER 1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user_agent": {
+                "original": "user-agent"
+            }
+        },
+        {
+            "@timestamp": "2023-10-03T16:40:40.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "722055",
+                "kind": "event",
+                "original": "<140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-722055: Group GROUP_1 User USER_1 IP 10.20.0.1 Client Type: user-agent",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "myAsaHostname"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 17
+                    },
+                    "priority": 140,
+                    "severity": {
+                        "code": 4
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "myAsaHostname",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "myAsaHostname"
+                ],
+                "ip": [
+                    "10.20.0.1"
+                ],
+                "user": [
+                    "USER_1"
+                ]
+            },
+            "source": {
+                "address": "10.20.0.1",
+                "ip": "10.20.0.1",
+                "user": {
+                    "group": {
+                        "name": "GROUP_1"
+                    },
+                    "name": "USER_1"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "user_agent": {
+                "original": "user-agent"
+            }
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -973,8 +973,8 @@ processors:
       field: "message"
       description: "722055"
       patterns:
-        - '^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> Client Type: %{GREEDYDATA:user_agent}$'
-        - '^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} Client Type: %{GREEDYDATA:user_agent}$'
+        - '^Group <%{NOTBRACKET:source.user.group.name}> User <%{NOTBRACKET:source.user.name}> IP <%{NOTBRACKET:source.address}> Client Type: %{GREEDYDATA:user_agent.original}$'
+        - '^Group %{NOTSPACE:source.user.group.name} User %{NOTSPACE:source.user.name} IP %{NOTSPACE:source.address} Client Type: %{GREEDYDATA:user_agent.original}$'
       pattern_definitions:
         NOTBRACKET: "[^<>]+"
   - grok:

--- a/packages/cisco_asa/data_stream/log/fields/ecs.yml
+++ b/packages/cisco_asa/data_stream/log/fields/ecs.yml
@@ -251,6 +251,8 @@
 - external: ecs
   name: url.username
 - external: ecs
+  name: user_agent.original
+- external: ecs
   name: user.email
 - external: ecs
   name: user.name

--- a/packages/cisco_asa/docs/README.md
+++ b/packages/cisco_asa/docs/README.md
@@ -373,3 +373,5 @@ An example event for `log` looks as following:
 | user.email | User email address. | keyword |
 | user.name | Short name or login of the user. | keyword |
 | user.name.text | Multi-field of `user.name`. | match_only_text |
+| user_agent.original | Unparsed user_agent string. | keyword |
+| user_agent.original.text | Multi-field of `user_agent.original`. | match_only_text |

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.35.0"
+version: "2.35.1"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Ensure that the user agent is extracted to user_agent.original for 722055 logs
- Add sample logs
- Add user_agent.original to ecs fields

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages_cisco/asa
elastic-package test
```

## Related issues

- Closes #10220
