### PR TITLE
[CI] Use the same commit from target branch for all steps in post-checkout hook

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -17,7 +17,7 @@ checkout_merge() {
         git checkout FETCH_HEAD
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
     else
-        echo "Retrieved commit from env. variable: ${REPOSITORY_TARGET_BRANCH_COMMIT}"
+        echo "Retrieved commit from meta-data: ${REPOSITORY_TARGET_BRANCH_COMMIT}"
         git checkout "${REPOSITORY_TARGET_BRANCH_COMMIT}"
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
     fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -13,8 +13,14 @@ checkout_merge() {
     fi
 
     git fetch -v origin "${target_branch}"
-    git checkout FETCH_HEAD
-    echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+    if [[ ${REPOSITORY_TARGET_BRANCH_COMMIT:-""} == "" ]]; then
+        git checkout FETCH_HEAD
+        echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+    else
+        echo "Retrieved commit from env. variable: ${REPOSITORY_TARGET_BRANCH_COMMIT}"
+        git checkout "${REPOSITORY_TARGET_BRANCH_COMMIT}"
+        echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
+    fi
 
     # create temporal branch to merge the PR with the target branch
     git checkout -b ${merge_branch}

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# ******************************* WARNING ******************************************
+# This post-checkout hook is not the same as in the rest of repositories e.g. beats
+# because some steps in this pipeline (in PR context) take a very long time and we
+# want to make sure that THE SAME COMMIT FROM TARGET BRANCH gets merged in every
+# pipeline step. Otherwise, HEAD (target branch) may have changed in the meantime
+# and therefore, some steps (e.g. sonarqube) may end up testing a different commit.
+#
+# Running builds from branches or tags (out of PR context) maintains the same behavior
+# as in the rest of the repositories.
+#
+# Reference: https://github.com/elastic/integrations/pull/10397
+# **********************************************************************************
+
 set -euo pipefail
 
 checkout_merge() {
@@ -17,6 +30,7 @@ checkout_merge() {
         git checkout FETCH_HEAD
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
     else
+        # Use the same commit from target branch as in the other steps.
         echo "Retrieved commit from meta-data: ${REPOSITORY_TARGET_BRANCH_COMMIT}"
         git checkout "${REPOSITORY_TARGET_BRANCH_COMMIT}"
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
@@ -50,6 +64,7 @@ PR_COMMIT="${BUILDKITE_COMMIT}"
 PR_ID=${BUILDKITE_PULL_REQUEST}
 MERGE_BRANCH="pr_merge_${PR_ID}"
 
+# This meta-data field is populated in the pre-command hook
 REPOSITORY_TARGET_BRANCH_COMMIT=$(buildkite-agent meta-data get "REPOSITORY_TARGET_BRANCH_COMMIT" --default "")
 
 checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -13,7 +13,7 @@ checkout_merge() {
     fi
 
     git fetch -v origin "${target_branch}"
-    if [[ ${REPOSITORY_TARGET_BRANCH_COMMIT:-""} == "" ]]; then
+    if [[ ${REPOSITORY_TARGET_BRANCH_COMMIT} == "" ]]; then
         git checkout FETCH_HEAD
         echo "Current branch: $(git rev-parse --abbrev-ref HEAD)"
     else
@@ -49,6 +49,8 @@ TARGET_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
 PR_COMMIT="${BUILDKITE_COMMIT}"
 PR_ID=${BUILDKITE_PULL_REQUEST}
 MERGE_BRANCH="pr_merge_${PR_ID}"
+
+REPOSITORY_TARGET_BRANCH_COMMIT=$(buildkite-agent meta-data get "REPOSITORY_TARGET_BRANCH_COMMIT" --default "")
 
 checkout_merge "${TARGET_BRANCH}" "${PR_COMMIT}" "${MERGE_BRANCH}"
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -74,8 +74,10 @@ if [ -n "${ELASTIC_PACKAGE_LINKS_FILE_PATH+x}" ]; then
     export ELASTIC_PACKAGE_LINKS_FILE_PATH=${BASE_DIR}/${ELASTIC_PACKAGE_LINKS_FILE_PATH}
 fi
 
-if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}" == "check" ]]; then
-    # Get the commit from target branch in the first step (check) that it does not run with any other step in parallel, to ensure that there is just one value for this variable
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}" == "reference-target-branch" ]]; then
+    # Get the commit from target branch in the first step (reference-target-branch).
+    # This step should not be the first one and not run in parallel with any other step to ensure
+    # that there is just one value for this variable
     if is_pr ; then
         git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
         commit_main=$(git rev-parse --verify FETCH_HEAD)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -76,7 +76,7 @@ fi
 
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}" == "reference-target-branch" ]]; then
     # Get the commit from target branch in the first step (reference-target-branch).
-    # This step should not be the first one and not run in parallel with any other step to ensure
+    # This step MUST be the first one and not run in parallel with any other step to ensure
     # that there is just one value for this variable
     if is_pr ; then
         git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -74,6 +74,15 @@ if [ -n "${ELASTIC_PACKAGE_LINKS_FILE_PATH+x}" ]; then
     export ELASTIC_PACKAGE_LINKS_FILE_PATH=${BASE_DIR}/${ELASTIC_PACKAGE_LINKS_FILE_PATH}
 fi
 
+if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}" == "check" ]]; then
+    # Get the commit from target branch in the first step (check) that it does not run with any other step in parallel, to ensure that there is just one value for this variable
+    if is_pr ; then
+        git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
+        commit_main=$(git rev-parse --verify HEAD)
+        export REPOSITORY_TARGET_BRANCH_COMMIT="${commit_main}"
+    fi
+fi
+
 if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations-publish" ]]; then
     if [[ "${BUILDKITE_STEP_KEY}" == "trigger-publish" ]]; then
         BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field buildkite_token ${BUILDKITE_API_TOKEN_PATH})

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -78,7 +78,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}"
     # Get the commit from target branch in the first step (check) that it does not run with any other step in parallel, to ensure that there is just one value for this variable
     if is_pr ; then
         git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
