### PR TITLE
Update auditd manager independent agent

### DIFF
--- a/packages/auditd_manager/data_stream/auditd/_dev/deploy/agent/custom-agent.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/deploy/agent/custom-agent.yml
@@ -1,8 +1,0 @@
-version: "2.3"
-services:
-  docker-custom-agent:
-    pid: host
-    cap_add:
-      - AUDIT_CONTROL
-      - AUDIT_READ
-    user: root

--- a/packages/auditd_manager/data_stream/auditd/_dev/test/system/test-default-config.yml
+++ b/packages/auditd_manager/data_stream/auditd/_dev/test/system/test-default-config.yml
@@ -15,3 +15,9 @@ data_stream:
       -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -F key=access
       -a always,exit -F arch=b64 -S open,truncate,ftruncate,creat,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -F key=access
     preserve_original_event: true
+agent:
+  runtime: docker
+  pid_mode: "host"
+  linux_capabilities:
+    - AUDIT_CONTROL
+    - AUDIT_READ


### PR DESCRIPTION
## Proposed commit message

Once `elastic-package` v0.101.1 has been updated in this repository, `auditd_manager` can start using independent Elastic Agents and for that it is needed to migrate from the old custom agents.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] elastic-package v0.102.0 published and merged in integrations

## How to test this PR locally

```shell
cd packages/auditd_manager
# use Elastic stack version as defined in manifest as conditions.kibana.version
elastic-package stack up -v -d --version 8.7.1

# run system tests and check the documents ingested in Elastic filtering
# by dataset in the Discover UI before the test scenario is cleanup
elastic-package test system -v --defer-cleanup 240s


# check documents in Elastic
elastic-package stack down -v
```


## Related issues

- Relates #10201 
- Depends on #10384
- Relates #10390


