### PR TITLE
[cisco_asa] Handle "Account has been locked out" reason parsing

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.36.4"
+  changes:
+    - description: Handle "Account has been locked out" reason parsing
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/666666
 - version: "2.36.3"
   changes:
     - description: Parse empty user names in message IDs 113005, 716002, 713049

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log
@@ -162,3 +162,4 @@ May  5 19:02:25 dev01: %ASA-6-716039: Group <malcorp group> User <malory> IP <17
 Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 10.0.0.0, IP = 10.0.0.0, Security negotiation complete for peer (10.0.0.0) Initiator, Inbound SPI = 0x6fdb0644, Outbound SPI = 0x14dde27d
 <166>Jul 12 2024 08:11:50 myAsaHostname : %ASA-6-605004: Login denied from 81.2.69.144/51215 to dmz-1000:81.2.69.145/https for user ""
 <166>Jul 12 2024 08:11:50 myAsaHostname : %ASA-6-113005: AAA user authentication Rejected : reason = Unspecified : server = 10.0.0.70 : user = : user IP = 81.2.69.144
+<190>Aug 08 2024 06:28:26 ciscoasa : %ASA-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 192.168.1.1 : user = ***** : user IP = 81.2.69.144

--- a/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
+++ b/packages/cisco_asa/data_stream/log/_dev/test/pipeline/test-additional-messages.log-expected.json
@@ -11453,6 +11453,90 @@
             "tags": [
                 "preserve_original_event"
             ]
+        },
+        {
+            "@timestamp": "2024-08-08T06:28:26.000Z",
+            "cisco": {
+                "asa": {
+                    "rejection_reason": "Account has been locked out"
+                }
+            },
+            "destination": {
+                "address": "192.168.1.1",
+                "ip": "192.168.1.1"
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "logon-failed",
+                "category": [
+                    "authentication",
+                    "network"
+                ],
+                "code": "113005",
+                "kind": "event",
+                "original": "<190>Aug 08 2024 06:28:26 ciscoasa : %ASA-6-113005: AAA user authentication Rejected : reason = Account has been locked out : server = 192.168.1.1 : user = ***** : user IP = 81.2.69.144",
+                "outcome": "failure",
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "denied",
+                    "info"
+                ]
+            },
+            "host": {
+                "hostname": "ciscoasa"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 23
+                    },
+                    "priority": 190,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "hostname": "ciscoasa",
+                "product": "asa",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "hosts": [
+                    "ciscoasa"
+                ],
+                "ip": [
+                    "81.2.69.144",
+                    "192.168.1.1"
+                ]
+            },
+            "source": {
+                "address": "81.2.69.144",
+                "geo": {
+                    "city_name": "London",
+                    "continent_name": "Europe",
+                    "country_iso_code": "GB",
+                    "country_name": "United Kingdom",
+                    "location": {
+                        "lat": 51.5142,
+                        "lon": -0.0931
+                    },
+                    "region_iso_code": "GB-ENG",
+                    "region_name": "England"
+                },
+                "ip": "81.2.69.144",
+                "user": {
+                    "name": "*****"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
         }
     ]
 }

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -392,7 +392,7 @@ processors:
       - "AAA user %{AUTH} Rejected(%{SPACE})?: reason = %{REASON:_temp_.cisco.rejection_reason}(%{SPACE})?: server = %{IP:destination.address}(%{SPACE})?: user = ?(%{CISCO_USER:source.user.name}|)(%{SPACE})?: user IP = %{IPORNONE}"
       pattern_definitions:
         AUTH: (authentication|authorization)
-        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified)
+        REASON: (AAA failure|Account has been disabled|Invalid password|Password is expiring|Password has expired|Password malformed|Unspecified|Account has been locked out)
         USERNAME: "[a-zA-Z0-9._'-]+"
         CISCO_USER: (?:\*\*\*\*\*|(?:(?:LOCAL\\)?(?:%{HOSTNAME}\\)?%{USERNAME}\$?(?:@%{HOSTNAME})?(?:, *%{NUMBER})?))
         IPORNONE: (%{IP:source.address}|None)

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.36.3"
+version: "2.36.4"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Handle "Account has been locked out" reason parsing

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/10738

