### PR TITLE
Elastic Agent: ensure syslog processor is not used with 7.17.X agents

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure the syslog processor is not used with Elastic Agent 7.17.X versions.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10162
+      link: https://github.com/elastic/integrations/pull/10471
 - version: "1.59.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.59.1"
+  changes:
+    - description: Ensure the syslog processor is not used with Elastic Agent 7.17.X versions.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10162
 - version: "1.59.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/system/data_stream/auth/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/auth/agent/stream/log.yml.hbs
@@ -36,6 +36,7 @@ processors:
     field: event.original
     ignore_missing: true
     ignore_failure: true
+  condition: startsWith(${agent.version.version}, "7.17") == false
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.59.0"
+version: "1.59.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.
Elastic Agent: ensure syslog processor is not used with 7.17.X agents
Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
Elastic Agent: ensure syslog processor is not used with 7.17.X agents by adding a condition.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
Tests:
- [x] 7.17.22 agent is now healthy
- [x] 8.15.0 agent is still healthy 
- [x] 7.17.22 agent is stuck in `configuring` if I reverse the condition check 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/integrations/issues/10457

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
