### PR TITLE
[checkpoint] Ensure event.original is always set to message

### DIFF
--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.31.1"
+  changes:
+    - description: Ensure event.original is always set to value of message.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "1.31.0"
   changes:
     - description: Update package-spec to 3.0.3.

--- a/packages/checkpoint/changelog.yml
+++ b/packages/checkpoint/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Ensure event.original is always set to value of message.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10645
 - version: "1.31.0"
   changes:
     - description: Update package-spec to 3.0.3.

--- a/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/checkpoint/data_stream/firewall/elasticsearch/ingest_pipeline/default.yml
@@ -4,11 +4,14 @@ processors:
   - set:
       field: ecs.version
       value: '8.11.0'
-  - rename:
+  - set:
+      tag: set_event_original
+      field: event.original
+      copy_from: message
+  - remove:
+      tag: remove_message
       field: message
-      target_field: event.original
       ignore_missing: true
-      if: ctx.event?.original == null
   - grok:
       field: event.original
       tag: "grok_syslog_line"

--- a/packages/checkpoint/manifest.yml
+++ b/packages/checkpoint/manifest.yml
@@ -1,6 +1,6 @@
 name: checkpoint
 title: Check Point
-version: "1.31.0"
+version: "1.31.1"
 description: Collect logs from Check Point with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
## Proposed commit message

- Situations may arise where event.original is set to non-standard or incorrect value by some external source, such as Logstash. Since the value we need is the contents of the message field, the value of event.original will be set to the value of message in all cases.
- Add remove processor to delete message field to mimic behavior of the old rename processor.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/checkpoint
elastic-package test
```

## Related issues

- Relates elastic/sdh-beats#4977
