### PR TITLE
Revert "Elastic Agent: ensure syslog processor is not used with 7.17.X agents"

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,9 +1,4 @@
 # newer versions go on top
-- version: "1.59.1"
-  changes:
-    - description: Ensure the syslog processor is not used with Elastic Agent 7.17.X versions.
-      type: bugfix
-      link: https://github.com/elastic/integrations/pull/10471
 - version: "1.59.0"
   changes:
     - description: ECS version updated to 8.11.0. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/system/data_stream/auth/agent/stream/log.yml.hbs
+++ b/packages/system/data_stream/auth/agent/stream/log.yml.hbs
@@ -36,7 +36,6 @@ processors:
     field: event.original
     ignore_missing: true
     ignore_failure: true
-  condition: startsWith(${agent.version.version}, "7.17") == false
 {{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.59.1"
+version: "1.59.0"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Reverts elastic/integrations#10471

Following this https://github.com/elastic/elastic-agent/issues/5137 discovery, we should revert this change to avoid `inspect` and `uninstall` command failing.

Even if we can fix the issue in Elastic Agent (and we should do it anyway), we will need to find another solution to fix the 7.17 issue we currently have with this integration.