### PR TITLE
Add back custom.yml files to LotL, DGA packages

### DIFF
--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.0.4"
+  changes:
+    - description: Add custom.yml for integration package testing
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10823
 - version: "2.0.3"
   changes:
     - description: Add mapping instructions

--- a/packages/dga/changelog.yml
+++ b/packages/dga/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.0.4"
   changes:
-    - description: Add custom.yml for integration package testing
+    - description: Add fields for integration package testing
       type: bugfix
       link: https://github.com/elastic/integrations/pull/10823
 - version: "2.0.3"

--- a/packages/dga/fields/base-fields.yml
+++ b/packages/dga/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/dga/fields/custom.yml
+++ b/packages/dga/fields/custom.yml
@@ -1,0 +1,4 @@
+- name: ml_is_dga.malicious_prediction
+  type: long
+- name: ml_is_dga.malicious_probability
+  type: float

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 2.2.0
 name: dga
 title: "Domain Generation Algorithm Detection"
-version: 2.0.3
+version: 2.0.4
 source:
   license: "Elastic-2.0"
 description: "ML solution package to detect domain generation algorithm (DGA) activity in your network data."

--- a/packages/problemchild/changelog.yml
+++ b/packages/problemchild/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.1.5"
   changes:
-    - description: Add custom.yml for integration package testing
+    - description: Add fields for integration package testing
       type: bugfix
       link: https://github.com/elastic/integrations/pull/10823
 - version: "2.1.4"

--- a/packages/problemchild/changelog.yml
+++ b/packages/problemchild/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.1.5"
+  changes:
+    - description: Add custom.yml for integration package testing
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10823
 - version: "2.1.4"
   changes:
     - description: Add mapping instructions

--- a/packages/problemchild/fields/base-fields.yml
+++ b/packages/problemchild/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.

--- a/packages/problemchild/fields/custom.yml
+++ b/packages/problemchild/fields/custom.yml
@@ -1,0 +1,6 @@
+- name: problemchild.prediction
+  type: long
+- name: problemchild.prediction_probability
+  type: float
+- name: blocklist_label
+  type: long

--- a/packages/problemchild/manifest.yml
+++ b/packages/problemchild/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: problemchild
 title: "Living off the Land Attack Detection"
-version: 2.1.4
+version: 2.1.5
 source:
   license: "Elastic-2.0"
 description: "ML solution package to detect Living off the Land (LotL) attacks in your environment. Requires a Platinum subscription."


### PR DESCRIPTION
## Proposed commit message

Adds `fields/custom.yml` files back to the DGA and Living off the Land (ProblemChild) integration packages. These files are used for integration testing done upstream.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] ~~I have verified that all data streams collect metrics or logs.~~ Not needed
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

- [x] Test with `elastic-package`

## How to test this PR locally

Build with `elastic-package`.

## Related issues

- https://github.com/elastic/security-ml/issues/474
