### PR TITLE
[Synthetics] add journey.duration mapping to browser fields

### DIFF
--- a/packages/synthetics/changelog.yml
+++ b/packages/synthetics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.2"
+  changes:
+    - description: Added mappings for journey.duration fields
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10497
 - version: "1.2.1"
   changes:
     - description: Re-introduce pre-release changes from 1.2.0-rc1

--- a/packages/synthetics/data_stream/browser/fields/synthetics.yml
+++ b/packages/synthetics/data_stream/browser/fields/synthetics.yml
@@ -11,7 +11,7 @@
     - name: index
       type: integer
       description: >
-        Indexed used for creating total order of all events in this invocation.
+        Index count used for creating total order of all events during invocation.
 
     - name: payload
       object_type: keyword
@@ -60,6 +60,13 @@
           type: text
         - name: stack
           type: text
+        - name: duration
+          type: group
+          description: Duration required to complete the journey.
+          fields:
+            - name: us
+              type: integer
+              description: Duration in microseconds
 - name: browser
   type: group
   fields:

--- a/packages/synthetics/manifest.yml
+++ b/packages/synthetics/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: synthetics
 title: Elastic Synthetics
 description: Internal Elastic integration for providing access to private locations.
-version: 1.2.1
+version: 1.2.2
 categories: ["observability"]
 type: integration
 source:


### PR DESCRIPTION
+ Follow up of the mapping changes from Synthetics - https://github.com/elastic/beats/pull/40230/

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
