### PR TITLE
[CI] Enable independent agents parallel tests

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -22,6 +22,8 @@ env:
   ELASTIC_PACKAGE_LINKS_FILE_PATH: "links_table.yml"
   # Disable comparison of results in pipeline tests to avoid errors related to GeoIP fields
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
+  # Enable independent Elastic Agents for all packages
+  ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
 
 steps:
   - input: "Input values for the variables"

--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -24,6 +24,8 @@ env:
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
   # Enable independent Elastic Agents for all packages
   ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
+  # Set maximum number of parallel tests to run if package allows it
+  ELASTIC_PACKAGE_MAXIMUM_NUMBER_PARALLEL_TESTS: "5"
 
 steps:
   - input: "Input values for the variables"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,8 @@ env:
   ELASTIC_PACKAGE_LINKS_FILE_PATH: "links_table.yml"
   # Disable comparison of results in pipeline tests to avoid errors related to GeoIP fields
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
+  # Enable independent Elastic Agents for all packages
+  ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
 
 steps:
   - label: ":white_check_mark: Check go sources"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,6 +22,8 @@ env:
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
   # Enable independent Elastic Agents for all packages
   ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
+  # Set maximum number of parallel tests to run if package allows it
+  ELASTIC_PACKAGE_MAXIMUM_NUMBER_PARALLEL_TESTS: "5"
 
 steps:
   - label: ":white_check_mark: Check go sources"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -742,7 +742,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E 'nginx|network_traffic'
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E 'nginx|network_traffic|zeek|oracle|auditd_manager'
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -742,7 +742,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E 'nginx|network_traffic|zeek|oracle|auditd_manager'
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -742,7 +742,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E 'nginx|network_traffic'
 }
 
 check_package() {

--- a/packages/network_traffic/_dev/test/config.yml
+++ b/packages/network_traffic/_dev/test/config.yml
@@ -1,0 +1,2 @@
+system:
+  parallel: true

--- a/packages/zeek/_dev/test/config.yml
+++ b/packages/zeek/_dev/test/config.yml
@@ -1,0 +1,2 @@
+system:
+  parallel: true


### PR DESCRIPTION
## Proposed commit message

Enable independent Elastic Agents and enable to run system tests in parallel for `network_traffic` and `zeek` packages.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~



## Related issues

- Closes #10201 
