### PR TITLE
.buildkite/pipeline.schedule-daily - Use v8.15 snapshot (#9585)

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -2,7 +2,7 @@
 name: integrations-schedule-daily
 
 env:
-  SETUP_GVM_VERSION: "v0.5.1"
+  SETUP_GVM_VERSION: "v0.5.2"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
 
 # The pipeline is triggered by the scheduler every day
@@ -28,14 +28,14 @@ steps:
       - step: "check"
         allow_failure: false
 
-  - label: "Check integrations local stacks - Stack Version v8.14"
+  - label: "Check integrations local stacks - Stack Version v8.15"
     trigger: "integrations"
     build:
       env:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        STACK_VERSION: 8.14.0-SNAPSHOT
+        STACK_VERSION: 8.15.0-SNAPSHOT
         PUBLISH_COVERAGE_REPORTS: "true"
     depends_on:
       - step: "check"


### PR DESCRIPTION
## Proposed commit message

Bump to 8.15.0-SNAPSHOT for dailying stack testing.

Also use gvm v0.5.2 to be consistent with other buildkite pipelines.
