### PR TITLE
Updated ingest pipeline default.yml to set event category and type

### DIFF
--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.2"
+  changes:
+    - description: "Updated ingest pipeline default.yml to set event category and type"
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10684
 - version: "1.22.1"
   changes:
     - description: Clarify configuration documentation.

--- a/packages/microsoft_exchange_online_message_trace/changelog.yml
+++ b/packages/microsoft_exchange_online_message_trace/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
-- version: "1.22.2"
+- version: "1.23.0"
   changes:
-    - description: "Updated ingest pipeline default.yml to set event category and type"
+    - description: Add `event.category` and `event.type` to all events.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10684
 - version: "1.22.1"

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/_dev/test/pipeline/test-log.log-expected.json
@@ -55,10 +55,16 @@
                 }
             },
             "event": {
+                "category": [
+                    "email"
+                ],
                 "end": "2022-09-05T21:46:46.420Z",
                 "original": "{\"EndDate\":\"2022-09-05T21:46:46.4206759Z\",\"FromIP\":\"81.2.69.144\",\"Index\":0,\"MessageId\":\"\\u003ca210cf91-4f2e-484c-8ada-3b27064ee5e3@az.uksouth.production.microsoft.com\\u003e\",\"MessageTraceId\":\"cf7a249a-5edd-4350-130a-08da8f69e0f6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-09-05T18:10:13.4907658\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"azure-noreply@azure.microsoft.com\",\"Size\":87891,\"StartDate\":\"2022-09-03T21:46:46.4206759Z\",\"Status\":\"Delivered\",\"Subject\":\"PIM: A privileged directory role was assigned outside of PIM\",\"ToIP\":\"216.160.83.56\"}",
                 "outcome": "success",
-                "start": "2022-09-03T21:46:46.420Z"
+                "start": "2022-09-03T21:46:46.420Z",
+                "type": [
+                    "info"
+                ]
             },
             "microsoft": {
                 "online_message_trace": {
@@ -159,10 +165,16 @@
                 }
             },
             "event": {
+                "category": [
+                    "email"
+                ],
                 "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 1\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22704,\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":1}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z"
