### PR TITLE
[Cloud Security] Bump 1.11.0 pre-release version and update 1.9.0 changelogs

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Promote integration
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10656
+      link: https://github.com/elastic/integrations/pull/10667
     - description: Support conditions in CSPM and KSPM
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10298

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Bump up pre-release version
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10668
+      link: https://github.com/elastic/integrations/pull/10669
 - version: "1.10.0"
   changes:
     - description: Promote integration
@@ -31,28 +31,20 @@
     - description: Add cloud formation template url to create direct access keys credentials
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9828
-- version: "1.9.0-preview05"
+- version: "1.9.0"
   changes:
     - description: Revert secret of textarea field
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9788
-- version: "1.9.0-preview04"
-  changes:
     - description: Bump cloudbeat version
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9624
-- version: "1.9.0-preview03"
-  changes:
     - description: Update findings ingest pipeline to remove empty cloud.account.id and cloud.account.name
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9470
-- version: "1.9.0-preview02"
-  changes:
     - description: Fix cluster_id missing error in the Ingest Pipeline
       type: bugfix
       link: https://github.com/elastic/integrations/pull/9434
-- version: "1.9.0-preview01"
-  changes:
     - description: Convert fields to secrets
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9331

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -9,6 +9,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.11.0-preview01"
+  changes:
+    - description: Bump up pre-release version
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10668
 - version: "1.10.0"
   changes:
     - description: Promote integration

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -9,21 +9,20 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.10.0-preview04"
+- version: "1.10.0"
   changes:
+    - description: Promote integration
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10656
     - description: Support conditions in CSPM and KSPM
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10298
-- version: "1.10.0-preview03"
-  changes:
     - description: Change field type to password where isSecret is true
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10208
     - description: Bump version
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10359
-- version: "1.10.0-preview01"
-  changes:
     - description: Add cloud formation template url to create direct access keys credentials
       type: enhancement
       link: https://github.com/elastic/integrations/pull/9828

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.10.0"
+version: "1.11.0-preview01"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.10.0-preview04"
+version: "1.10.0"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
### Summary

Bumping the next pre-release version 1.11.0 in preview mode. Also updating the 1.9.* changelogs that were still mentioning preview versions