### PR TITLE
Revert "Bump updatecli/updatecli-action from 2.62.0 to 2.65.0 (#10696)"

### DIFF
--- a/.github/workflows/bump-elastic-stack-version.yml
+++ b/.github/workflows/bump-elastic-stack-version.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@v2.65.0
+        uses: updatecli/updatecli-action@v2.62.0
 
       - name: Select diff action
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
This reverts commit d1a7f31c73e4026964904d5574b6e9ce9da18fa4.

Latest updatecli version seems to be still problematic, reverting last update.