### PR TITLE
m365_defender: Fix process executable containing duplicate process name.

### DIFF
--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix process executable containing duplicate process name.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/10280
 - version: "2.14.0"
   changes:
     - description: Improve ECS mappings

--- a/packages/m365_defender/changelog.yml
+++ b/packages/m365_defender/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.14.1"
+  changes:
+    - description: Fix process executable containing duplicate process name.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "2.14.0"
   changes:
     - description: Improve ECS mappings

--- a/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-device.log-expected.json
+++ b/packages/m365_defender/data_stream/event/_dev/test/pipeline/test-device.log-expected.json
@@ -4825,7 +4825,7 @@
                 ],
                 "args_count": 2,
                 "command_line": "\"DllHost.exe\" /Processid:{776DBC8D-7347-478C-8D71-791E12EF49D8}",
-                "executable": "c:\\windows\\syswow64\\dllhost.exe\\dllhost.exe",
+                "executable": "c:\\windows\\syswow64\\dllhost.exe",
                 "group_leader": {
                     "name": "svchost.exe",
                     "pid": 832,
@@ -4957,7 +4957,7 @@
                 ],
                 "args_count": 5,
                 "command_line": "iexplore.exe /c echo -Embedding ;C:\\Users\\Public\\iexplore.exe",
-                "executable": "c:\\users\\public\\iexplore.exe\\iexplore.exe",
+                "executable": "c:\\users\\public\\iexplore.exe",
                 "group_leader": {
                     "name": "python.exe",
                     "pid": 6968,

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
@@ -1629,9 +1629,9 @@ processors:
         ctx.event?.category != null 
         && ctx.event.category.contains('api') 
         && (ctx.m365_defender?.event?.action?.type != null && ['createremotethreadapicall', 'readprocessmemoryapicall', 'ntallocatevirtualmemoryremoteapicall', 'openprocessapicall'].contains(ctx.m365_defender.event.action.type.toLowerCase()))
-        && ctx.m365_defender?.event?.initiating_process?.folder_path != null 
-        && ctx.m365_defender?.event?.initiating_process?.file_name != null
-        && ctx.m365_defender.event.initiating_process.folder_path.endsWith(ctx.m365_defender.event.initiating_process.file_name)
+        && ctx.m365_defender?.event?.folder_path != null 
+        && ctx.m365_defender?.event?.file?.name != null
+        && ctx.m365_defender.event.folder_path.endsWith(ctx.m365_defender.event.file.name)
   - set:
       field: Target.process.executable
       value: >-

--- a/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
+++ b/packages/m365_defender/data_stream/event/elasticsearch/ingest_pipeline/pipeline_device.yml
@@ -1621,10 +1621,27 @@ processors:
       ignore_empty_value: true
   - set:
       field: Target.process.executable
+      copy_from: m365_defender.event.folder_path
+      description: Sometimes folder_path already includes the file.name
+      ignore_empty_value: true
+      tag: set_target_process_executable_folder_path
+      if: >-
+        ctx.event?.category != null 
+        && ctx.event.category.contains('api') 
+        && (ctx.m365_defender?.event?.action?.type != null && ['createremotethreadapicall', 'readprocessmemoryapicall', 'ntallocatevirtualmemoryremoteapicall', 'openprocessapicall'].contains(ctx.m365_defender.event.action.type.toLowerCase()))
+        && ctx.m365_defender?.event?.initiating_process?.folder_path != null 
+        && ctx.m365_defender?.event?.initiating_process?.file_name != null
+        && ctx.m365_defender.event.initiating_process.folder_path.endsWith(ctx.m365_defender.event.initiating_process.file_name)
+  - set:
+      field: Target.process.executable
       value: >-
         {{{m365_defender.event.folder_path}}}\{{{m365_defender.event.file.name}}}
       tag: set_Target_process_executable
-      if: ctx.event?.category != null && ctx.event.category.contains('api') && (ctx.m365_defender?.event?.action?.type != null && ['createremotethreadapicall', 'readprocessmemoryapicall', 'ntallocatevirtualmemoryremoteapicall', 'openprocessapicall'].contains(ctx.m365_defender.event.action.type.toLowerCase()))
+      if: >- 
+        ctx.event?.category != null 
+        && ctx.event.category.contains('api') 
+        && (ctx.m365_defender?.event?.action?.type != null && ['createremotethreadapicall', 'readprocessmemoryapicall', 'ntallocatevirtualmemoryremoteapicall', 'openprocessapicall'].contains(ctx.m365_defender.event.action.type.toLowerCase()))
+        && ctx.Target?.process?.executable == null
       ignore_empty_value: true
   ## Then, mapping process.* below.
   ## All other DeviceEvent types that is not DeviceProcessEvent or DeviceEvent map InitiatingProcess* to process.* rather than process.parent.*
@@ -1730,12 +1747,26 @@ processors:
             || (ctx._temp_deviceevents_that_map_process != null && ctx._temp_deviceevents_that_map_process == true))
   - set:
       field: process.executable
