### PR TITLE
[sql_input] Pin mssql docker image used for testing

### DIFF
--- a/packages/sql_input/_dev/deploy/docker/docker-compose.yml
+++ b/packages/sql_input/_dev/deploy/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       retries: 6
       test: ["CMD", "psql", "-h", "localhost", "-U", "postgres", "-l"]
   sql_input_mssql:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     ports:
       - 1433
     environment:


### PR DESCRIPTION
Latest image changed some things, at least the tools used for healthcheck
are installed in a different directory, and it looks like the service is started
with self-signed certificate.

These changes make healthchecks to fail consistently.

Pin the docker image to the newest version known to work.
