### PR TITLE
Copy log.syslog.appname to process.name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -328,7 +328,7 @@
 /packages/sysmon_linux @elastic/sec-linux-platform
 /packages/system @elastic/obs-infraobs-integrations
 /packages/system/changelog.yml @elastic/obs-infraobs-integrations @elastic/sec-linux-platform @elastic/sec-windows-platform
-/packages/system/data_stream/auth @elastic/sec-windows-platform
+/packages/system/data_stream/auth @elastic/sec-linux-platform
 /packages/system/data_stream/security @elastic/sec-windows-platform
 /packages/system/data_stream/application @elastic/sec-windows-platform
 /packages/system/data_stream/core @elastic/obs-infraobs-integrations

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.60.1"
+  changes:
+    - description: Ensure process.name is populated from syslog messages
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10646
 - version: "1.60.0"
   changes:
     - description: Add caseless fields to process events.

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json
@@ -1,0 +1,132 @@
+{
+  "events": [
+      {
+        "@timestamp": "2022-01-11T22:14:15.003Z",
+        "log": {
+          "syslog": {
+            "priority": 165,
+            "facility": {
+              "code": 20,
+              "name": "local4"
+            },
+            "severity": {
+              "code": 5,
+              "name": "Notice"
+            },
+            "hostname": "mymachine.example.com",
+            "appname": "eventslog",
+            "procid": "1024",
+            "msgid": "ID47",
+            "version": "1",
+            "structured_data": {
+              "exampleSDID@32473": {
+                "iut":         "3",
+                "eventSource": "Application",
+                "eventID":     "1011"
+              },
+              "examplePriority@32473": {
+                "class": "high"
+              }
+            }
+          }
+        },
+        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com eventslog 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+      },
+      {
+        "@timestamp": "2022-01-11T22:14:15.003Z",
+        "log": {
+          "syslog": {
+            "priority": 165,
+            "facility": {
+              "code": 20,
+              "name": "local4"
+            },
+            "severity": {
+              "code": 5,
+              "name": "Notice"
+            },
+            "hostname": "mymachine.example.com",
+            "appname": "groupdel",
+            "procid": "1024",
+            "msgid": "ID47",
+            "version": "1",
+            "structured_data": {
+              "exampleSDID@32473": {
+                "iut":         "3",
+                "eventSource": "Application",
+                "eventID":     "1011"
+              },
+              "examplePriority@32473": {
+                "class": "high"
+              }
+            }
+          }
+        },
+        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com groupadd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+      },
+      {
+        "@timestamp": "2022-01-11T22:14:15.003Z",
+        "log": {
+          "syslog": {
+            "priority": 165,
+            "facility": {
+              "code": 20,
+              "name": "local4"
+            },
+            "severity": {
+              "code": 5,
+              "name": "Notice"
+            },
+            "hostname": "mymachine.example.com",
+            "appname": "useradd",
+            "procid": "1024",
+            "msgid": "ID47",
+            "version": "1",
+            "structured_data": {
+              "exampleSDID@32473": {
+                "iut":         "3",
+                "eventSource": "Application",
+                "eventID":     "1011"
+              },
+              "examplePriority@32473": {
+                "class": "high"
+              }
+            }
+          }
+        },
+        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com useradd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+      },
+      {
+        "@timestamp": "2022-01-11T22:14:15.003Z",
+        "log": {
+          "syslog": {
+            "priority": 165,
+            "facility": {
+              "code": 20,
+              "name": "local4"
+            },
+            "severity": {
+              "code": 5,
+              "name": "Notice"
+            },
+            "hostname": "mymachine.example.com",
+            "appname": "usermod",
+            "procid": "1024",
+            "msgid": "ID47",
+            "version": "1",
+            "structured_data": {
+              "exampleSDID@32473": {
+                "iut":         "3",
+                "eventSource": "Application",
+                "eventID":     "1011"
+              },
+              "examplePriority@32473": {
+                "class": "high"
+              }
+            }
+          }
+        },
+        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com usermod 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+      }
+   ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json
@@ -1,6 +1,9 @@
 {
   "events": [
       {
+        "event" : {
+        "original": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com eventslog 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        },
         "@timestamp": "2022-01-11T22:14:15.003Z",
         "log": {
           "syslog": {
@@ -30,10 +33,13 @@
             }
           }
         },
-        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com eventslog 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        "message": "this is the message"
       },
       {
         "@timestamp": "2022-01-11T22:14:15.003Z",
+        "event" : {
+            "original": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com groupadd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        },
         "log": {
           "syslog": {
             "priority": 165,
@@ -62,10 +68,13 @@
             }
           }
         },
-        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com groupadd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        "message": "this is the message"
       },
       {
         "@timestamp": "2022-01-11T22:14:15.003Z",
+        "event" : {
+            "original": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com useradd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        },
         "log": {
           "syslog": {
             "priority": 165,
@@ -94,10 +103,13 @@
             }
           }
         },
-        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com useradd 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        "message": "this is the message"
       },
       {
         "@timestamp": "2022-01-11T22:14:15.003Z",
+        "event" : {
+            "original": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com usermod 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        },
         "log": {
           "syslog": {
             "priority": 165,
@@ -126,7 +138,7 @@
             }
           }
         },
-        "message": "<165>1 2022-01-11T22:14:15.003Z mymachine.example.com usermod 1024 ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@32473 class=\"high\"] this is the message"
+        "message": "this is the message"
       }
    ]
 }

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
@@ -1,0 +1,195 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2022-01-11T22:14:15.003Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30,
+                    "appname": "eventslog",
+                    "facility": {
+                        "code": 20,
+                        "name": "local4"
+                    },
+                    "hostname": "mymachine.example.com",
+                    "msgid": "ID47",
+                    "priority": 165,
+                    "procid": "1024",
+                    "severity": {
+                        "code": 5,
+                        "name": "Notice"
+                    },
+                    "structured_data": {
+                        "examplePriority@32473": {
+                            "class": "high"
+                        },
+                        "exampleSDID@32473": {
+                            "eventID": "1011",
+                            "eventSource": "Application",
+                            "iut": "3"
+                        }
+                    },
+                    "version": "1"
+                }
+            },
+            "process": {
+                "name": "eventslog"
+            }
+        },
+        {
+            "@timestamp": "2022-01-11T22:14:15.003Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "outcome": "success",
+                "type": [
+                    "group",
+                    "deletion"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30,
+                    "appname": "groupdel",
+                    "facility": {
+                        "code": 20,
+                        "name": "local4"
+                    },
+                    "hostname": "mymachine.example.com",
+                    "msgid": "ID47",
+                    "priority": 165,
+                    "procid": "1024",
+                    "severity": {
+                        "code": 5,
+                        "name": "Notice"
+                    },
+                    "structured_data": {
+                        "examplePriority@32473": {
+                            "class": "high"
+                        },
+                        "exampleSDID@32473": {
+                            "eventID": "1011",
+                            "eventSource": "Application",
+                            "iut": "3"
+                        }
+                    },
+                    "version": "1"
+                }
+            },
+            "process": {
+                "name": "groupdel"
+            }
+        },
+        {
+            "@timestamp": "2022-01-11T22:14:15.003Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "creation"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30,
+                    "appname": "useradd",
+                    "facility": {
+                        "code": 20,
+                        "name": "local4"
+                    },
+                    "hostname": "mymachine.example.com",
+                    "msgid": "ID47",
+                    "priority": 165,
+                    "procid": "1024",
+                    "severity": {
+                        "code": 5,
+                        "name": "Notice"
+                    },
+                    "structured_data": {
+                        "examplePriority@32473": {
+                            "class": "high"
+                        },
+                        "exampleSDID@32473": {
+                            "eventID": "1011",
+                            "eventSource": "Application",
+                            "iut": "3"
+                        }
+                    },
+                    "version": "1"
+                }
+            },
+            "process": {
+                "name": "useradd"
+            }
+        },
+        {
+            "@timestamp": "2022-01-11T22:14:15.003Z",
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "kind": "event",
+                "category": [
+                    "iam"
+                ],
+                "kind": "event",
+                "outcome": "success",
+                "type": [
+                    "user",
+                    "change"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "priority": 30,
+                    "appname": "usermod",
+                    "facility": {
+                        "code": 20,
+                        "name": "local4"
+                    },
+                    "hostname": "mymachine.example.com",
+                    "msgid": "ID47",
+                    "priority": 165,
+                    "procid": "1024",
+                    "severity": {
+                        "code": 5,
+                        "name": "Notice"
+                    },
+                    "structured_data": {
+                        "examplePriority@32473": {
+                            "class": "high"
+                        },
+                        "exampleSDID@32473": {
+                            "eventID": "1011",
+                            "eventSource": "Application",
+                            "iut": "3"
+                        }
+                    },
+                    "version": "1"
+                }
+            },
+            "process": {
+                "name": "usermod"
+            }
+        }
+    ]
+}

