### PR TITLE
[Linux] Add processors capability to Linux Metrics

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.10"
+  changes:
+    - description: Add processors capability to Linux Metrics.
+      type: enhancement
+      link: TBD
 - version: "0.6.9"
   changes:
     - description: Fix list type for filters
@@ -8,7 +13,7 @@
   changes:
     - description: Fix typo in docs.
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/3655
 - version: "0.6.7"
   changes:
     - description: Update documentation with additional context for new users.

--- a/packages/linux/data_stream/conntrack/manifest.yml
+++ b/packages/linux/data_stream/conntrack/manifest.yml
@@ -11,6 +11,14 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host conntrack metrics
     description: Collect network metrics from /proc/net/nf_conntrack

--- a/packages/linux/data_stream/entropy/manifest.yml
+++ b/packages/linux/data_stream/entropy/manifest.yml
@@ -11,6 +11,14 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host entropy metrics
     description: Collect Linux entropy metrics

--- a/packages/linux/data_stream/iostat/manifest.yml
+++ b/packages/linux/data_stream/iostat/manifest.yml
@@ -11,5 +11,13 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     title: Linux iostat metrics
     description: Linux disk stat metrics

--- a/packages/linux/data_stream/ksm/manifest.yml
+++ b/packages/linux/data_stream/ksm/manifest.yml
@@ -11,6 +11,14 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host KSM metrics
     description: Collect kernel samepage merging metrics

--- a/packages/linux/data_stream/memory/manifest.yml
+++ b/packages/linux/data_stream/memory/manifest.yml
@@ -11,5 +11,13 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     title: Linux memory metrics
     description: Linux paging and memory management metrics

--- a/packages/linux/data_stream/network_summary/manifest.yml
+++ b/packages/linux/data_stream/network_summary/manifest.yml
@@ -11,5 +11,13 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     title: Linux host network summary metrics
     description: Collect Linux network_summary metrics

--- a/packages/linux/data_stream/pageinfo/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/pageinfo/agent/stream/stream.yml.hbs
@@ -4,3 +4,7 @@ period: {{period}}
 {{#if system.hostfs}}
 hostfs: {{system.hostfs}}
 {{/if}}
+{{#if processors}}
+processors:
+{{processors}}
+{{/if}}

--- a/packages/linux/data_stream/pageinfo/manifest.yml
+++ b/packages/linux/data_stream/pageinfo/manifest.yml
@@ -11,6 +11,14 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host pageinfo metrics
     description: Collect paging statistics as found in /proc/pagetypeinfo

--- a/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/raid/agent/stream/stream.yml.hbs
@@ -10,3 +10,6 @@ hostfs: {{system.hostfs}}
 processors:
   - drop_fields:
       fields: event.module
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/linux/data_stream/raid/manifest.yml
+++ b/packages/linux/data_stream/raid/manifest.yml
@@ -19,7 +19,14 @@ streams:
         show_user: true
         description: >
           Specifty a RAID mount location. By default, Any available RAID mounts will be selected.
-
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host raid metrics
     description: Collect Linux raid metrics

--- a/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
@@ -22,3 +22,6 @@ hostfs: {{system.hostfs}}
 processors:
   - drop_fields:
       fields: event.module
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/linux/data_stream/service/manifest.yml
+++ b/packages/linux/data_stream/service/manifest.yml
@@ -31,6 +31,13 @@ streams:
         show_user: true
         description: >
           Filter systemd services based on a name pattern
-
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     title: Linux host service metrics
     description: Collect Linux service metrics

--- a/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/socket/agent/stream/stream.yml.hbs
@@ -16,3 +16,6 @@ hostfs: {{system.hostfs}}
 processors:
   - drop_fields:
       fields: event.module
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/linux/data_stream/socket/manifest.yml
+++ b/packages/linux/data_stream/socket/manifest.yml
@@ -34,5 +34,13 @@ streams:
         required: false
         show_user: true
         description: "Failure TTL for reverse DNS lookup on remote IP addresses in the socket dataset (sample: 10s)"
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     title: Linux host socket metrics
     description: Collect Linux socket metrics

--- a/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/users/agent/stream/stream.yml.hbs
@@ -7,3 +7,6 @@ hostfs: {{system.hostfs}}
 processors:
   - drop_fields:
       fields: event.module
+{{#if processors}}
+{{processors}}
+{{/if}}

--- a/packages/linux/data_stream/users/manifest.yml
+++ b/packages/linux/data_stream/users/manifest.yml
@@ -11,6 +11,14 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: processors
+        type: yaml
+        title: Processors
+        multi: false
+        required: false
+        show_user: false
+        description: >
+          Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the metrics are parsed. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
     enabled: false
     title: Linux host user metrics
     description: Collect Linux users metrics

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux Metrics
-version: 0.6.9
+version: 0.6.10
 license: basic
 description: Collect metrics from Linux servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## Proposed commit message
Add processors capability to Linux Metrics

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist



## How to test this PR locally



## Related issues



## Screenshots


