### PR TITLE
[k8s Integratiion] Adding container.id as filter of Cluster Overview and removing median filter occurencies

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.66.3
+  changes:
+    - description: Updating Cluster Overview Dashboard to use container.id as filter and replaced median functions from visualisations
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10893
 - version: 1.66.2
   changes:
     - description: Fixing missing processor block in kubernetes.audit_logs

--- a/packages/kubernetes/kibana/dashboard/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -271,16 +271,21 @@
                         "118dfa8c-388e-430c-860f-ce84cf88ac39": {
                           "customLabel": true,
                           "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "\"kubernetes.cronjob.next_schedule.sec\": *"
+                        },
                           "isBucketed": false,
                           "label": "Epoch Time until Next Schedule(sec)",
-                          "operationType": "median",
+                          "operationType": "last_value",
                           "params": {
                             "format": {
                               "id": "number",
                               "params": {
                                 "decimals": 0
                               }
-                            }
+                            },
+                            "sortField": "@timestamp"
                           },
                           "scale": "ratio",
                           "sourceField": "kubernetes.cronjob.next_schedule.sec"

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
@@ -95,7 +95,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Volume Used %",
-                                                    "operationType": "max",
+                                                    "operationType": "average",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -113,7 +113,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Used Bytes",
-                                                    "operationType": "max",
+                                                    "operationType": "average",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -183,7 +183,7 @@
                                                     "dataType": "number",
                                                     "isBucketed": false,
                                                     "label": "Volume Size",
-                                                    "operationType": "median",
+                                                    "operationType": "average",
                                                     "params": {
                                                         "emptyAsNull": true,
                                                         "format": {
@@ -582,8 +582,7 @@
                                                     "sourceField": "kubernetes.volume.fs.used.bytes"
                                                 }
                                             },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "metrics-*"
+                                            "incompleteColumns": {}
                                         }
                                     }
                                 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013.json
@@ -582,7 +582,8 @@
                                                     "sourceField": "kubernetes.volume.fs.used.bytes"
                                                 }
                                             },
-                                            "incompleteColumns": {}
+                                            "incompleteColumns": {},
+                                            "indexPatternId": "metrics-*"
                                         }
                                     }
                                 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -741,17 +741,22 @@
                         "9b5ed643-7572-4d3b-a9af-6265b3a5a515": {
                           "customLabel": true,
                           "dataType": "number",
+                          "filter": {
+                              "language": "kuery",
+                              "query": "\"kubernetes.deployment.replicas.desired\": *"
+                          },
                           "isBucketed": false,
                           "label": "Replicas Desired",
-                          "operationType": "median",
+                          "operationType": "last_value",
                           "params": {
-                            "emptyAsNull": true
+                            "sortField": "@timestamp"
                           },
                           "scale": "ratio",
                           "sourceField": "kubernetes.deployment.replicas.desired"
                         }
                       },
-                      "incompleteColumns": {}
+                      "incompleteColumns": {},
+                      "indexPatternId": "metrics-*"
                     }
                   }
                 }

--- a/packages/kubernetes/kibana/dashboard/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013.json
@@ -687,11 +687,15 @@
                         "34892916-522d-4b2e-b286-a534475b34a1": {
                           "customLabel": true,
                           "dataType": "number",
+                          "filter": {
+                            "language": "kuery",
+                            "query": "\"kubernetes.daemonset.replicas.desired\": *"
+                        },
                           "isBucketed": false,
                           "label": "Replicas Desired",
-                          "operationType": "median",
+                          "operationType": "last_value",
                           "params": {
-                            "emptyAsNull": true
+                            "sortField": "@timestamp"
                           },
                           "scale": "ratio",
                           "sourceField": "kubernetes.daemonset.replicas.desired"

--- a/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
+++ b/packages/kubernetes/kibana/dashboard/kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c.json
@@ -468,7 +468,7 @@
                                                 "7113c7e7-1af9-4350-b5d2-57abcb60c633": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.container.name",
+                                                    "label": "Top 10000 values of container.id",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "missingBucket": false,
@@ -494,7 +494,7 @@
                                                         "size": 10000
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "kubernetes.container.name"
+                                                    "sourceField": "container.id"
                                                 },
                                                 "830de93b-4051-4716-99e4-83d625a91288": {
                                                     "customLabel": true,
@@ -950,7 +950,7 @@
                                                 "6677e92c-5874-49c1-979e-c16c0d3838cd": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 10000 values of kubernetes.container.name",
+                                                    "label": "Top 10000 values of container.id",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "missingBucket": false,
@@ -976,7 +976,7 @@
                                                         "size": 10000
                                                     },
                                                     "scale": "ordinal",
-                                                    "sourceField": "kubernetes.container.name"
+                                                    "sourceField": "container.id"
                                                 }
                                             },
                                             "incompleteColumns": {},

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.66.2
+version: 1.66.3
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Bug

## Proposed commit message

- WHAT: Updated the Top Memory and Top CPU visualisations of `Cluster Overview Dashboard` in order to use the **container.id** filter
- WHY:  The kubernetes.container.name used in previous visualisations was not unique for all kinds of k8s resources (eg. the kubernetes.container.name is the same for all pods of same daemonset and this was creating false calculations)

Additionally we removed all median functions from or visualisations and replaced them either with Average or Last value
The updated dashboards where the median has been removed are:
- Cronjobs
- Deployments
- Volume 
- Daemonsets


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

0. Prequisite to have a local k8s cluster. Use kind and run `kind create cluster`
1. Install kube-state-metrics in your k8s cluster
2. Clone this branch
3. Change to directory  integrations/packages/kubernetes
4. Run `elastic-package stack up -d -v --version=8.15.0` in order to spin the ES locally
5. Run `docker network connect elastic-package-stack_default kind-control-plane` to connect the networks of the ES and your k8s node
6. Open the local kibana page and install a k8s integration and create a new Elastic Agent policy
7. Apply the new manfest to your k8s cluster and once the agents are up and running navigate to your dahboards
8. Validate the changes in the visualisations

## Related issues

- Closes #10887

## Screenshots

From Cluster Overview:

![Screenshot 2024-08-27 at 12 31 56 PM](https://github.com/user-attachments/assets/cacb0461-8701-4a75-ab7c-3a7250f4e8aa)


From Cronjobs:

![Screenshot 2024-08-27 at 12 32 23 PM](https://github.com/user-attachments/assets/4de8ccf2-d060-4ce4-bbeb-957cd9b0d325)
