### PR TITLE
[CI] Add support to run system tests with different Elastic Agent docker images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,9 @@ env:
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
+  STACK_VERSION: "8.16.0-SNAPSHOT"
+  ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/elastic-agent/elastic-agent"
+
 
   # Elastic package settings
   # Manage docker output/logs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,9 +10,6 @@ env:
   JQ_VERSION: '1.7'
   GH_CLI_VERSION: "2.29.0"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
-  STACK_VERSION: "8.16.0-SNAPSHOT"
-  ELASTIC_AGENT_DOCKER_IMAGE: "docker.elastic.co/elastic-agent/elastic-agent"
-
 
   # Elastic package settings
   # Manage docker output/logs

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -493,14 +493,22 @@ prepare_stack() {
     echo "--- Prepare stack"
 
     local args="-v"
+    local stack_version=""
     if [ -n "${STACK_VERSION}" ]; then
         args="${args} --version ${STACK_VERSION}"
+        stack_version="${STACK_VERSION}"
     else
         local version
         version=$(oldest_supported_version)
         if [[ "${version}" != "null" ]]; then
             args="${args} --version ${version}"
+            stack_version="${version}"
         fi
+    fi
+
+    if [[ "${ELASTIC_AGENT_DOCKER_IMAGE:-""}" != "" ]]; then
+        export ELASTIC_AGENT_IMAGE_REF_OVERRIDE="${ELASTIC_AGENT_DOCKER_IMAGE}:${stack_version}"
+        echo "Using Elastic Agent docker image: ${ELASTIC_AGENT_IMAGE_REF_OVERRIDE}"
     fi
 
     echo "Boot up the Elastic stack"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -518,6 +518,13 @@ prepare_stack() {
     echo ""
     ${ELASTIC_PACKAGE_BIN} stack status
     echo ""
+
+    if [[ "${ELASTIC_AGENT_DOCKER_IMAGE:-""}" != "" ]]; then
+        echo ""
+        echo "Images used for Elastic Agent"
+        docker ps --format "{{.Names}} {{.Image}}" |grep "elastic-agent"
+        echo ""
+    fi
 }
 
 is_serverless() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -521,7 +521,7 @@ prepare_stack() {
 
     if [[ "${ELASTIC_AGENT_DOCKER_IMAGE:-""}" != "" ]]; then
         echo ""
-        echo "Images used for Elastic Agent"
+        echo "Images used for Elastic Agent:"
         docker ps --format "{{.Names}} {{.Image}}" |grep "elastic-agent"
         echo ""
     fi

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E '^nginx$'
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
 }
 
 check_package() {

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -757,7 +757,7 @@ teardown_test_package() {
 }
 
 list_all_directories() {
-    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort
+    find . -maxdepth 1 -mindepth 1 -type d | xargs -I {} basename {} | sort | grep -E '^nginx$'
 }
 
 check_package() {

--- a/.buildkite/scripts/trigger_integrations_in_parallel.sh
+++ b/.buildkite/scripts/trigger_integrations_in_parallel.sh
@@ -59,6 +59,7 @@ for package in ${PACKAGE_LIST}; do
         FORCE_CHECK_ALL: "${FORCE_CHECK_ALL}"
         SERVERLESS: "false"
         UPLOAD_SAFE_LOGS: ${UPLOAD_SAFE_LOGS}
+        ELASTIC_AGENT_DOCKER_IMAGE: "${ELASTIC_AGENT_DOCKER_IMAGE:-""}"
       artifact_paths:
         - build/test-results/*.xml
         - build/test-coverage/*.xml


### PR DESCRIPTION
## Proposed commit message

Add support in the CI pipeline for Pull Requests to run system tests with different Elastic Agent docker images.

This is achieved by setting the `ELASTIC_AGENT_IMAGE_REF_OVERRIDE` environment variable, as mentioned in the docs: https://github.com/elastic/elastic-package/blob/main/docs/howto/custom_images.md#use-your-own-custom-images

Added temporarily a log message to show the base Elastic Agent docker image used in tests:
> Base Elastic Agent image: docker.elastic.co/elastic-agent/elastic-agent:8.13.0
> Base Elastic Agent image: docker.elastic.co/elastic-agent/elastic-agent:8.16.0-SNAPSHOT

Currently, by default `elastic-package` uses: `docker.elastic.co/elastic-agent/elastic-agent-complete`


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~[ ] I have verified that all data streams collect metrics or logs.~
- ~[ ] I have added an entry to my package's `changelog.yml` file.~
- ~[ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Test Elastic Agent docker image override in stack and tests.

## How to test this PR locally


The following steps will be performing the same changes as in this PR:
```shell
export ELASTIC_AGENT_IMAGE_REF_OVERRIDE=docker.elastic.co/elastic-agent/elastic-agent:8.16.0-SNAPSHOT

# This command should run Elastic Agent and Fleet Server with the docker image
# defined above instead of using the complete docker image
elastic-stack up -v -d --version 8.16.0-SNAPSHOT

# Check docker images
docker ps --format "{{.Names}} {{.Image}}" |grep "elastic-agent"

cd packages/nginx

# Run system tests to trigger new Elastic Agents
elastic-package test system -v 

# While running the system tests , check the docker images used by the Elastic Agent containers
docker ps --format "{{.Names}} {{.Image}}" |grep "elastic-agent"
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

