### PR TITLE
[gcp_metrics] Set kibana restriction to 8.15.0, where the scope for the geo_point was reduced

### DIFF
--- a/packages/gcp_metrics/changelog.yml
+++ b/packages/gcp_metrics/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 0.2.0
   changes:
-    - description: Add mapping for gcp.labels.resource.* field
+    - description: Set kibana restriction to 8.15.0, where was reduced scope of the ecs_geo_point
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10665
 - version: 0.1.0

--- a/packages/gcp_metrics/changelog.yml
+++ b/packages/gcp_metrics/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.2.0
+  changes:
+    - description: Add mapping for gcp.labels.resource.* field
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/8041
 - version: 0.1.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/gcp_metrics/changelog.yml
+++ b/packages/gcp_metrics/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add mapping for gcp.labels.resource.* field
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/8041
+      link: https://github.com/elastic/integrations/pull/10665
 - version: 0.1.0
   changes:
     - description: Update the package format_version to 3.0.0.

--- a/packages/gcp_metrics/fields/input.yml
+++ b/packages/gcp_metrics/fields/input.yml
@@ -1,3 +1,8 @@
 - name: input.name
   type: constant_keyword
   value: gcp_metrics
+- name: gcp.labels.resource.*
+  type: object
+  object_type: keyword
+  description: |
+    Labels of the Google resource

--- a/packages/gcp_metrics/fields/input.yml
+++ b/packages/gcp_metrics/fields/input.yml
@@ -1,8 +1,3 @@
 - name: input.name
   type: constant_keyword
   value: gcp_metrics
-- name: gcp.labels.resource.*
-  type: object
-  object_type: keyword
-  description: |
-    Labels of the Google resource

--- a/packages/gcp_metrics/manifest.yml
+++ b/packages/gcp_metrics/manifest.yml
@@ -14,7 +14,7 @@ categories:
   - google_cloud
 conditions:
   kibana:
-    version: ^8.5.0
+    version: ^8.15.0
   elastic:
     subscription: "basic"
 policy_templates:

--- a/packages/gcp_metrics/manifest.yml
+++ b/packages/gcp_metrics/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.0"
 name: gcp_metrics
 title: "GCP Metrics Input"
-version: "0.1.0"
+version: "0.2.0"
 description: "GCP Metrics Input"
 type: input
 icons:


### PR DESCRIPTION
## Proposed commit message

- WHAT: Set kibana restriction to 8.15.0, where the scope for the geo_point was reduced, see - [PR](https://github.com/elastic/elasticsearch/pull/108349)
- WHY:  The problem is mainly with the *.location field - that is considered as a `geo_point` type https://github.com/elastic/elasticsearch/blob/v8.14.3/x-pack/plugin/core/template-resources/src/main/resources/ecs%40mappings.json#L187-L196
This behavior is changed in this [PR](https://github.com/elastic/elasticsearch/pull/108349) and will be available in 8.15

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots
