### PR TITLE
[Crowdstrike] Fix handling of event.created and timestamp fields for FDR events

### DIFF
--- a/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
+++ b/packages/crowdstrike/data_stream/fdr/_dev/test/pipeline/test-fdr.log-expected.json
@@ -1,9 +1,10 @@
 {
     "expected": [
         {
-            "@timestamp": "2021-07-07T17:05:21.137Z",
+            "@timestamp": "2021-07-07T17:05:21.162Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:05:21.137Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "RGID": "501",
@@ -99,11 +100,12 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:23.068Z",
+            "@timestamp": "2021-07-07T17:05:24.102Z",
             "crowdstrike": {
                 "AsepWrittenCount": 0,
                 "ConfigStateHash": "3090255842",
                 "ContextProcessId": "365053603452626914",
+                "ContextTimeStamp": "2021-07-07T17:05:23.068Z",
                 "DirectoryCreatedCount": 0,
                 "DnsRequestCount": 0,
                 "EffectiveTransmissionClass": "3",
@@ -188,10 +190,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:48.594Z",
+            "@timestamp": "2021-07-07T17:04:48.615Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:04:48.594Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -575,10 +578,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:04.982Z",
+            "@timestamp": "2021-07-07T17:05:05.511Z",
             "crowdstrike": {
                 "ConfigStateHash": "1701000200",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:04.982Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -681,10 +685,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:21.866Z",
+            "@timestamp": "2021-07-07T17:05:22.009Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:21.866Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -785,10 +790,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:23.901Z",
+            "@timestamp": "2021-07-07T17:05:24.048Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:23.901Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -987,10 +993,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:03.713Z",
+            "@timestamp": "2021-07-07T17:05:03.947Z",
             "crowdstrike": {
                 "ConfigStateHash": "1701000200",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:03.713Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -1079,9 +1086,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:20.973Z",
+            "@timestamp": "2021-07-07T17:05:21.081Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:05:20.973Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -1159,10 +1167,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:30.308Z",
+            "@timestamp": "2021-07-07T17:05:30.841Z",
             "crowdstrike": {
                 "ConfigStateHash": "3469235958",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:30.308Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -1561,9 +1570,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:28.570Z",
+            "@timestamp": "2021-07-07T17:05:28.717Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:05:28.570Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -1642,10 +1652,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:12.700Z",
+            "@timestamp": "2021-07-07T17:05:12.892Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:12.700Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -1746,9 +1757,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:35.806Z",
+            "@timestamp": "2021-07-07T17:04:36.111Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:04:35.806Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -1829,9 +1841,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:04.770Z",
+            "@timestamp": "2021-07-07T17:05:40.055Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:05:04.770Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -1996,9 +2009,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:59.994Z",
+            "@timestamp": "2021-07-07T17:05:00.089Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:04:59.994Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "Flags": "0",
@@ -2084,10 +2098,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:17.658Z",
+            "@timestamp": "2021-07-07T17:05:17.986Z",
             "crowdstrike": {
                 "ConfigStateHash": "1479784503",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:17.658Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -2201,9 +2216,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:56.750Z",
+            "@timestamp": "2021-07-07T17:04:56.804Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:04:56.750Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "VolumeAppearanceTime": "1625677422.647",
@@ -2580,10 +2596,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:07.037Z",
+            "@timestamp": "2021-07-07T17:05:07.086Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:05:07.037Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -2671,9 +2688,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:36.729Z",
+            "@timestamp": "2021-07-07T17:05:36.784Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:05:36.729Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -2750,9 +2768,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:04.542Z",
+            "@timestamp": "2021-07-07T17:05:04.614Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:05:04.542Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -2823,9 +2842,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T01:52:50.595Z",
+            "@timestamp": "2021-07-07T17:04:40.056Z",
             "crowdstrike": {
                 "ConfigStateHash": "3967242894",
+                "ContextTimeStamp": "2021-07-07T01:52:50.595Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "IOServiceClass": "IOUSBDevice:IOUSBNub:IOService:IORegistryEntry:OSObject",
@@ -2893,9 +2913,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T01:50:02.031Z",
+            "@timestamp": "2021-07-07T17:04:38.739Z",
             "crowdstrike": {
                 "ConfigStateHash": "3967242894",
+                "ContextTimeStamp": "2021-07-07T01:50:02.031Z",
                 "DeviceId": "251658248",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
@@ -3059,10 +3080,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:34.875Z",
+            "@timestamp": "2021-07-07T17:04:35.413Z",
             "crowdstrike": {
                 "ConfigStateHash": "1701000200",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:04:34.875Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -3224,9 +3246,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:53.531Z",
+            "@timestamp": "2021-07-07T17:04:53.756Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:04:53.531Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "RequestType": "1",
@@ -3467,10 +3490,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:09.064Z",
+            "@timestamp": "2021-07-07T17:05:09.069Z",
             "crowdstrike": {
                 "BundleID": "com.apple.driver.AudioAUUC",
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:05:09.064Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -3844,9 +3868,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:24.929Z",
+            "@timestamp": "2021-07-07T17:05:25.128Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:05:24.929Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -3945,9 +3970,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:48.523Z",
+            "@timestamp": "2021-07-07T17:04:48.576Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:04:48.523Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -4099,9 +4125,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T01:50:11.845Z",
+            "@timestamp": "2021-07-07T17:04:39.336Z",
             "crowdstrike": {
                 "ConfigStateHash": "3967242894",
+                "ContextTimeStamp": "2021-07-07T01:50:11.845Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "MachOSubType": "3",
@@ -4186,10 +4213,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T01:50:08.014Z",
+            "@timestamp": "2021-07-07T17:04:38.929Z",
             "crowdstrike": {
                 "ConfigStateHash": "3967242894",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T01:50:08.014Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -4466,9 +4494,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:33.027Z",
+            "@timestamp": "2021-07-07T17:05:33.060Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:05:33.027Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "VnodeModificationType": "0",
@@ -4914,9 +4943,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:14.557Z",
+            "@timestamp": "2021-07-07T17:04:14.723Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:04:14.557Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -4995,7 +5025,7 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:05.731Z",
+            "@timestamp": "2021-07-07T17:04:20.451Z",
             "crowdstrike": {
                 "AgentLoadFlags": "0",
                 "AgentLocalTime": "2021-07-07T17:04:05.731Z",
@@ -5010,6 +5040,7 @@
                 "ConfigIDPlatform": "4",
                 "ConfigStateHash": "3967242894",
                 "ConfigurationVersion": "10",
+                "ContextTimeStamp": "2021-07-07T17:04:05.731Z",
                 "CpuFeaturesMask": "7494065083858915",
                 "CpuSignature": "591594",
                 "CpuVendor": "0",
@@ -5098,9 +5129,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:03:58.515Z",
+            "@timestamp": "2021-07-07T17:03:58.553Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:03:58.515Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "UnixMode": "384",
@@ -5427,9 +5459,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:02:33.633Z",
+            "@timestamp": "2021-07-07T17:02:33.895Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:02:33.633Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -5675,9 +5708,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:42.148Z",
+            "@timestamp": "2021-07-07T17:04:42.403Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:04:42.148Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "VnodeModificationType": "6",
@@ -5756,10 +5790,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:10.959Z",
+            "@timestamp": "2021-07-07T17:05:11.067Z",
             "crowdstrike": {
                 "ConfigStateHash": "1284133626",
                 "ContextProcessId": "130732827553316",
+                "ContextTimeStamp": "2021-07-07T17:05:10.959Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "cid": "ffffffff15754bcfb5f9152ec7ac90ac",
@@ -5899,9 +5934,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:02:12.283Z",
+            "@timestamp": "2021-07-07T17:02:14.451Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:02:12.283Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "VolumeIsNetwork": "0",
@@ -5970,10 +6006,11 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:04:34.525Z",
+            "@timestamp": "2021-07-07T17:04:34.879Z",
             "crowdstrike": {
                 "ConfigStateHash": "2300098580",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2021-07-07T17:04:34.525Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -6061,9 +6098,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:05:26.828Z",
+            "@timestamp": "2021-07-07T17:05:27.114Z",
             "crowdstrike": {
                 "ConfigStateHash": "1620585913",
+                "ContextTimeStamp": "2021-07-07T17:05:26.828Z",
                 "ELFSubType": "4",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
@@ -6224,9 +6262,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:03:59.099Z",
+            "@timestamp": "2021-07-07T17:03:59.398Z",
             "crowdstrike": {
                 "ConfigStateHash": "3090255842",
+                "ContextTimeStamp": "2021-07-07T17:03:59.099Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "USN": "89566685",
@@ -6386,9 +6425,10 @@
             }
         },
         {
-            "@timestamp": "2021-07-07T17:03:02.785Z",
+            "@timestamp": "2021-07-07T17:03:03.057Z",
             "crowdstrike": {
                 "ConfigStateHash": "1325353086",
+                "ContextTimeStamp": "2021-07-07T17:03:02.785Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "IsOnRemovableDisk": "0",
@@ -6833,11 +6873,12 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:04:56.730Z",
+            "@timestamp": "2020-11-08T17:04:59.646Z",
             "crowdstrike": {
                 "AsepWrittenCount": 0,
                 "ConfigStateHash": "1789338890",
                 "ContextProcessId": "317713210176499254",
+                "ContextTimeStamp": "2020-11-08T17:04:56.730Z",
                 "DirectoryCreatedCount": 0,
                 "DnsRequestCount": 0,
                 "Entitlements": "15",
@@ -6925,7 +6966,7 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:04:57.926Z",
+            "@timestamp": "2020-11-08T17:04:59.935Z",
             "crowdstrike": {
                 "AllocateVirtualMemoryCount": 0,
                 "ArchiveFileWrittenCount": 0,
@@ -6936,6 +6977,7 @@
                 "ConHostProcessId": "3099352216141",
                 "ConfigStateHash": "3343111420",
                 "ContextProcessId": "3100508103359",
+                "ContextTimeStamp": "2020-11-08T17:04:57.926Z",
                 "CreateProcessCount": 0,
                 "CycleTime": 2937514388,
                 "DirectoryCreatedCount": 0,
@@ -7066,11 +7108,12 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:01.341Z",
+            "@timestamp": "2020-11-08T17:05:00.139Z",
             "crowdstrike": {
                 "AsepWrittenCount": 0,
                 "ConfigStateHash": "3344040805",
                 "ContextProcessId": "311775981885093125",
+                "ContextTimeStamp": "2020-11-08T17:05:01.341Z",
                 "DirectoryCreatedCount": 0,
                 "DnsRequestCount": 0,
                 "Entitlements": "15",
@@ -7269,9 +7312,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:04:55.961Z",
+            "@timestamp": "2020-11-08T17:04:59.913Z",
             "crowdstrike": {
                 "ConfigStateHash": "2784638081",
+                "ContextTimeStamp": "2020-11-08T17:04:55.961Z",
                 "DnsRequestCount": 1,
                 "DualRequest": "0",
                 "EffectiveTransmissionClass": "3",
@@ -7351,9 +7395,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:01.645Z",
+            "@timestamp": "2020-11-08T17:05:02.247Z",
             "crowdstrike": {
                 "ConfigStateHash": "4288861242",
+                "ContextTimeStamp": "2020-11-08T17:05:01.645Z",
                 "Entitlements": "15",
                 "UnixMode": "32768",
                 "cid": "ffffffff30a3407dae27d0503611022d",
@@ -7546,9 +7591,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:14.133Z",
+            "@timestamp": "2020-11-08T17:05:14.427Z",
             "crowdstrike": {
                 "ConfigStateHash": "3899738370",
+                "ContextTimeStamp": "2020-11-08T17:05:14.133Z",
                 "DesiredAccess": "1180054",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
@@ -7638,10 +7684,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:16.421Z",
+            "@timestamp": "2020-11-08T17:05:16.502Z",
             "crowdstrike": {
                 "ConfigStateHash": "1306766522",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:05:16.421Z",
                 "Entitlements": "15",
                 "InContext": "0",
                 "LocalAddressIP4": [
@@ -7742,10 +7789,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:16.849Z",
+            "@timestamp": "2020-11-08T17:05:16.942Z",
             "crowdstrike": {
                 "ConfigStateHash": "2602391615",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:05:16.849Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -7859,11 +7907,12 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:04:51.781Z",
+            "@timestamp": "2020-11-08T17:05:21.077Z",
             "crowdstrike": {
                 "AuthenticationId": "6580764513",
                 "AuthenticationPackage": "Negotiate",
                 "ConfigStateHash": "3011122681",
+                "ContextTimeStamp": "2020-11-08T17:04:51.781Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "LogonDomain": "NT AUTHORITY",
@@ -7951,10 +8000,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:20.785Z",
+            "@timestamp": "2020-11-08T17:05:21.109Z",
             "crowdstrike": {
                 "AuthenticationId": "2007206396",
                 "ConfigStateHash": "3011122681",
+                "ContextTimeStamp": "2020-11-08T17:05:20.785Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileEcpBitmask": "0",
@@ -8142,9 +8192,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:03:45.966Z",
+            "@timestamp": "2020-11-08T17:05:49.643Z",
             "crowdstrike": {
                 "ConfigStateHash": "537307300",
+                "ContextTimeStamp": "2020-11-08T17:03:45.966Z",
                 "DesiredAccess": "1180054",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
@@ -8234,10 +8285,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:50.066Z",
+            "@timestamp": "2020-11-08T17:05:50.545Z",
             "crowdstrike": {
                 "ConfigStateHash": "3765958535",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:05:50.066Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -8329,10 +8381,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:52.993Z",
+            "@timestamp": "2020-11-08T17:05:54.274Z",
             "crowdstrike": {
                 "ClientComputerName": "com1",
                 "ConfigStateHash": "3011122681",
+                "ContextTimeStamp": "2020-11-08T17:05:52.993Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "EtwRawThreadId": 5304,
@@ -8435,9 +8488,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:51.534Z",
+            "@timestamp": "2020-11-08T17:05:54.670Z",
             "crowdstrike": {
                 "ConfigStateHash": "3343111420",
+                "ContextTimeStamp": "2020-11-08T17:05:51.534Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileObject": "18446636884348143072",
@@ -8521,11 +8575,12 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:35.209Z",
+            "@timestamp": "2020-11-08T17:06:00.047Z",
             "crowdstrike": {
                 "AsepWrittenCount": 0,
                 "ConfigStateHash": "230795414",
                 "ContextProcessId": "318137549555284836",
+                "ContextTimeStamp": "2020-11-08T17:05:35.209Z",
                 "DirectoryCreatedCount": 0,
                 "DnsRequestCount": 0,
                 "Entitlements": "15",
@@ -8613,10 +8668,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:11.731Z",
+            "@timestamp": "2020-11-08T17:06:13.077Z",
             "crowdstrike": {
                 "ApiReturnValue": "1",
                 "ConfigStateHash": "3338885535",
+                "ContextTimeStamp": "2020-11-08T17:06:11.731Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "cid": "ffffffff30a3407dae27d0503611022d",
@@ -8776,9 +8832,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:46.590Z",
+            "@timestamp": "2020-11-08T17:06:17.513Z",
             "crowdstrike": {
                 "ConfigStateHash": "1763245019",
+                "ContextTimeStamp": "2020-11-08T17:05:46.590Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileObject": "18446622606546437424",
@@ -8864,9 +8921,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:05.213Z",
+            "@timestamp": "2020-11-08T17:06:20.332Z",
             "crowdstrike": {
                 "ConfigStateHash": "402097454",
+                "ContextTimeStamp": "2020-11-08T17:06:05.213Z",
                 "DesiredAccess": "1048577",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
@@ -8955,10 +9013,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:36.468Z",
+            "@timestamp": "2020-11-08T17:06:36.635Z",
             "crowdstrike": {
                 "AuthenticationId": "999",
                 "ConfigStateHash": "3343111420",
+                "ContextTimeStamp": "2020-11-08T17:06:36.468Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
@@ -9052,10 +9111,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:40.751Z",
+            "@timestamp": "2020-11-08T17:06:40.836Z",
             "crowdstrike": {
                 "ConfigStateHash": "203564169",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:06:40.751Z",
                 "Entitlements": "15",
                 "InContext": "0",
                 "LocalAddressIP6": [
@@ -9369,9 +9429,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T09:58:32.519Z",
+            "@timestamp": "2020-11-08T17:07:22.091Z",
             "crowdstrike": {
                 "ConfigStateHash": "1763245019",
+                "ContextTimeStamp": "2020-11-08T09:58:32.519Z",
                 "DesiredAccess": "1179785",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
@@ -9461,7 +9522,7 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:07:54.377Z",
+            "@timestamp": "2020-11-08T17:07:56.657Z",
             "crowdstrike": {
                 "AllocateVirtualMemoryCount": 0,
                 "ArchiveFileWrittenCount": 0,
@@ -9472,6 +9533,7 @@
                 "ConHostProcessId": "1731198143955",
                 "ConfigStateHash": "2030177841",
                 "ContextProcessId": "1741732942772",
+                "ContextTimeStamp": "2020-11-08T17:07:54.377Z",
                 "CycleTime": 473618996,
                 "DirectoryCreatedCount": 0,
                 "DirectoryEnumeratedCount": 0,
@@ -9601,10 +9663,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:08:37.892Z",
+            "@timestamp": "2020-11-08T17:08:49.571Z",
             "crowdstrike": {
                 "AuthenticationId": "895027",
                 "ConfigStateHash": "3338885535",
+                "ContextTimeStamp": "2020-11-08T17:08:37.892Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileEcpBitmask": "0",
@@ -9693,10 +9756,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:09:11.158Z",
+            "@timestamp": "2020-11-08T17:09:11.798Z",
             "crowdstrike": {
                 "ConfigStateHash": "3765958535",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:09:11.158Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -9797,9 +9861,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T14:34:30.744Z",
+            "@timestamp": "2020-11-08T17:09:15.495Z",
             "crowdstrike": {
                 "ConfigStateHash": "1457965279",
+                "ContextTimeStamp": "2020-11-08T14:34:30.744Z",
                 "Entitlements": "15",
                 "VnodeModificationType": "10",
                 "cid": "ffffffff30a3407dae27d0503611022d",
@@ -9882,9 +9947,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:31.803Z",
+            "@timestamp": "2020-11-08T17:06:33.422Z",
             "crowdstrike": {
                 "ConfigStateHash": "3011122681",
+                "ContextTimeStamp": "2020-11-08T17:06:31.803Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "UserLogonFlags": "1",
@@ -9963,10 +10029,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:36.669Z",
+            "@timestamp": "2020-11-08T17:06:39.798Z",
             "crowdstrike": {
                 "ConfigStateHash": "1858880895",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:05:36.669Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InContext": "0",
@@ -10074,9 +10141,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T16:42:35.987Z",
+            "@timestamp": "2020-11-08T17:06:53.224Z",
             "crowdstrike": {
                 "ConfigStateHash": "1789338890",
+                "ContextTimeStamp": "2020-11-08T16:42:35.987Z",
                 "Entitlements": "15",
                 "TargetFileName": "/Library/Application Support/JAMF/tmp/6B24D2B6-BC17-4470-8078-91A787A19478",
                 "cid": "ffffffff30a3407dae27d0503611022d",
@@ -10159,10 +10227,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:07:48.323Z",
+            "@timestamp": "2020-11-08T17:07:48.755Z",
             "crowdstrike": {
                 "ConfigStateHash": "203564169",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:07:48.323Z",
                 "Entitlements": "15",
                 "InContext": "0",
                 "LocalAddressIP6": [
@@ -10249,9 +10318,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:08:00.307Z",
+            "@timestamp": "2020-11-08T17:08:43.217Z",
             "crowdstrike": {
                 "ConfigStateHash": "3765958535",
+                "ContextTimeStamp": "2020-11-08T17:08:00.307Z",
                 "DualRequest": "0",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
@@ -10326,8 +10396,9 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:08:35.034Z",
+            "@timestamp": "2020-11-08T17:08:49.102Z",
             "crowdstrike": {
+                "ContextTimeStamp": "2020-11-08T17:08:35.034Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "VolumeDeviceCharacteristics": "131072",
@@ -10410,10 +10481,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:05:27.011Z",
+            "@timestamp": "2020-11-08T17:05:28.936Z",
             "crowdstrike": {
                 "ConfigStateHash": "1789338890",
                 "ConnectionFlags": "0",
+                "ContextTimeStamp": "2020-11-08T17:05:27.011Z",
                 "Entitlements": "15",
                 "InContext": "0",
                 "LocalAddressIP4": [
@@ -10501,10 +10573,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:06:25.108Z",
+            "@timestamp": "2020-11-08T17:06:24.068Z",
             "crowdstrike": {
                 "AuthenticationId": "999",
                 "ConfigStateHash": "3338885535",
+                "ContextTimeStamp": "2020-11-08T17:06:25.108Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "InterfaceGuid": "367ABB81-9844-35F1-AD32-98F038001003",
@@ -10589,9 +10662,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:08:19.018Z",
+            "@timestamp": "2020-11-08T17:08:22.512Z",
             "crowdstrike": {
                 "ConfigStateHash": "3338885535",
+                "ContextTimeStamp": "2020-11-08T17:08:19.018Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "TargetThreadId": "24238019995551",
@@ -10661,10 +10735,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T17:07:07.625Z",
+            "@timestamp": "2020-11-08T17:07:44.313Z",
             "crowdstrike": {
                 "AuthenticationId": "3443175",
                 "ConfigStateHash": "3338885535",
+                "ContextTimeStamp": "2020-11-08T17:07:07.625Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileEcpBitmask": "0",
@@ -11019,10 +11094,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T15:57:10.593Z",
+            "@timestamp": "2020-11-08T15:57:11.298Z",
             "crowdstrike": {
                 "AuthenticationId": "703298",
                 "ConfigStateHash": "2642284486",
+                "ContextTimeStamp": "2020-11-08T15:57:10.593Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileEcpBitmask": "0",
@@ -11110,9 +11186,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T15:54:59.164Z",
+            "@timestamp": "2020-11-08T15:54:59.812Z",
             "crowdstrike": {
                 "ConfigStateHash": "666346415",
+                "ContextTimeStamp": "2020-11-08T15:54:59.164Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "VolumeName": "\\Device\\HarddiskVolume27",
@@ -11184,9 +11261,10 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T15:58:18.548Z",
+            "@timestamp": "2020-11-08T15:57:20.625Z",
             "crowdstrike": {
                 "ConfigStateHash": "3429017943",
+                "ContextTimeStamp": "2020-11-08T15:58:18.548Z",
                 "Entitlements": "15",
                 "cid": "ffffffff30a3407dae27d0503611022d",
                 "name": "FirewallDisabledMacV1"
@@ -11254,7 +11332,7 @@
             }
         },
         {
-            "@timestamp": "2021-11-09T05:47:19.952Z",
+            "@timestamp": "2024-08-23T11:14:24.764121836Z",
             "crowdstrike": {
                 "AgentLoadFlags": "0",
                 "AgentLocalTime": "2021-11-09T05:47:19.952Z",
@@ -11276,7 +11354,6 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2021-11-09T05:47:19.952Z",
                 "original": "{\"AgentLoadFlags\":\"0\",\"AgentLocalTime\":\"1636436839.9529998\",\"AgentTimeOffset\":\"125.319\",\"AgentVersion\":\"6.31.14404.0\",\"BiosManufacturer\":\"Apple Inc.\",\"BiosVersion\":\"1554.140.20.0.0 (iBridge: 18.16.14759.0.1,0)\",\"ChassisType\":\"Laptop\",\"City\":\"San Francisco\",\"ComputerName\":\"mac1\",\"ConfigBuild\":\"1007.4.0014404.1\",\"ConfigIDBuild\":\"14404\",\"Continent\":\"North America\",\"Country\":\"United States\",\"FalconGroupingTags\":\"-\",\"FirstSeen\":\"1625682391.0\",\"HostHiddenStatus\":\"Visible\",\"MachineDomain\":\"none\",\"OU\":\"none\",\"PointerSize\":\"none\",\"ProductType\":\"1\",\"SensorGroupingTags\":\"-\",\"ServicePackMajor\":\"none\",\"SiteName\":\"none\",\"SystemManufacturer\":\"Apple Inc.\",\"SystemProductName\":\"MacBookPro16,2\",\"Time\":\"1636448427.3539999\",\"Timezone\":\"America/Los_Angeles\",\"Version\":\"Big Sur (11.0)\",\"aid\":\"fffffffffffaaaaaaaaabbbbbbbb\",\"aip\":\"67.43.156.14\",\"cid\":\"ffffffff30a3407dae27d0503611022ff\",\"event_platform\":\"Mac\"}"
             },
             "host": {
@@ -11540,9 +11617,10 @@
             }
         },
         {
-            "@timestamp": "2022-12-03T18:43:39.000Z",
+            "@timestamp": "2020-11-08T15:54:59.812Z",
             "crowdstrike": {
                 "ConfigStateHash": "666346415",
+                "ContextTimeStamp": "2022-12-03T18:43:39.000Z",
                 "EffectiveTransmissionClass": "3",
                 "EndTime": "2022-12-03T18:42:00.000Z",
                 "Entitlements": "15",
@@ -11780,10 +11858,11 @@
             }
         },
         {
-            "@timestamp": "2020-11-08T15:57:10.593Z",
+            "@timestamp": "2020-11-08T15:57:11.298Z",
             "crowdstrike": {
                 "AuthenticationId": "703298",
                 "ConfigStateHash": "2642284486",
+                "ContextTimeStamp": "2020-11-08T15:57:10.593Z",
                 "EffectiveTransmissionClass": "3",
                 "Entitlements": "15",
                 "FileEcpBitmask": "0",
@@ -11872,10 +11951,11 @@
             }
         },
         {
-            "@timestamp": "2024-05-07T10:46:39.690Z",
+            "@timestamp": "2024-05-07T10:46:39.943Z",
             "crowdstrike": {
                 "AuthenticationId": "111112312312312321",
                 "ConfigStateHash": "821711964",
+                "ContextTimeStamp": "2024-05-07T10:46:39.690Z",
                 "EffectiveTransmissionClass": "2",
                 "Entitlements": "15",
                 "LogonTime": "2024-05-07T10:46:39.631Z",

--- a/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/crowdstrike/data_stream/fdr/elasticsearch/ingest_pipeline/default.yml
@@ -61,16 +61,6 @@ processors:
       ignore_failure: true
       if: ctx.event?.created == null
   - date:
-      tag: date-agent-local-time
-      description: Parse timestamp from event.
-      field: crowdstrike.AgentLocalTime
-      target_field: event.created
-      formats:
-        - ISO8601
-        - UNIX
-      ignore_failure: true
-      if: ctx.event?.created == null
-  - date:
       tag: date-_time
       description: Parse _time from event.
       field: crowdstrike._time
@@ -84,7 +74,7 @@ processors:
       tag: set-timestamp
       field: "@timestamp"
       copy_from: event.created
-      if: ctx.event?.created != null && (ctx.crowdstrike?.ContextTimeStamp == null || ctx.crowdstrike?.ContextTimeStamp == "")
+      if: ctx.event?.created != null
   - set:
       tag: set-timestamp-ingest
       field: "@timestamp"
@@ -107,13 +97,6 @@ processors:
         if (timestamp > 0x0100000000000000L) { // See https://devblogs.microsoft.com/oldnewthing/20030905-02/?p=42653 for constant.
           ctx.crowdstrike.ContextTimeStamp = (timestamp / 10000000) - 11644473600L;
         }
-  - date:
-      tag: date-context-timestamp
-      if: (ctx.crowdstrike?.ContextTimeStamp != null && ctx.crowdstrike?.ContextTimeStamp != "")
-      field: crowdstrike.ContextTimeStamp
-      formats:
-        - UNIX
-      ignore_failure: true
   - script:
       tag: date-start-timestamp-from-nt
       description: Conditionally convert StartTime from Windows NT timestamp format to UNIX.
@@ -2443,6 +2426,12 @@ processors:
         - UNIX
       if: ctx.crowdstrike?.Time != null && ctx.crowdstrike?.Time != ""
   - date:
+      field: crowdstrike.ContextTimeStamp
+      target_field: crowdstrike.ContextTimeStamp
+      formats:
+        - UNIX
+      if: ctx.crowdstrike?.ContextTimeStamp != null && ctx.crowdstrike?.ContextTimeStamp != ""
+  - date:
       field: crowdstrike.BiosReleaseDate
       target_field: crowdstrike.BiosReleaseDate
       formats:
@@ -2513,7 +2502,6 @@ processors:
         - _temp
         - crowdstrike.timestamp
         - crowdstrike._time
-        - crowdstrike.ContextTimeStamp
         - crowdstrike.CreationTimeStamp
         - crowdstrike.DomainName
         - crowdstrike.ConnectionDirection

--- a/packages/crowdstrike/data_stream/fdr/fields/fields.yml
+++ b/packages/crowdstrike/data_stream/fdr/fields/fields.yml
@@ -57,6 +57,9 @@
       type: keyword
     - name: ContextProcessId
       type: keyword
+    - name: ContextTimeStamp
+      type: date
+      description: System local time of event creation.
     - name: CreateProcessCount
       type: long
     - name: CreateProcessType

--- a/packages/crowdstrike/docs/README.md
+++ b/packages/crowdstrike/docs/README.md
@@ -1104,6 +1104,7 @@ and/or `session_token`.
 | crowdstrike.ConnectType |  | keyword |
 | crowdstrike.ConnectionFlags |  | keyword |
 | crowdstrike.ContextProcessId |  | keyword |
+| crowdstrike.ContextTimeStamp | System local time of event creation. | date |
 | crowdstrike.CpuClockSpeed |  | keyword |
 | crowdstrike.CpuFeaturesMask |  | keyword |
 | crowdstrike.CpuProcessorName |  | keyword |

--- a/packages/crowdstrike/manifest.yml
+++ b/packages/crowdstrike/manifest.yml
@@ -1,6 +1,6 @@
 name: crowdstrike
 title: CrowdStrike
-version: "1.39.2"
+version: "1.39.3"
 description: Collect logs from Crowdstrike with Elastic Agent.
 type: integration
 format_version: "3.0.3"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Recent reports show an issue where some CrowdStrike FDR ingested events seems to happen in the future as `event.ingested` is older than the event `@timestamp`.

The reason of this is the use of local timestamps (non UTC) as the `@timestamp` without taking the timezone into account. In particular:
- `AgentLocalTime` is the local time of the agent that collects the event
- `ContextTimeStamp` is the system time of event creation, which could be used as a timestamp if it were in UTC or came in a format in which the timezone can be extracted instead of coming in UNIX format

On the other hand, the timezone field from the event is in human-readable format (e.g. Europe/Berlin) so there is no an accurate way of calculating the timezone offset and standardise the timestamp.

Said that, this PR removes the use of `AgentLocalTime` and `ContextTimeStamp` as the event timestamp.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
