### PR TITLE
Add skip ignored fields for AWS WAF fields

### DIFF
--- a/packages/aws/data_stream/waf/_dev/test/system/test-default-config.yml
+++ b/packages/aws/data_stream/waf/_dev/test/system/test-default-config.yml
@@ -4,6 +4,10 @@ vars:
   access_key_id: "{{AWS_ACCESS_KEY_ID}}"
   secret_access_key: "{{AWS_SECRET_ACCESS_KEY}}"
   session_token: "{{AWS_SESSION_TOKEN}}"
+skip_ignored_fields:
+  - aws.waf.terminating_rule_match_details.location
+  - aws.waf.non_terminating_matching_rules.ruleMatchDetails.location
+  - aws.waf.rule_group_list.nonTerminatingMatchingRules.ruleMatchDetails.location
 data_stream:
   vars:
     queue_url: "{{TF_OUTPUT_queue_url}}"


### PR DESCRIPTION
 Bug

## Proposed commit message

https://github.com/elastic/elastic-package/pull/1738 is adding a check to elastic-package system tests for validating `_ignored` fields.

Creating this PR to ignore the check for AWS WAF, for the fields 

  - `aws.waf.terminating_rule_match_details.location`
  - `aws.waf.non_terminating_matching_rules.ruleMatchDetails.location`
  - `aws.waf.rule_group_list.nonTerminatingMatchingRules.ruleMatchDetails.location`


## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

```
elastic-package test system -d waf -v
```
```
--- Test results for package: aws - START ---
╭─────────┬─────────────┬───────────┬───────────┬────────┬─────────────────╮
│ PACKAGE │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │    TIME ELAPSED │
├─────────┼─────────────┼───────────┼───────────┼────────┼─────────────────┤
│ aws     │ waf         │ system    │ default   │ PASS   │ 1m45.866249876s │
╰─────────┴─────────────┴───────────┴───────────┴────────┴─────────────────╯
```
## Related issues

- Closes https://github.com/elastic/integrations/issues/10400

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
