### PR TITLE
[Mysql] Fix PR ID and changelog descriptions

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,12 +1,12 @@
 # newer versions go on top
 - version: 1.24.0
   changes:
-    - description: Add replica_status datastream.
+    - description: Add replica_status data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10344
 - version: 1.23.0
   changes:
-    - description: Add processor support for galera_status, performance and staus data streams.
+    - description: Add processor support for galera_status, performance and status data streams.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10410
 - version: "1.22.0"


### PR DESCRIPTION
- Bug

This PR fixes the PR ID in the changelog entry for this [PR](https://github.com/elastic/integrations/pull/10344/files#diff-6d411529872efe9148ddcff32c2958b311aec07db4207630c4f7cb89f00019ddR6:~:text=link%3A%20https%3A//github.com/elastic/integrations/pull/1) and the typo errors in the description for Mysql integration.



## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally
Verify the changelog entry and the descriptions.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
