### PR TITLE
Provide support of configuring ignore_older events in apache access-logs

### DIFF
--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.25.0"
+  changes:
+    - description: "Allow configuration of ignore_older."
+      type: enhancement
+      link: TODO
 - version: "1.24.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/apache/changelog.yml
+++ b/packages/apache/changelog.yml
@@ -1,9 +1,9 @@
 # newer versions go on top
 - version: "1.25.0"
   changes:
-    - description: "Allow configuration of ignore_older."
+    - description: "Allow configuration of ignoring older events in apache access log datastream."
       type: enhancement
-      link: TODO
+      link: https://github.com/elastic/integrations/pull/10809
 - version: "1.24.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/apache/data_stream/access/agent/stream/log.yml.hbs
+++ b/packages/apache/data_stream/access/agent/stream/log.yml.hbs
@@ -2,6 +2,9 @@ paths:
 {{#each paths as |path i|}}
  - {{path}}
 {{/each}}
+{{#if ignore_older}}
+ignore_older: {{ignore_older}}
+{{/if}}
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/apache/data_stream/access/manifest.yml
+++ b/packages/apache/data_stream/access/manifest.yml
@@ -13,6 +13,14 @@ streams:
           - /var/log/apache2/access.log*
           - /var/log/apache2/other_vhosts_access.log*
           - /var/log/httpd/access_log*
+      - name: ignore_older
+        type: text
+        title: Ignore events older than
+        default: 72h
+        required: false
+        show_user: false
+        description: >-
+          If this option is specified, events that are older than the specified amount of time are ignored. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       - name: tags
         type: text
         title: Tags

--- a/packages/apache/manifest.yml
+++ b/packages/apache/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: apache
 title: Apache HTTP Server
-version: "1.24.0"
+version: "1.25.0"
 source:
   license: Elastic-2.0
 description: Collect logs and metrics from Apache servers with Elastic Agent.


### PR DESCRIPTION
Please label as enhancement

Currently, there is no option for ignoring events older than X. This can be problematic, if there are hundreds of gigabytes of historical logfiles, that cannot be deleted, but shall not be ingested in Elastic.'

In more detail: We have apache as an internal core reverse-proxy and save the access logs on a fileshare, where elastic agent should ingest them. However some production environments have an uncompressed volume size of up to 227 GB, which currently should not all be ingested into Elastic, as there might be other retention periods as we currently have on our fileshare.

Therefore this option should prevent the ingestion of those old files, and should be configurable the same way, as it is already possible in the custom log integration.
