### PR TITLE
Convert error.code to string for winlog inputs

### DIFF
--- a/packages/hid_bravura_monitor/changelog.yml
+++ b/packages/hid_bravura_monitor/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Convert error.code to string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10529
 - version: "1.18.0"
   changes:
     - description: Add missing options to winlog input

--- a/packages/hid_bravura_monitor/data_stream/winlog/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/hid_bravura_monitor/data_stream/winlog/elasticsearch/ingest_pipeline/default.yml
@@ -385,6 +385,11 @@ processors:
         - winlog.event_data.Value8
         - winlog.event_data.Value9
 
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
+
 on_failure:
   - set:
       field: event.kind

--- a/packages/hid_bravura_monitor/manifest.yml
+++ b/packages/hid_bravura_monitor/manifest.yml
@@ -1,6 +1,6 @@
 name: hid_bravura_monitor
 title: Bravura Monitor
-version: "1.18.0"
+version: "1.18.1"
 categories: ["security", "iam"]
 description: Collect logs from Bravura Security Fabric with Elastic Agent.
 type: integration

--- a/packages/microsoft_dnsserver/changelog.yml
+++ b/packages/microsoft_dnsserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Convert error.code to string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10529
 - version: "0.1.0"
   changes:
     - description: Initial release

--- a/packages/microsoft_dnsserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_dnsserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -378,6 +378,11 @@ processors:
       allow_duplicates: false
       tag: append_related_source_ip
 
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
+
 # Remove duplicated and empty fields
   - script:
       lang: painless

--- a/packages/microsoft_dnsserver/manifest.yml
+++ b/packages/microsoft_dnsserver/manifest.yml
@@ -3,7 +3,7 @@ name: microsoft_dnsserver
 title: Microsoft DNS Server
 description: Collect logs from Microsoft DNS Server with Elastic Agent.
 type: integration
-version: 0.1.0
+version: 0.1.1
 conditions:
   kibana:
     version: ^8.13.0

--- a/packages/microsoft_sqlserver/changelog.yml
+++ b/packages/microsoft_sqlserver/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.9.1"
+  changes:
+    - description: Convert error.code to string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10529
 - version: "2.9.0"
   changes:
     - description: Add missing options to winlog input

--- a/packages/microsoft_sqlserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_sqlserver/data_stream/audit/elasticsearch/ingest_pipeline/default.yml
@@ -1234,6 +1234,12 @@ processors:
     field: winlog.record_id
     type: string
     ignore_missing: true
+
+- convert:
+    field: error.code
+    type: string
+    ignore_missing: true
+
 ##
 # Clean up
 ##

--- a/packages/microsoft_sqlserver/data_stream/performance/manifest.yml
+++ b/packages/microsoft_sqlserver/data_stream/performance/manifest.yml
@@ -26,6 +26,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
+
     title: Microsoft SQL Server performance metrics
     description: Collect Microsoft SQL Server performance metrics
 elasticsearch:

--- a/packages/microsoft_sqlserver/data_stream/transaction_log/manifest.yml
+++ b/packages/microsoft_sqlserver/data_stream/transaction_log/manifest.yml
@@ -34,6 +34,7 @@ streams:
         show_user: false
         description: >
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.
+
     title: Microsoft SQL Server transaction_log metrics
     description: Collect Microsoft SQL Server transaction_log metrics
 elasticsearch:

--- a/packages/microsoft_sqlserver/manifest.yml
+++ b/packages/microsoft_sqlserver/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_sqlserver
 title: "Microsoft SQL Server"
-version: "2.9.0"
+version: "2.9.1"
 description: Collect events from Microsoft SQL Server with Elastic Agent
 type: integration
 categories:

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.59.3"
+  changes:
+    - description: Convert error.code to string for winlog inputs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10529
 - version: "1.59.2"
   changes:
     - description: Reverting https://github.com/elastic/integrations/pull/10471.

--- a/packages/system/data_stream/application/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/application/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,10 @@ processors:
   - set:
       field: ecs.version
       value: 8.11.0
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 on_failure:
   - set:
       field: "error.message"

