### PR TITLE
Deprecate SQS queue global setting 

### DIFF
--- a/packages/carbon_black_cloud/_dev/build/docs/README.md
+++ b/packages/carbon_black_cloud/_dev/build/docs/README.md
@@ -31,7 +31,7 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 ### In order to ingest data from the AWS S3 bucket you must:
 1. Configure the [Data Forwarder](https://docs.vmware.com/en/VMware-Carbon-Black-Cloud/services/carbon-black-cloud-user-guide/GUID-F68F63DD-2271-4088-82C9-71D675CD0535.html) to ingest data into an AWS S3 bucket.
 2. Create an [AWS Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
-3. The default value of the "Bucket List Prefix" is listed below. However, the user can set the parameter "Bucket List Prefix" according to the requirement.
+3. The default values of the "Bucket List Prefix" are listed below. However, users can set the parameter "Bucket List Prefix" according to their requirements.
 
   | Data Stream Name  | Bucket List Prefix     |
   | ----------------- | ---------------------- |
@@ -42,17 +42,20 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
-2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
-  - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-3. Set up event notification for an S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
-  - The user has to perform Step 3 for all the data streams individually, and each time prefix parameter should be set the same as the S3 Bucket List Prefix as created earlier. (for example, `alert_logs/` for the alert data stream.)
-  - For all the event notifications that have been created, select the event type as s3:ObjectCreated:*, select the destination type SQS Queue, and select the queue that has been created in Step 2.
+2. Follow the steps below for each data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this data stream, e.g. `alert_logs/`
+         - Select the SQS queue that has been created for this data stream
 
 **Note**:
-  - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
-  - When configuring SQS queues, separate queues should be used for each data stream instead of the global SQS queue from version 1.21 onwards to avoid data 
-    loss. File selectors should not be used to filter out data stream logs using the global queue as it was in versions prior.
 
 ### In order to ingest data from the APIs you must generate API keys and API Secret Keys:
 1. In Carbon Black Cloud, On the left navigation pane, click **Settings > API Access**.

--- a/packages/carbon_black_cloud/_dev/build/docs/README.md
+++ b/packages/carbon_black_cloud/_dev/build/docs/README.md
@@ -44,9 +44,9 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this data stream, e.g. `alert_logs/`
@@ -54,7 +54,7 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 
 **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 
 ### In order to ingest data from the APIs you must generate API keys and API Secret Keys:

--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: Deprecate global SQS Queue URL to avoid data loss.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10672
 - version: "2.3.0"
   changes:
     - description: Improve error reporting for API request failures.

--- a/packages/carbon_black_cloud/data_stream/alert/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert/manifest.yml
@@ -62,13 +62,13 @@ streams:
     vars:
       - name: queue_url_alert
         type: text
-        title: "[Alert][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
         description: |-
           URL of the AWS SQS queue that messages will be received from. This is only required if you want to collect logs via AWS SQS.
-          This is an alert data stream specific queue URL. This will override the global queue URL if provided.
+          This is an alert data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream.
       - name: bucket_list_prefix
         type: text
         title: "[S3] Bucket Prefix"

--- a/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/manifest.yml
@@ -62,13 +62,13 @@ streams:
     vars:
       - name: queue_url_alert
         type: text
-        title: "[Alert][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
         description: |-
           URL of the AWS SQS queue that messages will be received from. This is only required if you want to collect logs via AWS SQS.
-          This is an alert data stream specific queue URL. This will override the global queue URL if provided.
+          This is an alert data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream.
       - name: bucket_list_prefix
         type: text
         title: "[S3] Bucket Prefix"

--- a/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/endpoint_event/manifest.yml
@@ -8,13 +8,13 @@ streams:
     vars:
       - name: queue_url_endpoint_event
         type: text
-        title: "[Endpoint Event][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
         description: |-
           URL of the AWS SQS queue that messages will be received from. This is only required if you want to collect logs via AWS SQS.
-          This is an endpoint event data stream specific queue URL. This will override the global queue URL if provided.
+          This is an endpoint event data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream.
       - name: bucket_list_prefix
         type: text
         title: "[S3] Bucket Prefix"

--- a/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
+++ b/packages/carbon_black_cloud/data_stream/watchlist_hit/manifest.yml
@@ -8,13 +8,13 @@ streams:
     vars:
       - name: queue_url_watchlist_hit
         type: text
-        title: "[Watchlist Hit][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
         description: |-
           URL of the AWS SQS queue that messages will be received from. This is only required if you want to collect logs via AWS SQS.
-          This is a watchlist hit data stream specific queue URL. This will override the global queue URL if provided.
+          This is a watchlist hit data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream.
       - name: bucket_list_prefix
         type: text
         title: "[S3] Bucket Prefix"

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -44,9 +44,9 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this data stream, e.g. `alert_logs/`
@@ -54,7 +54,7 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 
 **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 
 ### In order to ingest data from the APIs you must generate API keys and API Secret Keys:

--- a/packages/carbon_black_cloud/docs/README.md
+++ b/packages/carbon_black_cloud/docs/README.md
@@ -31,7 +31,7 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 ### In order to ingest data from the AWS S3 bucket you must:
 1. Configure the [Data Forwarder](https://docs.vmware.com/en/VMware-Carbon-Black-Cloud/services/carbon-black-cloud-user-guide/GUID-F68F63DD-2271-4088-82C9-71D675CD0535.html) to ingest data into an AWS S3 bucket.
 2. Create an [AWS Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
-3. The default value of the "Bucket List Prefix" is listed below. However, the user can set the parameter "Bucket List Prefix" according to the requirement.
+3. The default values of the "Bucket List Prefix" are listed below. However, users can set the parameter "Bucket List Prefix" according to their requirements.
 
   | Data Stream Name  | Bucket List Prefix     |
   | ----------------- | ---------------------- |
@@ -42,17 +42,20 @@ This module has been tested against `Alerts API (v7) [Beta]`, `Alerts API (v6)`,
 
 ### To collect data from AWS SQS, follow the below steps:
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
-2. To set up an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
-  - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-3. Set up event notification for an S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
-  - The user has to perform Step 3 for all the data streams individually, and each time prefix parameter should be set the same as the S3 Bucket List Prefix as created earlier. (for example, `alert_logs/` for the alert data stream.)
-  - For all the event notifications that have been created, select the event type as s3:ObjectCreated:*, select the destination type SQS Queue, and select the queue that has been created in Step 2.
+2. Follow the steps below for each data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this data stream, e.g. `alert_logs/`
+         - Select the SQS queue that has been created for this data stream
 
 **Note**:
-  - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
-  - When configuring SQS queues, separate queues should be used for each data stream instead of the global SQS queue from version 1.21 onwards to avoid data 
-    loss. File selectors should not be used to filter out data stream logs using the global queue as it was in versions prior.
 
 ### In order to ingest data from the APIs you must generate API keys and API Secret Keys:
 1. In Carbon Black Cloud, On the left navigation pane, click **Settings > API Access**.
@@ -1190,3 +1193,4 @@ An example event for `asset_vulnerability_summary` looks as following:
 | host.os.codename | OS codename, if any. | keyword |
 | input.type | Input type | keyword |
 | log.offset | Log offset | long |
+

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.3.0"
+version: "2.4.0"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:
@@ -191,16 +191,6 @@ policy_templates:
             required: false
             show_user: true
             description: It is a required parameter for collecting logs via the AWS S3 Bucket.
-          - name: queue_url
-            type: text
-            title: "[Global][SQS] Queue URL"
-            multi: false
-            required: false
-            show_user: true
-            description: |-
-              URL of the AWS SQS queue that messages will be received from.
-              This is only required if you want to collect logs via AWS SQS.
-              This is a global queue URL, i.e this can be overridden by specific local queue URLs for each data stream if required.
           - name: access_key_id
             type: password
             title: Access Key ID

--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -94,9 +94,9 @@ This module has been tested against **Cloudflare version v4**.
 1. If Logpush forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each Logpush data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this Logpush data stream, e.g. `audit_logs/`
@@ -104,7 +104,7 @@ This module has been tested against **Cloudflare version v4**.
 
  **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 

--- a/packages/cloudflare_logpush/_dev/build/docs/README.md
+++ b/packages/cloudflare_logpush/_dev/build/docs/README.md
@@ -66,8 +66,8 @@ This module has been tested against **Cloudflare version v4**.
 ## Setup
 
 ### To collect data from AWS S3 Bucket, follow the below steps:
-- Configure the [Data Forwarder](https://developers.cloudflare.com/logs/get-started/enable-destinations/aws-s3/) to ingest data into an AWS S3 bucket.
-- The default value of the "Bucket List Prefix" is listed below. However, the user can set the parameter "Bucket List Prefix" according to the requirement.
+- Configure [Cloudflare Logpush to Amazon S3](https://developers.cloudflare.com/logs/get-started/enable-destinations/aws-s3/) to send Cloudflare's data to an AWS S3 bucket.
+- The default values of the "Bucket List Prefix" are listed below. However, users can set the parameter "Bucket List Prefix" according to their requirements.
 
   | Data Stream Name           | Bucket List Prefix     |
   | -------------------------- | ---------------------- |
@@ -91,19 +91,22 @@ This module has been tested against **Cloudflare version v4**.
   | Workers Trace Events       | workers_trace          |
 
 ### To collect data from AWS SQS, follow the below steps:
-1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
-2. To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
-  - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-3. Setup event notification for an S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
-  - The user has to perform Step 3 for all the data-streams individually, and each time prefix parameter should be set the same as the S3 Bucket List Prefix as created earlier. (for example, `audit_logs/` for audit data stream.)
-  - For all the event notifications that have been created, select the event type as s3:ObjectCreated:*, select the destination type SQS Queue, and select the queue that has been created in Step 2.
+1. If Logpush forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
+2. Follow the steps below for each Logpush data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this Logpush data stream, e.g. `audit_logs/`
+         - Select the SQS queue that has been created for this data stream
 
-**Note**:
+ **Note**:
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
-  - You can configure a global SQS queue for all data streams or a local SQS queue for each data stream. Configuring
-    data stream specific SQS queues will enable better performance and scalability. Data stream specific SQS queues
-    will always override any global queue definitions for that specific data stream.
 
 ### To collect data from Cloudflare R2 Buckets, follow the below steps:
 - Configure the [Data Forwarder](https://developers.cloudflare.com/logs/get-started/enable-destinations/r2/) to push logs to Cloudflare R2.

--- a/packages/cloudflare_logpush/changelog.yml
+++ b/packages/cloudflare_logpush/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.0"
+  changes:
+    - description: Deprecate global SQS Queue URL to avoid data loss.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10672
 - version: "1.21.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/access_request/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_access_request
         type: text
-        title: "[Access Request][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Access Request data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Access Request data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/audit/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/audit/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_audit
         type: text
-        title: "[Audit][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is an audit data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is an audit data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/casb/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/casb/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_casb
         type: text
-        title: "[CASB Findings][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a CASB Findings data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a CASB Findings data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/device_posture/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_device_posture
         type: text
-        title: "[Device Posture Results][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Device Posture Results data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Device Posture Results data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_dns
         type: text
-        title: "[DNS][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a dns data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a dns data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/dns_firewall/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_dns_firewall
         type: text
-        title: "[DNS Firewall][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a DNS Firewall data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a DNS Firewall data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/firewall_event/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_firewall_event
         type: text
-        title: "[Firewall Event][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a firewall event data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a firewall event data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_dns/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_gateway_dns
         type: text
-        title: "[Gateway DNS][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway DNS data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway DNS data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_http/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_gateway_http
         type: text
-        title: "[Gateway HTTP][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway HTTP data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway HTTP data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/gateway_network/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_gateway_network
         type: text
-        title: "[Gateway Network][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway Network data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Gateway Network data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/http_request/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_http_request
         type: text
-        title: "[HTTP Request][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a http request data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a http request data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/magic_ids/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_magic_ids
         type: text
-        title: "[Magic IDS][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Magic IDS data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Magic IDS data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/nel_report/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_nel_report
         type: text
-        title: "[NEL Report][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a nel report data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a nel report data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_analytics/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_network_analytics
         type: text
-        title: "[Network Analytics][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a network analytics data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a network analytics data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/network_session/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_network_session
         type: text
-        title: "[Zero Trust Network Session][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Zero Trust Network Session data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Zero Trust Network Session data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/sinkhole_http/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_sinkhole_http
         type: text
-        title: "[Sinkhole HTTP][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Sinkhole HTTP data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Sinkhole HTTP data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/spectrum_event/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_spectrum_event
         type: text
-        title: "[Spectrum Event][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a spectrum event data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a spectrum event data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
+++ b/packages/cloudflare_logpush/data_stream/workers_trace/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_workers_trace
         type: text
-        title: "[Workers Trace Event][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Workers Trace Event data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Workers Trace Event data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -94,9 +94,9 @@ This module has been tested against **Cloudflare version v4**.
 1. If Logpush forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each Logpush data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this Logpush data stream, e.g. `audit_logs/`
@@ -104,7 +104,7 @@ This module has been tested against **Cloudflare version v4**.
 
  **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -66,8 +66,8 @@ This module has been tested against **Cloudflare version v4**.
 ## Setup
 
 ### To collect data from AWS S3 Bucket, follow the below steps:
-- Configure the [Data Forwarder](https://developers.cloudflare.com/logs/get-started/enable-destinations/aws-s3/) to ingest data into an AWS S3 bucket.
-- The default value of the "Bucket List Prefix" is listed below. However, the user can set the parameter "Bucket List Prefix" according to the requirement.
+- Configure [Cloudflare Logpush to Amazon S3](https://developers.cloudflare.com/logs/get-started/enable-destinations/aws-s3/) to send Cloudflare's data to an AWS S3 bucket.
+- The default values of the "Bucket List Prefix" are listed below. However, the user can set the parameter "Bucket List Prefix" according to their requirements.
 
   | Data Stream Name           | Bucket List Prefix     |
   | -------------------------- | ---------------------- |
@@ -91,19 +91,22 @@ This module has been tested against **Cloudflare version v4**.
   | Workers Trace Events       | workers_trace          |
 
 ### To collect data from AWS SQS, follow the below steps:
-1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
-2. To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
-  - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-3. Setup event notification for an S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html).
-  - The user has to perform Step 3 for all the data-streams individually, and each time prefix parameter should be set the same as the S3 Bucket List Prefix as created earlier. (for example, `audit_logs/` for audit data stream.)
-  - For all the event notifications that have been created, select the event type as s3:ObjectCreated:*, select the destination type SQS Queue, and select the queue that has been created in Step 2.
+1. If Logpush forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
+2. Follow the steps below for each Logpush data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this Logpush data stream, e.g. `audit_logs/`
+         - Select the SQS queue that has been created for this data stream
 
-**Note**:
+ **Note**:
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
-  - You can configure a global SQS queue for all data streams or a local SQS queue for each data stream. Configuring
-    data stream specific SQS queues will enable better performance and scalability. Data stream specific SQS queues
-    will always override any global queue definitions for that specific data stream.
 
 ### To collect data from Cloudflare R2 Buckets, follow the below steps:
 - Configure the [Data Forwarder](https://developers.cloudflare.com/logs/get-started/enable-destinations/r2/) to push logs to Cloudflare R2.

--- a/packages/cloudflare_logpush/docs/README.md
+++ b/packages/cloudflare_logpush/docs/README.md
@@ -67,7 +67,7 @@ This module has been tested against **Cloudflare version v4**.
 
 ### To collect data from AWS S3 Bucket, follow the below steps:
 - Configure [Cloudflare Logpush to Amazon S3](https://developers.cloudflare.com/logs/get-started/enable-destinations/aws-s3/) to send Cloudflare's data to an AWS S3 bucket.
-- The default values of the "Bucket List Prefix" are listed below. However, the user can set the parameter "Bucket List Prefix" according to their requirements.
+- The default values of the "Bucket List Prefix" are listed below. However, users can set the parameter "Bucket List Prefix" according to their requirements.
 
   | Data Stream Name           | Bucket List Prefix     |
   | -------------------------- | ---------------------- |

--- a/packages/cloudflare_logpush/manifest.yml
+++ b/packages/cloudflare_logpush/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: cloudflare_logpush
 title: Cloudflare Logpush
-version: "1.21.0"
+version: "1.22.0"
 description: Collect and parse logs from Cloudflare API with Elastic Agent.
 type: integration
 categories:
@@ -125,13 +125,6 @@ policy_templates:
             description: |-
               Cloudflare R2 is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Cloudflare R2 or another 3rd party S3-compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required.
               Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the non-AWS S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint.
-          - name: queue_url
-            type: text
-            title: "[Global][SQS] Queue URL"
-            multi: false
-            required: false
-            show_user: true
-            description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a global queue URL, i.e this can be overriden by specific local queue URLs for each data stream if required."
           - name: access_key_id
             type: password
             title: Access Key ID

--- a/packages/jamf_protect/_dev/build/docs/README.md
+++ b/packages/jamf_protect/_dev/build/docs/README.md
@@ -79,6 +79,24 @@ For more information on configuring Jamf Protect, see
 - [Enabling Data Forwarding to AWS S3](https://learn.jamf.com/en-US/bundle/jamf-protect-documentation/page/Data_Forwarding_to_a_Third_Party_Storage_Solution.html#ariaid-title2)
 - [Configure Threat Event Stream](https://learn.jamf.com/en-US/bundle/jamf-protect-documentation/page/Configuring_the_Threat_Events_Stream_to_Send_Events_to_AWS_S3.html)
 
+### To collect data from AWS SQS, follow the below steps:
+1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
+2. Follow the steps below for each data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this data stream, e.g. `protect-/alerts/`
+         - Select the SQS queue that has been created for this data stream
+
+ **Note**:
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
+  - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
+
 
 **Copyright (c) 2024, Jamf Software, LLC.  All rights reserved.**
 

--- a/packages/jamf_protect/_dev/build/docs/README.md
+++ b/packages/jamf_protect/_dev/build/docs/README.md
@@ -83,9 +83,9 @@ For more information on configuring Jamf Protect, see
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this data stream, e.g. `protect-/alerts/`
@@ -93,7 +93,7 @@ For more information on configuring Jamf Protect, see
 
  **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.3.0"
+  changes:
+    - description: Deprecate global SQS Queue URL to avoid data loss.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10672
 - version: "2.2.0"
   changes:
     - description: Resolved issues for "authentication" and "btm_launch_item_add" events related to start_time renaming. Added new Dashboard for Telemetry data stream.

--- a/packages/jamf_protect/data_stream/alerts/manifest.yml
+++ b/packages/jamf_protect/data_stream/alerts/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_alerts
         type: text
-        title: "[Alerts][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Alerts data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Alerts data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/jamf_protect/data_stream/telemetry/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_telemetry
         type: text
-        title: "[Telemetry][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Telemetry data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Telemetry data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/jamf_protect/data_stream/telemetry_legacy/agent/stream/aws-s3.yml.hbs
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/agent/stream/aws-s3.yml.hbs
@@ -38,8 +38,8 @@ non_aws_bucket_name: {{global_bucket_name}}
 
 {{else}}
 
-{{#if queue_url_telemetry}}
-queue_url: {{queue_url_telemetry}}
+{{#if queue_url_telemetry_legacy}}
+queue_url: {{queue_url_telemetry_legacy}}
 {{else if queue_url}}
 queue_url: {{queue_url}}
 {{/if}}

--- a/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
+++ b/packages/jamf_protect/data_stream/telemetry_legacy/manifest.yml
@@ -62,11 +62,11 @@ streams:
     vars:
       - name: queue_url_telemetry_legacy
         type: text
-        title: "[Telemetry][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Telemetry data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Telemetry data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_threat_events/manifest.yml
@@ -71,11 +71,11 @@ streams:
     vars:
       - name: queue_url_webthreats
         type: text
-        title: "[Telemetry][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Threat Events data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Threat Events data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
+++ b/packages/jamf_protect/data_stream/web_traffic_events/manifest.yml
@@ -71,11 +71,11 @@ streams:
     vars:
       - name: queue_url_webtraffic
         type: text
-        title: "[Web Traffic][SQS] Queue URL"
+        title: "[SQS] Queue URL"
         multi: false
         required: false
         show_user: true
-        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Web Traffic data stream specific queue URL. This will override the global queue URL if provided."
+        description: "URL of the AWS SQS queue that messages will be received from.\nThis is only required if you want to collect logs via AWS SQS.\nThis is a Web Traffic data stream specific queue URL. In order to avoid data loss, do not configure the same SQS queue for more than one data stream."
       - name: bucket_list_prefix
         type: text
         title: '[S3] Bucket Prefix'

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -79,6 +79,24 @@ For more information on configuring Jamf Protect, see
 - [Enabling Data Forwarding to AWS S3](https://learn.jamf.com/en-US/bundle/jamf-protect-documentation/page/Data_Forwarding_to_a_Third_Party_Storage_Solution.html#ariaid-title2)
 - [Configure Threat Event Stream](https://learn.jamf.com/en-US/bundle/jamf-protect-documentation/page/Configuring_the_Threat_Events_Stream_to_Send_Events_to_AWS_S3.html)
 
+### To collect data from AWS SQS, follow the below steps:
+1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
+2. Follow the steps below for each data stream that has been enabled:
+     1. Create an SQS queue
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
+     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+        - Event type: `All object create events` (`s3:ObjectCreated:*`)
+         - Destination: SQS Queue
+         - Prefix (filter): enter the prefix for this data stream, e.g. `protect-/alerts/`
+         - Select the SQS queue that has been created for this data stream
+
+ **Note**:
+  - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
+  - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
+
 
 **Copyright (c) 2024, Jamf Software, LLC.  All rights reserved.**
 

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -83,9 +83,9 @@ For more information on configuring Jamf Protect, see
 1. If data forwarding to an AWS S3 Bucket hasn't been configured, then first setup an AWS S3 Bucket as mentioned in the above documentation.
 2. Follow the steps below for each data stream that has been enabled:
      1. Create an SQS queue
-         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
+         - To setup an SQS queue, follow "Step 1: Create an Amazon SQS queue" mentioned in the [Amazon documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
          - While creating an SQS Queue, please provide the same bucket ARN that has been generated after creating an AWS S3 Bucket.
-     2. Setup event notification from the S3 bucket. Follow this [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
+     2. Setup event notification from the S3 bucket using the instructions [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications.html). Use the following settings:
         - Event type: `All object create events` (`s3:ObjectCreated:*`)
          - Destination: SQS Queue
          - Prefix (filter): enter the prefix for this data stream, e.g. `protect-/alerts/`
@@ -93,7 +93,7 @@ For more information on configuring Jamf Protect, see
 
  **Note**:
   - A separate SQS queue and S3 bucket notification is required for each enabled data stream.
-  - Permissions for the above AWS S3 bucket and SQS queues should be configured as per the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
+  - Permissions for the above AWS S3 bucket and SQS queues should be configured according to the [Filebeat S3 input documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_aws_permissions_2)
   - Credentials for the above AWS S3 and SQS input types should be configured using the [link](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#aws-credentials-config).
   - Data collection via AWS S3 Bucket and AWS SQS are mutually exclusive in this case.
 

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.2.0"
+version: "2.3.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:
@@ -97,13 +97,6 @@ policy_templates:
             description: |-
               Jamf Protect is an S3-compatible, globally distributed object storage. This parameter can replace Bucket ARN with a Bucket Name for collecting logs from Jamf Protect or another 3rd party S3-compatible service. This is a global setting which can be overriden by specific local bucket names for each data stream if required.
               Using non-AWS S3 compatible buckets requires the use of Access Key ID and Secret Access Key for authentication. To specify the non-AWS S3 bucket name, use the non_aws_bucket_name config and the endpoint must be set to replace the default API endpoint.
-          - name: queue_url
-            type: text
-            title: "[Global][SQS] Queue URL"
-            multi: false
-            required: false
-            show_user: true
-            description: "URL of the AWS SQS queue that messages will be received from. \nThis is only required if you want to collect logs via AWS SQS.\nThis is a global queue URL, i.e this can be overriden by specific local queue URLs for each data stream if required."
           - name: access_key_id
             type: password
             secret: true


### PR DESCRIPTION
## Proposed commit message

Recent tests and reports have revealed that using the same SQS queue for multiple data streams results in data loss even with a very low event load.

For this reason, this pull request updates the affected integrations by forcing users to configure a separate SQS queue for each enabled data stream, as well as updating the related documentation for their knowledge.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/integrations/issues/5526
- Relates https://github.com/elastic/integrations/pull/5687
