### PR TITLE
[cef] Make dataset name configurable

### DIFF
--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -2,7 +2,7 @@
 - version: "2.17.2"
   changes:
     - description: Make dataset name configurable
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/10866
 - version: "2.17.1"
   changes:

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.17.2"
+  changes:
+    - description: Make dataset name configurable
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "2.17.1"
   changes:
     - description: Add ignore_failure to the community_id processor in the ingest node pipeline.

--- a/packages/cef/changelog.yml
+++ b/packages/cef/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Make dataset name configurable
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/10866
 - version: "2.17.1"
   changes:
     - description: Add ignore_failure to the community_id processor in the ingest node pipeline.

--- a/packages/cef/data_stream/log/agent/stream/log.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/log.yml.hbs
@@ -1,3 +1,5 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
 paths:
   {{#each paths as |path i|}}
 - {{path}}

--- a/packages/cef/data_stream/log/agent/stream/tcp.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/tcp.yml.hbs
@@ -1,3 +1,5 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
 host: "{{syslog_host}}:{{syslog_port}}"
 {{#if tcp_options.length}}
 {{tcp_options}}

--- a/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
+++ b/packages/cef/data_stream/log/agent/stream/udp.yml.hbs
@@ -1,3 +1,5 @@
+data_stream:
+  dataset: {{data_stream.dataset}}
 host: "{{syslog_host}}:{{syslog_port}}"
 {{#if udp_options.length}}
 {{udp_options}}

--- a/packages/cef/data_stream/log/manifest.yml
+++ b/packages/cef/data_stream/log/manifest.yml
@@ -14,6 +14,14 @@ streams:
         multi: true
         default:
           - /var/log/cef.log
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: |
+          Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: cef.log
+        required: true
+        show_user: true
       - name: decode_cef_timezone
         title: CEF Timezone
         type: text
@@ -69,6 +77,14 @@ streams:
         show_user: true
         multi: false
         default: 9003
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: |
+          Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: cef.log
+        required: true
+        show_user: true
       - name: decode_cef_timezone
         title: CEF Timezone
         type: text
@@ -134,6 +150,14 @@ streams:
         show_user: true
         multi: false
         default: 9004
+      - name: data_stream.dataset
+        type: text
+        title: Dataset name
+        description: |
+          Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+        default: cef.log
+        required: true
+        show_user: true
       - name: decode_cef_timezone
         title: CEF Timezone
         type: text

--- a/packages/cef/manifest.yml
+++ b/packages/cef/manifest.yml
@@ -1,6 +1,6 @@
 name: cef
 title: Common Event Format (CEF)
-version: "2.17.1"
+version: "2.17.2"
 description: Collect logs from CEF Logs with Elastic Agent.
 categories:
   - security


### PR DESCRIPTION
## Proposed commit message

Make dataset name configurable

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/5379

## Screenshots

Example of customized dataset names with the policy

<img width="715" alt="Screenshot 2024-08-23 at 2 05 20 PM" src="https://github.com/user-attachments/assets/28bf8bab-7dc5-4ca2-a630-f31bddc4f746">


<img width="375" alt="Screenshot 2024-08-23 at 2 07 01 PM" src="https://github.com/user-attachments/assets/ef846844-3cad-4509-a786-f626c05ccecd">

<img width="575" alt="Screenshot 2024-08-23 at 2 07 19 PM" src="https://github.com/user-attachments/assets/f4821d10-5dcc-4fc1-bca9-75f01c00e789">


