### PR TITLE
Added host.name as ECS field, resolved some issues related to start_t…

### DIFF
--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.0"
+  changes:
+    - description: Added host.name field, added "Security Solution" tag to Telemetry dashboard and modified the Jamf Protect Alerts dashboard to have some additional filters applied to not show Telemetry data, also changed start_time in authentication pipeline.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10813
 - version: "2.4.0"
   changes:
     - description: Added process.name and some minor enhancements to some events

--- a/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
+++ b/packages/jamf_protect/data_stream/telemetry/_dev/test/pipeline/test-jamf-protect-telemetry-sample-logs.log-expected.json
@@ -32,6 +32,7 @@
                 "ip": [
                     "192.168.4.252"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -144,6 +145,7 @@
                 "ip": [
                     "192.168.4.252"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -259,6 +261,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -370,6 +373,7 @@
                 "ip": [
                     "192.168.5.190"
                 ],
+                "name": "sevro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -490,6 +494,7 @@
                     "192.168.64.1",
                     "192.168.11.232"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.5 (Build 23F79)",
@@ -629,6 +634,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -750,6 +756,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -868,6 +875,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -978,6 +986,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1094,6 +1103,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1211,6 +1221,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1328,6 +1339,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1440,6 +1452,7 @@
                 "ip": [
                     "192.168.4.252"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1552,6 +1565,7 @@
                 "ip": [
                     "192.168.4.252"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1666,6 +1680,7 @@
                 "ip": [
                     "192.168.5.190"
                 ],
+                "name": "sevro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1783,6 +1798,7 @@
                     "192.168.11.251",
                     "192.168.11.232"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -1898,6 +1914,7 @@
                     "192.168.11.251",
                     "192.168.11.232"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2011,6 +2028,7 @@
                 "ip": [
                     "192.168.5.190"
                 ],
+                "name": "sevro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2140,6 +2158,7 @@
                 "ip": [
                     "192.168.5.190"
                 ],
+                "name": "sevro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2273,6 +2292,7 @@
                     "192.168.64.1",
                     "169.254.100.182"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2434,6 +2454,7 @@
                 "ip": [
                     "192.168.5.190"
                 ],
+                "name": "sevro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2552,6 +2573,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -2671,6 +2693,7 @@
                 "ip": [
                     "192.168.1.37"
                 ],
+                "name": "Direct’s Virtual Machine",
                 "os": {
                     "family": "macos",
                     "full": "14.2.1 (Build 23C71)",
@@ -2788,6 +2811,7 @@
                 "ip": [
                     "192.168.4.252"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.5 (Build 23F79)",
@@ -2900,6 +2924,7 @@
                     "192.168.11.232",
                     "192.168.64.1"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -3022,6 +3047,7 @@
                     "192.168.11.232",
                     "192.168.64.1"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -3136,6 +3162,7 @@
                 "ip": [
                     "192.168.1.27"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -3200,6 +3227,7 @@
                     "192.168.11.232",
                     "192.168.64.1"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -3313,6 +3341,7 @@
                     "192.168.64.1",
                     "192.168.11.232"
                 ],
+                "name": "MacBookPro-Sjaffy (2)",
                 "os": {
                     "family": "macos",
                     "full": "14.5 (Build 23F79)",
@@ -3428,6 +3457,7 @@
                 "ip": [
                     "192.168.0.185"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.5 (Build 23F79)",
@@ -3491,6 +3521,7 @@
                 "ip": [
                     "192.168.0.185"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.4.1 (Build 23E224)",
@@ -3550,6 +3581,7 @@
                 "ip": [
                     "192.168.100.102"
                 ],
+                "name": "MacBookPro",
                 "os": {
                     "family": "macos",
                     "full": "14.5 (Build 23F79)",

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/default.yml
@@ -101,6 +101,10 @@ processors:
         field: jamf_protect.telemetry.host.hostname
         target_field: host.hostname
         ignore_missing: true
+    - set:
+        field: host.name
+        copy_from: host.hostname
+        ignore_empty_value: true
     - rename:
         field: jamf_protect.telemetry.host.provisioningUDID
         target_field: host.id

--- a/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
+++ b/packages/jamf_protect/data_stream/telemetry/elasticsearch/ingest_pipeline/pipeline_event_authentication.yml
@@ -105,14 +105,16 @@ processors:
         field: jamf_protect.telemetry.event.authentication.data.token.instigator.start_time
         target_field: process.start
         ignore_missing: true
+        if: ctx.process?.start == null
     - rename:
         field: jamf_protect.telemetry.event.authentication.data.touchid.instigator.start_time
         target_field: process.start
-        ignore_missing: false
+        ignore_missing: true
+        if: ctx.process?.start == null
     - rename:
         field: jamf_protect.telemetry.event.authentication.data.auto_unlock.instigator.start_time
         target_field: process.start
-        ignore_missing: false
+        ignore_missing: true
         if: ctx.process?.start == null
 
     - convert:

--- a/packages/jamf_protect/data_stream/telemetry/sample_event.json
+++ b/packages/jamf_protect/data_stream/telemetry/sample_event.json
@@ -49,6 +49,7 @@
             "192.168.64.1",
             "192.168.11.232"
         ],
+        "name": "MacBookPro",
         "os": {
             "family": "macos",
             "full": "14.5 (Build 23F79)",

--- a/packages/jamf_protect/kibana/dashboard/jamf_protect-d23dda91-658e-4ab0-8e06-b42ce435e473.json
+++ b/packages/jamf_protect/kibana/dashboard/jamf_protect-d23dda91-658e-4ab0-8e06-b42ce435e473.json
@@ -2321,6 +2321,11 @@
             "id": "logs-*",
             "name": "controlGroup_cfc38094-55dc-442a-bc2e-3f09e45eaab6:optionsListDataView",
             "type": "index-pattern"
+        },
+        {
+            "id": "jamf_protect-security-solution-default",
+            "name": "tag-ref-jamf_protect-security-solution-default",
+            "type": "tag"
         }
     ],
     "type": "dashboard",

--- a/packages/jamf_protect/kibana/dashboard/jamf_protect-e9b86210-c65c-11ee-882f-57f79af43d7f.json
+++ b/packages/jamf_protect/kibana/dashboard/jamf_protect-e9b86210-c65c-11ee-882f-57f79af43d7f.json
@@ -4,12 +4,35 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\":false,\"ignoreQuery\":false,\"ignoreTimerange\":false,\"ignoreValidations\":false}",
-            "panelsJSON": "{\"d1892683-e559-40f2-9b70-90e8e29439f7\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"small\",\"explicitInput\":{\"id\":\"d1892683-e559-40f2-9b70-90e8e29439f7\",\"fieldName\":\"host.hostname\",\"title\":\"hostname\",\"grow\":true,\"width\":\"small\",\"enhancements\":{},\"selectedOptions\":[]}},\"04593aef-ec66-4a07-a579-13a12d086631\":{\"type\":\"optionsListControl\",\"order\":2,\"grow\":true,\"width\":\"small\",\"explicitInput\":{\"id\":\"04593aef-ec66-4a07-a579-13a12d086631\",\"fieldName\":\"event.module\",\"title\":\"Product module\",\"grow\":true,\"width\":\"small\",\"selectedOptions\":[],\"existsSelected\":false,\"enhancements\":{}}},\"bcdd443f-9e3d-4186-be15-ba54190ae096\":{\"type\":\"timeSlider\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"bcdd443f-9e3d-4186-be15-ba54190ae096\",\"title\":\"Time slider\",\"enhancements\":{},\"timesliceStartAsPercentageOfTimeRange\":0.08333333429783951,\"timesliceEndAsPercentageOfTimeRange\":0.9583333444251545}}}"
+            "panelsJSON": "{\"80859a5a-4b22-4e0c-85fc-525e81731a96\":{\"type\":\"optionsListControl\",\"order\":1,\"grow\":true,\"width\":\"small\",\"explicitInput\":{\"id\":\"80859a5a-4b22-4e0c-85fc-525e81731a96\",\"fieldName\":\"host.hostname\",\"title\":\"hostname\",\"grow\":true,\"width\":\"small\",\"enhancements\":{},\"selectedOptions\":[]}},\"852fc3bb-087f-40a6-a483-7f075c05b75f\":{\"type\":\"timeSlider\",\"order\":0,\"grow\":true,\"width\":\"large\",\"explicitInput\":{\"id\":\"852fc3bb-087f-40a6-a483-7f075c05b75f\",\"title\":\"Time slider\",\"enhancements\":{},\"timesliceStartAsPercentageOfTimeRange\":0.08333333429783951,\"timesliceEndAsPercentageOfTimeRange\":0.9583333444251545}}}"
         },
         "description": "",
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
-                "filter": [],
+                "filter": [
+                    {
+                        "$state": {
+                            "store": "appState"
+                        },
+                        "meta": {
+                            "alias": null,
+                            "disabled": false,
+                            "field": "observer.product",
+                            "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
+                            "key": "observer.product",
+                            "negate": false,
+                            "params": {
+                                "query": "Jamf Protect"
+                            },
+                            "type": "phrase"
+                        },
+                        "query": {
+                            "match_phrase": {
+                                "observer.product": "Jamf Protect"
+                            }
+                        }
+                    }
+                ],
                 "query": {
                     "language": "kuery",
                     "query": ""
@@ -52,12 +75,12 @@
                 },
                 "gridData": {
                     "h": 5,
-                    "i": "1e937160-72d3-495f-9d99-a5441c7f7a72",
+                    "i": "e136bb70-f16b-4343-ab70-6844c7528b7f",
                     "w": 48,
                     "x": 0,
                     "y": 0
                 },
-                "panelIndex": "1e937160-72d3-495f-9d99-a5441c7f7a72",
+                "panelIndex": "e136bb70-f16b-4343-ab70-6844c7528b7f",
                 "type": "visualization"
             },
             {
@@ -113,7 +136,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(observer.product : \"Jamf Protect\" and event.module : \"Alerts\" and event.severity : 1) or (observer.product :\"Jamf Protect\" and event.module :\"Threat Events Stream\" and event.severity : 4)"
+                                "query": "observer.product : \"Jamf Protect\" and event.kind:\"alert\" and event.severity: (\"0\" or \"4\")"
                             },
                             "visualization": {
                                 "accessor": "5760cc55-e167-4ca1-882c-27413cb07e5e",
@@ -158,12 +181,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "a8e0995f-628e-43ff-8052-0ec18332c1da",
+                    "i": "06764aa0-868e-43ea-8696-b70fb235ae74",
                     "w": 16,
                     "x": 0,
                     "y": 5
                 },
-                "panelIndex": "a8e0995f-628e-43ff-8052-0ec18332c1da",
+                "panelIndex": "06764aa0-868e-43ea-8696-b70fb235ae74",
                 "title": "Low Alerts",
                 "type": "lens"
             },
@@ -182,7 +205,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b": {
                                             "columnOrder": [
@@ -206,8 +228,7 @@
                                                     "sourceField": "event.severity"
                                                 }
                                             },
-                                            "incompleteColumns": {},
-                                            "indexPatternId": "logs-*"
+                                            "incompleteColumns": {}
                                         }
                                     }
                                 },
@@ -222,7 +243,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(observer.product : \"Jamf Protect\" and event.module : \"Alerts\" and event.severity : 2) or (observer.product :\"Jamf Protect\" and event.module :\"Threat Events Stream\" and event.severity : 6)"
+                                "query": "observer.product : \"Jamf Protect\" and event.kind:\"alert\" and event.severity: (\"2\" or \"6\")"
                             },
                             "visualization": {
                                 "accessor": "5760cc55-e167-4ca1-882c-27413cb07e5e",
@@ -285,12 +306,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "1d177394-ad48-4393-b81c-319a894a5686",
+                    "i": "e5805399-e483-4ae4-862a-ff6adb9b0935",
                     "w": 16,
                     "x": 16,
                     "y": 5
                 },
-                "panelIndex": "1d177394-ad48-4393-b81c-319a894a5686",
+                "panelIndex": "e5805399-e483-4ae4-862a-ff6adb9b0935",
                 "title": "Medium Alerts",
                 "type": "lens"
             },
@@ -347,7 +368,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "(observer.product : \"Jamf Protect\" and event.module : \"Alerts\" and event.severity : 3) or (observer.product :\"Jamf Protect\" and event.module :\"Threat Events Stream\" and event.severity \u003e= 8)"
+                                "query": "observer.product : \"Jamf Protect\" and event.kind:\"alert\" and (event.severity: 3  or event.severity \u003e= 8)"
                             },
                             "visualization": {
                                 "accessor": "5760cc55-e167-4ca1-882c-27413cb07e5e",
@@ -392,12 +413,12 @@
                 },
                 "gridData": {
                     "h": 8,
-                    "i": "a5ced168-f931-484a-bf34-898dee052142",
+                    "i": "688954c1-306c-4592-a857-7196d09a38ac",
                     "w": 16,
                     "x": 32,
                     "y": 5
                 },