--- a/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
+++ b/packages/system/data_stream/auth/_dev/test/pipeline/test-host-syslog-processor.json-expected.json
@@ -37,6 +37,7 @@
                     "version": "1"
                 }
             },
+            "message": "this is the message",
             "process": {
                 "name": "eventslog"
             }
@@ -87,6 +88,7 @@
                     "version": "1"
                 }
             },
+            "message": "this is the message",
             "process": {
                 "name": "groupdel"
             }
@@ -137,6 +139,7 @@
                     "version": "1"
                 }
             },
+            "message": "this is the message",
             "process": {
                 "name": "useradd"
             }
@@ -187,6 +190,7 @@
                     "version": "1"
                 }
             },
+            "message": "this is the message",
             "process": {
                 "name": "usermod"
             }

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -303,6 +303,12 @@ processors:
           ctx.event.action = "ssh_login";
           ctx.event.outcome = "failure";
         }
+  - set:
+      tag: set_process_name-log_syslog_appname
+      field: process.name
+      copy_from: log.syslog.appname
+      override : false
+      ignore_empty_value: true
   - append:
       tag: append_category-iam
       field: event.category

--- a/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/system/data_stream/auth/elasticsearch/ingest_pipeline/default.yml
@@ -307,7 +307,7 @@ processors:
       tag: set_process_name-log_syslog_appname
       field: process.name
       copy_from: log.syslog.appname
-      override : false
+      override: false
       ignore_empty_value: true
   - append:
       tag: append_category-iam

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.60.0"
+version: "1.60.1"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Before the syslog processor was added to the default filebeat yaml configuration, process.name was set by a Grok ingest pipeline. However, when the syslog processor was added a condition was also added to the Grok ingest pipeline, `if: ctx.log?.syslog == null`. This condition always evaluates to false when the data is supplied by the syslog processor, and therefore `process.name` is not extraced from the syslog message. This commit copies the process name from `log.syslog.appname` to `process.name` before an pipeline processors which use it are executed. With this change, `process.name`, `event.category`, and `event.type` are now populated when data arrives from the syslog processor.

And add tests.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
~/git/integrations/main/packages/system$ elastic-package test pipeline -d auth -v
```

## Related issues
- Closes #9565
