### PR TITLE
Add user mappings for Cloud Security Posture

### DIFF
--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -138,3 +138,9 @@
   external: ecs
 - name: user.name
   external: ecs
+- name: user.id
+  external: ecs
+- name: user.effective.name
+  external: ecs
+- name: user.effective.id
+  external: ecs

--- a/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
+++ b/packages/cloud_security_posture/data_stream/findings/fields/ecs.yml
@@ -136,3 +136,5 @@
   external: ecs
 - name: cloud.region
   external: ecs
+- name: user.name
+  external: ecs


### PR DESCRIPTION
Add `user.*` field mappings for Cloud Security Posture integration.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Follow-up to https://github.com/elastic/cloudbeat/issues/2081
