### PR TITLE
[CI] Add gh cli version to report failing tests in daily jobs

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -4,11 +4,12 @@ env:
   SETUP_GVM_VERSION: "v0.5.2"
   LINUX_AGENT_IMAGE: "golang:${GO_VERSION}"
   DOCKER_COMPOSE_VERSION: "v2.24.1"
-  DOCKER_VERSION: "false"
+  DOCKER_VERSION: "false" # not required to set since system tests are not running yet
   KIND_VERSION: 'v0.20.0'
   K8S_VERSION: 'v1.29.0'
   YQ_VERSION: 'v4.35.2'
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
+  GH_CLI_VERSION: "2.29.0"
 
   # Elastic package settings
   # Manage docker output/logs

--- a/dev/testsreporter/testsreporter.go
+++ b/dev/testsreporter/testsreporter.go
@@ -89,7 +89,6 @@ func errorsFromTests(options checkOptions) ([]PackageError, error) {
 		if info.IsDir() {
 			return nil
 		}
-		fmt.Println("Reading file:", path)
 		cases, err := testFailures(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Proposed commit message

Add the required version to install `gh` tool in pipeline.

Example of build failed: https://buildkite.com/elastic/integrations-serverless/builds/509#01907639-ce7b-4310-9e84-e886d735b0e6/88-116


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Related issues

- Follows https://github.com/elastic/integrations/pull/10234
- Relates https://github.com/elastic/integrations/issues/6071

