### PR TITLE
Adding missing fields in the status metricset of the kibana integration

### DIFF
--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.4"
+  changes:
+    - description: Adding support for Kibana status metricset
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10944
 - version: "2.5.3"
   changes:
     - description: Remove documentation about xpack.enabled settings

--- a/packages/kibana/changelog.yml
+++ b/packages/kibana/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "2.5.4"
   changes:
-    - description: Adding support for Kibana status metricset
+    - description: Adding missing fields in the Kibana status metricset
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10944
 - version: "2.5.3"

--- a/packages/kibana/data_stream/status/fields/fields.yml
+++ b/packages/kibana/data_stream/status/fields/fields.yml
@@ -9,6 +9,30 @@
       type: keyword
       description: |
         Kibana overall state.
+    - name: status.overall.level
+      type: keyword
+      description: >
+        Kibana overall level (v8 format).
+    - name: status.overall.summary
+      type: text
+      description: >
+        Kibana overall state in a human-readable format.
+    - name: status.core.elasticsearch.level
+      type: keyword
+      description: >
+        Kibana Elasticsearch client's status
+    - name: status.core.elasticsearch.summary
+      type: text
+      description: >
+        Kibana Elasticsearch client's status in a human-readable format.
+    - name: status.core.savedObjects.level
+      type: keyword
+      description: >
+        Kibana Saved Objects client's status
+    - name: status.core.savedObjects.summary
+      type: text
+      description: >
+        Kibana Saved Objects client's status in a human-readable format.
     - name: metrics
       type: group
       fields:

--- a/packages/kibana/data_stream/status/fields/fields.yml
+++ b/packages/kibana/data_stream/status/fields/fields.yml
@@ -20,7 +20,7 @@
     - name: status.core.elasticsearch.level
       type: keyword
       description: >
-        Kibana Elasticsearch client's status
+        Kibana Elasticsearch client's status.
     - name: status.core.elasticsearch.summary
       type: text
       description: >
@@ -28,7 +28,7 @@
     - name: status.core.savedObjects.level
       type: keyword
       description: >
-        Kibana Saved Objects client's status
+        Kibana Saved Objects client's status.
     - name: status.core.savedObjects.summary
       type: text
       description: >

--- a/packages/kibana/data_stream/status/sample_event.json
+++ b/packages/kibana/data_stream/status/sample_event.json
@@ -60,7 +60,20 @@
             },
             "name": "kibana",
             "status": {
-                "overall": {}
+                "overall": {
+                    "level": "available",
+                    "summary": "All services and plugins are available"
+                },
+                "core": {
+                    "elasticsearch": {
+                        "level": "available",
+                        "summary": "Elasticsearch is available"
+                    },
+                    "savedObjects": {
+                        "level": "available",
+                        "summary": "SavedObjects service has completed migrations and is available"
+                    }
+                }
             }
         }
     },

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -794,7 +794,7 @@ This status endpoint is available in 6.0 by default and can be enabled in Kibana
 | kibana.status.status.overall.state | Kibana overall state. | keyword |
 | kibana.status.status.overall.level | Kibana overall level (v8 format). | keyword |
 | kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | text |
-| kibana.status.status.core.elasticsearch.level | Kibana overall state. | keyword |
+| kibana.status.status.core.elasticsearch.level | Kibana Elasticsearch client's status. | keyword |
 | kibana.status.status.core.elasticsearch.summary | Kibana Elasticsearch client's status in a human-readable format. | text |
 | kibana.status.status.core.savedObjects.level | Kibana Saved Objects client's status. | keyword |
 | kibana.status.status.core.savedObjects.summary | Kibana Saved Objects client's status in a human-readable format. | text |
