### PR TITLE
[aws] Add S3 option to s3access logs

### DIFF
--- a/packages/aws/data_stream/s3access/manifest.yml
+++ b/packages/aws/data_stream/s3access/manifest.yml
@@ -6,27 +6,65 @@ streams:
     title: AWS S3 Access Logs
     description: Collect AWS s3access logs using s3 input
     vars:
+      - name: collect_s3_logs
+        required: true
+        show_user: true
+        title: Collect logs via S3 Bucket
+        description: To Collect logs via S3 bucket enable the toggle switch. By default, it will collect logs via SQS Queue.
+        type: bool
+        multi: false
+        default: false
+      - name: bucket_arn
+        type: text
+        title: "[S3] Bucket ARN"
+        multi: false
+        required: false
+        show_user: true
+        description: Mandatory if the "Collect logs via S3 Bucket" switch is on. It is a required parameter for collecting logs via the AWS S3 Bucket.
+      - name: bucket_list_prefix
+        type: text
+        title: "[S3] Bucket Prefix"
+        multi: false
+        required: false
+        show_user: false
+        description: Prefix to apply for the list request to the S3 bucket.
+      - name: interval
+        type: text
+        title: "[S3] Interval"
+        multi: false
+        required: false
+        show_user: false
+        default: 1m
+        description: "Time interval for polling listing of the S3 bucket. NOTE: Supported units for this parameter are h/m/s."
+      - name: number_of_workers
+        type: integer
+        title: "[S3] Number of Workers"
+        multi: false
+        required: false
+        show_user: false
+        default: 5
+        description: Number of workers that will process the S3 objects listed.
       - name: visibility_timeout
         type: text
-        title: Visibility Timeout
+        title: "[SQS] Visibility Timeout"
         multi: false
         required: false
         show_user: false
         description: The duration that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.  The maximum is 12 hours.
       - name: api_timeout
         type: text
-        title: API Timeout
+        title: "[SQS] API Timeout"
         multi: false
         required: false
         show_user: false
         description: The maximum duration of AWS API can take. The maximum is half of the visibility timeout value.
       - name: queue_url
         type: text
-        title: Queue URL
+        title: "[SQS] Queue URL"
         multi: false
-        required: true
+        required: false
         show_user: true
-        description: URL of the AWS SQS queue that messages will be received from.
+        description: Mandatory if the "Collect logs via S3 Bucket" switch is off. URL of the AWS SQS queue that messages will be received from.
       - name: endpoint
         type: text
         title: Endpoint
@@ -92,4 +130,3 @@ streams:
         show_user: false
         description: >
           Additional settings to be added to the configuration. Be careful using this as it might break the input as those settings are not validated and can override the settings specified above. See [`aws-s3` input settings docs](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html) for details.
-


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR is to add reading logs directly from S3 as an option for `s3access` data stream. 

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