-                "panelIndex": "a5ced168-f931-484a-bf34-898dee052142",
+                "panelIndex": "688954c1-306c-4592-a857-7196d09a38ac",
                 "title": "High",
                 "type": "lens"
             },
@@ -416,7 +437,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "56e39079-aa13-438a-8f1e-39d3d1207797": {
                                             "columnOrder": [
@@ -426,7 +446,6 @@
                                                 "69fab47a-bf55-434a-93a8-755f9431e010",
                                                 "67bdcdac-9fa9-41c7-8070-3c82ae0e88a2",
                                                 "f11f1a0a-2fab-4220-9cab-08dd6518b5fa",
-                                                "eb44692c-2d2e-4f61-8883-3d24d57bdc16",
                                                 "92d876fd-cc9e-4914-a68c-f6dcbe26a803"
                                             ],
                                             "columns": {
@@ -440,7 +459,7 @@
                                                             {
                                                                 "input": {
                                                                     "language": "kuery",
-                                                                    "query": "\"event.module\" : \"Alerts\" or event.module : \"Threat Events Stream\" "
+                                                                    "query": "observer.vendor :\"Jamf\" and event.kind:\"alert\" "
                                                                 },
                                                                 "label": ""
                                                             }
@@ -544,32 +563,6 @@
                                                     "scale": "ordinal",
                                                     "sourceField": "event.action"
                                                 },
-                                                "eb44692c-2d2e-4f61-8883-3d24d57bdc16": {
-                                                    "customLabel": true,
-                                                    "dataType": "string",
-                                                    "isBucketed": true,
-                                                    "label": "Product module",
-                                                    "operationType": "terms",
-                                                    "params": {
-                                                        "exclude": [],
-                                                        "excludeIsRegex": false,
-                                                        "include": [],
-                                                        "includeIsRegex": false,
-                                                        "missingBucket": false,
-                                                        "orderBy": {
-                                                            "columnId": "92d876fd-cc9e-4914-a68c-f6dcbe26a803",
-                                                            "type": "column"
-                                                        },
-                                                        "orderDirection": "desc",
-                                                        "otherBucket": true,
-                                                        "parentFormat": {
-                                                            "id": "terms"
-                                                        },
-                                                        "size": 50
-                                                    },
-                                                    "scale": "ordinal",
-                                                    "sourceField": "event.module"
-                                                },
                                                 "ecd6f817-327d-4598-8c3a-5177c5916f7d": {
                                                     "customLabel": true,
                                                     "dataType": "date",
@@ -612,7 +605,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -665,10 +657,6 @@
                                         "columnId": "39191bf7-977f-4f41-bdf4-58d2ef9ae23a",
                                         "hidden": true,
                                         "isTransposed": false
-                                    },
-                                    {
-                                        "columnId": "eb44692c-2d2e-4f61-8883-3d24d57bdc16",
-                                        "isTransposed": false
                                     }
                                 ],
                                 "layerId": "56e39079-aa13-438a-8f1e-39d3d1207797",