@@ -870,7 +870,20 @@ An example event for `status` looks as following:
             },
             "name": "kibana",
             "status": {
-                "overall": {}
+                "overall": {
+                    "level": "available",
+                    "summary": "All services and plugins are available"
+                },
+                "core": {
+                    "elasticsearch": {
+                        "level": "available",
+                        "summary": "Elasticsearch is available"
+                    },
+                    "savedObjects": {
+                        "level": "available",
+                        "summary": "SavedObjects service has completed migrations and is available"
+                    }
+                }
             }
         }
     },

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -791,13 +791,13 @@ This status endpoint is available in 6.0 by default and can be enabled in Kibana
 | kibana.status.metrics.requests.disconnects | Total number of disconnected connections. | long |
 | kibana.status.metrics.requests.total | Total number of connections. | long |
 | kibana.status.name | Kibana instance name. | keyword |
-| kibana.status.status.overall.state | Kibana overall state. | keyword |
-| kibana.status.status.overall.level | Kibana overall level (v8 format). | keyword |
-| kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | text |
 | kibana.status.status.core.elasticsearch.level | Kibana Elasticsearch client's status. | keyword |
 | kibana.status.status.core.elasticsearch.summary | Kibana Elasticsearch client's status in a human-readable format. | text |
 | kibana.status.status.core.savedObjects.level | Kibana Saved Objects client's status. | keyword |
 | kibana.status.status.core.savedObjects.summary | Kibana Saved Objects client's status in a human-readable format. | text |
+| kibana.status.status.overall.level | Kibana overall level (v8 format). | keyword |
+| kibana.status.status.overall.state | Kibana overall state. | keyword |
+| kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | text |
 | service.address | Address where data about this service was collected from. | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -792,6 +792,12 @@ This status endpoint is available in 6.0 by default and can be enabled in Kibana
 | kibana.status.metrics.requests.total | Total number of connections. | long |
 | kibana.status.name | Kibana instance name. | keyword |
 | kibana.status.status.overall.state | Kibana overall state. | keyword |
+| kibana.status.status.overall.level | Kibana overall level (v8 format). | keyword |
+| kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | keyword |
+| kibana.status.status.core.elasticsearch.level | Kibana overall state. | keyword |
+| kibana.status.status.core.elasticsearch.summary | Kibana Elasticsearch client's status in a human-readable format. | text |
+| kibana.status.status.core.savedObjects.level | Kibana Saved Objects client's status. | keyword |
+| kibana.status.status.core.savedObjects.summary | Kibana Saved Objects client's status in a human-readable format. | text |
 | service.address | Address where data about this service was collected from. | keyword |
 | service.id | Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes. This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event. Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead. | keyword |
 | service.name | Name of the service data is collected from. The name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified. | keyword |

--- a/packages/kibana/docs/README.md
+++ b/packages/kibana/docs/README.md
@@ -793,7 +793,7 @@ This status endpoint is available in 6.0 by default and can be enabled in Kibana
 | kibana.status.name | Kibana instance name. | keyword |
 | kibana.status.status.overall.state | Kibana overall state. | keyword |
 | kibana.status.status.overall.level | Kibana overall level (v8 format). | keyword |
-| kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | keyword |
+| kibana.status.status.overall.summary | Kibana overall state in a human-readable format. | text |
 | kibana.status.status.core.elasticsearch.level | Kibana overall state. | keyword |
 | kibana.status.status.core.elasticsearch.summary | Kibana Elasticsearch client's status in a human-readable format. | text |
 | kibana.status.status.core.savedObjects.level | Kibana Saved Objects client's status. | keyword |

--- a/packages/kibana/manifest.yml
+++ b/packages/kibana/manifest.yml
@@ -1,6 +1,6 @@
 name: kibana
 title: Kibana
-version: 2.5.3
+version: 2.5.4
 description: Collect logs and metrics from Kibana with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Description

https://github.com/elastic/beats/pull/40275 added some new fields to the `status` metricset of the `kibana` module, but they are missing in the `kibana` integration

## Proposed commit message

See title

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have added an entry to my package's `changelog.yml` file.

## Related issues

Closes https://github.com/elastic/integrations/issues/10623