### PR TITLE
[Nginx_ingress_controller] fix nginx_ingress_controller.access.remote_ip_list field mapping

### DIFF
--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Fix nginx_ingress_controller.access.remote_ip_list field mapping.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pulls/10293
 - version: "1.10.0"
   changes:
     - description: Migrate to format_version v3.

--- a/packages/nginx_ingress_controller/changelog.yml
+++ b/packages/nginx_ingress_controller/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix nginx_ingress_controller.access.remote_ip_list field mapping.
       type: bugfix
-      link: https://github.com/elastic/integrations/pulls/10293
+      link: https://github.com/elastic/integrations/pulls/10921
 - version: "1.10.0"
   changes:
     - description: Migrate to format_version v3.

--- a/packages/nginx_ingress_controller/data_stream/access/fields/fields.yml
+++ b/packages/nginx_ingress_controller/data_stream/access/fields/fields.yml
@@ -2,7 +2,7 @@
   type: group
   fields:
     - name: remote_ip_list
-      type: ip
+      type: keyword
       description: |
         An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like `X-Forwarded-For`. Real source IP is restored to `source.ip`.
     - name: http.request.length

--- a/packages/nginx_ingress_controller/docs/README.md
+++ b/packages/nginx_ingress_controller/docs/README.md
@@ -209,7 +209,7 @@ An example event for `access` looks as following:
 | nginx_ingress_controller.access.http.request.id | The randomly generated ID of the request | text |
 | nginx_ingress_controller.access.http.request.length | The request length (including request line, header, and request body) | long |
 | nginx_ingress_controller.access.http.request.time | Time elapsed since the first bytes were read from the client | double |
-| nginx_ingress_controller.access.remote_ip_list | An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like `X-Forwarded-For`. Real source IP is restored to `source.ip`. | ip |
+| nginx_ingress_controller.access.remote_ip_list | An array of remote IP addresses. It is a list because it is common to include, besides the client IP address, IP addresses from headers like `X-Forwarded-For`. Real source IP is restored to `source.ip`. | keyword |
 | nginx_ingress_controller.access.upstream.alternative_name | The name of the alternative upstream. | text |
 | nginx_ingress_controller.access.upstream.ip | The IP address of the upstream server. If several servers were contacted during request processing, their addresses are separated by commas. | ip |
 | nginx_ingress_controller.access.upstream.name | The name of the upstream. | keyword |

--- a/packages/nginx_ingress_controller/manifest.yml
+++ b/packages/nginx_ingress_controller/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.4
 name: nginx_ingress_controller
 title: Nginx Ingress Controller Logs
-version: 1.10.0
+version: 1.10.1
 description: Collect Nginx Ingress Controller logs.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Please explain:

- WHAT: In this [PR](https://github.com/elastic/integrations/pull/10293) I've changed type of the `remote_ip_list` from `array` (this type is not available anymore) to `ip`, that introduce a breaking change, but it should be a `keyword`
- WHY:  2 reasons: to revert introduced breaking change; align with the nginx package `remote_ip_list` [field](https://github.com/elastic/integrations/blob/main/packages/nginx/data_stream/access/fields/fields.yml#L4-L7)

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
