### PR TITLE
microsoft_defender_cloud: Store eventhub metdata inside azure-eventhub field.

### DIFF
--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.0"
+  changes:
+    - description: Store eventhub metdata inside azure-eventhub field.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Store eventhub metdata inside azure-eventhub field.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/10821
 - version: "1.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/microsoft_defender_cloud/changelog.yml
+++ b/packages/microsoft_defender_cloud/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.0.0"
   changes:
-    - description: Store eventhub metdata inside azure-eventhub field.
+    - description: Store eventhub metadata inside azure-eventhub field.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10821
 - version: "1.2.0"

--- a/packages/microsoft_defender_cloud/data_stream/event/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/microsoft_defender_cloud/data_stream/event/elasticsearch/ingest_pipeline/default.yml
@@ -5,6 +5,11 @@ processors:
       field: ecs.version
       value: 8.11.0
       tag: set_ecs_version
+  - rename:
+      field: azure
+      target_field: azure-eventhub
+      ignore_missing: true
+      tag: rename_azure
   - set:
       field: event.kind
       value: alert

--- a/packages/microsoft_defender_cloud/manifest.yml
+++ b/packages/microsoft_defender_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: microsoft_defender_cloud
 title: Microsoft Defender for Cloud
-version: "1.2.0"
+version: "2.0.0"
 description: Collect logs from Microsoft Defender for Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Store eventhub metdata inside `azure-eventhub` field instead of `azure`.

In `microsoft_defender_cloud `, the field `azure.eventhub` comes from `Azure EventHub` 
input and is mapped as `keyword`. But `Azure` integration's `eventhub` datastream 
uses `azure.eventhub` field as an object to store custom fields. This is a design decision 
for most integrations to map custom fields into `package.datastream`. This causes conflict 
when users setup both `microsoft_defender_cloud.event` and `azure.eventhub` datastreams. 
Most `Azure` datastreams rename the top level `azure` field coming from the input into 
`azure-eventhub`, which stores the metadata for eventhub. To avoid conflict in similar way, 
`microsoft_defender_cloud ` also need to rename `azure` to `azure-eventhub`.

NOTE: Bumping major version since it is a breaking change.

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/elastic/beats/issues/40561
