### PR TITLE
Fix the Cisco_ISE toggle description for filestream input

### DIFF
--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix the Cisco_ISE toggle description for filestream input
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/666666
+      link: https://github.com/elastic/integrations/pull/10534
 - version: "1.22.2"
   changes:
     - description: Handle logs that start with ISO8601 timestamp

--- a/packages/cisco_ise/changelog.yml
+++ b/packages/cisco_ise/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.3"
+  changes:
+    - description: Fix the Cisco_ISE toggle description for filestream input
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/666666
 - version: "1.22.2"
   changes:
     - description: Handle logs that start with ISO8601 timestamp

--- a/packages/cisco_ise/data_stream/log/manifest.yml
+++ b/packages/cisco_ise/data_stream/log/manifest.yml
@@ -75,7 +75,7 @@ streams:
   - input: filestream
     template_path: filestream.yml.hbs
     title: Cisco_ISE logs
-    description: Collect Cisco ISE logs via TCP input.
+    description: Collect Cisco ISE logs via file input.
     vars:
       - name: paths
         title: Paths

--- a/packages/cisco_ise/manifest.yml
+++ b/packages/cisco_ise/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ise
 title: Cisco ISE
-version: "1.22.2"
+version: "1.22.3"
 description: Collect logs from Cisco ISE with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix the Cisco_ISE toggle description for filestream input


This is to follow up on SDH that was fixed earlier, this fixes the incorrect UX toggle description.

Before the change:
<img width="842" alt="Screenshot 2024-07-18 at 10 35 35 AM" src="https://github.com/user-attachments/assets/f7457377-1812-4095-a246-9f37000baca6">

After this change:
<img width="768" alt="Screenshot 2024-07-18 at 10 44 34 AM" src="https://github.com/user-attachments/assets/749e755a-a026-4013-b5a7-ff1caf5ee20b">



## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

