### PR TITLE
[Cloud Asset Inventory] Add Azure Inventory

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Add Azure Asset Inventory
       type: enhancement
-      link:
+      link: https://github.com/elastic/integrations/pull/10663
 - version: "0.1.4"
   changes:
     - description: Add Cloud Asset Inventory

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.1.5"
+  changes:
+    - description: Add Azure Asset Inventory
+      type: enhancement
+      link:
 - version: "0.1.4"
   changes:
     - description: Add Cloud Asset Inventory

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/aws.yml.hbs
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/aws.yml.hbs
@@ -2,6 +2,7 @@ period: 24h
 config:
   v1:
     type: asset_inventory
+    asset_inventory_provider: aws
     aws:
       account_type: single-account
       credentials:

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/azure.yml.hbs
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/azure.yml.hbs
@@ -1,0 +1,34 @@
+period: 24h
+config:
+  v1:
+    type: asset_inventory
+    asset_inventory_provider: azure
+    azure:
+      {{#if azure.account_type}}
+      account_type: {{azure.account_type}}
+      {{/if}}
+      credentials:
+        {{#if azure.credentials.type}}
+        type: {{azure.credentials.type}}
+        {{/if}}
+        {{#if azure.credentials.client_id}}
+        client_id: {{azure.credentials.client_id}}
+        {{/if}}
+        {{#if azure.credentials.tenant_id}}
+        tenant_id: {{azure.credentials.tenant_id}}
+        {{/if}}
+        {{#if azure.credentials.client_secret}}
+        client_secret: {{azure.credentials.client_secret}}
+        {{/if}}
+        {{#if azure.credentials.client_username}}
+        client_username: {{azure.credentials.client_username}}
+        {{/if}}
+        {{#if azure.credentials.client_password}}
+        client_password: {{azure.credentials.client_password}}
+        {{/if}}
+        {{#if azure.credentials.client_certificate_path}}
+        client_certificate_path: {{azure.credentials.client_certificate_path}}
+        {{/if}}
+        {{#if azure.credentials.client_certificate_password}}
+        client_certificate_password: {{azure.credentials.client_certificate_password}}
+        {{/if}}

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/manifest.yml
@@ -7,12 +7,13 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+# IMPORTANT: set all streams as disabled by default
 streams:
   - input: cloudbeat/asset_inventory_aws
     title: AWS Asset Inventory
     description: Asset Inventory Discovery for AWS
     template_path: aws.yml.hbs
-    enabled: true
+    enabled: false
     vars:
       - name: access_key_id
         type: text
@@ -58,3 +59,66 @@ streams:
         multi: false
         required: false
         show_user: false
+  - input: cloudbeat/asset_inventory_azure
+    title: Azure Asset Inventory
+    description: Asset Inventory Discovery for Azure
+    template_path: azure.yml.hbs
+    enabled: false
+    vars:
+      - name: azure.account_type
+        type: text
+        title: Account type
+        multi: false
+        required: false
+        show_user: false
+      - name: azure.credentials.type
+        type: text
+        title: Credentials type
+        multi: false
+        required: false
+        show_user: false
+      - name: azure.credentials.client_id
+        type: text
+        title: Client ID
+        multi: false
+        required: false
+        show_user: true
+      - name: azure.credentials.tenant_id
+        type: text
+        title: Tenant ID
+        multi: false
+        required: false
+        show_user: true
+      - name: azure.credentials.client_secret
+        type: password
+        title: Client Secret
+        multi: false
+        required: false
+        show_user: true
+        secret: true
+      - name: azure.credentials.client_username
+        type: text
+        title: Client Username
+        multi: false
+        required: false
+        show_user: true
+      - name: azure.credentials.client_password
+        type: password
+        title: Client Password
+        multi: false
+        required: false
+        show_user: true
+        secret: true
+      - name: azure.credentials.client_certificate_path
+        type: text
+        title: Client Certificate Path
+        multi: false
+        required: false
+        show_user: true
+      - name: azure.credentials.client_certificate_password
+        type: password
+        title: Client Certificate Password
+        multi: false
+        required: false
+        show_user: true
+        secret: true

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.1.4"
+version: "0.1.5"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"
@@ -40,10 +40,13 @@ policy_templates:
           title: AWS Asset Inventory
           description: AWS Asset Inventory
           vars: []
+        - type: cloudbeat/asset_inventory_azure
+          title: Azure Asset Inventory
+          description: Azure Asset Inventory
+          vars: []
     categories:
       - security
       - cloud
-      - aws
 owner:
   github: elastic/cloud-security-posture
   type: elastic


### PR DESCRIPTION
This PR adds support for second data stream in Cloud Asset inventory - Azure. It also sets a new cloudbeat configuration parameter `config.v1.asset_inventory_provider` where necessary.

## Proposed commit message

Introduce support for Azure data stream in Cloud Asset Inventory

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Closes https://github.com/elastic/security-team/issues/10084
