### PR TITLE
[CI] Allow github-actions bot user to trigger builds

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,7 +5,7 @@
       "pipelineSlug": "integrations",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
-      "allowed_list": ["dependabot[bot]", "mergify[bot]", "elastic-vault-github-plugin-prod[bot]"],
+      "allowed_list": ["dependabot[bot]", "mergify[bot]", "elastic-vault-github-plugin-prod[bot]", "github-actions[bot]"],
       "set_commit_status": true,
       "build_on_commit": true,
       "build_on_comment": true,


### PR DESCRIPTION
## Proposed commit message

Allow `github-actions[bot]` user to trigger PR builds (like updatecli Pull Requests) in Buildkite. 
