### PR TITLE
Revert update of updatecli

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.64.0 # updatecli v0.80.0
+        uses: updatecli/updatecli-action@v2.62.0
 
       - name: Select diff action
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Our actions started failing after the time of this upgrade, revert it to see if it fixes the issue.