@@ -688,12 +676,12 @@
                 },
                 "gridData": {
                     "h": 13,
-                    "i": "35f2db30-0cb1-4d9d-9afe-dce4d8a973c9",
+                    "i": "ba075c83-e38a-42ab-95d9-8d0a53c5fa87",
                     "w": 48,
                     "x": 0,
                     "y": 13
                 },
-                "panelIndex": "35f2db30-0cb1-4d9d-9afe-dce4d8a973c9",
+                "panelIndex": "ba075c83-e38a-42ab-95d9-8d0a53c5fa87",
                 "title": "Most recent alerts",
                 "type": "lens"
             },
@@ -706,13 +694,17 @@
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-fecd3402-4076-4ff6-8a63-e975ad495ec6",
                                 "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "32155b41-f592-45dd-b5d1-4d801bc7e19c",
+                                "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "fecd3402-4076-4ff6-8a63-e975ad495ec6": {
                                             "columnOrder": [
@@ -813,7 +805,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -825,7 +816,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "event.kind",
+                                        "index": "32155b41-f592-45dd-b5d1-4d801bc7e19c",
+                                        "key": "event.kind",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "alert"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.kind": "alert"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -861,12 +875,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "2fe17682-0e60-4338-a47a-971521a5e034",
+                    "i": "e9bc58a1-a920-45ad-9089-d3e5ef635723",
                     "w": 24,
                     "x": 0,
                     "y": 26
                 },
