### PR TITLE
[Security Detection Engine] Incorrect Indices for "Suspicious Web Browser Sensitive File Access" Rule

### DIFF
--- a/packages/security_detection_engine/kibana/security_rule/20457e4f-d1de-4b92-ae69-142e27a4342a_207.json
+++ b/packages/security_detection_engine/kibana/security_rule/20457e4f-d1de-4b92-ae69-142e27a4342a_207.json
@@ -6,7 +6,7 @@
         "description": "Identifies the access or file open of web browser sensitive files by an untrusted/unsigned process or osascript. Adversaries may acquire credentials from web browsers by reading files specific to the target browser.",
         "from": "now-9m",
         "index": [
-            "logs-endpoint.events.file.*"
+            "logs-endpoint.events.process.*"
         ],
         "language": "eql",
         "license": "Elastic License v2",
@@ -105,7 +105,7 @@
         ],
         "timestamp_override": "event.ingested",
         "type": "eql",
-        "version": 207
+        "version": 208
     },
     "id": "20457e4f-d1de-4b92-ae69-142e27a4342a_207",
     "type": "security-rule"

--- a/packages/security_detection_engine/kibana/security_rule/20457e4f-d1de-4b92-ae69-142e27a4342a_207.json
+++ b/packages/security_detection_engine/kibana/security_rule/20457e4f-d1de-4b92-ae69-142e27a4342a_207.json
@@ -6,7 +6,7 @@
         "description": "Identifies the access or file open of web browser sensitive files by an untrusted/unsigned process or osascript. Adversaries may acquire credentials from web browsers by reading files specific to the target browser.",
         "from": "now-9m",
         "index": [
-            "logs-endpoint.events.process.*"
+            "logs-endpoint.events.process-*"
         ],
         "language": "eql",
         "license": "Elastic License v2",


### PR DESCRIPTION
Type of change:
- Bug

## Proposed commit message

The detection rule "Suspicious Web Browser Sensitive File Access" is currently configured to query the logs-endpoint.events.file.* indices, but it is a process-related rule and needs to instead be looking at the logs-endpoint.events.process.* indices. As the rule is currently configured, execution results in an error:

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes #10901 

## Screenshots

![image](https://github.com/user-attachments/assets/f4b3e42b-671e-4210-b6b4-cdbb0215e12f)