### PR TITLE
[integrations][keycloak] - Fixed parser config default value and updated GROK pattern to account for multiline error logs

### DIFF
--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fixed parser config default value and updated GROK pattern to account for multiline logs.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1111
+      link: https://github.com/elastic/integrations/pull/10549
 - version: "1.22.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.1"
+  changes:
+    - description: Fixed parser config default value and updated GROK pattern to account for multiline logs.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1111
 - version: "1.22.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/keycloak/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -514,7 +514,6 @@
             ],
             "url": {
                 "domain": "www.example.com",
-                "extension": "sso/SAML2/POST",
                 "original": "https://www.example.com/Shibboleth.sso/SAML2/POST",
                 "path": "/Shibboleth.sso/SAML2/POST",
                 "scheme": "https"
@@ -1072,7 +1071,7 @@
                 "level": "ERROR",
                 "logger": "com.example.BaseUserProvider"
             },
-            "message": "Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)",
+            "message": "Error getting user: org.apache.http.conn.HttpHostConnectException: Connect to host.docker.internal:8080 [host.docker.internal/10.2.2.156] failed: Connection refused (Connection refused)\n    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)\n    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)\n    at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)\n    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)\n    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)\n    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)",
             "process": {
                 "thread": {
                     "name": "default task-8"

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -12,7 +12,7 @@ processors:
   - grok:
       field: event.original
       patterns:
-        - "%{TIMESTAMP_ISO8601:_tmp.timestamp} %{LOGLEVEL:log.level}%{SPACE}\\[%{JAVACLASS:log.logger}\\] \\(%{DATA:process.thread.name}\\) %{GREEDYDATA:message}"
+        - "%{TIMESTAMP_ISO8601:_tmp.timestamp} %{LOGLEVEL:log.level}%{SPACE}\\[%{JAVACLASS:log.logger}\\] \\(%{DATA:process.thread.name}\\) (?<message>(.|\r|\n)*)"
   - set:
       field: event.timezone
       value: "{{_tmp.tz_offset}}"

--- a/packages/keycloak/data_stream/log/manifest.yml
+++ b/packages/keycloak/data_stream/log/manifest.yml
@@ -63,7 +63,7 @@ streams:
         multi: false
         default: |
           - multiline:
-              pattern: '^\d{4}-\w{2}-\d{2}'
+              pattern: '^\d{4}-\d{2}-\d{2}'
               negate: true
               match: after
     template_path: "filestream.yml.hbs"

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.22.0"
+version: "1.22.1"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Type of change
- Bug

## Proposed commit message
1. The default parser regex pattern was faulty based on the parser requirements, hence updated it accordingly. 
2. The existing GROK pattern did not pick up multiline error logs, hence updated it accordingly and regenerated tests reflecting the change.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] URL extention detections seems to have stopped after the change, and the extention is part of the url now. 

## NOTE: 
I revisited the url extention issue and seems even after a revert the extension field is no longer generated. This seems it might not be related to this change but rather how url extensions are now handled in ecs. It seems only file extensions are parsed now instead of a ".path".  (could be wrong) 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