-                "panelIndex": "2fe17682-0e60-4338-a47a-971521a5e034",
+                "panelIndex": "e9bc58a1-a920-45ad-9089-d3e5ef635723",
                 "title": "Top processes related to detection and hostname",
                 "type": "lens"
             },
@@ -878,6 +892,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-2c906641-fc29-4d9a-829e-c62e84234311",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "e5444272-f867-4521-a5c3-051e91a4a8a8",
                                 "type": "index-pattern"
                             }
                         ],
@@ -941,7 +960,30 @@
                                     "layers": {}
                                 }
                             },
-                            "filters": [],
+                            "filters": [
+                                {
+                                    "$state": {
+                                        "store": "appState"
+                                    },
+                                    "meta": {
+                                        "alias": null,
+                                        "disabled": false,
+                                        "field": "event.kind",
+                                        "index": "e5444272-f867-4521-a5c3-051e91a4a8a8",
+                                        "key": "event.kind",
+                                        "negate": false,
+                                        "params": {
+                                            "query": "alert"
+                                        },
+                                        "type": "phrase"
+                                    },
+                                    "query": {
+                                        "match_phrase": {
+                                            "event.kind": "alert"
+                                        }
+                                    }
+                                }
+                            ],
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
@@ -976,12 +1018,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "c21c7eaa-0dd6-4360-990c-8ef0dc734f2e",
+                    "i": "cda43da6-0335-4749-8670-95a452e65cc6",
                     "w": 24,
                     "x": 24,
                     "y": 26
                 },
