### PR TITLE
Revert vuln data views

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -13,7 +13,7 @@
   changes:
     - description: Deprecate data views assets.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10692
+      link: https://github.com/elastic/integrations/pull/10767
 - version: "1.11.0-preview02"
   changes:
     - description: Add `related.entity` to cspm

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -9,7 +9,7 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
-- version: "1.11.0-preview03"
+- version: "1.11.0-preview04"
   changes:
     - description: Deprecate data views assets.
       type: enhancement

--- a/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-07a5e6d6-982d-4c7c-a845-5f2be43279c9.json
+++ b/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-07a5e6d6-982d-4c7c-a845-5f2be43279c9.json
@@ -1,0 +1,14 @@
+{
+  "attributes": {
+    "description": "",
+    "title": "logs-cloud_security_posture.vulnerabilities_latest-*",
+    "timeFieldName": "@timestamp",
+    "namespaces": "[*]"
+  },
+  "coreMigrationVersion": "8.3.0",
+  "id": "cloud_security_posture-07a5e6d6-982d-4c7c-a845-5f2be43279c9",
+  "migrationVersion": {
+    "index-pattern": "8.0.0"
+  },
+  "type": "index-pattern"
+}

--- a/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-c406d945-a359-4c04-9a6a-65d66de8706b.json.json
+++ b/packages/cloud_security_posture/kibana/index_pattern/cloud_security_posture-c406d945-a359-4c04-9a6a-65d66de8706b.json.json
@@ -1,0 +1,14 @@
+{
+  "attributes": {
+    "description": "",
+    "title": "logs-cloud_security_posture.vulnerabilities-*",
+    "timeFieldName": "@timestamp",
+    "namespaces": "[*]"
+  },
+  "coreMigrationVersion": "8.1.0",
+  "id": "cloud_security_posture-c406d945-a359-4c04-9a6a-65d66de8706b",
+  "migrationVersion": {
+    "index-pattern": "8.0.0"
+  },
+  "type": "index-pattern"
+}

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.11.0-preview03"
+version: "1.11.0-preview04"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"


### PR DESCRIPTION
Revert cloud security vulnerability data views.
In [this GitHub pull request](https://github.com/elastic/integrations/pull/10692), we deprecated all cloud security data views. We should postpone deprecating the vulnerability data views until the requirements are more clearly defined.

