### PR TITLE
Update Cloud Defend integration to include `beta` release tag

### DIFF
--- a/packages/cloud_defend/manifest.yml
+++ b/packages/cloud_defend/manifest.yml
@@ -10,6 +10,7 @@ categories:
   - containers
   - kubernetes
   - security
+release: beta
 conditions:
   kibana:
     version: ^8.11.0


### PR DESCRIPTION
This PR resolves https://github.com/elastic/security-docs/issues/5583 and adds the `beta` tag to the [Cloud Defend integration](https://www.elastic.co/docs/current/integrations/cloud_defend). I'm not sure how to test this to ensure the changes appear as they should before merging; can someone help with that? 