### PR TITLE
[fortinet_fortiproxy] Remap devname to observer.name and process url field

### DIFF
--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.0"
+  changes:
+    - description: Remap devname to observer.name and process url field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.2.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI. Expanded categories.

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remap devname to observer.name and process url field.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10679
 - version: "0.2.0"
   changes:
     - description: Add tags.yml file so that integration's dashboards and saved searches are tagged with "Security Solution" and displayed in the Security Solution UI. Expanded categories.

--- a/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-example.log-expected.json
+++ b/packages/fortinet_fortiproxy/data_stream/log/_dev/test/pipeline/test-example.log-expected.json
@@ -361,12 +361,12 @@
                         "name": "external"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "internal"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -493,12 +493,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -616,12 +616,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -737,12 +737,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -775,6 +775,12 @@
                 "ip": "10.0.0.3",
                 "packets": 0,
                 "port": 40946
+            },
+            "url": {
+                "domain": "google.com",
+                "original": "https://google.com/",
+                "path": "/",
+                "scheme": "https"
             },
             "user_agent": {
                 "device": {
@@ -869,12 +875,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -907,6 +913,12 @@
                 "ip": "10.0.0.3",
                 "packets": 0,
                 "port": 57748
+            },
+            "url": {
+                "domain": "steampowered.com",
+                "original": "https://steampowered.com/",
+                "path": "/",
+                "scheme": "https"
             },
             "user_agent": {
                 "device": {
@@ -997,12 +1009,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1035,6 +1047,12 @@
                 "ip": "10.0.0.3",
                 "packets": 0,
                 "port": 36834
+            },
+            "url": {
+                "domain": "github.com",
+                "original": "https://github.com/",
+                "path": "/",
+                "scheme": "https"
             },
             "user_agent": {
                 "device": {
@@ -1137,7 +1155,7 @@
                 "bytes": 290
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1177,6 +1195,8 @@
             },
             "url": {
                 "domain": "google.com",
+                "original": "https://google.com/",
+                "path": "/",
                 "scheme": "https"
             },
             "user_agent": {
@@ -1270,7 +1290,7 @@
                 "bytes": 82
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1301,6 +1321,8 @@
             },
             "url": {
                 "domain": "google.com",
+                "original": "https://google.com/",
+                "path": "/",
                 "scheme": "https"
             },
             "user_agent": {
@@ -1394,7 +1416,7 @@
                 "bytes": 743
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1425,6 +1447,8 @@
             },
             "url": {
                 "domain": "google.com",
+                "original": "https://google.com/",
+                "path": "/",
                 "scheme": "https"
             },
             "user_agent": {
@@ -1518,7 +1542,7 @@
                 "bytes": 80
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1549,6 +1573,8 @@
             },
             "url": {
                 "domain": "adobe.com",
+                "original": "https://adobe.com/",
+                "path": "/",
                 "scheme": "https"
             },
             "user_agent": {
@@ -1642,7 +1668,7 @@
                 "bytes": 88
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1673,6 +1699,8 @@
             },
             "url": {
                 "domain": "www.adobe.com",
+                "original": "https://www.adobe.com/",
+                "path": "/",
                 "scheme": "https"
             },
             "user_agent": {
@@ -1736,7 +1764,7 @@
             },
             "message": "Performance statistics: average CPU: 0, memory:  29, concurrent sessions:  119, setup-rate: 0",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1783,7 +1811,7 @@
             },
             "message": "failed to send urlfilter packet",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1829,7 +1857,7 @@
             },
             "message": "interface port1 gets a DHCP lease, ip:10.0.128.2, mask:255.255.255.255, gateway:10.0.128.1, lease expires:Tue May  7 10:11:16 2024",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1900,7 +1928,7 @@
             },
             "message": "Administrator Admin login failed from https(175.16.199.42) because of invalid user name",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -1965,7 +1993,7 @@
             },
             "message": "Fortiproxyupdate now  fsci=yes from 175.16.199:443",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2019,7 +2047,7 @@
             },
             "message": "Edit firewall.policy 1",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2072,7 +2100,7 @@
             },
             "message": "Delete firewall.policy 3",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2126,7 +2154,7 @@
             },
             "message": "Add firewall.policy 2",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2179,7 +2207,7 @@
             },
             "message": "Move firewall.policy 2 to 1",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2233,7 +2261,7 @@
                 }
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2287,7 +2315,7 @@
                 }
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2341,7 +2369,7 @@
                 }
             },
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2388,7 +2416,7 @@
             },
             "message": "Attempt to add tag FCTEMS_ALL_FORTICLOUD_SERVERS failed. Code (-2147483646)",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2459,12 +2487,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2569,12 +2597,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2658,7 +2686,7 @@
             },
             "message": "Performance statistics: average CPU: 0, memory:  29, concurrent sessions:  38, setup-rate: 1",
             "observer": {
-                "hostname": "TEST-PXY01",
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",
@@ -2749,12 +2777,12 @@
                         "name": "port1"
                     }
                 },
