### PR TITLE
[qualys_vmdr] Fix CEL access to unset state.params in knowledge_base

### DIFF
--- a/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
+++ b/packages/qualys_vmdr/_dev/deploy/docker/files/config.yml
@@ -302,7 +302,6 @@ rules:
   - path: /api/2.0/fo/knowledge_base/vuln/
     methods: ['GET']
     query_params:
-      ids: 456
     responses:
       - status_code: 200
         body: |-

--- a/packages/qualys_vmdr/changelog.yml
+++ b/packages/qualys_vmdr/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "4.2.1"
+  changes:
+    - description: Fix CEL access to unset state.params in knowledge_base.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10677
 - version: "4.2.0"
   changes:
     - description: Map cloud provider metadata to cloud fields.

--- a/packages/qualys_vmdr/data_stream/knowledge_base/_dev/test/system/test-1_invalid-config.yml
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/_dev/test/system/test-1_invalid-config.yml
@@ -6,7 +6,6 @@ vars:
 data_stream:
   vars:
     url: http://{{Hostname}}:{{Port}}
-    input_parameters: ids=456
     preserve_duplicate_custom_fields: true
     enable_request_tracer: true
 assert:

--- a/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
+++ b/packages/qualys_vmdr/data_stream/knowledge_base/agent/stream/input.yml.hbs
@@ -26,14 +26,11 @@ redact:
     - password
 program: |
   state.with(
-    request("GET", state.url.trim_right("/") + "/api/2.0/fo/knowledge_base/vuln/?action=list&last_modified_after=" +
-      string(
-        state.?cursor.last_modified.orValue(null) != null
-        ?
-          timestamp(state.cursor.last_modified)
-        :
-          now - duration(state.initial_interval)
-      ) + (state.params != "" ? "&" + state.params : "")
+    request("GET", state.url.trim_right("/") + "/api/2.0/fo/knowledge_base/vuln/?" +
+      state.?params.orValue("").parse_query().with({
+        "action": ["list"],
+        "last_modified_after": [state.?cursor.last_modified.orValue(string(now - duration(state.initial_interval)))],
+      }).format_query()
     ).with({
       "Header":{
         "X-Requested-With": ["curl"],
@@ -62,12 +59,12 @@ program: |
               }])
           ),
           "cursor": {
-            "last_modified": (
+            ?"last_modified": (
               has(body.?doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN) && body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.size() > 0
               ?
-                body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, e.LAST_SERVICE_MODIFICATION_DATETIME).max()
+                optional.of(body.doc.KNOWLEDGE_BASE_VULN_LIST_OUTPUT.RESPONSE.VULN_LIST.VULN.map(e, e.LAST_SERVICE_MODIFICATION_DATETIME).max())
               :
-                state.?cursor.last_modified.orValue(null)
+                state.?cursor.last_modified
             )
           },
         }))

--- a/packages/qualys_vmdr/manifest.yml
+++ b/packages/qualys_vmdr/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: qualys_vmdr
 title: Qualys VMDR
-version: "4.2.0"
+version: "4.2.1"
 description: Collect data from Qualys VMDR platform with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[qualys_vmdr] Fix CEL access to unset state.params in knowledge_base (#10677)

When the `input_parameters` variable is not set, `state.params` is not
set. The CEL program needs to account for that possibility when it
accesses it. It was already handled correctly for the
asset_host_detection data stream, and the user_activity data stream
doesn't have that variable.

Co-authored-by: Dan Kortschak <dan.kortschak@elastic.co>
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).