### PR TITLE
[prisma_cloud] Fix null checks in host_profile CEL program

### DIFF
--- a/packages/prisma_cloud/changelog.yml
+++ b/packages/prisma_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.3.1"
+  changes:
+    - description: Fix null checks in the host_profile CEL program, simplify the host CEL expression.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10681
 - version: "1.3.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/prisma_cloud/data_stream/host/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/host/agent/stream/input.yml.hbs
@@ -62,21 +62,22 @@ program: |
             "password": state.password,
             "batch_size": string(state.batch_size),
             "access_token": state.access_token,
-            "cursor":
-            {
-              "new_offset":
-              (
-                has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
-                 ?
-                   (
-                    inner_body != null && inner_body.size() > 0
-                   ?
-                     string(int(state.cursor.new_offset) + int(inner_body.size()))
-                   :
-                     state.cursor.new_offset
-                   )
-                 :
-                  string(int(state.offset) + (inner_body != null ? int(inner_body.size()) : 0))
+            "cursor": {
+              "new_offset": (
+                (
+                  has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
+                ?
+                  int(state.cursor.new_offset)
+                :
+                  int(state.offset)
+                ) +
+                (
+                  inner_body != null && inner_body.size() > 0
+                ?
+                  inner_body.size()
+                :
+                  0
+                )
               )
             },
         }))

--- a/packages/prisma_cloud/data_stream/host/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/host/agent/stream/input.yml.hbs
@@ -65,7 +65,7 @@ program: |
             "cursor": {
               "new_offset": (
                 (
-                  has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
+                  state.?cursor.new_offset.orValue(null) != null
                 ?
                   int(state.cursor.new_offset)
                 :

--- a/packages/prisma_cloud/data_stream/host_profile/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/host_profile/agent/stream/input.yml.hbs
@@ -57,26 +57,27 @@ program: |
                 []
             ),
             "url": state.url,
-            "want_more": inner_body.size() > 0,
+            "want_more": inner_body != null && inner_body.size() > 0,
             "user": state.user,
             "password": state.password,
             "batch_size": string(state.batch_size),
             "access_token": state.access_token,
-            "cursor":
-            {
-              "new_offset":
-              (
-                has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
-                 ?
-                   (
-                    inner_body != null && inner_body.size() > 0
-                   ?
-                     string(int(state.cursor.new_offset) + int(inner_body.size()))
-                   :
-                     state.cursor.new_offset
-                   )
-                 :
-                  string(int(state.offset) + int(inner_body.size()))
+            "cursor": {
+              "new_offset": (
+                (
+                  has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
+                ?
+                  int(state.cursor.new_offset)
+                :
+                  int(state.offset)
+                ) +
+                (
+                  inner_body != null && inner_body.size() > 0
+                ?
+                  inner_body.size()
+                :
+                  0
+                )
               )
             },
         }))

--- a/packages/prisma_cloud/data_stream/host_profile/agent/stream/input.yml.hbs
+++ b/packages/prisma_cloud/data_stream/host_profile/agent/stream/input.yml.hbs
@@ -65,7 +65,7 @@ program: |
             "cursor": {
               "new_offset": (
                 (
-                  has(state.cursor) && has(state.cursor.new_offset) && state.cursor.new_offset != null
+                  state.?cursor.new_offset.orValue(null) != null
                 ?
                   int(state.cursor.new_offset)
                 :

--- a/packages/prisma_cloud/manifest.yml
+++ b/packages/prisma_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: prisma_cloud
 title: "Palo Alto Prisma Cloud"
-version: "1.3.0"
+version: "1.3.1"
 description: "Collect logs from Prisma Cloud with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[prisma_cloud] Fix null checks in host_profile CEL program (#)

Requests made by the host and host_profile data streams sometime return
successful (HTTP 200) responses with the body set to the string `null`.
The CEL programs of both data streams did check for this, but the
host_profile data stream was missing checks in two places.

This change adds those missing checks in host_profile. It also
simplifies the calculation of the `new_offset` value, and applies that
simplification to the host data stream as well.

The host and host_profile data streams both use APIs provided by the
Cloud Workload Protection (CWP) module.

This is the relevant API documentation:
- https://pan.dev/prisma-cloud/api/cwpp/get-profiles-host/
- https://pan.dev/prisma-cloud/api/cwpp/get-hosts/

However, the `null` response is not documented.

The alert and audit data streams use APIs provided by a different
module, the Cloud Security Posture Management (CSPM) module, and have
not be changed.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).