### PR TITLE
[kibana] Improve docker scenario healthcheck

### DIFF
--- a/packages/kibana/_dev/deploy/docker/docker-compose.yml
+++ b/packages/kibana/_dev/deploy/docker/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     ports:
       - "127.0.0.1:5602:5601"
     healthcheck:
-      test: curl -sfo /dev/null http://localhost:5601 || exit 1
+      test: curl -sfo /dev/null http://localhost:5601/api/status || exit 1
       retries: 600
       interval: 1s
   log_generation:


### PR DESCRIPTION
Tests are frequently failing with connectivity errors with Kibana, try to improve the healthcheck.

Fixes https://github.com/elastic/integrations/issues/10525
Fixes https://github.com/elastic/integrations/issues/10524
Fixes https://github.com/elastic/integrations/issues/10513
Fixes https://github.com/elastic/integrations/issues/10482