### PR TITLE
Fixed typos in changelog url links to GitHub

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9569
+      link: https://github.com/elastic/integrations/pull/9569
 - version: "3.2.3"
   changes:
     - description: Treat FTD suffix as optional

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -18,17 +18,17 @@
   changes:
     - description: Fix parsing timezone with offset
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9890
+      link: https://github.com/elastic/integrations/pull/9890
 - version: "1.26.6"
   changes:
     - description: Fix handling of ACCESSLOGSP logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9662
+      link: https://github.com/elastic/integrations/pull/9662
 - version: "1.26.5"
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9566
+      link: https://github.com/elastic/integrations/pull/9566
 - version: "1.26.4"
   changes:
     - description: Fix hostname parsing for names that contain '_' underscore characters.

--- a/packages/cisco_nexus/changelog.yml
+++ b/packages/cisco_nexus/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9570
+      link: https://github.com/elastic/integrations/pull/9570
 - version: "1.1.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/cisco_secure_email_gateway/changelog.yml
+++ b/packages/cisco_secure_email_gateway/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9571
+      link: https://github.com/elastic/integrations/pull/9571
 - version: "1.23.1"
   changes:
     - description: Improve extraction and parsing of fields for consolidated events.

--- a/packages/fim/changelog.yml
+++ b/packages/fim/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix default backend to auto
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9702
+      link: https://github.com/elastic/integrations/pull/9702
 - version: "1.15.0"
   changes:
     - description: New event sourcing backends added

--- a/packages/juniper_junos/changelog.yml
+++ b/packages/juniper_junos/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Define missing fields
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9657
+      link: https://github.com/elastic/integrations/pull/9657
 - version: "0.10.1"
   changes:
     - description: Changed owners

--- a/packages/juniper_netscreen/changelog.yml
+++ b/packages/juniper_netscreen/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Define missing fields
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9658
+      link: https://github.com/elastic/integrations/pull/9658
 - version: "0.10.1"
   changes:
     - description: Changed owners

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9574
+      link: https://github.com/elastic/integrations/pull/9574
 - version: "1.8.2"
   changes:
     - description: Migrate Access and error logs dashboard visualizations to lens.
@@ -104,12 +104,12 @@
     - description: Release Nginx Ingress Controller as GA
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1615
-- version: '0.3.2'
+- version: "0.3.2"
   changes:
     - description: Convert to generated ECS fields
       type: enhancement
       link: https://github.com/elastic/integrations/pull/1517
-- version: '0.3.1'
+- version: "0.3.1"
   changes:
     - description: update to ECS 1.11.0
       type: enhancement

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9575
+      link: https://github.com/elastic/integrations/pull/9575
 - version: "1.19.0"
   changes:
     - description: Update package spec to 3.0.3.

--- a/packages/pulse_connect_secure/changelog.yml
+++ b/packages/pulse_connect_secure/changelog.yml
@@ -18,7 +18,7 @@
   changes:
     - description: Fix ingest pipeline warnings
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/9587
+      link: https://github.com/elastic/integrations/pull/9587
 - version: "1.19.0"
   changes:
     - description: Update manifest format version to v3.0.3.

--- a/packages/security_detection_engine/changelog.yml
+++ b/packages/security_detection_engine/changelog.yml
@@ -92,7 +92,7 @@
   changes:
     - description: Release security rules update
       type: enhancement
-      link: https://github.com/elastic/integrations/pulls/9412
+      link: https://github.com/elastic/integrations/pull/9412
 - version: 8.13.1
   changes:
     - description: Release security rules update
@@ -656,7 +656,7 @@
 - version: 0.16.2
   changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/3191
+      link: https://github.com/elastic/integrations/pull/3191
       type: enhancement
 - version: 0.16.1
   changes:
@@ -681,7 +681,7 @@
 - version: 0.14.1
   changes:
     - description: Release security rules update
-      link: https://github.com/elastic/integrations/pulls/1591
+      link: https://github.com/elastic/integrations/pull/1591
       type: enhancement
 - version: 0.13.3
   changes:


### PR DESCRIPTION
## Proposed commit message

```
Fixed typos in changelog url links to GitHub
```

## Checklist

N/A

## How to test this PR locally

If you browse the the old URLs (`.../pulls/...` rather than `.../pull/...`) then you incorrectly end up at the GitHub search bar.
