### PR TITLE
[tenable_io] Include last_fixed date in the fingerprint to avoid duplicated entries

### DIFF
--- a/packages/tenable_io/changelog.yml
+++ b/packages/tenable_io/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.1.1"
+  changes:
+    - description: Include `last_fixed` date in the fingerprint to avoid duplicated entries.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10356
 - version: "3.1.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/tenable_io/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/tenable_io/data_stream/vulnerability/elasticsearch/ingest_pipeline/default.yml
@@ -973,6 +973,7 @@ processors:
         - tenable_io.vulnerability.last_found
         - tenable_io.vulnerability.port.value
         - tenable_io.vulnerability.plugin.modification_date
+        - tenable_io.vulnerability.last_fixed
       target_field: _id
       method: MurmurHash3
       ignore_missing: true

--- a/packages/tenable_io/manifest.yml
+++ b/packages/tenable_io/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: tenable_io
 title: Tenable Vulnerability Management
-version: "3.1.0"
+version: "3.1.1"
 description: Collect logs from Tenable Vulnerability Management with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

From some customer's feedback, current fields for generating the fingerprint could not be enough in some cases to identify unique entries. When a vulnerability gets fixed, a new record can be triggered with the same `last_found` but including a `last_fixed` date.

These kind of events may be dropped since there exists any other entry with the same fingerprint as `_id`.

This pull request adds the `last_fixed` field to the fingerprint calculation.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
