### PR TITLE
chore: group to keyword

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: 1.66.3
   changes:
-    - description: Updating field groups to keyword in kubernetes.audit_logs
+    - description: Updating mapping of the field groups to keyword in kubernetes.audit_logs
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10713
 - version: 1.66.2

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.66.3
+  changes:
+    - description: Updating field groups to keyword in kubernetes.audit_logs
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10713
 - version: 1.66.2
   changes:
     - description: Fixing missing processor block in kubernetes.audit_logs

--- a/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
+++ b/packages/kubernetes/data_stream/audit_logs/fields/fields.yml
@@ -27,7 +27,7 @@
       description: Authenticated user information
       fields:
         - name: groups
-          type: text
+          type: keyword
           description: The names of groups this user is a part of
         - name: username
           type: keyword
@@ -47,7 +47,7 @@
       description: Impersonated user information
       fields:
         - name: groups
-          type: text
+          type: keyword
           description: The names of groups this user is a part of
         - name: username
           type: keyword

--- a/packages/kubernetes/docs/audit-logs.md
+++ b/packages/kubernetes/docs/audit-logs.md
@@ -132,7 +132,7 @@ An example event for `audit` looks as following:
 | kubernetes.audit.apiVersion | Audit event api version | keyword |
 | kubernetes.audit.auditID | Unique audit ID, generated for each request | keyword |
 | kubernetes.audit.impersonatedUser.extra.\* | Any additional information provided by the authenticator | object |
-| kubernetes.audit.impersonatedUser.groups | The names of groups this user is a part of | text |
+| kubernetes.audit.impersonatedUser.groups | The names of groups this user is a part of | keyword |
 | kubernetes.audit.impersonatedUser.uid | A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs | keyword |
 | kubernetes.audit.impersonatedUser.username | The name that uniquely identifies this user among all active users | keyword |
 | kubernetes.audit.kind | Kind of the audit event | keyword |
@@ -190,7 +190,7 @@ An example event for `audit` looks as following:
 | kubernetes.audit.stage | Stage of the request handling when this event instance was generated | keyword |
 | kubernetes.audit.stageTimestamp | Time the request reached current audit stage | date |
 | kubernetes.audit.user.extra.\* | Any additional information provided by the authenticator | object |
-| kubernetes.audit.user.groups | The names of groups this user is a part of | text |
+| kubernetes.audit.user.groups | The names of groups this user is a part of | keyword |
 | kubernetes.audit.user.uid | A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs | keyword |
 | kubernetes.audit.user.username | The name that uniquely identifies this user among all active users | keyword |
 | kubernetes.audit.userAgent | UserAgent records the user agent string reported by the client. Note that the UserAgent is provided by the client, and must not be trusted | text |

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.66.2
+version: 1.66.3
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Type of change
- Enhancement

## Proposed commit message

- Changed the group field from text to keyboard, the group field contains unique values. It will valuable to filtering and creating graphs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).



