### PR TITLE
[CI] Report skipped tests in junit annotations

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -76,8 +76,10 @@ steps:
 
   - label: ":junit: Junit annotate"
     plugins:
-      - junit-annotate#v2.4.1:
+      - junit-annotate#v2.5.0:
           artifacts: "build/test-results/*.xml"
+          failed-download-exit-code: 0 # Not fail the build in case there are no XML files
+          report-skipped: true
     agents:
       provider: "gcp"  # junit plugin requires docker
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -80,9 +80,10 @@ steps:
 
   - label: ":junit: Junit annotate"
     plugins:
-      - junit-annotate#v2.4.1:
+      - junit-annotate#v2.5.0:
           artifacts: "build/test-results/*.xml"
           failed-download-exit-code: 0 # Not fail the build in case there are no XML files
+          report-skipped: true
     agents:
       provider: "gcp"  # junit plugin requires docker
 


### PR DESCRIPTION
## Proposed commit message

Update junit buildkite plugin and enable reporting the skipped tests in the corresponding annotations.

Skipped tests just are shown if there is any test failing. 
Example of how these skipped tests are shown in the buildkite build:

![skipped tests annotation closed](https://github.com/user-attachments/assets/1dad74c3-2ba5-4b1d-a922-e722223ce0a7)

![skipped tests annotation opened](https://github.com/user-attachments/assets/5d7f4842-f9dc-46a6-8408-403f9b3032bb)

