### PR TITLE
sophos_central: Update docs for token_url configuration

### DIFF
--- a/packages/sophos_central/_dev/build/docs/README.md
+++ b/packages/sophos_central/_dev/build/docs/README.md
@@ -33,7 +33,7 @@ The Elastic Integration for Sophos Central requires the following Authentication
   - Grant Type
   - Scope
   - Tenant ID
-  - Token URL
+  - Token URL (without the URL path)
 
 **NOTE**: Sophos central supports logs only upto last 24 hrs.
 

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update docs for token_url configuration.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/10720
 - version: "1.15.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/sophos_central/changelog.yml
+++ b/packages/sophos_central/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.0"
+  changes:
+    - description: Update docs for token_url configuration.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.15.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/sophos_central/docs/README.md
+++ b/packages/sophos_central/docs/README.md
@@ -33,7 +33,7 @@ The Elastic Integration for Sophos Central requires the following Authentication
   - Grant Type
   - Scope
   - Tenant ID
-  - Token URL
+  - Token URL (without the URL path)
 
 **NOTE**: Sophos central supports logs only upto last 24 hrs.
 

--- a/packages/sophos_central/manifest.yml
+++ b/packages/sophos_central/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: sophos_central
 title: Sophos Central
-version: "1.15.0"
+version: "1.16.0"
 description: This Elastic integration collects logs from Sophos Central with Elastic Agent.
 type: integration
 categories:
@@ -73,7 +73,7 @@ policy_templates:
           - name: token_url
             type: text
             title: Token URL
-            description: "Token_url must be the same as used while generating tenant_id, follow this link(https://developer.sophos.com/getting-started-tenant) for configuration."
+            description: Token_url must be the same as used while generating tenant_id, follow this [link](https://developer.sophos.com/getting-started-tenant) for configuration. This URL should be without the url path, for example - `https://id.sophos.com` i.e., without the path `/api/v2/oauth2/token`.
             multi: false
             required: true
             show_user: false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Update docs for `token_url` configuration.

[The input](https://github.com/elastic/integrations/blob/main/packages/sophos_central/data_stream/alert/agent/stream/httpjson.yml.hbs#L9) already appends the token url path `/api/v2/oauth2/token`
to the `auth.oauth2.token_url`, needing the user to configure only 
the base url for `token_url` parameter. For example: `https://id.sophos.com`.
The current README doc doesn't indicate that the url path needs to be
removed when configuring `token_url`. This can lead to duplicate url path 
in the `auth.oauth2.token_url`, for example: 
`https://id.sophos.com/api/v2/oauth2/token/api/v2/oauth2/token`. 
The PR addresses this by updating the README doc.


<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

