### PR TITLE
[cisco_umbrella] Fix handling of parsers when file_selectors is not empty

### DIFF
--- a/packages/cisco_umbrella/changelog.yml
+++ b/packages/cisco_umbrella/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.1"
+  changes:
+    - description: Make file_selectors configurable to prevent parsers from being unintentionally overwritten.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10531
 - version: "1.25.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/cisco_umbrella/data_stream/log/_dev/test/system/test-default-config.yml
+++ b/packages/cisco_umbrella/data_stream/log/_dev/test/system/test-default-config.yml
@@ -9,5 +9,11 @@ data_stream:
     preserve_original_event: true
     file_selectors: |-
       - regex: '^(.+?)\.log'
+        parsers:
+          - multiline:
+              type: pattern
+              pattern: '\"$'
+              negate: true
+              match: before
 assert:
   hit_count: 19

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -7,16 +7,14 @@ bucket_arn: {{bucket_arn}}
 {{#if bucket_list_prefix}}
 bucket_list_prefix: {{bucket_list_prefix}}/
 {{/if}}
-{{#if bucket_list_prefix}}
-file_selectors: 
-  - regex: {{bucket_list_prefix}}/dnslogs/.+
-  - regex: {{bucket_list_prefix}}/proxylogs/.+
-  - regex: {{bucket_list_prefix}}/firewalllogs/.+
-  - regex: {{bucket_list_prefix}}/cloudfirewalllogs/.+
-  - regex: {{bucket_list_prefix}}/iplogs/.+
-  - regex: {{bucket_list_prefix}}/intrusionlogs/.+
-  - regex: {{bucket_list_prefix}}/dlplogs/.+
-  - regex: {{bucket_list_prefix}}/auditlogs/.+
+{{#if file_selectors}}
+file_selectors:
+{{file_selectors}}
+{{else}}
+{{#if parsers}}
+parsers:
+{{parsers}}
+{{/if}}
 {{/if}}
 {{#if region}}
 default_region: {{region}}
@@ -76,8 +74,4 @@ publisher_pipeline.disable_host: true
 {{#if processors}}
 processors:
 {{processors}}
-{{/if}}
-{{#if parsers}}
-parsers:
-{{parsers}}
 {{/if}}

--- a/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
+++ b/packages/cisco_umbrella/data_stream/log/agent/stream/aws-s3.yml.hbs
@@ -10,11 +10,9 @@ bucket_list_prefix: {{bucket_list_prefix}}/
 {{#if file_selectors}}
 file_selectors:
 {{file_selectors}}
-{{else}}
-{{#if parsers}}
+{{else if parsers}}
 parsers:
 {{parsers}}
-{{/if}}
 {{/if}}
 {{#if region}}
 default_region: {{region}}

--- a/packages/cisco_umbrella/data_stream/log/manifest.yml
+++ b/packages/cisco_umbrella/data_stream/log/manifest.yml
@@ -154,12 +154,38 @@ streams:
         type: bool
         multi: false
         default: false
+      - name: file_selectors
+        type: yaml
+        title: File Selectors
+        multi: false
+        required: false
+        show_user: false
+        description: >-
+          If the S3 bucket will have events that correspond to files that this integration shouldn't process, file_selectors can be used to limit the files that are downloaded. This is a list of selectors which are made up of regex and other options such as expand_event_list_from_field or parsers. If file_selectors is given, then any global expand_event_list_from_field or parsers values are ignored in favor of the ones specified in the file_selectors. Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed. For more information see [File Selectors](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_file_selectors)
+        default: |
+          - regex: "dnslogs/.+"
+          - regex: "proxylogs/.+"
+          - regex: "firewalllogs/.+"
+          - regex: "cloudfirewalllogs/.+"
+          - regex: "iplogs/.+"
+          - regex: "intrusionlogs/.+"
+          - regex: "dlplogs/.+"
+          - regex: "auditlogs/.+"
+            parsers:
+              - multiline:
+                  # Prevent multiline CSV being split in audit logs.
+                  type: pattern
+                  pattern: '\"$'
+                  negate: true
+                  match: before
       - name: parsers
         type: yaml
         title: Parsers
         multi: false
         required: false
         show_user: false
+        description: >-
+          This option expects a list of parsers that the payload has to go through. If file_selectors is given, parsers must be set for each regex entry in the file_selectors box as this global option will be ignored. For more information see [Parsers](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#input-aws-s3-parsers)
         default: |
           - multiline:
               # Prevent multiline CSV being split in audit logs.

--- a/packages/cisco_umbrella/manifest.yml
+++ b/packages/cisco_umbrella/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cisco_umbrella
 title: Cisco Umbrella
-version: "1.25.0"
+version: "1.25.1"
 description: Collect logs from Cisco Umbrella with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

There is an issue in the Filebeat AWS input where when `file_selectors` is set, the global `parsers` is overwritten by individual parsers for each entry in `file_selectors`.

In the Cisco Umbrella integration, `file_selectors` should not be hardcoded because it is permanently avoiding `parsers` to work, which is used to apply the multiline configuration for audit logs.

This PR fixes that by making `file_seletors` configurable so `parsers` can be set individually in there. In case `file_selectors` is not configured, `parsers` are applied globally.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

