### PR TITLE
[Kubernetes] Add last_terminated_timestamp metric to state_container datastream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.65.0
+  changes:
+    - description: Add last_terminated_timestamp metric to the kubernetes.state_container datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10213
 - version: 1.64.0
   changes:
     - description: Move namespace filter to the group level configuration

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add last_terminated_timestamp metric to the kubernetes.state_container datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10213
+      link: https://github.com/elastic/integrations/pull/10503
 - version: 1.64.0
   changes:
     - description: Move namespace filter to the group level configuration

--- a/packages/kubernetes/data_stream/state_container/fields/fields.yml
+++ b/packages/kubernetes/data_stream/state_container/fields/fields.yml
@@ -32,6 +32,9 @@
           type: keyword
           description: >
             The last reason the container was in terminated state (Completed, ContainerCannotRun, Error or OOMKilled).
+        - name: last_terminated_timestamp
+          type: double
+          description: Last terminated time (epoch) of the container
     - name: cpu
       type: group
       fields:

--- a/packages/kubernetes/docs/kube-state-metrics.md
+++ b/packages/kubernetes/docs/kube-state-metrics.md
@@ -178,6 +178,7 @@ An example event for `state_container` looks as following:
 | kubernetes.container.memory.request.bytes | Container requested memory in bytes | long | byte | gauge |
 | kubernetes.container.name | Kubernetes container name | keyword |  |  |
 | kubernetes.container.status.last_terminated_reason | The last reason the container was in terminated state (Completed, ContainerCannotRun, Error or OOMKilled). | keyword |  |  |
+| kubernetes.container.status.last_terminated_timestamp | Last terminated time (epoch) of the container | double |  |  |
 | kubernetes.container.status.phase | Container phase (running, waiting, terminated) | keyword |  |  |
 | kubernetes.container.status.ready | Container ready status | boolean |  |  |
 | kubernetes.container.status.reason | The reason the container is currently in waiting (ContainerCreating, CrashLoopBackoff, ErrImagePull, ImagePullBackoff) or terminated (Completed, ContainerCannotRun, Error, OOMKilled) state. | keyword |  |  |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.64.0
+version: 1.65.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- WHAT: Add last_terminated_timestamp metric to the kubernetes.state_container datastream
- WHY: Reflect corresponding changes in beats - https://github.com/elastic/beats/pull/39200 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

Relates https://github.com/elastic/elastic-agent/issues/3802

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/3802

## Screenshots

<img width="2554" alt="Screenshot 2024-07-15 at 16 02 07" src="https://github.com/user-attachments/assets/fed74417-c630-4118-8b51-15ad75c73944">