+      copy_from: m365_defender.event.initiating_process.folder_path
+      description: Sometimes folder_path already includes the file_name
+      ignore_empty_value: true
+      tag: set_process_executable_folder_path
+      if: >-
+        ctx.event?.category != null 
+        && (ctx.event.category.contains('api') || ctx.event.category.contains('driver'))
+        && ctx.m365_defender?.event?.initiating_process?.folder_path != null 
+        && ctx.m365_defender?.event?.initiating_process?.file_name != null
+        && ctx.m365_defender.event.initiating_process.folder_path.endsWith(ctx.m365_defender.event.initiating_process.file_name)
+  - set:
+      field: process.executable
       value: >-
         {{{m365_defender.event.initiating_process.folder_path}}}\{{{m365_defender.event.initiating_process.file_name}}}
+      description: If folder_path doesn't include the file_name, then append it.
       ignore_empty_value: true
-      tag: set_process_executable_api
+      tag: set_process_executable_folder_path_file
       if: >-
         ctx.event?.category != null && (ctx.event.category.contains('api') || ctx.event.category.contains('driver'))
+        && ctx.process?.executable == null
   - set:
       field: process.parent.name
       copy_from: m365_defender.event.initiating_process.parent_file_name

--- a/packages/m365_defender/manifest.yml
+++ b/packages/m365_defender/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: m365_defender
 title: Microsoft M365 Defender
-version: "2.14.0"
+version: "2.14.1"
 description: Collect logs from Microsoft M365 Defender with Elastic Agent.
 categories:
   - "security"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
See title

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
`elastic-package test pipeline --generate -v`
```
--- Test results for package: m365_defender - START ---
╭───────────────┬─────────────┬───────────┬─────────────────────────────────────┬────────┬──────────────╮
│ PACKAGE       │ DATA STREAM │ TEST TYPE │ TEST NAME                           │ RESULT │ TIME ELAPSED │
├───────────────┼─────────────┼───────────┼─────────────────────────────────────┼────────┼──────────────┤
│ m365_defender │ alert       │ pipeline  │ test-alert.log                      │ PASS   │   3.680791ms │
│ m365_defender │ event       │ pipeline  │ test-alert.log                      │ PASS   │    2.53025ms │
│ m365_defender │ event       │ pipeline  │ test-app-and-identity.log           │ PASS   │   3.684792ms │
│ m365_defender │ event       │ pipeline  │ test-device.log                     │ PASS   │  35.042625ms │
│ m365_defender │ event       │ pipeline  │ test-email.log                      │ PASS   │  10.539125ms │
│ m365_defender │ incident    │ pipeline  │ test-incident.log                   │ PASS   │  12.842792ms │
│ m365_defender │ log         │ pipeline  │ test-m365-defender-empty-ndjson.log │ PASS   │   1.326209ms │
│ m365_defender │ log         │ pipeline  │ test-m365-defender-ndjson.log       │ PASS   │   5.741041ms │
╰───────────────┴─────────────┴───────────┴─────────────────────────────────────┴────────┴──────────────╯
--- Test results for package: m365_defender - END   ---
Done
```
