### PR TITLE
Populate `event.outcome` based on `sso_token_success`, when present

### DIFF
--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.11.1"
+  changes:
+    - description: Populate 'event.outcome' based on 'sso_token_success', when present
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10697
 - version: "1.11.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/jumpcloud/changelog.yml
+++ b/packages/jumpcloud/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.11.1"
+- version: "1.12.0"
   changes:
     - description: Populate 'event.outcome' based on 'sso_token_success', when present
       type: enhancement

--- a/packages/jumpcloud/data_stream/events/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jumpcloud/data_stream/events/elasticsearch/ingest_pipeline/default.yml
@@ -164,6 +164,14 @@ processors:
   - set:
       field: event.outcome
       value: success
+      if: ctx.jumpcloud?.event?.sso_token_success == true
+  - set:
+      field: event.outcome
+      value: failure
+      if: ctx.jumpcloud?.event?.sso_token_success == false
+  - set:
+      field: event.outcome
+      value: success
       if: ctx.jumpcloud?.event?.success == true
   - set:
       field: event.outcome

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: jumpcloud
 title: "JumpCloud"
-version: "1.11.1"
+version: "1.12.0"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:

--- a/packages/jumpcloud/manifest.yml
+++ b/packages/jumpcloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: jumpcloud
 title: "JumpCloud"
-version: "1.11.0"
+version: "1.11.1"
 description: "Collect logs from JumpCloud Directory as a Service"
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
Populate `event.outcome` based on `sso_token_success`, when present

The `sso_token_success` field isn't in the API documentation, but we
do have a field definition for it and we see it returned with
`"event_type": "sso_auth"` (without the `success` field).
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).