--- a/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/security/elasticsearch/ingest_pipeline/default.yml
@@ -72,6 +72,10 @@ processors:
             value: "fail-{{{ _ingest.on_failure_processor_tag }}}"
         - fail:
             message: "Processor {{ _ingest.on_failure_processor_type }} with tag {{ _ingest.on_failure_processor_tag }} in pipeline {{ _ingest.on_failure_pipeline }} failed with message: {{ _ingest.on_failure_message }}"
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 on_failure:
   - set:
       field: event.kind

--- a/packages/system/data_stream/system/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/system/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,10 @@ processors:
   - set:
       field: ecs.version
       value: 8.11.0
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 on_failure:
   - set:
       field: "error.message"

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.59.2"
+version: "1.59.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:

--- a/packages/windows/changelog.yml
+++ b/packages/windows/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.46.1"
+  changes:
+    - description: Convert error.code to string
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10529
 - version: "1.46.0"
   changes:
     - description: Add initial Windows Defender data stream.

--- a/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_exe_and_dll/elasticsearch/ingest_pipeline/default.yml
@@ -165,6 +165,11 @@ processors:
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
+
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
       
 on_failure:
   - set:

--- a/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_msi_and_script/elasticsearch/ingest_pipeline/default.yml
@@ -165,6 +165,11 @@ processors:
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
+
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
       
 on_failure:
   - set:

--- a/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_deployment/elasticsearch/ingest_pipeline/default.yml
@@ -164,6 +164,11 @@ processors:
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
+
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
       
 on_failure:
   - set:

--- a/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/applocker_packaged_app_execution/elasticsearch/ingest_pipeline/default.yml
@@ -164,6 +164,11 @@ processors:
       copy_from: winlog.user_data.FileHash
       ignore_empty_value: true
       if: ctx.winlog?.user_data?.FileHash != "-"
+
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
       
 on_failure:
   - set:

--- a/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/forwarded/elasticsearch/ingest_pipeline/default.yml
@@ -45,7 +45,12 @@ processors:
       field: winlog.event_data._MemberAccountType
       ignore_missing: true
       ignore_failure: true
-      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)   
+      if: ctx.user?.roles != null && ctx.winlog?.event_data?._MemberAccountType != null && ctx.user.roles.contains(ctx.winlog.event_data._MemberAccountType)
+
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 
 on_failure:
   - set:

--- a/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell/elasticsearch/ingest_pipeline/default.yml
@@ -451,6 +451,11 @@ processors:
       ignore_missing: true
       if: ctx?.winlog?.event_data?.ScriptName != ""
 
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
+
   ## Cleanup.
 
   - remove:

--- a/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/powershell_operational/elasticsearch/ingest_pipeline/default.yml
@@ -511,6 +511,11 @@ processors:
       ignore_missing: true
       if: ctx?.winlog?.event_data?.ScriptName != ""
 
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
+
   ## Cleanup.
 
   - remove:

--- a/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/sysmon_operational/elasticsearch/ingest_pipeline/default.yml
@@ -1225,6 +1225,10 @@ processors:
       ignore_missing: true
       ignore_failure: true
       if: ctx?.winlog?.event_data?.IsExecutable != null && ctx?.winlog?.event_data?.IsExecutable != ""
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 
 ## Related fields
 

--- a/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/windows/data_stream/windows_defender/elasticsearch/ingest_pipeline/default.yml
@@ -45,6 +45,10 @@ processors:
       type: string
       ignore_failure: true
       ignore_missing: true
+  - convert:
+      field: error.code
+      type: string
+      ignore_missing: true
 
   ## User fields.
 

--- a/packages/windows/manifest.yml
+++ b/packages/windows/manifest.yml
@@ -1,6 +1,6 @@
 name: windows
 title: Windows
-version: 1.46.0
+version: 1.46.1
 description: Collect logs and metrics from Windows OS and services with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Convert error.code to string for winlog inputs.

Winlog integrations populate `error.code` coming from the windows events. The original field is a uint32, and it needs to be converted to a string to comply with the ECS `error.code` keyword type.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

