### PR TITLE
Fix event.module for Linux Metrics Service

### DIFF
--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.6.11"
+  changes:
+    - description: Fix Service processors.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/00000
 - version: "0.6.10"
   changes:
     - description: Add processors capability to Linux Metrics.

--- a/packages/linux/changelog.yml
+++ b/packages/linux/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix Service processors.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/00000
+      link: https://github.com/elastic/integrations/pull/10736
 - version: "0.6.10"
   changes:
     - description: Add processors capability to Linux Metrics.

--- a/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
+++ b/packages/linux/data_stream/service/agent/stream/stream.yml.hbs
@@ -20,8 +20,8 @@ period: {{period}}
 hostfs: {{system.hostfs}}
 {{/if}}
 processors:
-{{#if processors}}
 - drop_fields:
     fields: event.module
+{{#if processors}}
 {{processors}}
 {{/if}}

--- a/packages/linux/manifest.yml
+++ b/packages/linux/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: linux
 title: Linux Metrics
-version: 0.6.10
+version: 0.6.11
 license: basic
 description: Collect metrics from Linux servers with Elastic Agent.
 type: integration


### PR DESCRIPTION
## Proposed commit message

Since #10314 Linux Metrics Service fails with below message:
```[constant_keyword] field [event.module] only accepts values that are equal to the value defined in the mappings [linux], but got [system]```

This fixes this issue, by adding a single processor to the datastream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [X] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


