### PR TITLE
[OpenCanary] Correct issue with `remove` processors for source and destination ports

### DIFF
--- a/packages/opencanary/changelog.yml
+++ b/packages/opencanary/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fixes and issue where all source and destination details were removed if the source or destination port was an invalid "-1".
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10288
 - version: "0.1.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/opencanary/data_stream/events/_dev/test/pipeline/test-events.log-expected.json
+++ b/packages/opencanary/data_stream/events/_dev/test/pipeline/test-events.log-expected.json
@@ -502,7 +502,7 @@
                     "id": "opencanary-1"
                 },
                 "redis": {
-                    "command": "\u0000\f\u0000\u0000\u0010\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+                    "command": "\u0000\u000c\u0000\u0000\u0010\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
                 }
             },
             "related": {
@@ -886,6 +886,11 @@
                 "user": [
                     "jdoe"
                 ]
+            },
+            "source": {
+                "address": "192.168.0.10",
+                "domain": "Client1",
+                "ip": "192.168.0.10"
             },
             "tags": [
                 "preserve_original_event",

--- a/packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -655,7 +655,7 @@ processors:
   - redact:
       description: Redact any passwords in the log data
       tag: redact_event_original
-      if: 'ctx.tags?.contains("redact_passwords") && ctx.event?.original =~ /\"PASSWORD\": \"/'
+      if: 'ctx.tags != null && ctx.tags?.contains("redact_passwords") && ctx.event?.original =~ /\"PASSWORD\": \"/'
       field: event.original
       patterns:
         - '"PASSWORD": "%{DATA:REDACTED}"'
@@ -736,14 +736,14 @@ processors:
   - remove:
       description: Remove malformed source.* fields for LOG_BASE_MSG events
       tag: remove_source_port
-      field: source
+      field: source.port
       if: ctx.source?.port == -1
       ignore_missing: true
       ignore_failure: true
   - remove:
       description: Remove malformed destination.* fields for LOG_BASE_MSG events
       tag: remove_destination_port
-      field: destination
+      field: destination.port
       if: ctx.destination?.port == -1
       ignore_missing: true
       ignore_failure: true

--- a/packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -655,7 +655,7 @@ processors:
   - redact:
       description: Redact any passwords in the log data
       tag: redact_event_original
-      if: 'ctx.tags != null && ctx.tags?.contains("redact_passwords") && ctx.event?.original =~ /\"PASSWORD\": \"/'
+      if: 'ctx.tags != null && ctx.tags.contains("redact_passwords") && ctx.event?.original =~ /\"PASSWORD\": \"/'
       field: event.original
       patterns:
         - '"PASSWORD": "%{DATA:REDACTED}"'

--- a/packages/opencanary/manifest.yml
+++ b/packages/opencanary/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: opencanary
 title: "OpenCanary"
-version: "0.1.0"
+version: "0.1.1"
 description: "This integration collects and parses logs from OpenCanary honeypots."
 type: integration
 categories:


### PR DESCRIPTION
**Type of Change**:
- Bug

## Proposed commit message

Fixes and issue where all source and destination details were removed if the source or destination port was an invalid "-1". The intent was to remove `source.port` if the value was "-1", or `destination.port` if the value was "-1". The `remove` processors were removing the root `source` or `destination` fields. 

https://github.com/elastic/integrations/blob/466ca328df748d401081388190dec7cf4f7d781d/packages/opencanary/data_stream/events/elasticsearch/ingest_pipeline/default.yml#L736-L749

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #10287

