### PR TITLE
Rename from `related.entities` to `related.entity`

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Update from related.entities to related.entity
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10688
+      link: https://github.com/elastic/integrations/pull/10719
 - version: "0.1.6"
   changes:
     - description: Add related.entities field

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.1.7"
+  changes:
+    - description: Update from related.entities to related.entity
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10688
 - version: "0.1.6"
   changes:
     - description: Add related.entities field

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/related.yml
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/fields/related.yml
@@ -1,5 +1,5 @@
 - name: related
   type: group  
   fields:
-  - name: entities
+  - name: entity
     type: keyword

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.1.6"
+version: "0.1.7"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"


### PR DESCRIPTION
### Summary of your changes
Based on product decision, in the asset inventory integration, we are moving away from `related.entities` and towards `related.entity`


### Related Issues
- Related https://github.com/elastic/security-team/issues/10080
- Related https://github.com/elastic/integrations/pull/10688
- Counterpart of https://github.com/elastic/cloudbeat/pull/2398