### PR TITLE
[system] Fix broken visualization for User Renamed Metric in User Management Events Dashboard

### DIFF
--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix broken query on Users Renamed
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/99999999
+      link: https://github.com/elastic/integrations/pull/10698
 - version: "1.60.2"
   changes:
     - description: Add windows.forward where it was missing on visualizations and searches.

--- a/packages/system/changelog.yml
+++ b/packages/system/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.60.3"
+  changes:
+    - description: Fix broken query on Users Renamed
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/99999999
 - version: "1.60.2"
   changes:
     - description: Add windows.forward where it was missing on visualizations and searches.

--- a/packages/system/kibana/dashboard/system-71f720f0-ff18-11e9-8405-516218e3d268.json
+++ b/packages/system/kibana/dashboard/system-71f720f0-ff18-11e9-8405-516218e3d268.json
@@ -4193,7 +4193,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "((data_stream.dataset:windows.security OR data_stream.dataset:system.security OR data_stream.dataset:windows.forwarded) AND event.code: \"4781\""
+                                                        "query": "((data_stream.dataset:windows.security OR data_stream.dataset:system.security OR data_stream.dataset:windows.forwarded) AND event.code: \"4781\")"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Users Renamed",

--- a/packages/system/manifest.yml
+++ b/packages/system/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: system
 title: System
-version: "1.60.2"
+version: "1.60.3"
 description: Collect system logs and metrics from your servers with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug


## Proposed commit message
See title 


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


Related: https://github.com/elastic/integrations/issues/10431 -> All visualizations implemented here work, except this one. A missed ")" is causing this to break.

## Screenshots
![image](https://github.com/user-attachments/assets/14ad3b79-a079-440f-b305-dc828dbc560a)
