### PR TITLE
[aws custom logs] Updating file selector field to receive mutline configurations

### DIFF
--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -1,3 +1,8 @@
+- version: "1.4.0"
+  changes:
+    - description: Update file_selectors field to be able to receive multiline configuration 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10480
 - version: "1.3.1"
   changes:
     - description: Update max_number_of_messages parameter description

--- a/packages/aws_logs/changelog.yml
+++ b/packages/aws_logs/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Update file_selectors field to be able to receive multiline configuration 
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10480
+      link: https://github.com/elastic/integrations/pull/10789
 - version: "1.3.1"
   changes:
     - description: Update max_number_of_messages parameter description

--- a/packages/aws_logs/data_stream/generic/manifest.yml
+++ b/packages/aws_logs/data_stream/generic/manifest.yml
@@ -221,11 +221,24 @@ streams:
       - name: file_selectors
         type: yaml
         title: File Selectors
-        multi: true
+        multi: false
         required: false
         show_user: false
         description: >
           If the SQS queue will have events that correspond to files that this integration shouldn’t process file_selectors can be used to limit the files that are downloaded. This is a list of selectors which are made up of regex and expand_event_list_from_field options. The regex should match the S3 object key in the SQS message, and the optional expand_event_list_from_field is the same as the global setting. If file_selectors is given, then any global expand_event_list_from_field value is ignored in favor of the ones specified in the file_selectors. Regex syntax is the same as the Go language. Files that don’t match one of the regexes won’t be processed. content_type, parsers, include_s3_metadata,max_bytes, buffer_size, and encoding may also be set for each file selector.
+        default: |
+          #- regex: /CloudTrail/
+          #  parsers:
+          #    - multiline:
+          #        pattern: ^<Event
+          #        negate:  true
+          #        match:   after
+          #- regex: /CloudTrail-Digest/
+          #  parsers:
+          #    - multiline:
+          #        pattern: ^<Event
+          #        negate:  true
+          #        match:   after
 
       - name: fips_enabled
         type: bool

--- a/packages/aws_logs/manifest.yml
+++ b/packages/aws_logs/manifest.yml
@@ -3,7 +3,7 @@ name: aws_logs
 title: Custom AWS Logs
 description: Collect raw logs from AWS S3 or CloudWatch with Elastic Agent.
 type: integration
-version: "1.3.1"
+version: "1.4.0"
 categories:
   - observability
   - custom


### PR DESCRIPTION
- Enhancement


## Proposed commit message 

WHAT: Update the file selector field of `Collect Logs from S3 Bucket` datastream to be able to receive multiline configurations
WHY: It is needed in order to be able to provide specific parsers confguration to specific file selectors. Otherwise the parsers is not applied to the files selected

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

1. Clone this PR
2. Navigate to `/integrations/packages/aws_logs`
3. Run elastic-package build
4. Run `elastic-package stack up -d -v --version=8.15.0` within the same folder. This will create a local elastic stack
5. Create an agent policy with aws_custom_logs integration
6.  In the policy enable `Collect Logs from S3 Bucket` datastream
7. Under the `advanced options` update `File Selectors field`
```yaml
- regex: .*windows-events-.*
  parsers:
    - multiline:
        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]
        negate:  true
        match:   after
```

8. Update the credentials to connect to an s3 bucket
9   Upload a multiline file to your s3 bucket `aws s3 cp test.log s3://gizas-se-test2/windows-events-5.log` 

## Related issues

- Relates #https://github.com/elastic/beats/issues/40365

## Screenshots

<img width="2056" alt="Screenshot 2024-08-14 at 12 32 29 PM" src="https://github.com/user-attachments/assets/541d4794-bfac-4da4-82ba-46ec6625a1d5">

