### PR TITLE
[f5_bigip] Update event.kind values based on severity

### DIFF
--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.18.1"
+  changes:
+    - description: Update event.kind values based on severity.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.18.0"
   changes:
     - description: Add Support of System Info, iHealth information, BOT and DOS logs.

--- a/packages/f5_bigip/changelog.yml
+++ b/packages/f5_bigip/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update event.kind values based on severity.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10540
 - version: "1.18.0"
   changes:
     - description: Add Support of System Info, iHealth information, BOT and DOS logs.

--- a/packages/f5_bigip/data_stream/log/_dev/test/pipeline/test-pipeline-bigip-asm.log-expected.json
+++ b/packages/f5_bigip/data_stream/log/_dev/test/pipeline/test-pipeline-bigip-asm.log-expected.json
@@ -367,7 +367,7 @@
                 "category": [
                     "network"
                 ],
-                "kind": "alert",
+                "kind": "event",
                 "original": "{\"attack_type\":\"Test Attack\",\"date_time\":\"2018-11-19 22:34:40\",\"dest_ip\":\"10.160.77.77\",\"dest_port\":\"80\",\"geo_info\":\"info\",\"headers\":\"Host: 231213\",\"http_class\":\"/Common/Test\",\"ip_addr_intelli\":\"host1\",\"ip_client\":\"81.2.69.142\",\"ip_route_domain\":\"example.com\",\"is_trunct\":\"no\",\"manage_ip_addr\":\"81.2.69.142\",\"method\":\"POST\",\"policy_apply_date\":\"2021-09-30 02:51:31\",\"policy_name\":\"/Common/Test\",\"protocol\":\"HTTP\",\"query_string\":\"\",\"req\":\"POST /login.php HTTP/1.1\\\\r\\\\nHost: 81.2.69.142\",\"req_status\":\"passed\",\"resp\":\"HTTP/1.1 302 Found\\\\r\\\\nDate: Tue, 05 Oct 2021 17:30:14 \",\"resp_code\":\"302\",\"route_domain\":\"example.com\",\"session_id\":\"ab32bda123\",\"severity\":\"Informational\",\"sig_ids\":\"1abcd23bdc\",\"sig_names\":\"test\",\"src_port\":\"49744\",\"sub_violates\":\"Sub-violation\",\"support_id\":\"5438760667957952540\",\"unit_host\":\"hostname\",\"uri\":\"/login.php\",\"username\":\"Test User\",\"violate_details\":\"This is a details.\",\"violate_rate\":\"0\",\"violations\":\"deny\",\"virus_name\":\"abcd\",\"x_fwd_hdr_val\":\"test\",\"telemetryEventCategory\":\"ASM\",\"hostname\":\"localhost.localdomain\",\"tenant\":\"Common\",\"microservice\": \"N/A\",\"response\": \"Response logging disabled\",\"sig_cves\": \"N/A\",\"staged_sig_cves\": \"N/A\",\"tap_event_id\": \"N/A\",\"tap_vid\": \"N/A\",\"vs_name\": \"/Common/Server1_DVWA\"}",
                 "type": [
                     "info"
@@ -491,7 +491,7 @@
                 "category": [
                     "network"
                 ],
-                "kind": "alert",
+                "kind": "event",
                 "original": "{\"compression_method\":\"test_method\",\"client_type\":\"test_client\",\"conviction_traps\":\"test\",\"credential_stuffing_lookup_result\":\"pass\",\"enforced_by\":\"test\",\"enforcement_action\":\"test_action\",\"epoch_time\":\"1665576701\",\"ip_with_route_domain\":\"example.com\",\"is_truncated\":\"\",\"likely_false_positive_sig_ids\":\"12345678\",\"login_result\":\"success\",\"mobile_application_name\":\"test_application\",\"mobile_application_version\":\"test1.1\",\"operation_id\":\"12345\",\"password_hash_prefix\":\"test\",\"protocol_info\":\"test_info\",\"sig_set_names\":\"test_sig_name\",\"slot_number\":\"1234\",\"staged_sig_set_names\":\"test_staged_sig_name\",\"tap_requested_actions\":\"test_tap_action\",\"tap_sent_token\":\"20334\",\"tap_transaction_id\":\"12345\",\"unit_hostname\":\"hostname\",\"violation_details\":\"test_detail\",\"telemetryEventCategory\":\"ASM\"}",
                 "type": [
                     "info"

--- a/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipasm.yml
+++ b/packages/f5_bigip/data_stream/log/elasticsearch/ingest_pipeline/pipeline_bigipasm.yml
@@ -13,6 +13,7 @@ processors:
       field: event.kind
       tag: set_event_kind
       value: alert
+      if: ctx.json?.severity != null && ['emergency', 'critical', 'alert', 'warning', 'error'].contains(ctx.json.severity.toLowerCase())
   - set:
       field: observer.product
       tag: set_observer_product

--- a/packages/f5_bigip/data_stream/log/sample_event.json
+++ b/packages/f5_bigip/data_stream/log/sample_event.json
@@ -1,8 +1,8 @@
 {
     "@timestamp": "2018-11-19T22:34:40.000Z",
     "agent": {
-        "ephemeral_id": "aefdb8d4-40be-490a-b0e4-a53313e9e7af",
-        "id": "b76bed4f-0dc0-463b-b822-22e730e6cc74",
+        "ephemeral_id": "e5f59545-d8ac-4f69-9699-79bb945dff15",
+        "id": "5dfb7c6f-2d06-40bd-9835-16a8fd432357",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.13.0"
@@ -13,7 +13,7 @@
     },
     "data_stream": {
         "dataset": "f5_bigip.log",
-        "namespace": "ep",
+        "namespace": "25415",
         "type": "logs"
     },
     "destination": {
@@ -24,7 +24,7 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "b76bed4f-0dc0-463b-b822-22e730e6cc74",
+        "id": "5dfb7c6f-2d06-40bd-9835-16a8fd432357",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -34,7 +34,7 @@
             "network"
         ],
         "dataset": "f5_bigip.log",
-        "ingested": "2024-07-15T08:41:15Z",
+        "ingested": "2024-07-19T11:02:41Z",
         "kind": "alert",
         "original": "{\"application\":\"app.app\",\"attack_type\":\"Detection Evasion\",\"blocking_exception_reason\":\"test\",\"captcha_result\":\"not_received\",\"date_time\":\"2018-11-19 22:34:40\",\"dest_ip\":\"81.2.69.142\",\"dest_port\":\"80\",\"device_id\":\"12bdca32\",\"fragment\":\"test_Fragment\",\"geo_location\":\"US\",\"hostname\":\"hostname\",\"http_class_name\":\"/Common/abc/test\",\"ip_address_intelligence\":\"host1\",\"ip_client\":\"81.2.69.142\",\"management_ip_address\":\"81.2.69.142\",\"management_ip_address_2\":\"81.2.69.144\",\"method\":\"GET\",\"policy_apply_date\":\"2018-11-19 22:17:57\",\"policy_name\":\"/Common/abc\",\"protocol\":\"HTTP\",\"query_string\":\"name=abc\",\"request\":\"GET /admin/.\",\"request_status\":\"blocked\",\"response_code\":\"0\",\"route_domain\":\"example.com\",\"session_id\":\"abc123abcd\",\"severity\":\"Critical\",\"sig_ids\":\"abc12bcd\",\"sig_names\":\"Sig_Name\",\"src_port\":\"49804\",\"staged_sig_ids\":\"abc23121bc\",\"staged_sig_names\":\"test_name\",\"staged_threat_campaign_names\":\"test\",\"sub_violations\":\"Evasion technique detected:Directory traversals\",\"support_id\":\"123456789\",\"telemetryEventCategory\":\"ASM\",\"tenant\":\"Common\",\"threat_campaign_names\":\"threat\",\"uri\":\"/directory/file\",\"username\":\"test User\",\"violation_rating\":\"3\",\"violations\":\"Evasion technique detected\",\"virus_name\":\"test Virus\",\"web_application_name\":\"/Common/abc\",\"websocket_direction\":\"test\",\"websocket_message_type\":\"test\",\"x_forwarded_for_header_value\":\"81.2.69.144\"}",
         "type": [

--- a/packages/f5_bigip/docs/README.md
+++ b/packages/f5_bigip/docs/README.md
@@ -164,8 +164,8 @@ An example event for `log` looks as following:
 {
     "@timestamp": "2018-11-19T22:34:40.000Z",
     "agent": {
-        "ephemeral_id": "aefdb8d4-40be-490a-b0e4-a53313e9e7af",
-        "id": "b76bed4f-0dc0-463b-b822-22e730e6cc74",
+        "ephemeral_id": "e5f59545-d8ac-4f69-9699-79bb945dff15",
+        "id": "5dfb7c6f-2d06-40bd-9835-16a8fd432357",
         "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.13.0"
@@ -176,7 +176,7 @@ An example event for `log` looks as following:
     },
     "data_stream": {
         "dataset": "f5_bigip.log",
-        "namespace": "ep",
+        "namespace": "25415",
         "type": "logs"
     },
     "destination": {
@@ -187,7 +187,7 @@ An example event for `log` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "b76bed4f-0dc0-463b-b822-22e730e6cc74",
+        "id": "5dfb7c6f-2d06-40bd-9835-16a8fd432357",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -197,7 +197,7 @@ An example event for `log` looks as following:
             "network"
         ],
         "dataset": "f5_bigip.log",
-        "ingested": "2024-07-15T08:41:15Z",
+        "ingested": "2024-07-19T11:02:41Z",
         "kind": "alert",
         "original": "{\"application\":\"app.app\",\"attack_type\":\"Detection Evasion\",\"blocking_exception_reason\":\"test\",\"captcha_result\":\"not_received\",\"date_time\":\"2018-11-19 22:34:40\",\"dest_ip\":\"81.2.69.142\",\"dest_port\":\"80\",\"device_id\":\"12bdca32\",\"fragment\":\"test_Fragment\",\"geo_location\":\"US\",\"hostname\":\"hostname\",\"http_class_name\":\"/Common/abc/test\",\"ip_address_intelligence\":\"host1\",\"ip_client\":\"81.2.69.142\",\"management_ip_address\":\"81.2.69.142\",\"management_ip_address_2\":\"81.2.69.144\",\"method\":\"GET\",\"policy_apply_date\":\"2018-11-19 22:17:57\",\"policy_name\":\"/Common/abc\",\"protocol\":\"HTTP\",\"query_string\":\"name=abc\",\"request\":\"GET /admin/.\",\"request_status\":\"blocked\",\"response_code\":\"0\",\"route_domain\":\"example.com\",\"session_id\":\"abc123abcd\",\"severity\":\"Critical\",\"sig_ids\":\"abc12bcd\",\"sig_names\":\"Sig_Name\",\"src_port\":\"49804\",\"staged_sig_ids\":\"abc23121bc\",\"staged_sig_names\":\"test_name\",\"staged_threat_campaign_names\":\"test\",\"sub_violations\":\"Evasion technique detected:Directory traversals\",\"support_id\":\"123456789\",\"telemetryEventCategory\":\"ASM\",\"tenant\":\"Common\",\"threat_campaign_names\":\"threat\",\"uri\":\"/directory/file\",\"username\":\"test User\",\"violation_rating\":\"3\",\"violations\":\"Evasion technique detected\",\"virus_name\":\"test Virus\",\"web_application_name\":\"/Common/abc\",\"websocket_direction\":\"test\",\"websocket_message_type\":\"test\",\"x_forwarded_for_header_value\":\"81.2.69.144\"}",
         "type": [

--- a/packages/f5_bigip/manifest.yml
+++ b/packages/f5_bigip/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: f5_bigip
 title: F5 BIG-IP
-version: "1.18.0"
+version: "1.18.1"
 description: Collect logs from F5 BIG-IP with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Bug

## Proposed commit message

Modifying the value of `event.kind` dynamically according to [severity levels](https://clouddocs.f5.com/api/irules/ASM__severity.html). For the severity values of Emergency, Alert, Critical, Error, and Warning, `event.kind` is set to alert.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/f5_bigip directory.
- Run the following command to run tests.
> elastic-package test

## Related issues

- Closes #10528 


<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
