### PR TITLE
Adding process.name field and minor enhancements to od* events.

### DIFF
--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.4.0"
   changes:
     - description: Added process.name and some minor enhancements to some events
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/10813
 - version: "2.3.0"
   changes:

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Added process.name and some minor enhancements to some events
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10672
+      link: https://github.com/elastic/integrations/pull/10813
 - version: "2.3.0"
   changes:
     - description: Deprecate global SQS Queue URL to avoid data loss.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.4.0"
+  changes:
+    - description: Added process.name and some minor enhancements to some events
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10672
 - version: "2.3.0"
   changes:
     - description: Deprecate global SQS Queue URL to avoid data loss.

--- a/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
+++ b/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
@@ -75,6 +75,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "loginwindow",
                 "parent": {
                     "entity_id": "012139F5-CEED-5A0E-9862-451CDA9E492E",
                     "pid": 1,
@@ -186,6 +187,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "loginwindow",
                 "parent": {
                     "entity_id": "012139F5-CEED-5A0E-9862-451CDA9E492E",
                     "pid": 1,
@@ -300,6 +302,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "pwpolicy",
                 "parent": {
                     "entity_id": "82DE3938-6F90-5B78-8A01-C180CFA4E1C5",
                     "pid": 20757,
@@ -414,6 +417,7 @@
                     "sha256": "88b58d11983de9930f6ef9ff6518b6cd0712db6842a56f8d1cbb1f7c90569e28"
                 },
                 "interactive": true,
+                "name": "sudo",
                 "parent": {
                     "entity_id": "E34963DB-0286-5C1C-A5FB-95A31B9F5794",
                     "pid": 637,
@@ -548,6 +552,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "zsh",
                 "parent": {
                     "entity_id": "A7EDC884-C034-50E7-A3AA-2E281B3E0777",
                     "pid": 64632,
@@ -667,6 +672,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "dscl",
                 "parent": {
                     "entity_id": "E6DCCB86-1543-5107-AFBD-56BD9A88A7E0",
                     "pid": 86239,
@@ -728,7 +734,8 @@
                 "start": "2024-04-23T16:00:31.869Z",
                 "type": [
                     "info",
-                    "change"
+                    "change",
+                    "deletion"
                 ]
             },
             "file": {
@@ -786,6 +793,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "dscl",
                 "parent": {
                     "entity_id": "6575F576-09D5-5849-839A-281527615C08",
                     "pid": 86396,
@@ -902,6 +910,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "UsersGroups",
                 "parent": {
                     "entity_id": "87BE8C81-EE7F-5C5B-BFCD-D59AE17723C9",
                     "pid": 1,
@@ -1013,6 +1022,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "UsersGroups",
                 "parent": {
                     "entity_id": "87BE8C81-EE7F-5C5B-BFCD-D59AE17723C9",
                     "pid": 1,
@@ -1129,6 +1139,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "dscl",
                 "parent": {
                     "entity_id": "5A35DAE8-8E1A-587E-90CA-CC66560A01CB",
                     "pid": 17751,
@@ -1245,6 +1256,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "dscl",
                 "parent": {
                     "entity_id": "2EC711AB-099E-5111-93FE-C2938AAAB3EE",
                     "pid": 18069,
@@ -1360,6 +1372,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "SharePointManagementService",
                 "parent": {
                     "entity_id": "87BE8C81-EE7F-5C5B-BFCD-D59AE17723C9",
                     "pid": 1,
@@ -1471,6 +1484,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "coreauthd",
                 "parent": {
                     "entity_id": "012139F5-CEED-5A0E-9862-451CDA9E492E",
                     "pid": 1,
@@ -1581,6 +1595,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "loginwindow",
                 "parent": {
                     "entity_id": "012139F5-CEED-5A0E-9862-451CDA9E492E",
                     "pid": 1,
@@ -1695,6 +1710,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "sshd",
                 "parent": {
                     "entity_id": "0547F075-3A15-5FBC-B13B-4F28B75ACD31",
                     "pid": 1,
@@ -1809,6 +1825,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "login",
                 "parent": {
                     "entity_id": "F6DF1E37-4D2F-5AAF-BC45-A4B38181C045",
                     "pid": 42919,
@@ -1923,6 +1940,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "login",
                 "parent": {
                     "entity_id": "F6DF1E37-4D2F-5AAF-BC45-A4B38181C045",
                     "pid": 42919,
@@ -2039,6 +2057,7 @@
                     "sha256": "3f5067e550b7a5810e4d9df707dfd5d045d000bd97eb1c369569a256d88f31a5"
                 },
                 "interactive": true,
+                "name": "XProtectRemediatorKeySteal",
                 "parent": {
                     "entity_id": "7768699A-095C-5177-920C-4112827C959A",
                     "pid": 703,
@@ -2167,6 +2186,7 @@
                     "sha256": "4e51d34b4168a154df733fce18fa543743117bbf601835f26fa80e5ea2b9561e"
                 },
                 "interactive": false,
+                "name": "XprotectService",
                 "parent": {
                     "entity_id": "0547F075-3A15-5FBC-B13B-4F28B75ACD31",
                     "pid": 1,
@@ -2342,6 +2362,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "su",
                 "parent": {
                     "entity_id": "B3DF0942-6827-56F0-817A-ED114B670078",
                     "pid": 59258,
@@ -2459,6 +2480,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "screensharingd",
                 "parent": {
                     "entity_id": "0547F075-3A15-5FBC-B13B-4F28B75ACD31",
                     "pid": 1,
@@ -2576,6 +2598,7 @@
                     "sha256": "2d90d5798155f919965565a72e6065d3a1de6fd0c0f2134acdd3d1bced0a6114"
                 },
                 "interactive": false,
+                "name": "kernelmanagerd",
                 "parent": {
                     "entity_id": "87BE8C81-EE7F-5C5B-BFCD-D59AE17723C9",
                     "pid": 1,
@@ -2696,6 +2719,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "mdmclient",
                 "parent": {
                     "entity_id": "30C61A05-D41A-5837-A42E-F11FD2434A00",
                     "pid": 1,
@@ -2805,6 +2829,7 @@
                     }
                 },
                 "interactive": true,
+                "name": "sntp",
                 "parent": {
                     "entity_id": "5C5D5D79-2B3D-52BE-A494-74FA963791BC",
                     "pid": 70346,
@@ -2924,6 +2949,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "JamfCheck",
                 "parent": {
                     "entity_id": "650F695A-E78B-547C-B6B9-34D752DB435F",
                     "pid": 1,
@@ -3042,6 +3068,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "backgroundtaskmanagementd",
                 "parent": {
                     "entity_id": "650F695A-E78B-547C-B6B9-34D752DB435F",
                     "pid": 1,
@@ -3214,6 +3241,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "dirhelper",
                 "parent": {
                     "entity_id": "5BA4345F-357E-550B-9236-0BE320B979A9",
                     "pid": 14795,
@@ -3326,6 +3354,7 @@
                     }
                 },
                 "interactive": false,
+                "name": "mount_apfs",
                 "parent": {
                     "entity_id": "F7ED3BE5-780C-5F1B-AD74-F5F01CB3DC39",
                     "pid": 26930,

--- a/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
+++ b/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
@@ -2451,7 +2451,8 @@
                     "existing_session": true,
                     "graphical_authentication_username": "jappleseed",
                     "platform_binary": true,
-                    "session_username": "jappleseed"
+                    "session_username": "jappleseed",
+                    "source_address_type": "IPv4"
                 }
             },
             "observer": {

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
@@ -409,12 +409,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
 
     - rename:

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
@@ -405,6 +405,18 @@ processors:
         target_field: process.executable
         ignore_missing: true
 
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
+
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_add.yml
@@ -221,6 +221,18 @@ processors:
         target_field: process.executable
         ignore_missing: true
 
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
+
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_add.yml
@@ -225,12 +225,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
 
     - rename:

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_remove.yml
@@ -236,6 +236,18 @@ processors:
         if: ctx.jamf_protect.telemetry?.event?.btm_launch_item_remove?.app == null
         ignore_missing: true
 
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
+
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_btm_launch_item_remove.yml
@@ -240,12 +240,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
 
     - rename:

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_exec.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_exec.yml
@@ -107,12 +107,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_exec.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_exec.yml
@@ -11,6 +11,10 @@ processors:
     - append:
         field: event.type
         value: start
+    - rename:
+        field: jamf_protect.telemetry.event.exec.script.path
+        target_field: file.path
+        ignore_missing: true
 
 ##########################
 ## ECS Process ##
@@ -99,6 +103,17 @@ processors:
         field: jamf_protect.telemetry.event.exec.target.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_set.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_set.yml
@@ -128,12 +128,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_set.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_set.yml
@@ -124,6 +124,17 @@ processors:
         field: jamf_protect.telemetry.event.od_attribute_set.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_add.yml
@@ -123,6 +123,17 @@ processors:
         field: jamf_protect.telemetry.event.od_attribute_value_add.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_add.yml
@@ -127,12 +127,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_remove.yml
@@ -123,6 +123,17 @@ processors:
         field: jamf_protect.telemetry.event.od_attribute_value_remove.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_attribute_value_remove.yml
@@ -127,12 +127,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_group.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_group.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_create_group.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_group.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_group.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_user.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_create_user.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_create_user.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_group.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_group.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_delete_group.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_group.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_group.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_user.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_delete_user.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_delete_user.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_disable_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_disable_user.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_disable_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_disable_user.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_disable_user.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_enable_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_enable_user.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_enable_user.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_enable_user.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_enable_user.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_add.yml
@@ -12,6 +12,9 @@ processors:
         field: event.type
         value: change
     - append:
+        field: event.type
+        value: creation
+    - append:
         field: event.category
         value: configuration  
     - rename:
@@ -114,6 +117,17 @@ processors:
         field: jamf_protect.telemetry.event.od_group_add.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_add.yml
@@ -121,12 +121,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_remove.yml
@@ -13,7 +13,10 @@ processors:
         value: change
     - append:
         field: event.category
-        value: configuration  
+        value: configuration
+    - append:
+        field: event.type
+        value: deletion  
     - rename:
         field: jamf_protect.telemetry.event.od_group_remove.group_name
         target_field: group.name
@@ -114,6 +117,17 @@ processors:
         field: jamf_protect.telemetry.event.od_group_remove.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_remove.yml
@@ -121,12 +121,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_set.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_set.yml
@@ -118,12 +118,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_set.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_group_set.yml
@@ -114,6 +114,17 @@ processors:
         field: jamf_protect.telemetry.event.od_group_set.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_modify_password.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_modify_password.yml
@@ -206,12 +206,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_modify_password.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_od_modify_password.yml
@@ -202,6 +202,17 @@ processors:
         field: jamf_protect.telemetry.event.od_modify_password.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_add.yml
@@ -145,6 +145,17 @@ processors:
         field: jamf_protect.telemetry.event.profile_add.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_add.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_add.yml
@@ -149,12 +149,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_remove.yml
@@ -139,6 +139,17 @@ processors:
         field: jamf_protect.telemetry.event.profile_remove.instigator.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_remove.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_profile_remove.yml
@@ -143,12 +143,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_screensharing_attach.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_screensharing_attach.yml
@@ -80,6 +80,21 @@ processors:
         value: '{{{jamf_protect.telemetry.graphical_authentication_username}}}'
         if: ctx.jamf_protect?.graphical_authentication_username != null
         allow_duplicates: false
+    - script:
+        lang: painless
+        params:
+            itemTypeMap:
+                '0': Unknown
+                '1': IPv4
+                '2': IPv6
+                '3': UNIX Socket
+        source: >
+            if (ctx.jamf_protect?.telemetry?.event?.screensharing_attach?.source_address_type != null) {
+                String itemType = ctx.jamf_protect.telemetry.event.screensharing_attach.source_address_type.toString();
+                def itemTypeString = params.itemTypeMap.containsKey(itemType) ? params.itemTypeMap[itemType] : 'Unknown';
+                ctx.jamf_protect = ctx.jamf_protect != null ? ctx.jamf_protect : new HashMap();
+                ctx.jamf_protect.telemetry.source_address_type = itemTypeString;
+            }
 ##########################
 ## ECS Process ##
 ##########################

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_screensharing_detach.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_screensharing_detach.yml
@@ -44,6 +44,21 @@ processors:
         field: jamf_protect.telemetry.event.screensharing_detach.source_address
         target_field: source.ip
         ignore_missing: true
+    - script:
+        lang: painless
+        params:
+            itemTypeMap:
+                '0': Unknown
+                '1': IPv4
+                '2': IPv6
+                '3': UNIX Socket
+        source: >
+            if (ctx.jamf_protect?.telemetry?.event?.screensharing_detach?.source_address_type != null) {
+                String itemType = ctx.jamf_protect.telemetry.event.screen?.screensharing_detach.source_address_type.toString();
+                def itemTypeString = params.itemTypeMap.containsKey(itemType) ? params.itemTypeMap[itemType] : 'Unknown';
+                ctx.jamf_protect = ctx.jamf_protect != null ? ctx.jamf_protect : new HashMap();
+                ctx.jamf_protect.telemetry.source_address_type = itemTypeString;
+            }
 ##########################
 ## ECS Process ##
 ##########################

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_object_process.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_object_process.yml
@@ -93,12 +93,12 @@ processors:
         lang: painless
         source: >
             if (ctx.process?.executable != null) {
-            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
-            if (lastSlashIndex != -1) {
-                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
-            } else {
-                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
-            }
+                int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+                if (lastSlashIndex != -1) {
+                    ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+                } else {
+                    ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+                }
             }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_object_process.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_object_process.yml
@@ -89,6 +89,17 @@ processors:
         field: jamf_protect.telemetry.process.executable.path
         target_field: process.executable
         ignore_missing: true
+    - script:
+        lang: painless
+        source: >
+            if (ctx.process?.executable != null) {
+            int lastSlashIndex = ctx.process.executable.lastIndexOf('/');
+            if (lastSlashIndex != -1) {
+                ctx.process.name = ctx.process.executable.substring(lastSlashIndex + 1);
+            } else {
+                ctx.process.name = ctx.process.executable; // Fallback if no slash is found
+            }
+            }
     - rename:
         field: jamf_protect.telemetry.thread.thread_id
         target_field: process.thread.id

--- a/packages/jamf_protect/data_stream/telemetry/sample_event.json
+++ b/packages/jamf_protect/data_stream/telemetry/sample_event.json
@@ -97,7 +97,6 @@
             "XPC_FLAGS=0x0"
         ],
         "executable": "/bin/zsh",
-        "name": "zsh",
         "group_leader": {
             "entity_id": "A7EDC884-C034-50E7-A3AA-2E281B3E0777",
             "pid": 64632,
@@ -112,6 +111,7 @@
             }
         },
         "interactive": false,
+        "name": "zsh",
         "parent": {
             "entity_id": "A7EDC884-C034-50E7-A3AA-2E281B3E0777",
             "pid": 64632,

--- a/packages/jamf_protect/data_stream/telemetry/sample_event.json
+++ b/packages/jamf_protect/data_stream/telemetry/sample_event.json
@@ -97,6 +97,7 @@
             "XPC_FLAGS=0x0"
         ],
         "executable": "/bin/zsh",
+        "name": "zsh",
         "group_leader": {
             "entity_id": "A7EDC884-C034-50E7-A3AA-2E281B3E0777",
             "pid": 64632,

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -414,6 +414,7 @@ An example event for `telemetry` looks as following:
             }
         },
         "interactive": false,
+        "name": "zsh",
         "parent": {
             "entity_id": "A7EDC884-C034-50E7-A3AA-2E281B3E0777",
             "pid": 64632,

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.3.0"
+version: "2.4.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change:
- Enhancement

## Proposed commit message


- Added `process.name` field, this for preparations for Event Visualiser
- Minor enhancements to `od*` pipeline events
  - `pipeline_event_od_group_add` -> added `event.type` field
  - `pipeline_event_od_group_remove` -> added `event.type` field
 - Minor enhancements to `screensharing*` events
    - `pipeline_event_screensharing_attach` added `jamf_protect.telemetry.source_address_type` field
    - `pipeline_event_screensharing_detach` added `jamf_protect.telemetry.source_address_type` field

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
`elastic-package test system`

```
2024/08/19 16:45:26  INFO Write container logs to file: /Users/thijs.xhaflaire/Documents/GitHub/Elastic/integrations/build/container-logs/jamf-protect-webtraffic-http-endpoint-1724078726146769000.log
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬───────────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME     │ RESULT │  TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼───────────────┼────────┼───────────────┤
│ jamf_protect │ alerts             │ system    │ http-endpoint │ PASS   │ 56.502828708s │
│ jamf_protect │ telemetry          │ system    │ http-endpoint │ PASS   │ 52.955471459s │
│ jamf_protect │ telemetry_legacy   │ system    │ http-endpoint │ PASS   │  57.11250125s │
│ jamf_protect │ web_threat_events  │ system    │ http-endpoint │ PASS   │      55.1454s │
│ jamf_protect │ web_traffic_events │ system    │ http-endpoint │ PASS   │ 52.103597834s │
╰──────────────┴────────────────────┴───────────┴───────────────┴────────┴───────────────╯
--- Test results for package: jamf_protect - END   ---
Done
```
