### PR TITLE
[LMD] Remove "scripted_metric" aggregation from the pivot transform

### DIFF
--- a/packages/lmd/changelog.yml
+++ b/packages/lmd/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Remove scripted_metric aggregation from pivot transform
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/9791
+      link: https://github.com/elastic/integrations/pull/10820
 - version: "2.1.3"
   changes:
     - description: Improve package installation documentation

--- a/packages/lmd/changelog.yml
+++ b/packages/lmd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.4"
+  changes:
+    - description: Remove scripted_metric aggregation from pivot transform
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/9791
 - version: "2.1.3"
   changes:
     - description: Improve package installation documentation

--- a/packages/lmd/elasticsearch/transform/pivot_transform/transform.yml
+++ b/packages/lmd/elasticsearch/transform/pivot_transform/transform.yml
@@ -36,33 +36,18 @@ pivot:
     total_length_process_args:
       sum:
         field: process.args_count
-    session:
-      scripted_metric:
-        combine_script: return state.docs
-        init_script: |-
-          state.docs = []
-        map_script: |-
-          Map span = [
-              '@timestamp':doc['@timestamp'].value
-            ];
-            state.docs.add(span)
-        reduce_script: |-
-          def all_docs = [];
-            for (s in states) {
-              for (span in s) {
-                all_docs.add(span);
-              }
-            }
-            all_docs.sort((HashMap o1, HashMap o2)->o1['@timestamp'].toEpochMilli().compareTo(o2['@timestamp'].toEpochMilli()));
-            def size = all_docs.size();
-            def min_time = all_docs[0]['@timestamp'];
-            def max_time = all_docs[size-1]['@timestamp'];
-            def duration = (max_time.toEpochMilli() - min_time.toEpochMilli())/1000;
-            def ret = new HashMap();
-            ret['start_time'] = min_time;
-            ret['complete_time'] = max_time;
-            ret['duration'] = duration;
-            return ret;
+    session.start_time:
+      min:
+        field: '@timestamp'
+    session.complete_time:
+      max:
+        field: '@timestamp'
+    session.duration:
+      bucket_script:
+        buckets_path:
+          start_time: session.start_time.value
+          complete_time: session.complete_time.value
+        script: Math.round((params.complete_time - params.start_time)/1000)
   group_by:
     'host.name':
       terms:

--- a/packages/lmd/elasticsearch/transform/pivot_transform/transform.yml
+++ b/packages/lmd/elasticsearch/transform/pivot_transform/transform.yml
@@ -73,5 +73,5 @@ sync:
     delay: 60s
     field: '@timestamp'
 _meta:
-  fleet_transform_version: 2.1.2
+  fleet_transform_version: 2.1.4
   run_as_kibana_system: false

--- a/packages/lmd/manifest.yml
+++ b/packages/lmd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: lmd
 title: "Lateral Movement Detection"
-version: 2.1.3
+version: 2.1.4
 source:
   license: "Elastic-2.0"
 description: "ML package to detect lateral movement based on file transfer activity and Windows RDP events."


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->
The "scripted_metric" aggregation is being deprecated in Serverless as it was causing OOM errors. As a result, we're removing this aggregation from the LMD pivot transform and replacing it with alternatives like min, max, and bucket_script.
## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- Tested the pivot transform after replacing the `scripted_metric` with `min`, `max`, and `bucket_script`, and it’s producing the same results as before after comparison. A screenshot showing this is included in the comments.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