-                "panelIndex": "c21c7eaa-0dd6-4360-990c-8ef0dc734f2e",
+                "panelIndex": "cda43da6-0335-4749-8670-95a452e65cc6",
                 "title": "Event actions",
                 "type": "lens"
             },
@@ -1000,7 +1042,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "9e7e8b50-1080-47d3-8575-2564576e134a": {
                                             "columnOrder": [
@@ -1012,7 +1053,7 @@
                                                     "customLabel": true,
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Domain name",
+                                                    "label": "Top 10 values of dns.question.name",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -1047,7 +1088,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -1087,12 +1127,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "c667337a-237f-4002-9f74-4d914712fde5",
+                    "i": "89f4d966-e3ef-48ea-adca-ec8104ec2e78",
                     "w": 24,
                     "x": 0,
                     "y": 41
                 },
-                "panelIndex": "c667337a-237f-4002-9f74-4d914712fde5",
+                "panelIndex": "89f4d966-e3ef-48ea-adca-ec8104ec2e78",
                 "title": "Top requested DNS requests",
                 "type": "lens"
             },
@@ -1158,7 +1198,7 @@
                                                 "ab9c6f3d-8c01-4bce-8d34-918c5cabc370": {
                                                     "dataType": "string",
                                                     "isBucketed": true,
-                                                    "label": "Top 3 values of event.reason",
+                                                    "label": "Top 5 values of event.reason",
                                                     "operationType": "terms",
                                                     "params": {
                                                         "exclude": [],
@@ -1175,7 +1215,7 @@
                                                         "parentFormat": {
                                                             "id": "terms"
                                                         },
-                                                        "size": 3
+                                                        "size": 5
                                                     },
                                                     "scale": "ordinal",
                                                     "sourceField": "event.reason"
@@ -1197,7 +1237,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "observer.product : \"Jamf Protect\" and event.kind : \"alert\""
+                                "query": "event.kind : \"alert\""
                             },
                             "visualization": {
                                 "axisTitlesVisibilitySettings": {
@@ -1252,12 +1292,12 @@
                 },
                 "gridData": {
                     "h": 15,
-                    "i": "d73b82e9-36bf-4d4b-a8e5-97f2dfa66d08",
+                    "i": "09d2ca1e-6e42-40e6-901e-6706b0544839",
                     "w": 24,
                     "x": 24,
                     "y": 41
                 },
-                "panelIndex": "d73b82e9-36bf-4d4b-a8e5-97f2dfa66d08",
+                "panelIndex": "09d2ca1e-6e42-40e6-901e-6706b0544839",
                 "title": "Top event actions",
                 "type": "lens"
             },
