### PR TITLE
[cisco_aironet] support for additional syslog timestamp formats

### DIFF
--- a/packages/cisco_aironet/changelog.yml
+++ b/packages/cisco_aironet/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.13.3"
+  changes:
+    - description: Add additional syslog timestamp format support.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10329
 - version: "1.13.2"
   changes:
     - description: Make LOG-3-Q_IND parsing optional.

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log
@@ -33,3 +33,4 @@
 <132>WLC001: *spamReceiveTask: Dec 17 19:59:10.223: %LOG-3-Q_IND: mm_aplist.c:734 Could not delete an AP from the AP list.
 <132>WLC001: *spamApTask4: Jun 08 04:26:43.773: %LOG-3-Q_IND: spam_lrad.c:11366 Country code (CN ) not configured for AP 6c:99:89:b0:XX:XX[…It occurred 2 times.!]
 <132>WLC001: *emWeb: Jan 22 11:42:50.501: %LOG-3-Q_IND: spam_lrad.c:52448 The system is unable to find WLAN 1 to be deleted; AP XX:XX:XX:XX:XX:XX[...It occurred 3 times.!]
+<190>1925541: Jul  1 14:54:19.882: %ROGUE_SYSLOG-6-AP_IMPERSONATION: Chassis 1 R0/0: rogued: Impersonation of AP with Radio MAC XXXX.XXXX.XXXX using source MAC address XXXX.XXXX.XXXX has been detected by AP MY_AP with Radio MAC XXXX.XXXX.XXXX, Slot 34

--- a/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
+++ b/packages/cisco_aironet/data_stream/log/_dev/test/pipeline/test-aironet-messages.log-expected.json
@@ -1344,6 +1344,34 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-07-01T14:54:19.882Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "AP_IMPERSONATION",
+                "original": "<190>1925541: Jul  1 14:54:19.882: %ROGUE_SYSLOG-6-AP_IMPERSONATION: Chassis 1 R0/0: rogued: Impersonation of AP with Radio MAC XXXX.XXXX.XXXX using source MAC address XXXX.XXXX.XXXX has been detected by AP MY_AP with Radio MAC XXXX.XXXX.XXXX, Slot 34",
+                "provider": "ROGUE_SYSLOG",
+                "severity": "6"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "message": "Chassis 1 R0/0: rogued: Impersonation of AP with Radio MAC XXXX.XXXX.XXXX using source MAC address XXXX.XXXX.XXXX has been detected by AP MY_AP with Radio MAC XXXX.XXXX.XXXX, Slot 34",
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_aironet/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -14,13 +14,12 @@ processors:
       field: event.original
       patterns:
         - "%{SYSLOG_HEADER}:\\s%%{GREEDYDATA:_temp_.full_message}"
-        - "%{SYSLOGFACILITY}%{INT}: AP:%{MAC:host.mac}: \\*%{AIRONET_DATE:_temp_.raw_date}: %%{GREEDYDATA:_temp_.full_message}"
-        - "%{SYSLOGFACILITY}%{INT}: %{AIRONET_DATE:_temp_.raw_date}: %%{GREEDYDATA:_temp_.full_message}"
+        - "%{SYSLOGFACILITY}%{INT}: AP:%{MAC:host.mac}: \\*%{SYSLOGTIMESTAMP:_temp_.raw_date}: %%{GREEDYDATA:_temp_.full_message}"
+        - "%{SYSLOGFACILITY}%{INT}: %{SYSLOGTIMESTAMP:_temp_.raw_date}: %%{GREEDYDATA:_temp_.full_message}"
         - "%{SYSLOGFACILITY}%{DATA:host.name}: -%{GREEDYDATA:_temp_.full_message}"
       pattern_definitions:
-        SYSLOG_HEADER: "%{SYSLOGFACILITY}%{DATA:host.name}:\\s\\*%{DATA:process.name}:\\s%{AIRONET_DATE:_temp_.raw_date}"
+        SYSLOG_HEADER: "%{SYSLOGFACILITY}%{DATA:host.name}:\\s\\*%{DATA:process.name}:\\s%{SYSLOGTIMESTAMP:_temp_.raw_date}"
         SYSLOGFACILITY: "<%{NONNEGINT:log.syslog.priority:int}>"
-        AIRONET_DATE: "%{MONTH} %{MONTHDAY} %{TIME}"
   - script:
       lang: painless
       source: |
@@ -88,6 +87,10 @@ processors:
       target_field: "@timestamp"
       formats:
         - "MMM d HH:mm:ss.SSS"
+        - "MMM  d HH:mm:ss.SSS"
+        - "MMM  d HH:mm:ss"
+        - "MMM dd HH:mm:ss"
+        - "MMM d HH:mm:ss"
       timezone: '{{{_conf.tz_offset}}}'
 
   # Adding information to event types

--- a/packages/cisco_aironet/manifest.yml
+++ b/packages/cisco_aironet/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_aironet
 title: "Cisco Aironet"
-version: "1.13.2"
+version: "1.13.3"
 description: "Integration for Cisco Aironet WLC Logs"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Add support for additional syslog timestamp  formats.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

Currently a timestamp like `Jul  1 14:54:19.882` is not supported and can not be ingested without failure. This PR adds support for these types of formats:
```
MMM  d HH:mm:ss.SSS
MMM  d HH:mm:ss
MMM dd HH:mm:ss
MMM d HH:mm:ss
``` 

Additionally it removes the definition of `AIRONET_DATE` in favor of `SYSLOGTIMESTAMP`, which is the same and already pre-defined here: https://github.com/logstash-plugins/logstash-patterns-core/blob/f01f3f34cfab13a28b0822bdba33db41823cb1d8/patterns/ecs-v1/grok-patterns#L81
