### PR TITLE
[iptables] Fix failing test daily: system test: journald in iptables.log

### DIFF
--- a/packages/iptables/changelog.yml
+++ b/packages/iptables/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.16.2"
+  changes:
+    - description: Fixes "field "journald.custom.realtime_timestamp" is undefined" in the tests. Adds mapping for "journald.custom.realtime_timestamp".
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.16.1"
   changes:
     - description: Invoke community_id processor only for supported protocols

--- a/packages/iptables/data_stream/log/fields/journald-input.yml
+++ b/packages/iptables/data_stream/log/fields/journald-input.yml
@@ -1,3 +1,8 @@
+- name: journald.custom.realtime_timestamp
+  type: date
+  description: >
+    Realtime timestamp.
+
 - name: journald.host.boot_id
   type: keyword
   description: >

--- a/packages/iptables/manifest.yml
+++ b/packages/iptables/manifest.yml
@@ -1,6 +1,6 @@
 name: iptables
 title: Iptables
-version: "1.16.1"
+version: "1.16.2"
 description: Collect logs from Iptables with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

[iptables] Fix failing test daily: system test: journald in iptables.log

The latest version of filebeat sends the new field ```journald.custom.realtime_timestamp``` that didn't have mapping defined. Adding the mapping resolves the issue. 

Example:
```
          "journald": {
            "custom": {
              "realtime_timestamp": "1642033008518660"
            },
            "host": {
              "boot_id": "c2f79f985830406a9e08241d015eff05"
            }
          },
```

The "auto-mapping" that was created for the index
<img width="392" alt="Screenshot 2024-08-26 at 9 26 47 AM" src="https://github.com/user-attachments/assets/cfdfb62c-ffe0-4a14-a091-cccddf978119">


I'm not 100% sure if this field should present in the first place, but adding the mapping fixes the test failure.
@andrewkroh @taylor-swanson 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## Related issues

- Closes https://github.com/elastic/integrations/issues/10757