-        commit_main=$(git rev-parse --verify HEAD)
+        commit_main=$(git rev-parse --verify FETCH_HEAD)
         buildkite-agent meta-data set "REPOSITORY_TARGET_BRANCH_COMMIT" "${commit_main}"
     fi
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -79,7 +79,7 @@ if [[ "${BUILDKITE_PIPELINE_SLUG}" == "integrations" &&  "${BUILDKITE_STEP_KEY}"
     if is_pr ; then
         git fetch -v origin ${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
         commit_main=$(git rev-parse --verify HEAD)
-        export REPOSITORY_TARGET_BRANCH_COMMIT="${commit_main}"
+        buildkite-agent meta-data set "REPOSITORY_TARGET_BRANCH_COMMIT" "${commit_main}"
     fi
 fi
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,12 +23,21 @@ env:
 
 steps:
   - label: ":white_check_mark: Check go sources"
+    key: "reference-target-branch"
+    command: "echo 'Get reference from main'"
+    agents:
+      image: "${LINUX_AGENT_IMAGE}"
+
+  - label: ":white_check_mark: Check go sources"
     key: "check"
     command: ".buildkite/scripts/check_sources.sh"
     agents:
       image: "${LINUX_AGENT_IMAGE}"
       cpu: "8"
       memory: "4G"
+    depends_on:
+      - step: "reference-target-branch"
+        allow_failure: false
 
   - label: "Trigger integrations"
     key: "test-integrations"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,7 +22,7 @@ env:
   ELASTIC_PACKAGE_SERVERLESS_PIPELINE_TEST_DISABLE_COMPARE_RESULTS: "true"
 
 steps:
-  - label: ":white_check_mark: Check go sources"
+  - label: "Get reference from target branch"
     key: "reference-target-branch"
     command: "echo 'Get reference from main'"
     agents:

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -742,7 +742,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep elastic_package_registry
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -742,7 +742,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort |grep elastic_package_registry
 }
 
 check_package() {


### PR DESCRIPTION
## Proposed commit message

Use the same commit (SHA changeset) from the target branch, e.g. main branch, for all steps run in the Buildkite pipeline in the context of Pull Requests. This commit from main will be used in the` post-checkout` hook when available. Using the same changeset from the target branch in all steps avoids that some steps could be using a newer commit from the target branch if a new PR is merged during the build is running. That would create a different merge branch in the post-checkout hook with different contents.

For instance in this build, sonar step runs a different changeset than previous steps:
https://buildkite.com/elastic/integrations/builds/13288

Looking into that build, it can be observed how two different steps are using different changesets from main (there was a PR merged while the PR was being tested) to generate the temporal branch in the `post-checkout` hook:
- Trigger integrations step:
```
HEAD is now at 0c17c7a80 all: harmonise http status error return behaviour (#10346)
```
- Sonarqube step (this step runs after all packages have been tested):
```
HEAD is now at 185d53021 [AWS] Migrate AWS package to ecs@mappings (#10223)
```


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

