### PR TITLE
[IIS] Add processors capability to IIS Metrics

### DIFF
--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add processors capability to IIS Metrics.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9869
+      link: https://github.com/elastic/integrations/pull/10285
 - version: "1.18.0"
   changes:
     - description: Add global filter on data_stream.dataset to improve performance.

--- a/packages/iis/changelog.yml
+++ b/packages/iis/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.0"
+  changes:
+    - description: Add processors capability to IIS Metrics.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9869
 - version: "1.18.0"
   changes:
     - description: Add global filter on data_stream.dataset to improve performance.

--- a/packages/iis/data_stream/application_pool/agent/stream/stream.yml.hbs
+++ b/packages/iis/data_stream/application_pool/agent/stream/stream.yml.hbs
@@ -9,3 +9,7 @@ application_pool.name::
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/iis/data_stream/application_pool/manifest.yml
+++ b/packages/iis/data_stream/application_pool/manifest.yml
@@ -18,7 +18,8 @@ streams:
         required: false
         show_user: false
         description: >
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
+
 
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/data_stream/application_pool/manifest.yml
+++ b/packages/iis/data_stream/application_pool/manifest.yml
@@ -11,5 +11,14 @@ streams:
         multi: true
         required: false
         show_user: true
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/data_stream/error/_dev/test/pipeline/test-common-config.yml
+++ b/packages/iis/data_stream/error/_dev/test/pipeline/test-common-config.yml
@@ -1,7 +1,6 @@
 fields:
   tags:
     - preserve_original_event
-
 dynamic_fields:
   # This can be removed after ES 8.14 is the minimum version.
   # Relates: https://github.com/elastic/elasticsearch/pull/105689

--- a/packages/iis/data_stream/webserver/agent/stream/stream.yml.hbs
+++ b/packages/iis/data_stream/webserver/agent/stream/stream.yml.hbs
@@ -3,3 +3,7 @@ period: {{period}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/iis/data_stream/webserver/manifest.yml
+++ b/packages/iis/data_stream/webserver/manifest.yml
@@ -4,5 +4,15 @@ streams:
   - input: iis/metrics
     title: IIS web server metrics
     description: Collect IIS web server metrics
+    vars:
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/data_stream/webserver/manifest.yml
+++ b/packages/iis/data_stream/webserver/manifest.yml
@@ -12,7 +12,7 @@ streams:
         required: false
         show_user: false
         description: >
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/data_stream/website/agent/stream/stream.yml.hbs
+++ b/packages/iis/data_stream/website/agent/stream/stream.yml.hbs
@@ -3,3 +3,7 @@ period: {{period}}
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/iis/data_stream/website/manifest.yml
+++ b/packages/iis/data_stream/website/manifest.yml
@@ -4,5 +4,15 @@ streams:
   - input: iis/metrics
     title: IIS website metrics
     description: Collect IIS website metrics
+    vars:
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/data_stream/website/manifest.yml
+++ b/packages/iis/data_stream/website/manifest.yml
@@ -12,7 +12,7 @@ streams:
         required: false
         show_user: false
         description: >
-          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
 
 elasticsearch:
   index_mode: "time_series"

--- a/packages/iis/manifest.yml
+++ b/packages/iis/manifest.yml
@@ -1,6 +1,6 @@
 name: iis
 title: IIS
-version: "1.18.0"
+version: "1.19.0"
 description: Collect logs and metrics from Internet Information Services (IIS) servers with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Add processors capability to IIS Metrics

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist



## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes https://github.com/elastic/integrations/issues/10271

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