@@ -1289,12 +1329,12 @@
                 },
                 "gridData": {
                     "h": 3,
-                    "i": "d13c506e-7389-4132-abdf-f7e0edaf6e09",
+                    "i": "44779ebe-24c9-438a-8bec-8bbd27423a0b",
                     "w": 48,
                     "x": 0,
                     "y": 56
                 },
-                "panelIndex": "d13c506e-7389-4132-abdf-f7e0edaf6e09",
+                "panelIndex": "44779ebe-24c9-438a-8bec-8bbd27423a0b",
                 "type": "visualization"
             },
             {
@@ -1305,6 +1345,11 @@
                             {
                                 "id": "logs-*",
                                 "name": "indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+                                "type": "index-pattern"
+                            },
+                            {
+                                "id": "logs-*",
+                                "name": "c6fafc83-fda4-488f-80b1-81b9979dca2f",
                                 "type": "index-pattern"
                             }
                         ],
@@ -1404,19 +1449,52 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "1392e022-2f27-496c-9eb7-a0afac25bead",
-                                        "key": "file.hash.sha1",
-                                        "negate": true,
-                                        "params": {
-                                            "query": ""
-                                        },
-                                        "type": "phrase"
+                                        "index": "c6fafc83-fda4-488f-80b1-81b9979dca2f",
+                                        "negate": false,
+                                        "params": [
+                                            {
+                                                "meta": {
+                                                    "alias": null,
+                                                    "disabled": false,
+                                                    "field": "observer.vendor",
+                                                    "index": "logs-*",
+                                                    "key": "observer.vendor",
+                                                    "negate": false,
+                                                    "params": {
+                                                        "query": "Jamf"
+                                                    },
+                                                    "type": "phrase"
+                                                },
+                                                "query": {
+                                                    "match_phrase": {
+                                                        "observer.vendor": "Jamf"
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "meta": {
+                                                    "alias": null,
+                                                    "disabled": false,
+                                                    "field": "event.kind",
+                                                    "index": "logs-*",
+                                                    "key": "event.kind",
+                                                    "negate": false,
+                                                    "params": {
+                                                        "query": "alert"
+                                                    },
+                                                    "type": "phrase"
+                                                },
+                                                "query": {
+                                                    "match_phrase": {
+                                                        "event.kind": "alert"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "relation": "AND",
+                                        "type": "combined"
                                     },
-                                    "query": {
-                                        "match_phrase": {
-                                            "file.hash.sha1": ""
-                                        }
-                                    }
+                                    "query": {}
                                 }
                             ],
                             "internalReferences": [],
@@ -1492,12 +1570,12 @@
                 },
                 "gridData": {
                     "h": 23,
-                    "i": "273e31c4-09aa-4378-a9e2-280c302ac86c",
+                    "i": "92aa58f1-4186-46e1-b84d-3855d0db39d0",
                     "w": 19,
                     "x": 0,
                     "y": 59
                 },
-                "panelIndex": "273e31c4-09aa-4378-a9e2-280c302ac86c",
+                "panelIndex": "92aa58f1-4186-46e1-b84d-3855d0db39d0",
                 "title": "Top 10 file sha1hex values seen",
                 "type": "lens"
             },
@@ -1516,7 +1594,6 @@
                             "adHocDataViews": {},
                             "datasourceStates": {
                                 "formBased": {
-                                    "currentIndexPatternId": "logs-*",
                                     "layers": {
                                         "26090b76-c5f9-4191-bfef-7ff1d4482507": {
                                             "columnOrder": [
@@ -1619,7 +1696,6 @@
                                                 }
                                             },
                                             "incompleteColumns": {},
-                                            "indexPatternId": "logs-*",
                                             "sampling": 1
                                         }
                                     }
@@ -1635,7 +1711,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "observer.product : \"Jamf Protect\" and event.module : \"Alerts\" "
+                                "query": "observer.product : \"Jamf Protect\" and event.kind:\"alert\" "
                             },
                             "visualization": {
                                 "columns": [
@@ -1673,12 +1749,12 @@
                 },
                 "gridData": {
                     "h": 23,
-                    "i": "ecb673d5-334d-4705-ac46-1f4878937090",
+                    "i": "7dfd2f84-b2f0-4dd3-abd6-4d44611c9f69",
                     "w": 29,
                     "x": 19,
                     "y": 59
                 },
-                "panelIndex": "ecb673d5-334d-4705-ac46-1f4878937090",
+                "panelIndex": "7dfd2f84-b2f0-4dd3-abd6-4d44611c9f69",
                 "title": "Top 10 process shahex values by process executable",
                 "type": "lens"
             },
@@ -1815,7 +1891,7 @@
                             "internalReferences": [],
                             "query": {
                                 "language": "kuery",
-                                "query": "observer.product : \"Jamf Protect\" and event.module : \"Alerts\" and NOT process.code_signature.signing_id:com.apple.*"
+                                "query": "observer.product : \"Jamf Protect\" and event.kind:\"alert\" and NOT process.code_signature.signing_id:com.apple.*"
                             },
                             "visualization": {
                                 "columns": [
@@ -1854,93 +1930,108 @@
                 },
                 "gridData": {
                     "h": 14,
-                    "i": "e5f7a9d1-2951-4189-b17b-9657bc27a70e",
+                    "i": "1e23947b-9bf2-4083-831f-a439c069db2f",
                     "w": 48,
                     "x": 0,
                     "y": 82
                 },
-                "panelIndex": "e5f7a9d1-2951-4189-b17b-9657bc27a70e",
+                "panelIndex": "1e23947b-9bf2-4083-831f-a439c069db2f",
                 "title": "Top process Signing Information by TeamID",
                 "type": "lens"
             }
         ],
         "timeRestore": false,
