### PR TITLE
[CI] Fix reporting failing tests in serverless pipeline

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -10,6 +10,8 @@ env:
   YQ_VERSION: 'v4.35.2'
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
   GH_CLI_VERSION: "2.29.0"
+  # This pipeline is intended to test packages with Elastic Serverless
+  SERVERLESS: true
 
   # Elastic package settings
   # Manage docker output/logs
@@ -52,7 +54,6 @@ steps:
     command: ".buildkite/scripts/test_integrations_with_serverless.sh"
     timeout_in_minutes: 240
     env:
-      SERVERLESS: true
       FORCE_CHECK_ALL: true
       UPLOAD_SAFE_LOGS: 1
     agents:


### PR DESCRIPTION
## Proposed commit message

Set SERVERLESS environment variable globally. All this Buildkite pipeline is intended to test packages with Elastic serverless.

It also fixes the scenario when there is no closed issue present in the description when the tool is trying to update an existing GitHub issue.

Failed build: https://buildkite.com/elastic/integrations-serverless/builds/510#01907b60-6a24-4da2-afd7-9c6a333329a2/839-880

Issues to update the title to include `[Serverless observability]`:
- #10372 
- #10373

## Related issues

- Follows #10234 
- Relates #6071

