### PR TITLE
[CI] Show always junit reports/annotation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,6 +84,7 @@ steps:
           artifacts: "build/test-results/*.xml"
           failed-download-exit-code: 0 # Not fail the build in case there are no XML files
           report-skipped: true
+          always-annotate: true
     agents:
       provider: "gcp"  # junit plugin requires docker
 


### PR DESCRIPTION
## Proposed commit message

Show always the annotation related to JUnit reports.
This would help to show always the skipped tests.


## Screenshots
- Build: https://buildkite.com/elastic/integrations/builds/14778

![example showing always annotation](https://github.com/user-attachments/assets/4d5436e0-17ce-4c56-8a9e-0e6ed2a8c972)
