### PR TITLE
Fix missing processors block in kubernetes.audit_logs integration

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.66.2
+  changes:
+    - description: Fixing missing processor block in kubernetes.audit_logs
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10535
 - version: 1.66.1
   changes:
     - description: Fixing Title in Volumes Dashboard

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixing missing processor block in kubernetes.audit_logs
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10535
+      link: https://github.com/elastic/integrations/pull/10548
 - version: 1.66.1
   changes:
     - description: Fixing Title in Volumes Dashboard

--- a/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
@@ -8,6 +8,7 @@ parsers:
     add_error_key: true
     target: "kubernetes.audit"
 {{#if processors}}
+processors:
 {{processors}}
 {{/if}}
 {{#if condition}}

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.66.1
+version: 1.66.2
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

- Bug
## Proposed commit message


- WHAT: Fix missing processors block in kubernetes.audit_logs integration
- WHY:  User cannot add new processors in the kubernetes.audit_logs  data stream through Kibana anymore

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
