### PR TITLE
[fortinet_fortiproxy] Fix udp_options in UDP agent file

### DIFF
--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.3.1"
+  changes:
+    - description: Fix udp_options in UDP agent file.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.0"
   changes:
     - description: Remap devname to observer.name and process url field.

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix udp_options in UDP agent file.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10771
 - version: "0.3.0"
   changes:
     - description: Remap devname to observer.name and process url field.

--- a/packages/fortinet_fortiproxy/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/fortinet_fortiproxy/data_stream/log/agent/stream/udp.yml.hbs
@@ -16,6 +16,6 @@ ssl: {{ssl}}
 processors:
 {{processors}}
 {{/if}}
-{{#if tcp_options}}
-{{tcp_options}}
+{{#if udp_options}}
+{{udp_options}}
 {{/if}}

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 0.3.0
+version: 0.3.1
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Fix udp_options in UDP agent file having incorrect variable

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
