### PR TITLE
Retry requests to artifacts API from CI jobs

### DIFF
--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -50,6 +50,7 @@ for package in ${PACKAGE_LIST}; do
     - label: "Check integrations ${package}"
       key: "test-integrations-${package}"
       command: ".buildkite/scripts/test_one_package.sh ${package} ${from} ${to}"
+      timeout_in_minutes: 240
       agents:
         provider: gcp
         image: ${IMAGE_UBUNTU_X86_64}


### PR DESCRIPTION
Retry forever if the artifacts API is not available, and assume it will come back at some point.
If it doesn't come back, the job would fail in any case.