### PR TITLE
Add AWS Bedrock runtime metrics to Firehose rerouting

### DIFF
--- a/packages/aws_bedrock/changelog.yml
+++ b/packages/aws_bedrock/changelog.yml
@@ -1,3 +1,8 @@
+- version: "0.4.0"
+  changes:
+    - description: Add dot_expander processor into metrics ingest pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10699
 - version: "0.3.0"
   changes:
     - description: Add runtime dataset for collecting runtime metrics.

--- a/packages/aws_bedrock/data_stream/runtime/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/aws_bedrock/data_stream/runtime/elasticsearch/ingest_pipeline/default.yml
@@ -1,6 +1,9 @@
 ---
 description: Pipeline for AWS Bedrock runtime metrics
 processors:
+  - dot_expander:
+      field: "*"
+      ignore_failure: true
   - rename:   
       field: aws.bedrock.metrics
       target_field: aws_bedrock.runtime

--- a/packages/aws_bedrock/manifest.yml
+++ b/packages/aws_bedrock/manifest.yml
@@ -3,7 +3,7 @@ name: aws_bedrock
 title: AWS Bedrock
 description: Collect AWS Bedrock model invocation logs and runtime metrics with Elastic Agent.
 type: integration
-version: "0.3.0"
+version: "0.4.0"
 categories:
   - aws
 conditions:

--- a/packages/awsfirehose/changelog.yml
+++ b/packages/awsfirehose/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.0"
+  changes:
+    - description: Add AWS Bedrock runtime metrics to Firehose rerouting.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10699
 - version: "1.1.0"
   changes:
     - description: Add routing rules for metrics from Firehose.

--- a/packages/awsfirehose/data_stream/metrics/routing_rules.yml
+++ b/packages/awsfirehose/data_stream/metrics/routing_rules.yml
@@ -105,3 +105,8 @@
       namespace:
         - "{{data_stream.namespace}}"
         - default
+    - target_dataset: aws_bedrock.runtime
+      if: ctx['aws.cloudwatch.namespace'] != null &&  ctx['aws.cloudwatch.namespace'] == "AWS/Bedrock"
+      namespace:
+        - "{{data_stream.namespace}}"
+        - default

--- a/packages/awsfirehose/manifest.yml
+++ b/packages/awsfirehose/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.1.0"
 name: awsfirehose
 title: Amazon Data Firehose
-version: 1.1.0
+version: 1.2.0
 description: Stream logs and metrics from Amazon Data Firehose into Elastic Cloud.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This PR is to add Firehose support for AWS/Bedrock runtime metrics.
- add AWS/Bedrock to metrics rerouting
- add dot expander processor to expand fields with dots into object fields which allows fields with dots to be accessible by other processors later.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
