### PR TITLE
ti_crowdstrike: fix time stamp handling

### DIFF
--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,12 @@
 # newer versions go on top
+- version: "1.1.2"
+  changes:
+    - description: Fix handling of timestamps with positive time zone offsets.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10545
+    - description: Fix cursor timestamp handling in ioc data stream.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10545
 - version: "1.1.1"
   changes:
     - description: Remove reference to a Kibana version from the README.

--- a/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
@@ -32,15 +32,19 @@ redact:
   fields: ~
 program: |
   (
-    !state.want_more ?
-      request("GET", state.url + "/intel/combined/indicators/v1?offset=0&sort=_marker.asc&limit=" + string(state.batch_size) + '&filter=_marker:>"' + (
-        has(state.cursor) && has(state.cursor.last_timestamp) && state.cursor.last_timestamp != null ?
-          string(int(state.cursor.last_timestamp))
-        :
-          string(int(now - duration(state.initial_interval)))
-      ) + '"')
-    :
-      request("GET", state.url + string(state.next_url[0]))
+    request("GET", state.url.trim_right("/") + (
+      state.want_more ?
+        string(state.next_url[0])
+      :
+        "/intel/combined/indicators/v1?" + {
+          "sort": ["_marker.asc"],
+          "offset": ["0"],
+          "limit": [string(state.batch_size)],
+          "filter": [
+            '_marker:>"' + string(state.?cursor.last_timestamp.orValue(int(now - duration(state.initial_interval)))) + '"'
+          ],
+        }.format_query()
+    ))
   ).do_request().as(resp,
     resp.StatusCode == 200 ?
       bytes(resp.Body).decode_json().as(body, {
@@ -53,22 +57,10 @@ program: |
         "initial_interval": state.initial_interval,
         "next_url": "Next-Page" in resp.Header ? resp.Header["Next-Page"] : "",
         "cursor": {
-          "last_timestamp": (
-            has(body.resources) && body.resources.size() > 0 ?
-              (
-                has(state.cursor) && has(state.cursor.last_timestamp) && body.resources.map(e, e.last_updated).max() < state.cursor.last_timestamp ?
-                  state.cursor.last_timestamp
-                :
-                  body.resources.map(e, e.last_updated).max()
-              )
-            :
-              (
-                has(state.cursor) && has(state.cursor.last_timestamp) ?
-                  state.cursor.last_timestamp
-                :
-                  null
-              )
-          ),
+          ?"last_timestamp": has(body.resources) ?
+            optional.of(([?state.?cursor.last_timestamp] + body.resources.map(e, e.last_updated)).max())
+          :
+            state.?cursor.last_timestamp,
         },
       })
     :

--- a/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
@@ -33,20 +33,24 @@ redact:
   fields: ~
 program: |
   (
-    !state.want_more ?
-      request("GET", state.url + "/iocs/combined/indicator/v1?sort=modified_on&offset=0&limit=" + string(state.batch_size) + '&filter=modified_on:>"' + (
-        has(state.cursor) && has(state.cursor.last_timestamp) && state.cursor.last_timestamp != null ?
-          state.cursor.last_timestamp + '"'
-        :
-          (now - duration(state.initial_interval)).format(time_layout.RFC3339) + '"'
-      ))
-    :
-      request("GET", state.url + "/iocs/combined/indicator/v1?sort=modified_on&limit=" + string(state.batch_size) + "&offset=" + string(state.offset) + '&filter=modified_on:>"' + (
-        has(state.cursor) && has(state.cursor.first_timestamp) && state.cursor.first_timestamp != null ?
-          state.cursor.first_timestamp + '"'
-        :
-          '"'
-      ))
+    request("GET", state.url.trim_right("/") + "/iocs/combined/indicator/v1?" + (
+      state.want_more ?
+        {
+          "sort": ["modified_on"],
+          "offset": [string(state.offset)],
+          "limit": [string(state.batch_size)],
+          "filter": ['modified_on:>"' + state.?cursor.first_timestamp.orValue("") + '"'],
+        }
+      :
+        {
+          "sort": ["modified_on"],
+          "offset": ["0"],
+          "limit": [string(state.batch_size)],
+          "filter": [
+            'modified_on:>"' + state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)) + '"',
+          ],
+        }
+    ).format_query())
   ).do_request().as(resp,
     resp.StatusCode == 200 ?
       bytes(resp.Body).decode_json().as(body, {
@@ -62,33 +66,16 @@ program: |
         "batch_size": state.batch_size,
         "initial_interval": state.initial_interval,
         "cursor": {
-          "last_timestamp": (
-            has(body.resources) && body.resources.size() > 0 ?
-              (
-                has(state.cursor) && has(state.cursor.last_timestamp) && body.resources.map(e, e.modified_on).max() < state.cursor.last_timestamp ?
-                  state.cursor.last_timestamp
-                :
-                  body.resources.map(e, e.modified_on).max()
-              )
-            :
-              (
-                has(state.cursor) && has(state.cursor.last_timestamp) ?
-                  state.cursor.last_timestamp
-                :
-                  null
-              )
-          ),
-          "first_timestamp": (
-            has(state.cursor) && has(state.cursor.first_timestamp) && state.cursor.first_timestamp != null ?
-              (
-                state.want_more ?
-                  state.cursor.first_timestamp
-                :
-                  state.cursor.last_timestamp
-              )
-            :
-              (now - duration(state.initial_interval)).format(time_layout.RFC3339)
-          ),
+          ?"last_timestamp": has(body.resources) ?
+            optional.of(([?state.?cursor.last_timestamp] + body.resources.map(e, e.modified_on)).map(t, timestamp(t)).max())
+          :
+            state.?cursor.last_timestamp,
+          ?"first_timestamp": !has(state.?cursor.first_timestamp) ?
+            optional.of((now - duration(state.initial_interval)).format(time_layout.RFC3339))
+          : state.want_more ?
+            state.?cursor.first_timestamp
+          :
+            state.?cursor.last_timestamp,
         },
       })
     :

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "1.1.1"
+version: "1.1.2"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The previous code used plain string operations to construct URL queries, allowing inclusion of invalid syntax when timestamps are in eastern time zones due to the inclusion of the '+' for the time zone offset. Use format_query to properly format URL queries.

In the ioc data stream, timestamps are RFC3339 formatted. These are usually sortable by stringly comparison, but not always, so make sure the comparisons are always based on time by converting candidate cursor timestamps to the timestamp type before comparison.

Also make use of optional types more carefully.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Fixes #10526

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
