### PR TITLE
[Keycloak] Fix missing value in pipeline condition

### DIFF
--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix missing value in pipeline condition.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/12345
+      link: https://github.com/elastic/integrations/pull/10751
 - version: "1.22.2"
   changes:
     - description: Enhanced kv processor to trim escape sequences properly.

--- a/packages/keycloak/changelog.yml
+++ b/packages/keycloak/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.22.3"
+  changes:
+    - description: Fix missing value in pipeline condition.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/12345
 - version: "1.22.2"
   changes:
     - description: Enhanced kv processor to trim escape sequences properly.

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -9,14 +9,17 @@ processors:
       target_field: event.original
       ignore_missing: true
       if: ctx.event?.original == null
+      tag: rename_event_original
   - grok:
       field: event.original
       patterns:
         - "%{TIMESTAMP_ISO8601:_tmp.timestamp} %{LOGLEVEL:log.level}%{SPACE}\\[%{JAVACLASS:log.logger}\\] \\(%{DATA:process.thread.name}\\) (?<message>(.|\r|\n)*)"
+      tag: grok_event_original
   - set:
       field: event.timezone
       value: "{{_tmp.tz_offset}}"
       if: ctx._tmp?.tz_offset != null && ctx._tmp?.tz_offset != 'local'
+      tag: set_event_timezone
   - date:
       field: _tmp.timestamp
       target_field: '@timestamp'
@@ -24,29 +27,36 @@ processors:
       formats:
         - yyyy-MM-dd HH:mm:ss,SSS
       if: ctx.event?.timezone != null
+      tag: date_timestamp_timezone
   - date:
       field: _tmp.timestamp
       target_field: '@timestamp'
       formats:
         - yyyy-MM-dd HH:mm:ss,SSS
       if: ctx.event?.timezone == null
+      tag: date_timestamp_no_timezone
   - pipeline:
       name: '{{ IngestPipeline "events" }}'
       if: "ctx.log?.logger == 'org.keycloak.events'"
+      tag: pipeline_events
   - drop:
-      if: "ctx._tmp?.only_user_events && ctx.log?.logger != 'org.keycloak.events'"
+      if: "ctx._tmp?.only_user_events == true && ctx.log?.logger != 'org.keycloak.events'"
+      tag: drop_user_events
   - remove:
       field:
         - _tmp
       ignore_missing: true
+      tag: remove_tmp
   - remove:
       field: event.original
       if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
       ignore_failure: true
       ignore_missing: true
+      tag: remove_event_original
   - script:
       lang: painless
       description: This script processor iterates over the whole document to remove fields with null values.
+      tag: painless_remove_null
       source: |
         void handleMap(Map map) {
           for (def x : map.values()) {
@@ -70,9 +80,10 @@ processors:
         }
         handleMap(ctx);
 on_failure:
+  - append:
+      field: error.message
+      value: |-
+        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
   - set:
       field: event.kind
       value: pipeline_error
-  - append:
-      field: error.message
-      value: '{{{ _ingest.on_failure_message }}}'

--- a/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
+++ b/packages/keycloak/data_stream/log/elasticsearch/ingest_pipeline/events.yml
@@ -8,6 +8,7 @@ processors:
     value_split: "="
     trim_value: "\\\\\""
     ignore_missing: true
+    tag: kv_message
 - rename:
     field: json.type
     target_field: keycloak.login.type
@@ -132,6 +133,7 @@ processors:
       - 'groups/%{UUID:group.id}'
     ignore_failure: true
     ignore_missing: true
+    tag: grok_admin_resource_path
 - set:
     field: event.kind
     value: event
@@ -209,11 +211,13 @@ processors:
     field:
       - message
       - json
-    ignore_missing: true  
+    ignore_missing: true
+    tag: remove_message_json
 on_failure:
-- set:
-    field: event.kind
-    value: pipeline_error
-- append:
-    field: error.message
-    value: '{{{ _ingest.on_failure_message }}}'
+  - append:
+      field: error.message
+      value: |-
+        Processor "{{ _ingest.on_failure_processor_type }}" with tag "{{ _ingest.on_failure_processor_tag }}" in pipeline "{{ _ingest.on_failure_pipeline }}" failed with message "{{ _ingest.on_failure_message }}"
+  - set:
+      field: event.kind
+      value: pipeline_error

--- a/packages/keycloak/manifest.yml
+++ b/packages/keycloak/manifest.yml
@@ -1,6 +1,6 @@
 name: keycloak
 title: Keycloak
-version: "1.22.2"
+version: "1.22.3"
 description: Collect logs from Keycloak with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Fixed a condition in a `drop` processor for the Keycloak ingest pipeline, where the value was missing.

To help identify the pipeline error, some tags have been added to the more elaborate processors in the pipeline.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

Before the change, ingesting an event into the pipeline as follows:
```
POST /_ingest/pipeline/logs-keycloak.log-1.22.2/_simulate
{
  "docs": [
    {
      "_index": "index",
      "_id": "id",
      "_source": {
        "message": "2024-07-17 12:05:32,104 INFO [org.keycloak.events] (main-thread-1) type=\"LOGOUT\", realmId=\"12345678-9abc-def0-1234-56789abcdef0\", clientId=\"user-console\", userId=\"abcdef12-3456-7890-abcd-ef1234567890\", sessionId=\"abcd1234-5678-90ab-cdef-1234567890ab\", ipAddress=\"192.168.1.1\", auth_method=\"oauth2\", auth_type=\"token\", response_type=\"token\", redirect_uri=\"https://example.com/realms/demo/account/\", consent=\"consent_required\", code_id=\"abcd1234-5678-90ab-cdef-1234567890ab\", response_mode=\"fragment\", username=\"dummyuser\", authSessionParentId=\"abcd1234-5678-90ab-cdef-1234567890ab\", authSessionTabId=\"zXY987wvuTsr\""
      }
    }
  ]
}
```

produces the pipeline error:
```
"error": {
  "message": [
    "Processor \"conditional\" with tag \"drop_user_events\" in pipeline \"logs-keycloak.log-1.22.2\" failed with message \"Cannot invoke \\\"Object.getClass()\\\" because \\\"value\\\null\""
  ]
},
```

After the fix, the event is ingested properly.