### PR TITLE
Update daily job with 7.17.23-SNAPSHOT stack version

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -22,8 +22,7 @@ steps:
         SERVERLESS: "false"
         SKIP_PUBLISHING: "true"
         FORCE_CHECK_ALL: "true"
-        # STACK_VERSION: 7.17-SNAPSHOT # Using 7.17.19 till https://github.com/elastic/fleet-server/issues/3435 is solved.
-        STACK_VERSION: 7.17.19
+        STACK_VERSION: 7.17.23-SNAPSHOT
     depends_on:
       - step: "check"
         allow_failure: false

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,6 @@ env:
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
-  STACK_VERSION: 7.17.23-SNAPSHOT
 
   # Elastic package settings
   # Manage docker output/logs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ env:
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
+  STACK_VERSION: 7.17.23-SNAPSHOT
 
   # Elastic package settings
   # Manage docker output/logs


### PR DESCRIPTION
## Proposed commit message

Update Elastic stack version 7.17.x to the latest snapshot.

Previously, it was used 7.17-SNAPSHOT, but it looks like this is not updated. Latest kibana docker image 7.17-SNAPSHOT has these labels:
```
                "org.label-schema.build-date": "2024-03-25T11:07:08.779Z",
                "org.label-schema.version": "7.17.19-SNAPSHOT",
```

Latest 7.17.23-SNAPSHOT has these ones:
```
                "org.label-schema.build-date": "2024-07-08T11:06:40.687Z",
                "org.label-schema.version": "7.17.23-SNAPSHOT",
```

Build running PR pipeline with 7.17.23-SNAPSHOT: https://buildkite.com/elastic/integrations/builds/13450


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Update serverless pipeline

## How to test this PR locally

Start a Elastic stack with 7.17.23-SNAPSHOT version and test some package
```
elastic-package stack up -v -d --version 7.17.23-SNAPSHOT
elastic-package test -v
elastic-package stack down -v
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