-                "hostname": "TEST-PXY01",
                 "ingress": {
                     "interface": {
                         "name": "port2"
                     }
                 },
+                "name": "TEST-PXY01",
                 "product": "FortiProxy",
                 "serial_number": "FPXTESTPXY01",
                 "type": "proxy",

--- a/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -563,14 +563,10 @@ processors:
       field: client.ip
       if: ctx._fields_.clientip != null
 
-  - set:
-      tag: set_url_original
-      field: url.original
-      copy_from: _fields_.url
-      ignore_empty_value: true
   - uri_parts:
       tag: process_url
-      field: url.original
+      field: _fields_.url
+      keep_original: true
       ignore_missing: true
 
 # ------------------------------------------------------------------------------

--- a/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -351,7 +351,7 @@ processors:
   - rename:
       tag: rename_devname
       field: _fields_.devname
-      target_field: observer.hostname
+      target_field: observer.name
       ignore_missing: true
   - rename:
       tag: rename_direction
@@ -562,6 +562,16 @@ processors:
       copy_from: _fields_.clientip
       field: client.ip
       if: ctx._fields_.clientip != null
+
+  - set:
+      tag: set_url_original
+      field: url.original
+      copy_from: _fields_.url
+      ignore_empty_value: true
+  - uri_parts:
+      tag: process_url
+      field: url.original
+      ignore_missing: true
 
 # ------------------------------------------------------------------------------
 # Cleanup.

--- a/packages/fortinet_fortiproxy/data_stream/log/fields/ecs.yml
+++ b/packages/fortinet_fortiproxy/data_stream/log/fields/ecs.yml
@@ -209,6 +209,30 @@
 - external: ecs
   name: url.scheme
 - external: ecs
+  name: url.extension
+- external: ecs
+  name: url.original
+- external: ecs
+  name: url.path
+- external: ecs
+  name: url.fragment
+- external: ecs
+  name: url.port
+- external: ecs
+  name: url.query
+- external: ecs
+  name: url.username
+- external: ecs
+  name: url.password
+- external: ecs
+  name: url.subdomain
+- external: ecs
+  name: url.top_level_domain
+- external: ecs
+  name: url.full
+- external: ecs
+  name: url.registered_domain
+- external: ecs
   name: user_agent.device.name
 - external: ecs
   name: user_agent.name

--- a/packages/fortinet_fortiproxy/docs/README.md
+++ b/packages/fortinet_fortiproxy/docs/README.md
@@ -888,7 +888,21 @@ An example event for `log` looks as following:
 | tags | List of keywords used to tag each event. | keyword |
 | threat.feed.name | The name of the threat feed in UI friendly format. | keyword |
 | url.domain | Domain of the url, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field. | keyword |
+| url.extension | The field contains the file extension from the original request url, excluding the leading dot. The file extension is only set if it exists, as not every url has a file extension. The leading period must not be included. For example, the value must be "png", not ".png". Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz"). | keyword |
+| url.fragment | Portion of the url after the `#`, such as "top". The `#` is not part of the fragment. | keyword |
+| url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | wildcard |
+| url.full.text | Multi-field of `url.full`. | match_only_text |
+| url.original | Unmodified original url as seen in the event source. Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not. | wildcard |
+| url.original.text | Multi-field of `url.original`. | match_only_text |
+| url.password | Password of the request. | keyword |
+| url.path | Path of the request, such as "/search". | wildcard |
+| url.port | Port of the request, such as 443. | long |
+| url.query | The query field describes the query string of the request, such as "q=elasticsearch". The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | keyword |
+| url.registered_domain | The highest registered url domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
 | url.scheme | Scheme of the request, such as "https". Note: The `:` is not part of the scheme. | keyword |
+| url.subdomain | The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain.  In a partially qualified domain, or if the the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain. For example the subdomain portion of "www.east.mydomain.co.uk" is "east". If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
+| url.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
+| url.username | Username of the request. | keyword |
 | user_agent.device.name | Name of the device. | keyword |
 | user_agent.name | Name of the user agent. | keyword |
 | user_agent.original | Unparsed user_agent string. | keyword |

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 0.2.0
+version: 0.3.0
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Remap the devname vendor field to observer.name
- Remap the url vendor field to url.original and run through uri_parts processor

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/fortinet_fortiproxy
elastic-package test
```

## Related issues

- Relates #10659
- Note: Waiting on clarification of session ID fields and any other ECS remappings.
