### PR TITLE
[cisco_asa] Grok parsing fixes for an SDH

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix patterns for 113008, 725002.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10283
 - version: "2.35.2"
   changes:
     - description: Loosen a grok pattern for a customer SDH.

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.35.3"
+  changes:
+    - description: Fix patterns for 113008, 725002.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.35.2"
   changes:
     - description: Loosen a grok pattern for a customer SDH.

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -120,7 +120,7 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106023: Deny udp src outside:172.31.98.44/0 dst myInterfaceName:192.168.2.2/80 by access-group "outside" [0x24c36bb3, 0x0]
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106012: Deny IP from 10.1.2.1 to 172.31.98.44, IP options: "Router Alert"
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113008: AAA transaction status ACCEPT: user = USER_1
-<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = pslvii
+<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = USER_1
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113009: AAA retrieved default group policy GROUP_POLICY_1 for user USER_1
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-302010: 12 in use, 10 most used
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.1 on interface inside for user USER_1 disconnected by SSH server, reason: Out of memory

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -120,6 +120,7 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106023: Deny udp src outside:172.31.98.44/0 dst myInterfaceName:192.168.2.2/80 by access-group "outside" [0x24c36bb3, 0x0]
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-4-106012: Deny IP from 10.1.2.1 to 172.31.98.44, IP options: "Router Alert"
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113008: AAA transaction status ACCEPT: user = USER_1
+<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = pslvii
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-113009: AAA retrieved default group policy GROUP_POLICY_1 for user USER_1
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-302010: 12 in use, 10 most used
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-315011: SSH session from 10.1.2.1 on interface inside for user USER_1 disconnected by SSH server, reason: Out of memory
@@ -131,6 +132,7 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-5-722032: Group GROUP_1 User USER_1 IP 10.20.0.1 New SVC connection replacing old connection.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725001: Starting SSL handshake with client inside:172.16.0.1/1133 for TLSv1.2 session.
+<166>2024-06-26T01:35:50Z: %ASA-6-725001: Starting SSL handshake with client outside:10.20.0.1/57700 to 172.16.0.1/443 for TLS session
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725002: Device completed SSL handshake with client inside:172.16.0.1/1133 to 10.20.0.1/443 for TLSv1.2 session.
 <140>Oct 03 2023 16:40:40 myAsaHostname : %ASA-6-725007: SSL session with client inside:172.16.0.1/1133 to 10.20.0.1/443 terminated.
 <166>2024-06-20T22:25:26Z: %ASA-6-725007: SSL session with client outside:172.16.0.1/49243 to 10.20.0.1/443 terminated

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -8644,6 +8644,59 @@
             ]
         },
         {
+            "@timestamp": "2024-06-26T01:35:42.000Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "logged-in",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113008",
+                "kind": "event",
+                "original": "<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = pslvii",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "allowed",
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "user": [
+                    "pslvii"
+                ]
+            },
+            "source": {
+                "user": {
+                    "name": "pslvii"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
             "@timestamp": "2023-10-03T16:40:40.000Z",
             "cisco": {
                 "asa": {
@@ -9386,6 +9439,75 @@
             ],
             "tls": {
                 "version": "1.2",
+                "version_protocol": "tls"
+            }
+        },
+        {
+            "@timestamp": "2024-06-26T01:35:50.000Z",
+            "cisco": {
+                "asa": {
+                    "peer_type": "client",
+                    "source_interface": "outside"
+                }
+            },
+            "destination": {
+                "ip": "172.16.0.1",
+                "port": 443
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "725001",
+                "kind": "event",
+                "original": "<166>2024-06-26T01:35:50Z: %ASA-6-725001: Starting SSL handshake with client outside:10.20.0.1/57700 to 172.16.0.1/443 for TLS session",
+                "outcome": "success",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "connection",
+                    "start"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "ingress": {
+                    "interface": {
+                        "name": "outside"
+                    }
+                },
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.20.0.1",
+                    "172.16.0.1"
+                ]
+            },
+            "source": {
+                "ip": "10.20.0.1",
+                "port": 57700
+            },
+            "tags": [
+                "preserve_original_event"
+            ],
+            "tls": {
                 "version_protocol": "tls"
             }
         },

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -8656,7 +8656,7 @@
                 ],
                 "code": "113008",
                 "kind": "event",
-                "original": "<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = pslvii",
+                "original": "<166>2024-06-26T01:35:42Z: %ASA-6-113008: AAA transaction status ACCEPT : user = USER_1",
                 "outcome": "success",
                 "severity": 6,
                 "timezone": "UTC",
@@ -8684,12 +8684,12 @@
             },
             "related": {
                 "user": [
-                    "pslvii"
+                    "USER_1"
                 ]
             },
             "source": {
                 "user": {
-                    "name": "pslvii"
+                    "name": "USER_1"
                 }
             },
             "tags": [

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -390,17 +390,18 @@ processors:
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
         IPORNONE: (%{IP:source.address}|None)
-  - dissect:
+  - grok:
       if: "ctx._temp_.cisco.message_id == '113008'"
       tag: parse_113008
       field: message
       description: "113008"
-      pattern: 'AAA transaction status ACCEPT: user = %{source.user.name}'
+      patterns:
+      - "AAA transaction status ACCEPT(%{SPACE})?: user = %{GREEDYDATA:source.user.name}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '113009'"
       tag: parse_113009
       field: message
-      description: "113008"
+      description: "113009"
       pattern: 'AAA retrieved default group policy %{_temp_.cisco.group_policy} for user %{source.user.name}'
   - grok:
       if: "ctx._temp_.cisco.message_id == '113012'"
@@ -2222,6 +2223,7 @@ processors:
       tag: parse_tls_version
       patterns:
         - "%{PROTO:tls.version_protocol}v%{NUMBER:tls.version}"
+        - "%{PROTO:tls.version_protocol}"
       pattern_definitions:
         PROTO: "[A-Z]+"
   - lowercase:

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.35.2"
+version: "2.35.3"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Bug Fix

## Proposed commit message

[cisco_asa] Customer reports grok failures for 138008, 725001 messages
- Customer was seeing a spacing variation in 138008, and a missing numeric version for SSL/TLS in 725001
- Updated parsing code to handle the message variations
- Added sample data and verified the fix


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

```
cd packages/cisco_asa
elastic-package test
```

## Related issues

-

## Screenshots
