### PR TITLE
Add search reference that was removed from Elastic-Agent dashboard

### DIFF
--- a/packages/elastic_agent/changelog.yml
+++ b/packages/elastic_agent/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.2"
+  changes:
+    - description: Restore Agent errors visualisation
+      type: bugfix
+      link: "https://github.com/elastic/integrations/pull/10728"
 - version: "2.0.1"
   changes:
     - description: Add back apm-server metrics dropped due to TSDB

--- a/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
+++ b/packages/elastic_agent/kibana/dashboard/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824.json
@@ -870,6 +870,11 @@
             "type": "index-pattern"
         },
         {
+            "id": "elastic_agent-522c9e20-ad53-11ed-957f-f1c897630287",
+            "name": "9604578e-7da2-4575-923e-f15e51bca436:panel_9604578e-7da2-4575-923e-f15e51bca436",
+            "type": "search"
+        },
+        {
             "id": "logs-*",
             "name": "controlGroup_280071dd-16c7-4610-bae7-bc8f07cc6a1b:optionsListDataView",
             "type": "index-pattern"

--- a/packages/elastic_agent/manifest.yml
+++ b/packages/elastic_agent/manifest.yml
@@ -1,6 +1,6 @@
 name: elastic_agent
 title: Elastic Agent
-version: 2.0.1
+version: 2.0.2
 description: Collect logs and metrics from Elastic Agents.
 type: integration
 format_version: 3.1.4

--- a/packages/elastic_agent/validation.yml
+++ b/packages/elastic_agent/validation.yml
@@ -1,3 +1,4 @@
 errors:
   exclude_checks:
     - SVR00002
+    - SVR00004


### PR DESCRIPTION
## Proposed commit message

This commit re-adds a search that was removed by accident from the
[Elastic Agent] Agent Info dashboard and add an exception to the lint
so the package can be compiled.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

~~## Author's Checklist~~
## How to test this PR locally

1. Build the elastic-agent package
2. go to the dashboard: https://127.0.0.1:5601/app/dashboards#/view/elastic_agent-0600ffa0-6b5e-11ed-98de-67bdecd21824

## Related issues
- https://github.com/elastic/integrations/pull/10217

~~## Screenshots~~
