### PR TITLE
ti_eclecticiq: Add CEL resource.tracer limit

### DIFF
--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Increase CEL resource.tracer.maxsize to prevent loss of trace responses.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/10232
 - version: "1.1.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ti_eclecticiq/changelog.yml
+++ b/packages/ti_eclecticiq/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Increase CEL resource.tracer.maxsize to prevent loss of trace responses.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.1.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/ti_eclecticiq/data_stream/threat/agent/stream/input.yml.hbs
+++ b/packages/ti_eclecticiq/data_stream/threat/agent/stream/input.yml.hbs
@@ -5,6 +5,8 @@ resource.url: {{url}}
 
 {{#if enable_request_tracer}}
 resource.tracer.filename: "../../logs/cel/http-request-trace-*.ndjson"
+resource.tracer.maxbackups: 5
+resource.tracer.maxsize: 5
 {{/if}}
 {{#if ssl}}
 resource.ssl: {{ssl}}

--- a/packages/ti_eclecticiq/manifest.yml
+++ b/packages/ti_eclecticiq/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_eclecticiq
 title: EclecticIQ
-version: "1.1.0"
+version: "1.2.0"
 description: Ingest threat intelligence from EclecticIQ with Elastic Agent
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
```
Add CEL resource.tracer limit.

We have seen cases where the response size exceeds the default 
`resource.tracer.maxsize` 1 MB and responses are dropped. 
Add `resource.tracer.maxsize` and `resource.tracer.maxbackups` 
to capture large responses and avoid loss of visibility.
```

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

