### PR TITLE
qualys_vmdr.user_activity - handle headers and footers

### DIFF
--- a/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
+++ b/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
@@ -317,12 +317,27 @@ rules:
   - path: /api/2.0/fo/activity_log/
     methods: ['GET']
     query_params:
+      id_max: 1425858279 # Pagination request.
       action: list
       truncation_limit: 1000
       since_datetime: '{since_datetime:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}}Z'
     responses:
       - status_code: 200
         body: |-
+          ----BEGIN_RESPONSE_BODY_CSV
+          "Date","Action","Module","Details","User Name","User Role","User IP"
+          "2024-01-18T12:45:24Z","request","auth","API: /api/2.0/fo/activity_log/index.php","john","Reader","10.113.195.136"
+          ----END_RESPONSE_BODY_CSV
+  - path: /api/2.0/fo/activity_log/
+    methods: ['GET']
+    query_params:
+      action: list
+      truncation_limit: 1000
+      since_datetime: '{since_datetime:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}}Z'
+    responses:
+      - status_code: 200
+        body: |-
+          ----BEGIN_RESPONSE_BODY_CSV
           "Date","Action","Module","Details","User Name","User Role","User IP"
           "2024-02-03T04:35:38Z","login","auth","user_logged in","saand_rn","Manager","10.113.195.136"
           "2024-02-02T13:58:16Z","login","auth","user_logged in","saand_rn","Manager","10.113.195.136"
@@ -332,3 +347,10 @@ rules:
           "2024-02-02T13:28:17Z","request","auth","API: /api/2.0/fo/activity_log/index.php","saand_rn","Manager","10.113.195.136"
           "2024-02-02T13:27:27Z","request","auth","API: /api/2.0/fo/activity_log/index.php","saand_rn","Manager","10.113.195.136"
           "2024-02-02T13:26:41Z","request","auth","API: /api/2.0/fo/activity_log/index.php","saand_rn","Manager","10.113.195.136"
+          ----END_RESPONSE_BODY_CSV
+          ----BEGIN_RESPONSE_FOOTER_CSV
+          WARNING
+          "CODE","TEXT","URL"
+          "1980","1000 record limit exceeded. Use URL to get next batch of results.","http://{{ env "SERVER_ADDRESS" }}/api/2.0/fo/activity_log/?action=list&since_datetime=2024-06-16T22%3a00%3a00Z&truncation_limit=1000&id_max=1425858279"
+          ----END_RESPONSE_FOOTER_CSV
+

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.1.1"
+  changes:
+    - description: Fix handling of the activity_log API response body.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10477
 - version: "4.1.0"
   changes:
     - description: Check the HTTP status code before processing the response.

--- a/packages/qualys_vmdr/data_stream/user_activity/_dev/test/system/test-user-activity-config.yml
+++ b/packages/qualys_vmdr/data_stream/user_activity/_dev/test/system/test-user-activity-config.yml
@@ -10,4 +10,4 @@ data_stream:
     preserve_original_event: true
     enable_request_tracer: true
 assert:
-  hit_count: 8
+  hit_count: 9

--- a/packages/qualys_vmdr/data_stream/user_activity/agent/stream/cel.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/user_activity/agent/stream/cel.yml.hbs
@@ -26,13 +26,17 @@ redact:
     - password
 program: |
   state.with(
-    request(
-      "GET",
-      state.url.trim_right("/") + "/api/2.0/fo/activity_log/?" + {
-        "action": ["list"],
-        "since_datetime": [string(state.?cursor.latest_ts.orValue(now - duration(state.initial_interval)).format(time_layout.RFC3339))],
-        ?"truncation_limit": has(state.batch_size) ? optional.of([string(state.batch_size)]) : optional.none(),
-      }.format_query()
+    request("GET",
+      state.?want_more.orValue(false) ?
+        state.pagination_url
+      :
+        state.url.trim_right("/") + "/api/2.0/fo/activity_log/?" + {
+          "action": ["list"],
+          "since_datetime": [state.?cursor.latest_ts.orValue(
+            (now - duration(state.initial_interval)).format(time_layout.RFC3339)
+          )],
+          ?"truncation_limit": has(state.batch_size) ? optional.of([string(state.batch_size)]) : optional.none(),
+        }.format_query()
     ).with({
       "Header":{
         "Authorization": ["Basic " + (state.user + ":" + state.password).base64()],
@@ -41,12 +45,30 @@ program: |
     }).do_request().as(resp,
       resp.StatusCode == 200
       ?
-        bytes(resp.Body).mime("text/csv; header=present").as(events, {
-            "events": events.map(e, {"message": e.encode_json()}),
-            "want_more": has(state.batch_size) && size(events) >= state.batch_size,
+        string(resp.Body).as(text, {
+          "csv": (
+            text.contains_substr("----BEGIN_RESPONSE_BODY_CSV") ?
+              bytes(text.substring(
+                text.index("----BEGIN_RESPONSE_BODY_CSV")+size("----BEGIN_RESPONSE_BODY_CSV\n"),
+                text.index("----END_RESPONSE_BODY_CSV")
+              ))
+            :
+              resp.Body
+            ).mime("text/csv; header=present"),
+          ?"next": text.contains_substr("----BEGIN_RESPONSE_FOOTER_CSV") ?
+            bytes(text.substring(
+              text.index("----BEGIN_RESPONSE_FOOTER_CSV")+size("----BEGIN_RESPONSE_FOOTER_CSV\n"),
+              text.index("----END_RESPONSE_FOOTER_CSV")
+            ).trim_prefix("WARNING\n")).mime("text/csv; header=present")[?0]
+          :
+            optional.none(),
+        }).as(data, {
+            "events": data.csv.map(e, {"message": e.encode_json()}),
+            "want_more": data.?next.URL.hasValue(),
+            "pagination_url": data.?next.URL.orValue(null),
             "cursor": {
-                ?"latest_ts": size(events) > 0 ?
-                  optional.of(events.map(e, e.Date.parse_time(time_layout.RFC3339)).max())
+                ?"latest_ts": size(data.csv) > 0 ?
+                  optional.of(data.csv.map(e, e.Date.parse_time(time_layout.RFC3339)).max())
                 :
                   state.?cursor.latest_ts,
             },

--- a/packages/qualys_vmdr/data_stream/user_activity/agent/stream/cel.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/user_activity/agent/stream/cel.yml.hbs
@@ -67,7 +67,10 @@ program: |
             "want_more": data.?next.URL.hasValue(),
             "pagination_url": data.?next.URL.orValue(null),
             "cursor": {
-                ?"latest_ts": size(data.csv) > 0 ?
+                // The API roughly returns data from newest to oldest. For simplicity
+                // only update the cursor for the non-pagination response which
+                // should hold newer data than any of the pagination responses.
+                ?"latest_ts": !state.?want_more.orValue(false) && size(data.csv) > 0 ?
                   optional.of(data.csv.map(e, e.Date.parse_time(time_layout.RFC3339)).max())
                 :
                   state.?cursor.latest_ts,

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "4.1.0"
+version: "4.1.1"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix handling of the qualys VMDR activity_log API response. The response includes elements that are not documented. The response body contains wrappers around the CSV and an optional footer containing the pagination URL when the response was truncated.

The implementation here may be optimized after elastic/mito#67 becomes available in a release of Elastic Agent.

Fixes #10183

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Verify this against the real activity_log API

## Related issues

- Fixes #10183
