### PR TITLE
Update owner for Team:Security-Applied ML packages

### DIFF
--- a/packages/beaconing/manifest.yml
+++ b/packages/beaconing/manifest.yml
@@ -22,5 +22,5 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/ml-ui
+  github: elastic/sec-applied-ml
   type: elastic

--- a/packages/ded/manifest.yml
+++ b/packages/ded/manifest.yml
@@ -32,5 +32,5 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/ml-ui
+  github: elastic/sec-applied-ml
   type: elastic

--- a/packages/dga/manifest.yml
+++ b/packages/dga/manifest.yml
@@ -25,4 +25,4 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/ml-ui
+  github: elastic/sec-applied-ml

--- a/packages/lmd/manifest.yml
+++ b/packages/lmd/manifest.yml
@@ -27,5 +27,5 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/ml-ui
+  github: elastic/sec-applied-ml
   type: elastic

--- a/packages/problemchild/manifest.yml
+++ b/packages/problemchild/manifest.yml
@@ -27,5 +27,5 @@ icons:
     size: 32x32
     type: image/svg+xml
 owner:
-  github: elastic/ml-ui
+  github: elastic/sec-applied-ml
   type: elastic


### PR DESCRIPTION
## Proposed commit message

The maintainer of these packages is the elastic/sec-applied-ml team. The elastic/ml-ui team maintains the ML platform, and helps review changes to these packages, but the maintainer and owner is the security protections applied ML team.

No changelog is being added because this change does not affect users.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10354
