### PR TITLE
crowdstrike: Return empty events array when no resources in alert, host.

### DIFF
--- a/packages/crowdstrike/_dev/deploy/docker/files/config-alert.yml
+++ b/packages/crowdstrike/_dev/deploy/docker/files/config-alert.yml
@@ -19,7 +19,7 @@ rules:
           Content-Type:
             - application/json
         body: |
-          {"meta":{"query_time":0.017724698,"pagination":{"offset":0,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"a21557a2-abd0-4363-9293-727c38084b3b"},"resources":["abc"]}
+          {"meta":{"query_time":0.017724698,"pagination":{"offset":0,"limit":1,"total":3},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"a21557a2-abd0-4363-9293-727c38084b3b"},"resources":["abc"]}
   - path: /alerts/queries/alerts/v2
     methods: ['GET']
     query_params:
@@ -31,7 +31,19 @@ rules:
           Content-Type:
             - application/json
         body: |
-          {"meta":{"query_time":0.017734699,"pagination":{"offset":1,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"cc557a2-aad0-4364-9293-727c38084n3b"},"resources":["def"]}
+          {"meta":{"query_time":0.017734699,"pagination":{"offset":1,"limit":1,"total":3},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"cc557a2-aad0-4364-9293-727c38084n3b"},"resources":["def"]}
+  - path: /alerts/queries/alerts/v2
+    methods: ['GET']
+    query_params:
+      offset: 2
+      limit: 1
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |
+          {"meta":{"query_time":0.017733700,"pagination":{"offset":2,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"cd657a2-aad0-4364-9293-727c38084f3c"},"resources":[]}
   - path: /alerts/entities/alerts/v2
     methods: ['POST']
     request_body: /.*"abc"*/

--- a/packages/crowdstrike/_dev/deploy/docker/files/config-host.yml
+++ b/packages/crowdstrike/_dev/deploy/docker/files/config-host.yml
@@ -19,7 +19,7 @@ rules:
           Content-Type:
             - application/json
         body: |
-          {"meta":{"query_time":0.017724698,"pagination":{"offset":0,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"a21557a2-abd0-4363-9293-727c38084b3b"},"resources":["abc"]}
+          {"meta":{"query_time":0.017724698,"pagination":{"offset":0,"limit":1,"total":3},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"a21557a2-abd0-4363-9293-727c38084b3b"},"resources":["abc"]}
   - path: /devices/queries/devices/v1
     methods: ['GET']
     query_params:
@@ -31,7 +31,19 @@ rules:
           Content-Type:
             - application/json
         body: |
-          {"meta":{"query_time":0.017724698,"pagination":{"offset":1,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"b21557a2-abd0-4363-9293-727c384b3b"},"resources":["def"]}
+          {"meta":{"query_time":0.017724698,"pagination":{"offset":1,"limit":1,"total":3},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"b21557a2-abd0-4363-9293-727c384b3b"},"resources":["def"]}
+  - path: /devices/queries/devices/v1
+    methods: ['GET']
+    query_params:
+      offset: 2
+      limit: 1
+    responses:
+      - status_code: 200
+        headers:
+          Content-Type:
+            - application/json
+        body: |
+          {"meta":{"query_time":0.017725698,"pagination":{"offset":2,"limit":1,"total":2},"writes":{"resources_affected":0},"powered_by":"detectsapi","trace_id":"a31557a2-abd0-4363-9293-727c384b3b"},"resources":[]}
   - path: /devices/entities/devices/v2
     methods: ['POST']
     request_body: /.*"abc"*/

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.39.1"
+  changes:
+    - description: Return empty `events` array when no resources in alert, host.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.39.0"
   changes:
     - description: Improve document deduplication behavior.

--- a/packages/crowdstrike/changelog.yml
+++ b/packages/crowdstrike/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Return empty `events` array when no resources in alert, host.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/10831
 - version: "1.39.0"
   changes:
     - description: Improve document deduplication behavior.

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -75,7 +75,7 @@ program: |
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
+    !has(state.resources) ? {"events": []} : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url.trim_right("/") + "/alerts/entities/alerts/v2",
         "application/json",

--- a/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/alert/agent/stream/cel.yml.hbs
@@ -51,6 +51,7 @@ program: |
     ).do_request().as(get_resp, get_resp.StatusCode == 200 ?
       bytes(get_resp.Body).decode_json().as(body, {
         ?"resources": has(body.resources) && body.resources.size() > 0 ? optional.of(body.resources) : optional.none(),
+        "events": [],
         "want_more": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total),
         "offset": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total) ?
           int(state.offset) + body.resources.size()
@@ -75,7 +76,7 @@ program: |
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? {"events": []} : // Exit early due to GET failure or no resources to collect.
+    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url.trim_right("/") + "/alerts/entities/alerts/v2",
         "application/json",

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -75,7 +75,7 @@ program: |
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
+    !has(state.resources) ? {"events": []} : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url + "/devices/entities/devices/v2",
         "application/json",

--- a/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
+++ b/packages/crowdstrike/data_stream/host/agent/stream/cel.yml.hbs
@@ -51,6 +51,7 @@ program: |
     ).do_request().as(get_resp, get_resp.StatusCode == 200 ?
       bytes(get_resp.Body).decode_json().as(body, {
         ?"resources": has(body.resources) && body.resources.size() > 0 ? optional.of(body.resources) : optional.none(),
+        "events": [],
         "want_more": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total),
         "offset": ((int(state.offset) + body.resources.size()) < body.meta.pagination.total) ?
           int(state.offset) + body.resources.size()
@@ -75,7 +76,7 @@ program: |
       }
     )
   ).as(state, state.with(
-    !has(state.resources) ? {"events": []} : // Exit early due to GET failure or no resources to collect.
+    !has(state.resources) ? state : // Exit early due to GET failure or no resources to collect.
       post_request(
         state.url + "/devices/entities/devices/v2",
         "application/json",

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.39.0"
+version: "1.39.1"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message
Return empty `events` array when no `resources` in `alert` and `host` data-streams.

When there are no `resources` in first API call, current CEL code returns `state`.
But this `state` doesn't have `events` inside it. As per [CEL docs](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#input-state-cel:~:text=The%20events%20field%20must%20be%20present), the `events` field 
is necessary. Without this, the following errors appear and lead to restarting of input.

```
{"log.level":"error","@timestamp":"2024-08-21T06:26:37.252Z","message":"unexpected missing events array from evaluation","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"input_source":"http://svc-crowdstrike-host:8090","input_url":"http://svc-crowdstrike-host:8090","ecs.version":"1.6.0","log.logger":"input.cel","log.origin":{"file.line":350,"file.name":"cel/input.go","function":"github.com/elastic/beats/v7/x-pack/filebeat/input/cel.input.run.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-08-21T06:26:37.252Z","message":"unregistering","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"input_type":"cel","key":"cel-crowdstrike_host-20697e27-0353-4b36-8c17-18f5ea89ae90::http://svc-crowdstrike-host:8090","ecs.version":"1.6.0","log.logger":"metric_registry","log.origin":{"file.line":70,"file.name":"inputmon/input.go","function":"github.com/elastic/beats/v7/libbeat/monitoring/inputmon.NewInputRegistry.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90::http://svc-crowdstrike-host:8090","uuid":"4ee4a37e-1dde-445d-9f17-2429c435d848","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2024-08-21T06:26:37.252Z","message":"Input 'cel' failed with: input.go:130: input cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90 failed (id=cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90)\n\tunexpected type returned for evaluation events: <nil>","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"log.logger":"input.cel","log.origin":{"file.line":132,"file.name":"compat/compat.go","function":"github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90","ecs.version":"1.6.0","ecs.version":"1.6.0"}
```
 
<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
By modifying `"resources": []` in the `config-alert.yml` and `config-host.yml`:

**Before:** (example with `host`)
`eval "$(elastic-package stack shellinit)" && elastic-package test system --generate  -v --data-streams=host`
```
{"log.level":"error","@timestamp":"2024-08-21T06:26:37.252Z","message":"unexpected missing events array from evaluation","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"input_source":"http://svc-crowdstrike-host:8090","input_url":"http://svc-crowdstrike-host:8090","ecs.version":"1.6.0","log.logger":"input.cel","log.origin":{"file.line":350,"file.name":"cel/input.go","function":"github.com/elastic/beats/v7/x-pack/filebeat/input/cel.input.run.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2024-08-21T06:26:37.252Z","message":"unregistering","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"input_type":"cel","key":"cel-crowdstrike_host-20697e27-0353-4b36-8c17-18f5ea89ae90::http://svc-crowdstrike-host:8090","ecs.version":"1.6.0","log.logger":"metric_registry","log.origin":{"file.line":70,"file.name":"inputmon/input.go","function":"github.com/elastic/beats/v7/libbeat/monitoring/inputmon.NewInputRegistry.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90::http://svc-crowdstrike-host:8090","uuid":"4ee4a37e-1dde-445d-9f17-2429c435d848","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2024-08-21T06:26:37.252Z","message":"Input 'cel' failed with: input.go:130: input cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90 failed (id=cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90)\n\tunexpected type returned for evaluation events: <nil>","component":{"binary":"filebeat","dataset":"elastic_agent.filebeat","id":"cel-default","type":"cel"},"log":{"source":"cel-default"},"log.logger":"input.cel","log.origin":{"file.line":132,"file.name":"compat/compat.go","function":"github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start.func1"},"service.name":"filebeat","id":"cel-crowdstrike.host-20697e27-0353-4b36-8c17-18f5ea89ae90","ecs.version":"1.6.0","ecs.version":"1.6.0"}
```

**After:**
No error messages in agent logs.

`eval "$(elastic-package stack shellinit)" && elastic-package test system --generate  -v --data-streams=host,alert`

```
--- Test results for package: crowdstrike - START ---
╭─────────────┬─────────────┬───────────┬───────────┬────────┬───────────────╮
│ PACKAGE     │ DATA STREAM │ TEST TYPE │ TEST NAME │ RESULT │  TIME ELAPSED │
├─────────────┼─────────────┼───────────┼───────────┼────────┼───────────────┤
│ crowdstrike │ alert       │ system    │ common    │ PASS   │ 37.831208584s │
│ crowdstrike │ host        │ system    │ common    │ PASS   │ 36.294177167s │
╰─────────────┴─────────────┴───────────┴───────────┴────────┴───────────────╯
--- Test results for package: crowdstrike - END   ---
Done
```

