### PR TITLE
Enable policy tests in serverless builds

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -819,6 +819,9 @@ test_package_in_serverless() {
     if ! ${ELASTIC_PACKAGE_BIN} test pipeline ${TEST_OPTIONS} ; then
         return 1
     fi
+    if ! ${ELASTIC_PACKAGE_BIN} test policy ${TEST_OPTIONS} ${COVERAGE_OPTIONS}; then
+        return 1
+    fi
     echo ""
     return 0
 }


### PR DESCRIPTION
Policy tests only make use of remote APIs, so they should work in serverless.

Thanks @mrodm for the suggestion!