### PR TITLE
[Logstash] Ready Agent-driven monitoring for GA

### DIFF
--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove "technical preview language from agent-driven monitoring, and enabled by default
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10164
+      link: https://github.com/elastic/integrations/pull/10316
 - version: "2.4.10"
   changes:
     - description: Add Pipeline information to Pipelines View page

--- a/packages/logstash/changelog.yml
+++ b/packages/logstash/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.11"
+  changes:
+    - description: Remove "technical preview language from agent-driven monitoring, and enabled by default
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10164
 - version: "2.4.10"
   changes:
     - description: Add Pipeline information to Pipelines View page

--- a/packages/logstash/data_stream/node/manifest.yml
+++ b/packages/logstash/data_stream/node/manifest.yml
@@ -7,6 +7,7 @@ elasticsearch:
       dynamic: false
 streams:
   - input: logstash/metrics
+    enabled: false
     title: Logstash node metrics
     description: Collect Logstash node metrics
     vars:

--- a/packages/logstash/data_stream/node_cel/manifest.yml
+++ b/packages/logstash/data_stream/node_cel/manifest.yml
@@ -8,7 +8,7 @@ elasticsearch:
       dynamic: false
 streams:
   - input: cel
-    enabled: false
+    enabled: true
     title: "Collect Node Metrics"
     description: "Collect Metrics related to Nodes running Logstash"
     template_path: cel.yml.hbs

--- a/packages/logstash/data_stream/node_stats/manifest.yml
+++ b/packages/logstash/data_stream/node_stats/manifest.yml
@@ -7,6 +7,7 @@ elasticsearch:
       dynamic: false
 streams:
   - input: logstash/metrics
+    enabled: false
     title: Logstash node stats metrics
     description: Collect Logstash node stats metrics
     vars:

--- a/packages/logstash/data_stream/pipeline/manifest.yml
+++ b/packages/logstash/data_stream/pipeline/manifest.yml
@@ -8,7 +8,7 @@ elasticsearch:
       dynamic: false
 streams:
   - input: cel
-    enabled: false
+    enabled: true
     title: "Collect Pipeline Metrics"
     description: "Collect Metrics related to Logstash Pipeline usage"
     template_path: cel.yml.hbs

--- a/packages/logstash/data_stream/plugins/manifest.yml
+++ b/packages/logstash/data_stream/plugins/manifest.yml
@@ -8,7 +8,7 @@ elasticsearch:
       dynamic: false
 streams:
   - input: cel
-    enabled: false
+    enabled: true
     title: "Collect Plugin Metrics"
     description: "Collect metrics for Logstash plugin use. Note that large pipelines will increase the volume of plugin metrics, and a slower rate of collection may be appropriate"
     template_path: cel.yml.hbs

--- a/packages/logstash/manifest.yml
+++ b/packages/logstash/manifest.yml
@@ -1,6 +1,6 @@
 name: logstash
 title: Logstash
-version: 2.4.10
+version: 2.4.11
 description: Collect logs and metrics from Logstash with Elastic Agent.
 type: integration
 icons:
@@ -45,9 +45,51 @@ policy_templates:
             multi: false
             required: false
             show_user: false
+      - type: cel
+        title: "Metrics (Agent-driven Monitoring). Should only be enabled when using Elastic Agent with Logstash dashboards.\n"
+        description: "Collect Metrics and stats from Logstash instances to power dedicated Logstash Dashboards in Kibana"
+        vars:
+          - name: url
+            type: text
+            title: Logstash URL
+            show_user: true
+            required: true
+            default: http://localhost:9600
+          - name: username
+            type: text
+            title: Username
+            description: Use when connecting to logstash
+            multi: false
+            required: false
+            show_user: false
+          - name: password
+            type: password
+            title: Password
+            description: Use when connecting to logstash
+            multi: false
+            required: false
+            show_user: false
+          - name: resource_ssl
+            type: yaml
+            title: SSL Configuration
+            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
+            multi: false
+            required: false
+            show_user: false
+            default: |
+              #certificate_authorities: ["/etc/ca.crt"]
+              #certificate: "/etc/client.crt"
+              #key: "/etc/client.key"
+          - name: condition
+            title: Condition
+            description: Condition to filter when to collect this input
+            type: text
+            multi: false
+            required: false
+            show_user: false
       - type: logstash/metrics
-        title: "Metrics (Stack Monitoring)"
-        description: "Collect node metrics and stats from Logstash instances to power the Stack Monitoring application in Kibana.\n Please disable if only using Technical Preview Logstash Monitoring"
+        title: "Metrics (Stack Monitoring). Should only be enabled when using traditional Stack Monitoring."
+        description: "Collect node metrics and stats from Logstash instances to power the Stack Monitoring application in Kibana.\n Please disable if using Agent-driven Logstash Monitoring"
         vars:
           - name: hosts
             type: text
@@ -89,45 +131,4 @@ policy_templates:
             multi: false
             required: false
             show_user: false
-      - type: cel
-        title: "Metrics (Technical Preview).\nPlease disable if using Stack Monitoring"
-        description: "Collect Metrics and stats from Logstash instances to power dedicated Logstash Dashboards in Kibana"
-        vars:
-          - name: url
-            type: text
-            title: Logstash URL
-            show_user: true
-            required: true
-            default: http://localhost:9600
-          - name: username
-            type: text
-            title: Username
-            description: Use when connecting to logstash
-            multi: false
-            required: false
-            show_user: false
-          - name: password
-            type: password
-            title: Password
-            description: Use when connecting to logstash
-            multi: false
-            required: false
-            show_user: false
-          - name: resource_ssl
-            type: yaml
-            title: SSL Configuration
-            description: i.e. certificate, certificate_authorities, verification_mode etc. See [SSL](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#ssl-client-config) for details.
-            multi: false
-            required: false
-            show_user: false
-            default: |
-              #certificate_authorities: ["/etc/ca.crt"]
-              #certificate: "/etc/client.crt"
-              #key: "/etc/client.key"
-          - name: condition
-            title: Condition
-            description: Condition to filter when to collect this input
-            type: text
-            multi: false
-            required: false
-            show_user: false
+


### PR DESCRIPTION
Remove technical preview language from selections
Enabled agent-driven monitoring collection by default Disable stack monitoring collection by default


<img width="831" alt="Screenshot 2024-07-01 at 3 45 19 PM" src="https://github.com/elastic/integrations/assets/4061337/9719933b-6d35-4ef0-9dc0-f8a687a64e7b">