-        "title": "Jamf Protect",
-        "version": 1
+        "title": "Jamf Protect - Alerts",
+        "version": 2
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-12T08:20:22.255Z",
+    "created_at": "2024-08-29T07:16:25.436Z",
     "id": "jamf_protect-e9b86210-c65c-11ee-882f-57f79af43d7f",
     "managed": false,
     "references": [
         {
             "id": "logs-*",
-            "name": "a8e0995f-628e-43ff-8052-0ec18332c1da:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
+            "name": "kibanaSavedObjectMeta.searchSourceJSON.filter[0].meta.index",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "1d177394-ad48-4393-b81c-319a894a5686:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
+            "name": "06764aa0-868e-43ea-8696-b70fb235ae74:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "a5ced168-f931-484a-bf34-898dee052142:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
+            "name": "e5805399-e483-4ae4-862a-ff6adb9b0935:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "35f2db30-0cb1-4d9d-9afe-dce4d8a973c9:indexpattern-datasource-layer-56e39079-aa13-438a-8f1e-39d3d1207797",
+            "name": "688954c1-306c-4592-a857-7196d09a38ac:indexpattern-datasource-layer-bbbfa9bf-6f8a-4a2a-bae1-04e7b8b5649b",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "2fe17682-0e60-4338-a47a-971521a5e034:indexpattern-datasource-layer-fecd3402-4076-4ff6-8a63-e975ad495ec6",
+            "name": "ba075c83-e38a-42ab-95d9-8d0a53c5fa87:indexpattern-datasource-layer-56e39079-aa13-438a-8f1e-39d3d1207797",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "c21c7eaa-0dd6-4360-990c-8ef0dc734f2e:indexpattern-datasource-layer-2c906641-fc29-4d9a-829e-c62e84234311",
+            "name": "e9bc58a1-a920-45ad-9089-d3e5ef635723:indexpattern-datasource-layer-fecd3402-4076-4ff6-8a63-e975ad495ec6",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "c667337a-237f-4002-9f74-4d914712fde5:indexpattern-datasource-layer-9e7e8b50-1080-47d3-8575-2564576e134a",
+            "name": "e9bc58a1-a920-45ad-9089-d3e5ef635723:32155b41-f592-45dd-b5d1-4d801bc7e19c",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "d73b82e9-36bf-4d4b-a8e5-97f2dfa66d08:indexpattern-datasource-layer-7927b71e-c9eb-4afe-baa5-f19e68ca53e2",
+            "name": "cda43da6-0335-4749-8670-95a452e65cc6:indexpattern-datasource-layer-2c906641-fc29-4d9a-829e-c62e84234311",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "273e31c4-09aa-4378-a9e2-280c302ac86c:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+            "name": "cda43da6-0335-4749-8670-95a452e65cc6:e5444272-f867-4521-a5c3-051e91a4a8a8",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "ecb673d5-334d-4705-ac46-1f4878937090:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+            "name": "89f4d966-e3ef-48ea-adca-ec8104ec2e78:indexpattern-datasource-layer-9e7e8b50-1080-47d3-8575-2564576e134a",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "e5f7a9d1-2951-4189-b17b-9657bc27a70e:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+            "name": "09d2ca1e-6e42-40e6-901e-6706b0544839:indexpattern-datasource-layer-7927b71e-c9eb-4afe-baa5-f19e68ca53e2",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_d1892683-e559-40f2-9b70-90e8e29439f7:optionsListDataView",
+            "name": "92aa58f1-4186-46e1-b84d-3855d0db39d0:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
             "type": "index-pattern"
         },
         {
             "id": "logs-*",
-            "name": "controlGroup_04593aef-ec66-4a07-a579-13a12d086631:optionsListDataView",
+            "name": "92aa58f1-4186-46e1-b84d-3855d0db39d0:c6fafc83-fda4-488f-80b1-81b9979dca2f",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "7dfd2f84-b2f0-4dd3-abd6-4d44611c9f69:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "1e23947b-9bf2-4083-831f-a439c069db2f:indexpattern-datasource-layer-26090b76-c5f9-4191-bfef-7ff1d4482507",
+            "type": "index-pattern"
+        },
+        {
+            "id": "logs-*",
+            "name": "controlGroup_80859a5a-4b22-4e0c-85fc-525e81731a96:optionsListDataView",
             "type": "index-pattern"
         },
         {
             "id": "jamf_protect-security-solution-default",
-            "name": "tag-ref-security-solution-default",
+            "name": "tag-ref-jamf_protect-security-solution-default",
             "type": "tag"
         }
     ],

