### PR TITLE
[O11y][MYSQL] Add `schemaname` field in the performance data stream

### DIFF
--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.25.0
+  changes:
+    - description: Add `schemaname` field in the performance data stream.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1 #Fix me
 - version: 1.24.0
   changes:
     - description: Add replica_status data stream.

--- a/packages/mysql/changelog.yml
+++ b/packages/mysql/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add `schemaname` field in the performance data stream.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1 #Fix me
+      link: https://github.com/elastic/integrations/pull/10749
 - version: 1.24.0
   changes:
     - description: Add replica_status data stream.

--- a/packages/mysql/data_stream/performance/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/mysql/data_stream/performance/elasticsearch/ingest_pipeline/default.yml
@@ -17,7 +17,9 @@ processors:
         ctx.mysql.performance.events_statements.query = digest.text;
 
 - fingerprint:
-    fields: ["mysql.performance.events_statements.query"]
+    fields: 
+      - mysql.performance.events_statements.query
+      - mysql.performance.events_statements.schemaname
     target_field: mysql.performance.events_statements.query_id
     ignore_failure: true
     ignore_missing: true

--- a/packages/mysql/data_stream/performance/fields/fields.yml
+++ b/packages/mysql/data_stream/performance/fields/fields.yml
@@ -4,6 +4,10 @@
     - name: events_statements
       type: group
       fields:
+        - name: schemaname
+          type: keyword
+          dimension: true
+          description: Alias for the database name within certain SQL statements.
         - name: query_id
           type: keyword
           # Reason to add as a dimension field: shows results based on queries.

--- a/packages/mysql/manifest.yml
+++ b/packages/mysql/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: mysql
 title: MySQL
-version: "1.24.0"
+version: "1.25.0"
 description: Collect logs and metrics from MySQL servers with Elastic Agent.
 type: integration
 categories:
@@ -9,7 +9,7 @@ categories:
   - observability
 conditions:
   kibana:
-    version: "^8.14.0"
+    version: "^8.15.0"
   elastic:
     subscription: basic
 screenshots:


### PR DESCRIPTION
- Enhancement
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Breaking change
- Deprecation
-->

## Proposed commit message

- Update kibana version to `8.15.0`.
- Add `schemaname` field in the performance data stream

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #9239