+                "start": "2022-10-21T09:40:10.000Z",
+                "type": [
+                    "info"
+                ]
             },
             "microsoft": {
                 "online_message_trace": {
@@ -262,10 +274,16 @@
                 }
             },
             "event": {
+                "category": [
+                    "email"
+                ],
                 "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z"
+                "start": "2022-10-21T09:40:10.000Z",
+                "type": [
+                    "info"
+                ]
             },
             "microsoft": {
                 "online_message_trace": {
@@ -365,10 +383,16 @@
                 }
             },
             "event": {
+                "category": [
+                    "email"
+                ],
                 "end": "2022-10-22T09:40:10.000Z",
                 "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@contoso.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"81.2.69.144\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
                 "outcome": "success",
-                "start": "2022-10-21T09:40:10.000Z"
+                "start": "2022-10-21T09:40:10.000Z",
+                "type": [
+                    "info"
+                ]
             },
             "microsoft": {
                 "online_message_trace": {

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -29,6 +29,13 @@ processors:
       field: event.outcome
       value: unknown
       if: ctx.event?.outcome == null
+  # Event Category & Type https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html#ecs-event-category-email
+  - set:
+      field: event.category
+      value: email
+  - set:
+      field: event.type
+      value: info
   - set:
       field: _temp_.email.from.address
       copy_from: microsoft.online_message_trace.SenderAddress

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -32,10 +32,10 @@ processors:
   # Event Category & Type https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html#ecs-event-category-email
   - set:
       field: event.category
-      value: email
+      value: [email]
   - set:
       field: event.type
-      value: info
+      value: [info]
   - set:
       field: _temp_.email.from.address
       copy_from: microsoft.online_message_trace.SenderAddress

--- a/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
+++ b/packages/microsoft_exchange_online_message_trace/data_stream/log/sample_event.json
@@ -1,15 +1,15 @@
 {
-    "@timestamp": "2022-10-21T17:25:36.969Z",
+    "@timestamp": "2022-10-21T17:25:30.600Z",
     "agent": {
-        "ephemeral_id": "7db2c43f-4281-444d-b5b8-242a7ddf8ba2",
-        "id": "d2a14a09-96fc-4f81-94ef-b0cd75ad71e7",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "1928ec83-7c3a-4ad0-9066-63dae084a2e1",
+        "id": "bd32c689-9c8b-44ea-ae34-b04c1bf3fd7d",
+        "name": "elastic-agent-75168",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.15.3"
     },
     "data_stream": {
         "dataset": "microsoft_exchange_online_message_trace.log",
-        "namespace": "63147",
+        "namespace": "89156",
         "type": "logs"
     },
     "destination": {
@@ -27,25 +27,25 @@
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d2a14a09-96fc-4f81-94ef-b0cd75ad71e7",
+        "id": "bd32c689-9c8b-44ea-ae34-b04c1bf3fd7d",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.15.3"
     },
     "email": {
         "attachments": {
             "file": {
-                "size": 22761
+                "size": 22704
             }
         },
-        "delivery_timestamp": "2022-10-21T17:25:36.969376Z",
+        "delivery_timestamp": "2022-10-21T17:25:30.6006882Z",
         "from": {
             "address": [
                 "noreply@azure.microsoft.com"
             ]
         },
-        "local_id": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
-        "message_id": "<GVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
-        "subject": "testmail 2",
+        "local_id": "a6f62809-5cda-4454-0962-08dab38940d6",
+        "message_id": "<GVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
+        "subject": "testmail 1",
         "to": {
             "address": [
                 "linus@contoso.com"
@@ -54,37 +54,38 @@
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "email"
+        ],
+        "created": "2024-11-04T20:39:54.654Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
         "end": "2022-10-22T09:40:10.000Z",
-        "ingested": "2024-06-12T03:18:25Z",
-        "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"40.107.23.54\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
+        "ingested": "2024-11-04T20:39:57Z",
+        "original": "{\"EndDate\":\"2022-10-22T09:40:10Z\",\"FromIP\":\"40.107.23.81\",\"Index\":1,\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"Size\":22704,\"StartDate\":\"2022-10-21T09:40:10Z\",\"Status\":\"Delivered\",\"Subject\":\"testmail 1\",\"ToIP\":null}",
         "outcome": "success",
-        "start": "2022-10-21T09:40:10.000Z"
+        "start": "2022-10-21T09:40:10.000Z",
+        "type": [
+            "info"
+        ]
     },
     "input": {
-        "type": "log"
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/microsoft_exchange_online_message_trace_test.ndjson.log"
-        },
-        "offset": 0
+        "type": "httpjson"
     },
     "microsoft": {
         "online_message_trace": {
             "EndDate": "2022-10-22T09:40:10Z",
-            "FromIP": "40.107.23.54",
-            "Index": 0,
-            "MessageId": "<GVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
-            "MessageTraceId": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
+            "FromIP": "40.107.23.81",
+            "Index": 1,
+            "MessageId": "<GVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
+            "MessageTraceId": "a6f62809-5cda-4454-0962-08dab38940d6",
             "Organization": "contoso.com",
-            "Received": "2022-10-21T17:25:36.969376Z",
+            "Received": "2022-10-21T17:25:30.6006882Z",
             "RecipientAddress": "linus@contoso.com",
             "SenderAddress": "noreply@azure.microsoft.com",
-            "Size": 22761,
+            "Size": 22704,
             "StartDate": "2022-10-21T09:40:10Z",
             "Status": "Delivered",
-            "Subject": "testmail 2"
+            "Subject": "testmail 1"
         }
     },
     "related": {
@@ -97,7 +98,7 @@
     },
     "source": {
         "domain": "azure.microsoft.com",
-        "ip": "40.107.23.54",
+        "ip": "40.107.23.81",
         "registered_domain": "microsoft.com",
         "subdomain": "azure",
         "top_level_domain": "com",
@@ -110,7 +111,6 @@
     },
     "tags": [
         "preserve_original_event",
-        "microsoft-defender-endpoint",
         "forwarded"
     ]
 }

--- a/packages/microsoft_exchange_online_message_trace/docs/README.md
+++ b/packages/microsoft_exchange_online_message_trace/docs/README.md
@@ -139,17 +139,17 @@ An example event for `log` looks as following:
 
 ```json
 {
-    "@timestamp": "2022-10-21T17:25:36.969Z",
+    "@timestamp": "2022-10-21T17:25:30.600Z",
     "agent": {
-        "ephemeral_id": "7db2c43f-4281-444d-b5b8-242a7ddf8ba2",
-        "id": "d2a14a09-96fc-4f81-94ef-b0cd75ad71e7",
-        "name": "docker-fleet-agent",
+        "ephemeral_id": "1928ec83-7c3a-4ad0-9066-63dae084a2e1",
+        "id": "bd32c689-9c8b-44ea-ae34-b04c1bf3fd7d",
+        "name": "elastic-agent-75168",
         "type": "filebeat",
-        "version": "8.13.0"
+        "version": "8.15.3"
     },
     "data_stream": {
         "dataset": "microsoft_exchange_online_message_trace.log",
-        "namespace": "63147",
+        "namespace": "89156",
         "type": "logs"
     },
     "destination": {
@@ -167,25 +167,25 @@ An example event for `log` looks as following:
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "d2a14a09-96fc-4f81-94ef-b0cd75ad71e7",
+        "id": "bd32c689-9c8b-44ea-ae34-b04c1bf3fd7d",
         "snapshot": false,
-        "version": "8.13.0"
+        "version": "8.15.3"
     },
     "email": {
         "attachments": {
             "file": {
-                "size": 22761
+                "size": 22704
             }
         },
-        "delivery_timestamp": "2022-10-21T17:25:36.969376Z",
+        "delivery_timestamp": "2022-10-21T17:25:30.6006882Z",
         "from": {
             "address": [
                 "noreply@azure.microsoft.com"
             ]
         },
-        "local_id": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
-        "message_id": "<GVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
-        "subject": "testmail 2",
+        "local_id": "a6f62809-5cda-4454-0962-08dab38940d6",
+        "message_id": "<GVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
+        "subject": "testmail 1",
         "to": {
             "address": [
                 "linus@contoso.com"
@@ -194,37 +194,38 @@ An example event for `log` looks as following:
     },
     "event": {
         "agent_id_status": "verified",
+        "category": [
+            "email"
+        ],
+        "created": "2024-11-04T20:39:54.654Z",
         "dataset": "microsoft_exchange_online_message_trace.log",
         "end": "2022-10-22T09:40:10.000Z",
-        "ingested": "2024-06-12T03:18:25Z",
-        "original": "{\"Organization\":\"contoso.com\",\"MessageId\":\"\\u003cGVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"Received\":\"2022-10-21T17:25:36.969376Z\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"RecipientAddress\":\"linus@contoso.com\",\"Subject\":\"testmail 2\",\"Status\":\"Delivered\",\"ToIP\":null,\"FromIP\":\"40.107.23.54\",\"Size\":22761,\"MessageTraceId\":\"a5e6dc0f-23df-4b20-d240-08dab38944a1\",\"StartDate\":\"2022-10-21T09:40:10Z\",\"EndDate\":\"2022-10-22T09:40:10Z\",\"Index\":0}",
+        "ingested": "2024-11-04T20:39:57Z",
+        "original": "{\"EndDate\":\"2022-10-22T09:40:10Z\",\"FromIP\":\"40.107.23.81\",\"Index\":1,\"MessageId\":\"\\u003cGVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM\\u003e\",\"MessageTraceId\":\"a6f62809-5cda-4454-0962-08dab38940d6\",\"Organization\":\"contoso.com\",\"Received\":\"2022-10-21T17:25:30.6006882Z\",\"RecipientAddress\":\"linus@contoso.com\",\"SenderAddress\":\"noreply@azure.microsoft.com\",\"Size\":22704,\"StartDate\":\"2022-10-21T09:40:10Z\",\"Status\":\"Delivered\",\"Subject\":\"testmail 1\",\"ToIP\":null}",
         "outcome": "success",
-        "start": "2022-10-21T09:40:10.000Z"
+        "start": "2022-10-21T09:40:10.000Z",
+        "type": [
+            "info"
+        ]
     },
     "input": {
-        "type": "log"
-    },
-    "log": {
-        "file": {
-            "path": "/tmp/service_logs/microsoft_exchange_online_message_trace_test.ndjson.log"
-        },
-        "offset": 0
+        "type": "httpjson"
     },
     "microsoft": {
         "online_message_trace": {
             "EndDate": "2022-10-22T09:40:10Z",
-            "FromIP": "40.107.23.54",
-            "Index": 0,
-            "MessageId": "<GVAP278MB037586A65EF1FB2F844B0258DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
-            "MessageTraceId": "a5e6dc0f-23df-4b20-d240-08dab38944a1",
+            "FromIP": "40.107.23.81",
+            "Index": 1,
+            "MessageId": "<GVAP278MB037518E76F4082DFE9B607B3DA2D9@GVAP278MB0375.CHEP278.PROD.OUTLOOK.COM>",
+            "MessageTraceId": "a6f62809-5cda-4454-0962-08dab38940d6",
             "Organization": "contoso.com",
-            "Received": "2022-10-21T17:25:36.969376Z",
+            "Received": "2022-10-21T17:25:30.6006882Z",
             "RecipientAddress": "linus@contoso.com",
             "SenderAddress": "noreply@azure.microsoft.com",
-            "Size": 22761,
+            "Size": 22704,
             "StartDate": "2022-10-21T09:40:10Z",
             "Status": "Delivered",
-            "Subject": "testmail 2"
+            "Subject": "testmail 1"
         }
     },
     "related": {
@@ -237,7 +238,7 @@ An example event for `log` looks as following:
     },
     "source": {
         "domain": "azure.microsoft.com",
-        "ip": "40.107.23.54",
+        "ip": "40.107.23.81",
         "registered_domain": "microsoft.com",
         "subdomain": "azure",
         "top_level_domain": "com",
@@ -250,7 +251,6 @@ An example event for `log` looks as following:
     },
     "tags": [
         "preserve_original_event",
-        "microsoft-defender-endpoint",
         "forwarded"
     ]
 }

--- a/packages/microsoft_exchange_online_message_trace/manifest.yml
+++ b/packages/microsoft_exchange_online_message_trace/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_exchange_online_message_trace
 title: "Microsoft Exchange Online Message Trace"
-version: "1.22.1"
+version: "1.23.0"
 description: "Microsoft Exchange Online Message Trace Integration"
 type: integration
 categories:


### PR DESCRIPTION
Updated to set the event.category to 'email' and type to 'info' the only supported type for this category according to https://www.elastic.co/guide/en/ecs/current/ecs-allowed-values-event-category.html#ecs-event-category-email

Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement

## Proposed commit message

Please explain:
- WHAT: Currently the ingest pipeline does not set the `event.category` or `event.type` fields.
- WHY:  By having these fields set, mainly `event.category` users can easily use this with the timeline EQL.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Screenshots
NA