--- a/packages/jamf_protect/kibana/tag/jamf_protect-security-solution-default.json
+++ b/packages/jamf_protect/kibana/tag/jamf_protect-security-solution-default.json
@@ -5,7 +5,7 @@
         "name": "Security Solution"
     },
     "coreMigrationVersion": "8.8.0",
-    "created_at": "2024-02-08T14:04:04.315Z",
+    "created_at": "2024-08-27T06:22:32.633Z",
     "id": "jamf_protect-security-solution-default",
     "managed": true,
     "references": [],

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.4.0"
+version: "2.5.0"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change:
- Enhancement

## Proposed commit message


- Added `host.name` field, this to enrich events.
- Minor enhancements to `authentication` pipeline
  - `process.start` -> added `event.type` had some issues with the configured rename processors.
 - Minor enhancements to the dashboards
    - Added the `Security Solution` tag to the Telemetry dashboard
    - Added filters to the `Jamf Protect - Alerts` dashboard to exclude Telemetry and other data.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
`elastic-package test system`

```
2024/08/29 10:38:10 DEBUG running command: /usr/local/bin/docker compose -f /Users/thijs.xhaflaire/.elastic-package/profiles/default/stack/snapshot.yml -p elastic-package-stack logs package-registry
--- Test results for package: jamf_protect - START ---
╭──────────────┬────────────────────┬───────────┬───────────────┬────────┬───────────────╮
│ PACKAGE      │ DATA STREAM        │ TEST TYPE │ TEST NAME     │ RESULT │  TIME ELAPSED │
├──────────────┼────────────────────┼───────────┼───────────────┼────────┼───────────────┤
│ jamf_protect │ alerts             │ system    │ http-endpoint │ PASS   │  56.25015525s │
│ jamf_protect │ telemetry          │ system    │ http-endpoint │ PASS   │ 57.780828625s │
│ jamf_protect │ telemetry_legacy   │ system    │ http-endpoint │ PASS   │ 52.658920042s │
│ jamf_protect │ web_threat_events  │ system    │ http-endpoint │ PASS   │ 52.821989708s │
│ jamf_protect │ web_traffic_events │ system    │ http-endpoint │ PASS   │ 51.540370541s │
╰──────────────┴────────────────────┴───────────┴───────────────┴────────┴───────────────╯
--- Test results for package: jamf_protect - END   ---
Done
```