### PR TITLE
[cisco_ios] Fix CISCO-IOS integration failed to parse logs coming from different application versions

### DIFF
--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix CISCO-IOS integration failing to parse logs coming from different application versions
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/10948
 - version: "1.26.10"
   changes:
     - description: Restore system Message handling for Cisco IOS

--- a/packages/cisco_ios/changelog.yml
+++ b/packages/cisco_ios/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.26.11"
+  changes:
+    - description: Fix CISCO-IOS integration failing to parse logs coming from different application versions
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.26.10"
   changes:
     - description: Restore system Message handling for Cisco IOS

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-parsing-issue-5150.log
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-parsing-issue-5150.log
@@ -1,0 +1,154 @@
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.167: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.672: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.237: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.733: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:55.952: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.170: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.514: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.732: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:56.941: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:56.967: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:56 UTC Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:56.967: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:56 GMT Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.007: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.015: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.158: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.166: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.460: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.460: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.678: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:58.904: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.122: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.341: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.458: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:00:59.567: %SYS-5-CONFIG_I: Configured from memory by console
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:00.590: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <187>26: 000028: *Jan  2 00:01:01.916: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>27: 000029: *Jan  2 00:01:01.924: %SYS-5-RESTART: System restarted --
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>28: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>29: Technical Support: http://www.cisco.com/techsupport
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Copyright (c) 1986-2022 by Cisco Systems, Inc.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Compiled Thu 22-Sep-22 08:48 by mcpre
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>32: 000030: *Jan  2 00:01:02.008: %SSH-5-ENABLED: SSH 2.0 has been enabled
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>33: 000031: *Jan  2 00:01:02.008: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>34: 000032: *Jan  2 00:01:02.369: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:02.369: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>36: 000034: *Jan  2 00:01:02.922: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <187>37: 000035: *Jan  2 00:01:04.021: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.320: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:06.320: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up
+Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>40: 000038: *Jan  2 00:01:06.731: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up
+Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>41: 000039: *Jan  2 00:01:07.041: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)
+Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:07.041: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP
+Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>43: 000041: *Jan  2 00:01:07.041: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)
+Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <189>44: 000042: *Jan  2 00:01:07.301: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up
+Aug 22 05:11:16 es-tf-sw-224.vceaa.votorantim.grupo <189>45: 000044: *Jan  2 00:01:17.653: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted
+Aug 22 05:11:57 es-tf-sw-224.vceaa.votorantim.grupo <187>46: 000045: *Jan  2 00:01:58.716: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up
+Aug 22 05:11:59 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:02:00.737: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.125: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.630: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.187: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.926: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:56.144: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.363: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.715: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.925: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:57.143: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:57.159: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:57.168: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.200: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.200: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.351: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.359: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.653: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.653: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.871: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:59.097: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.315: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.533: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.651: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:01:00.406: %SYS-5-CONFIG_I: Configured from memory by console
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:01.429: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>26: 000028: *Jan  2 00:01:02.000: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <187>27: 000029: *Jan  2 00:01:02.763: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <187>28: 000030: *Jan  2 00:01:02.763: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>29: 000031: *Jan  2 00:01:02.780: %SYS-5-RESTART: System restarted --
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Technical Support: http://www.cisco.com/techsupport
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>32: Copyright (c) 1986-2022 by Cisco Systems, Inc.
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>33: Compiled Thu 22-Sep-22 08:48 by mcpre
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>34: 000032: *Jan  2 00:01:02.855: %SSH-5-ENABLED: SSH 2.0 has been enabled
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:03.199: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>36: 000034: *Jan  2 00:01:03.199: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated
+Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>37: 000035: *Jan  2 00:01:03.770: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.915: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:07.561: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>40: 000038: *Jan  2 00:01:08.132: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>41: 000039: *Jan  2 00:01:08.132: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:08.132: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>43: 000041: *Jan  2 00:01:08.165: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up
+Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>44: 000042: *Jan  2 00:01:08.165: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up
+Aug 22 06:27:07 es-tf-sw-224.vceaa.votorantim.grupo <189>45: 000044: *Jan  2 00:01:18.525: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted
+Aug 22 06:27:48 es-tf-sw-224.vceaa.votorantim.grupo <187>46: 000045: *Jan  2 00:01:59.404: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up
+Aug 22 06:27:50 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:02:01.425: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up
+Aug 22 06:37:59 es-tf-sw-224.vceaa.votorantim.grupo <187>48: 000047: Aug 22 06:37:59.591: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up
+Aug 22 06:37:59 es-tf-sw-224.vceaa.votorantim.grupo <189>49: 000048: Aug 22 06:38:00.597: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 06:38:02 es-tf-sw-224.vceaa.votorantim.grupo <189>50: 000049: Aug 22 06:38:01.881: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down
+Aug 22 06:38:02 es-tf-sw-224.vceaa.votorantim.grupo <187>51: 000050: Aug 22 06:38:02.887: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to down
+Aug 22 06:38:09 es-tf-sw-224.vceaa.votorantim.grupo <187>52: 000051: Aug 22 06:38:09.665: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up
+Aug 22 06:38:09 es-tf-sw-224.vceaa.votorantim.grupo <189>53: 000052: Aug 22 06:38:10.672: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:18:10 es-tf-sw-224.vceaa.votorantim.grupo <189>54: 000053: Aug 22 07:18:10.711: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down
+Aug 22 07:18:12 es-tf-sw-224.vceaa.votorantim.grupo <189>55: 000054: Aug 22 07:18:12.716: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:22:23 es-tf-sw-224.vceaa.votorantim.grupo <189>56: 000055: Aug 22 07:22:23.169: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down
+Aug 22 07:22:25 es-tf-sw-224.vceaa.votorantim.grupo <189>57: 000056: Aug 22 07:22:25.174: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:22:28 es-tf-sw-224.vceaa.votorantim.grupo <189>58: 000057: Aug 22 07:22:28.605: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down
+Aug 22 07:22:29 es-tf-sw-224.vceaa.votorantim.grupo <187>59: 000058: Aug 22 07:22:29.603: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to down
+Aug 22 07:22:32 es-tf-sw-224.vceaa.votorantim.grupo <187>60: 000059: Aug 22 07:22:32.640: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:22:32 es-tf-sw-224.vceaa.votorantim.grupo <189>61: 000060: Aug 22 07:22:33.647: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.109: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.647: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.220: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.851: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:56.069: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.287: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.639: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.849: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:57.067: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:57.084: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:57.092: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.141: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.141: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.292: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.300: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.594: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.602: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.820: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:59.039: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.257: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.483: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.601: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:00:59.701: %SYS-5-CONFIG_I: Configured from memory by console
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:00.733: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <187>26: 000028: *Jan  2 00:01:02.058: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>27: 000029: *Jan  2 00:01:02.067: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>28: 000030: *Jan  2 00:01:02.075: %SYS-5-RESTART: System restarted --
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>29: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Technical Support: http://www.cisco.com/techsupport
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Copyright (c) 1986-2022 by Cisco Systems, Inc.
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>32: Compiled Thu 22-Sep-22 08:48 by mcpre
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>33: 000031: *Jan  2 00:01:02.142: %SSH-5-ENABLED: SSH 2.0 has been enabled
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>34: 000032: *Jan  2 00:01:02.503: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:02.503: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>36: 000034: *Jan  2 00:01:03.073: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <187>37: 000035: *Jan  2 00:01:04.156: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.714: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:06.840: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>40: 000038: *Jan  2 00:01:08.241: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>41: 000039: *Jan  2 00:01:08.241: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:08.409: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>43: 000041: *Jan  2 00:01:08.409: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP
+Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>44: 000042: *Jan  2 00:01:08.409: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)
+Aug 22 07:57:37 es-tf-sw-224.vceaa.votorantim.grupo <187>45: 000043: *Jan  2 00:01:10.179: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:57:37 es-tf-sw-224.vceaa.votorantim.grupo <189>46: 000044: *Jan  2 00:01:11.185: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up
+Aug 22 07:57:45 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:01:17.846: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted
+Aug 22 07:58:26 es-tf-sw-224.vceaa.votorantim.grupo <187>48: 000047: *Jan  2 00:01:58.774: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up
+Aug 22 07:58:28 es-tf-sw-224.vceaa.votorantim.grupo <189>49: 000048: *Jan  2 00:02:00.796: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up

--- a/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-parsing-issue-5150.log-expected.json
+++ b/packages/cisco_ios/data_stream/log/_dev/test/pipeline/test-parsing-issue-5150.log-expected.json
@@ -1,0 +1,6533 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-01-02T00:00:43.167Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "sequence": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.167: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down",
+                "provider": "firewall",
+                "sequence": 2,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:47.672Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SPANTREE",
+                    "sequence": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "EXTENDED_SYSID",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.672: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan",
+                "provider": "firewall",
+                "sequence": 3,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Extended SysId enabled for type vlan",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:51.237Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "sequence": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STARTED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.237: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started",
+                "provider": "firewall",
+                "sequence": 4,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery started",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:55.733Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 5,
+                    "sequence": "000006"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOG_CONFIG_CHANGE",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.733: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled",
+                "provider": "firewall",
+                "sequence": 6,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Console logging disabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:55.952Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 6,
+                    "sequence": "000007"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:55.952: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+                "provider": "firewall",
+                "sequence": 7,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.170Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 7,
+                    "sequence": "000008"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.170: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 8,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.514Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 8,
+                    "sequence": "000009"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.514: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 9,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.732Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 9,
+                    "sequence": "000010"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.732: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 10,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.941Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 10,
+                    "sequence": "000011"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:56.941: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 11,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.967Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 11,
+                    "sequence": "000012"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:56.967: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:56 UTC Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 12,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 00:00:56 UTC Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.967Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 12,
+                    "sequence": "000013"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:56.967: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:56 GMT Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 13,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 01:00:56 GMT Mon Jan 2 2006 to 01:00:56 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.007Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 13,
+                    "sequence": "000014"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.007: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down",
+                "provider": "firewall",
+                "sequence": 14,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.015Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 14,
+                    "sequence": "000015"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.015: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down",
+                "provider": "firewall",
+                "sequence": 15,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.158Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 15,
+                    "sequence": "000016"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.158: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 16,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.166Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 16,
+                    "sequence": "000017"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.166: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 17,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.460Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 17,
+                    "sequence": "000018"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.460: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 18,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.460Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 18,
+                    "sequence": "000019"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.460: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up",
+                "provider": "firewall",
+                "sequence": 19,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Loopback10, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.678Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 19,
+                    "sequence": "000020"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.678: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 20,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.904Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 20,
+                    "sequence": "000021"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:58.904: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 21,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.122Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 21,
+                    "sequence": "000022"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.122: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 22,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.341Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 22,
+                    "sequence": "000023"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.341: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 23,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.458Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SW_VLAN",
+                    "message_count": 23,
+                    "sequence": "000024"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "VTP_DOMAIN_NAME_CHG",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.458: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.",
+                "provider": "firewall",
+                "sequence": 24,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "VTP domain name changed to cimpornet.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.567Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 24,
+                    "sequence": "000025"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CONFIG_I",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:00:59.567: %SYS-5-CONFIG_I: Configured from memory by console",
+                "provider": "firewall",
+                "sequence": 25,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Configured from memory by console",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:00.590Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PHY",
+                    "message_count": 25,
+                    "sequence": "000026"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "TRANSCEIVERINSERTED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:00.590: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted",
+                "provider": "firewall",
+                "sequence": 26,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Slot=1 Port=9: Transceiver has been inserted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:01.916Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 26,
+                    "sequence": "000028"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <187>26: 000028: *Jan  2 00:01:01.916: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 28,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:01.924Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 27,
+                    "sequence": "000029"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "RESTART",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>27: 000029: *Jan  2 00:01:01.924: %SYS-5-RESTART: System restarted --",
+                "provider": "firewall",
+                "sequence": 29,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "System restarted --",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "28"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>28: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+                "provider": "firewall",
+                "sequence": 28,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "29"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>29: Technical Support: http://www.cisco.com/techsupport",
+                "provider": "firewall",
+                "sequence": 29,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Technical Support: http://www.cisco.com/techsupport",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "30"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+                "provider": "firewall",
+                "sequence": 30,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "31"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Compiled Thu 22-Sep-22 08:48 by mcpre",
+                "provider": "firewall",
+                "sequence": 31,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Compiled Thu 22-Sep-22 08:48 by mcpre",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.008Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SSH",
+                    "message_count": 32,
+                    "sequence": "000030"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "ENABLED",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>32: 000030: *Jan  2 00:01:02.008: %SSH-5-ENABLED: SSH 2.0 has been enabled",
+                "provider": "firewall",
+                "sequence": 30,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "SSH 2.0 has been enabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.008Z",
+            "cisco": {
+                "ios": {
+                    "facility": "USB_CONSOLE",
+                    "message_count": 33,
+                    "sequence": "000031"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "MEDIA_RJ45",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>33: 000031: *Jan  2 00:01:02.008: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.",
+                "provider": "firewall",
+                "sequence": 31,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Console media-type is RJ45.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.369Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 34,
+                    "sequence": "000032"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>34: 000032: *Jan  2 00:01:02.369: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 32,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.369Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 35,
+                    "sequence": "000033"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:02.369: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 33,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.922Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 36,
+                    "sequence": "000034"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>36: 000034: *Jan  2 00:01:02.922: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 34,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:04.021Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 37,
+                    "sequence": "000035"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <187>37: 000035: *Jan  2 00:01:04.021: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 35,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.320Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 38,
+                    "sequence": "000036"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.320: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up",
+                "provider": "firewall",
+                "sequence": 36,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.320Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 39,
+                    "sequence": "000037"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:06.320: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up",
+                "provider": "firewall",
+                "sequence": 37,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.731Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 40,
+                    "sequence": "000038"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:06 es-tf-sw-224.vceaa.votorantim.grupo <189>40: 000038: *Jan  2 00:01:06.731: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 38,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:07.041Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 41,
+                    "sequence": "000039"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_BEST_UDI_UPDATE",
+                "original": "Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>41: 000039: *Jan  2 00:01:07.041: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+                "provider": "firewall",
+                "sequence": 39,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:07.041Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 42,
+                    "sequence": "000040"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_CDP_UPDATE",
+                "original": "Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:07.041: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+                "provider": "firewall",
+                "sequence": 40,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:07.041Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 43,
+                    "sequence": "000041"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STOPPED",
+                "original": "Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <190>43: 000041: *Jan  2 00:01:07.041: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)",
+                "provider": "firewall",
+                "sequence": 41,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery stopped (Startup Config Present)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:07.301Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 44,
+                    "sequence": "000042"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:07 es-tf-sw-224.vceaa.votorantim.grupo <189>44: 000042: *Jan  2 00:01:07.301: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up",
+                "provider": "firewall",
+                "sequence": 42,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:17.653Z",
+            "cisco": {
+                "ios": {
+                    "facility": "ILPOWER",
+                    "message_count": 45,
+                    "sequence": "000044"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "POWER_GRANTED",
+                "original": "Aug 22 05:11:16 es-tf-sw-224.vceaa.votorantim.grupo <189>45: 000044: *Jan  2 00:01:17.653: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted",
+                "provider": "firewall",
+                "sequence": 44,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Interface Fa0/1: Power granted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:58.716Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 46,
+                    "sequence": "000045"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:57 es-tf-sw-224.vceaa.votorantim.grupo <187>46: 000045: *Jan  2 00:01:58.716: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 45,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:02:00.737Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 47,
+                    "sequence": "000046"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 05:11:59 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:02:00.737: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 46,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:43.125Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "sequence": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.125: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down",
+                "provider": "firewall",
+                "sequence": 2,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:47.630Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SPANTREE",
+                    "sequence": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "EXTENDED_SYSID",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.630: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan",
+                "provider": "firewall",
+                "sequence": 3,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Extended SysId enabled for type vlan",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:51.187Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "sequence": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STARTED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.187: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started",
+                "provider": "firewall",
+                "sequence": 4,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery started",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:55.926Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 5,
+                    "sequence": "000006"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOG_CONFIG_CHANGE",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.926: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled",
+                "provider": "firewall",
+                "sequence": 6,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Console logging disabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.144Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 6,
+                    "sequence": "000007"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:56.144: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+                "provider": "firewall",
+                "sequence": 7,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.363Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 7,
+                    "sequence": "000008"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.363: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 8,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.715Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 8,
+                    "sequence": "000009"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.715: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 9,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.925Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 9,
+                    "sequence": "000010"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.925: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 10,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.143Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 10,
+                    "sequence": "000011"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:57.143: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 11,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.159Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 11,
+                    "sequence": "000012"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:57.159: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 12,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.168Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 12,
+                    "sequence": "000013"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:57.168: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 13,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.200Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 13,
+                    "sequence": "000014"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.200: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down",
+                "provider": "firewall",
+                "sequence": 14,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.200Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 14,
+                    "sequence": "000015"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.200: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down",
+                "provider": "firewall",
+                "sequence": 15,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.351Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 15,
+                    "sequence": "000016"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.351: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 16,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.359Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 16,
+                    "sequence": "000017"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.359: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 17,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.653Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 17,
+                    "sequence": "000018"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.653: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 18,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.653Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 18,
+                    "sequence": "000019"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.653: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up",
+                "provider": "firewall",
+                "sequence": 19,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Loopback10, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.871Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 19,
+                    "sequence": "000020"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.871: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 20,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.097Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 20,
+                    "sequence": "000021"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:59.097: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 21,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.315Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 21,
+                    "sequence": "000022"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.315: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 22,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.533Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 22,
+                    "sequence": "000023"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.533: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 23,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.651Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SW_VLAN",
+                    "message_count": 23,
+                    "sequence": "000024"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "VTP_DOMAIN_NAME_CHG",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.651: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.",
+                "provider": "firewall",
+                "sequence": 24,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "VTP domain name changed to cimpornet.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:00.406Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 24,
+                    "sequence": "000025"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CONFIG_I",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:01:00.406: %SYS-5-CONFIG_I: Configured from memory by console",
+                "provider": "firewall",
+                "sequence": 25,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Configured from memory by console",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:01.429Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PHY",
+                    "message_count": 25,
+                    "sequence": "000026"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "TRANSCEIVERINSERTED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:01.429: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted",
+                "provider": "firewall",
+                "sequence": 26,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Slot=1 Port=9: Transceiver has been inserted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.000Z",
+            "cisco": {
+                "ios": {
+                    "facility": "USB_CONSOLE",
+                    "message_count": 26,
+                    "sequence": "000028"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "MEDIA_RJ45",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>26: 000028: *Jan  2 00:01:02.000: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.",
+                "provider": "firewall",
+                "sequence": 28,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Console media-type is RJ45.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.763Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 27,
+                    "sequence": "000029"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <187>27: 000029: *Jan  2 00:01:02.763: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 29,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.763Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 28,
+                    "sequence": "000030"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <187>28: 000030: *Jan  2 00:01:02.763: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 30,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.780Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 29,
+                    "sequence": "000031"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "RESTART",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>29: 000031: *Jan  2 00:01:02.780: %SYS-5-RESTART: System restarted --",
+                "provider": "firewall",
+                "sequence": 31,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "System restarted --",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "30"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+                "provider": "firewall",
+                "sequence": 30,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "31"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Technical Support: http://www.cisco.com/techsupport",
+                "provider": "firewall",
+                "sequence": 31,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Technical Support: http://www.cisco.com/techsupport",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "32"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>32: Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+                "provider": "firewall",
+                "sequence": 32,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "33"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>33: Compiled Thu 22-Sep-22 08:48 by mcpre",
+                "provider": "firewall",
+                "sequence": 33,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Compiled Thu 22-Sep-22 08:48 by mcpre",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.855Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SSH",
+                    "message_count": 34,
+                    "sequence": "000032"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "ENABLED",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>34: 000032: *Jan  2 00:01:02.855: %SSH-5-ENABLED: SSH 2.0 has been enabled",
+                "provider": "firewall",
+                "sequence": 32,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "SSH 2.0 has been enabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:03.199Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 35,
+                    "sequence": "000033"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:03.199: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 33,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:03.199Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 36,
+                    "sequence": "000034"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <190>36: 000034: *Jan  2 00:01:03.199: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 34,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:03.770Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 37,
+                    "sequence": "000035"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:55 es-tf-sw-224.vceaa.votorantim.grupo <189>37: 000035: *Jan  2 00:01:03.770: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 35,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.915Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 38,
+                    "sequence": "000036"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.915: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up",
+                "provider": "firewall",
+                "sequence": 36,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:07.561Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 39,
+                    "sequence": "000037"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:07.561: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 37,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.132Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 40,
+                    "sequence": "000038"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_BEST_UDI_UPDATE",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>40: 000038: *Jan  2 00:01:08.132: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+                "provider": "firewall",
+                "sequence": 38,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.132Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 41,
+                    "sequence": "000039"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_CDP_UPDATE",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>41: 000039: *Jan  2 00:01:08.132: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+                "provider": "firewall",
+                "sequence": 39,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.132Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 42,
+                    "sequence": "000040"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STOPPED",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:08.132: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)",
+                "provider": "firewall",
+                "sequence": 40,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery stopped (Startup Config Present)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.165Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 43,
+                    "sequence": "000041"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>43: 000041: *Jan  2 00:01:08.165: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up",
+                "provider": "firewall",
+                "sequence": 41,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.165Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 44,
+                    "sequence": "000042"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:26:56 es-tf-sw-224.vceaa.votorantim.grupo <189>44: 000042: *Jan  2 00:01:08.165: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up",
+                "provider": "firewall",
+                "sequence": 42,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:18.525Z",
+            "cisco": {
+                "ios": {
+                    "facility": "ILPOWER",
+                    "message_count": 45,
+                    "sequence": "000044"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "POWER_GRANTED",
+                "original": "Aug 22 06:27:07 es-tf-sw-224.vceaa.votorantim.grupo <189>45: 000044: *Jan  2 00:01:18.525: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted",
+                "provider": "firewall",
+                "sequence": 44,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Interface Fa0/1: Power granted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:59.404Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 46,
+                    "sequence": "000045"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:27:48 es-tf-sw-224.vceaa.votorantim.grupo <187>46: 000045: *Jan  2 00:01:59.404: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 45,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:02:01.425Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 47,
+                    "sequence": "000046"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:27:50 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:02:01.425: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 46,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:37:59.591Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 48,
+                    "sequence": "000047"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:37:59 es-tf-sw-224.vceaa.votorantim.grupo <187>48: 000047: Aug 22 06:37:59.591: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 47,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:38:00.597Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 49,
+                    "sequence": "000048"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:37:59 es-tf-sw-224.vceaa.votorantim.grupo <189>49: 000048: Aug 22 06:38:00.597: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 48,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:38:01.881Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 50,
+                    "sequence": "000049"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:38:02 es-tf-sw-224.vceaa.votorantim.grupo <189>50: 000049: Aug 22 06:38:01.881: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 49,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:38:02.887Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 51,
+                    "sequence": "000050"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:38:02 es-tf-sw-224.vceaa.votorantim.grupo <187>51: 000050: Aug 22 06:38:02.887: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 50,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:38:09.665Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 52,
+                    "sequence": "000051"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:38:09 es-tf-sw-224.vceaa.votorantim.grupo <187>52: 000051: Aug 22 06:38:09.665: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 51,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T06:38:10.672Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 53,
+                    "sequence": "000052"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 06:38:09 es-tf-sw-224.vceaa.votorantim.grupo <189>53: 000052: Aug 22 06:38:10.672: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 52,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:18:10.711Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 54,
+                    "sequence": "000053"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:18:10 es-tf-sw-224.vceaa.votorantim.grupo <189>54: 000053: Aug 22 07:18:10.711: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 53,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:18:12.716Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 55,
+                    "sequence": "000054"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:18:12 es-tf-sw-224.vceaa.votorantim.grupo <189>55: 000054: Aug 22 07:18:12.716: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 54,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:23.169Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 56,
+                    "sequence": "000055"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:23 es-tf-sw-224.vceaa.votorantim.grupo <189>56: 000055: Aug 22 07:22:23.169: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 55,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:25.174Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 57,
+                    "sequence": "000056"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:25 es-tf-sw-224.vceaa.votorantim.grupo <189>57: 000056: Aug 22 07:22:25.174: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 56,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:28.605Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 58,
+                    "sequence": "000057"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:28 es-tf-sw-224.vceaa.votorantim.grupo <189>58: 000057: Aug 22 07:22:28.605: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 57,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:29.603Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 59,
+                    "sequence": "000058"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:29 es-tf-sw-224.vceaa.votorantim.grupo <187>59: 000058: Aug 22 07:22:29.603: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to down",
+                "provider": "firewall",
+                "sequence": 58,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:32.640Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 60,
+                    "sequence": "000059"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:32 es-tf-sw-224.vceaa.votorantim.grupo <187>60: 000059: Aug 22 07:22:32.640: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 59,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-08-22T07:22:33.647Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 61,
+                    "sequence": "000060"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:22:32 es-tf-sw-224.vceaa.votorantim.grupo <189>61: 000060: Aug 22 07:22:33.647: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 60,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:43.109Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "sequence": "2"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>2: *Jan  2 00:00:43.109: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to down",
+                "provider": "firewall",
+                "sequence": 2,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:47.647Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SPANTREE",
+                    "sequence": "3"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "EXTENDED_SYSID",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>3: *Jan  2 00:00:47.647: %SPANTREE-5-EXTENDED_SYSID: Extended SysId enabled for type vlan",
+                "provider": "firewall",
+                "sequence": 3,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Extended SysId enabled for type vlan",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:51.220Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "sequence": "4"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STARTED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>4: *Jan  2 00:00:51.220: %PNP-6-PNP_DISCOVERY_STARTED: PnP Discovery started",
+                "provider": "firewall",
+                "sequence": 4,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery started",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:55.851Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 5,
+                    "sequence": "000006"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOG_CONFIG_CHANGE",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>5: 000006: *Jan  2 00:00:55.851: %SYS-5-LOG_CONFIG_CHANGE: Console logging disabled",
+                "provider": "firewall",
+                "sequence": 6,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Console logging disabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.069Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 6,
+                    "sequence": "000007"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>6: 000007: *Jan  2 00:00:56.069: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+                "provider": "firewall",
+                "sequence": 7,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 5 password. However, type 5 passwords will soon be deprecated. Migrate to a strong password type.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.287Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 7,
+                    "sequence": "000008"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>7: 000008: *Jan  2 00:00:56.287: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 8,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.639Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 8,
+                    "sequence": "000009"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>8: 000009: *Jan  2 00:00:56.639: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 9,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:56.849Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 9,
+                    "sequence": "000010"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>9: 000010: *Jan  2 00:00:56.849: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 10,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.067Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 10,
+                    "sequence": "000011"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>10: 000011: *Jan  2 00:00:57.067: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 11,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.084Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 11,
+                    "sequence": "000012"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>11: 000012: *Jan  2 00:00:57.084: %SYS-6-CLOCKUPDATE: System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 12,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 00:00:57 UTC Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:57.092Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 12,
+                    "sequence": "000013"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLOCKUPDATE",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>12: 000013: *Jan  2 00:00:57.092: %SYS-6-CLOCKUPDATE: System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+                "provider": "firewall",
+                "sequence": 13,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "System clock has been updated from 01:00:57 GMT Mon Jan 2 2006 to 01:00:57 GMT Mon Jan 2 2006, configured from console by vty0.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.141Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 13,
+                    "sequence": "000014"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>13: 000014: *Jan  2 00:00:58.141: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to down",
+                "provider": "firewall",
+                "sequence": 14,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.141Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 14,
+                    "sequence": "000015"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>14: 000015: *Jan  2 00:00:58.141: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to down",
+                "provider": "firewall",
+                "sequence": 15,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to down",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.292Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 15,
+                    "sequence": "000016"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>15: 000016: *Jan  2 00:00:58.292: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 16,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.300Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 16,
+                    "sequence": "000017"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>16: 000017: *Jan  2 00:00:58.300: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+                "provider": "firewall",
+                "sequence": 17,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 0 CLI Request Triggered",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.594Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 17,
+                    "sequence": "000018"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>17: 000018: *Jan  2 00:00:58.594: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 18,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.602Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 18,
+                    "sequence": "000019"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>18: 000019: *Jan  2 00:00:58.602: %LINEPROTO-5-UPDOWN: Line protocol on Interface Loopback10, changed state to up",
+                "provider": "firewall",
+                "sequence": 19,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Loopback10, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:58.820Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 19,
+                    "sequence": "000020"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>19: 000020: *Jan  2 00:00:58.820: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 20,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.039Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 20,
+                    "sequence": "000021"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>20: 000021: *Jan  2 00:00:59.039: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 21,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.257Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 21,
+                    "sequence": "000022"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>21: 000022: *Jan  2 00:00:59.257: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 22,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.483Z",
+            "cisco": {
+                "ios": {
+                    "facility": "AAAA",
+                    "message_count": 22,
+                    "sequence": "000023"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CLI_DEPRECATED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <188>22: 000023: *Jan  2 00:00:59.483: %AAAA-4-CLI_DEPRECATED: WARNING: Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+                "provider": "firewall",
+                "sequence": 23,
+                "severity": 4,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "warning",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 188
+                }
+            },
+            "message": "Command has been added to the configuration using a type 7 password. However, type 7 passwords will soon be deprecated. Migrate to a supported password type",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.601Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SW_VLAN",
+                    "message_count": 23,
+                    "sequence": "000024"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "VTP_DOMAIN_NAME_CHG",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>23: 000024: *Jan  2 00:00:59.601: %SW_VLAN-6-VTP_DOMAIN_NAME_CHG: VTP domain name changed to cimpornet.",
+                "provider": "firewall",
+                "sequence": 24,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "VTP domain name changed to cimpornet.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:00:59.701Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 24,
+                    "sequence": "000025"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "CONFIG_I",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>24: 000025: *Jan  2 00:00:59.701: %SYS-5-CONFIG_I: Configured from memory by console",
+                "provider": "firewall",
+                "sequence": 25,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Configured from memory by console",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:00.733Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PHY",
+                    "message_count": 25,
+                    "sequence": "000026"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "TRANSCEIVERINSERTED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>25: 000026: *Jan  2 00:01:00.733: %PHY-5-TRANSCEIVERINSERTED: Slot=1 Port=9: Transceiver has been inserted",
+                "provider": "firewall",
+                "sequence": 26,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Slot=1 Port=9: Transceiver has been inserted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.058Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 26,
+                    "sequence": "000028"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <187>26: 000028: *Jan  2 00:01:02.058: %LINK-3-UPDOWN: Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 28,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.067Z",
+            "cisco": {
+                "ios": {
+                    "facility": "USB_CONSOLE",
+                    "message_count": 27,
+                    "sequence": "000029"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "MEDIA_RJ45",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>27: 000029: *Jan  2 00:01:02.067: %USB_CONSOLE-6-MEDIA_RJ45: Console media-type is RJ45.",
+                "provider": "firewall",
+                "sequence": 29,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Console media-type is RJ45.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.075Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 28,
+                    "sequence": "000030"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "RESTART",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>28: 000030: *Jan  2 00:01:02.075: %SYS-5-RESTART: System restarted --",
+                "provider": "firewall",
+                "sequence": 30,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "System restarted --",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "29"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>29: Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+                "provider": "firewall",
+                "sequence": 29,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Cisco IOS Software, C2960C Software (C2960c405-UNIVERSALK9-M), Version 15.2(7)E7, RELEASE SOFTWARE (fc10)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "30"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>30: Technical Support: http://www.cisco.com/techsupport",
+                "provider": "firewall",
+                "sequence": 30,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Technical Support: http://www.cisco.com/techsupport",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "31"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>31: Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+                "provider": "firewall",
+                "sequence": 31,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Copyright (c) 1986-2022 by Cisco Systems, Inc.",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "cisco": {
+                "ios": {
+                    "sequence": "32"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>32: Compiled Thu 22-Sep-22 08:48 by mcpre",
+                "provider": "firewall",
+                "sequence": 32,
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Compiled Thu 22-Sep-22 08:48 by mcpre",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.142Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SSH",
+                    "message_count": 33,
+                    "sequence": "000031"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "ENABLED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>33: 000031: *Jan  2 00:01:02.142: %SSH-5-ENABLED: SSH 2.0 has been enabled",
+                "provider": "firewall",
+                "sequence": 31,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "SSH 2.0 has been enabled",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.503Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 34,
+                    "sequence": "000032"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>34: 000032: *Jan  2 00:01:02.503: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.0.119 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 32,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.0.119 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:02.503Z",
+            "cisco": {
+                "ios": {
+                    "facility": "SYS",
+                    "message_count": 35,
+                    "sequence": "000033"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "LOGGINGHOST_STARTSTOP",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>35: 000033: *Jan  2 00:01:02.503: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 10.112.1.129 port 514 started - CLI initiated",
+                "provider": "firewall",
+                "sequence": 33,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Logging to host 10.112.1.129 port 514 started - CLI initiated",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:03.073Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 36,
+                    "sequence": "000034"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>36: 000034: *Jan  2 00:01:03.073: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 34,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:04.156Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 37,
+                    "sequence": "000035"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <187>37: 000035: *Jan  2 00:01:04.156: %LINK-3-UPDOWN: Interface FastEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 35,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.714Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 38,
+                    "sequence": "000036"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>38: 000036: *Jan  2 00:01:06.714: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan22, changed state to up",
+                "provider": "firewall",
+                "sequence": 36,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan22, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:06.840Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 39,
+                    "sequence": "000037"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>39: 000037: *Jan  2 00:01:06.840: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 37,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.241Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 40,
+                    "sequence": "000038"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>40: 000038: *Jan  2 00:01:08.241: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan1, changed state to up",
+                "provider": "firewall",
+                "sequence": 38,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.241Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 41,
+                    "sequence": "000039"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <189>41: 000039: *Jan  2 00:01:08.241: %LINEPROTO-5-UPDOWN: Line protocol on Interface Vlan718, changed state to up",
+                "provider": "firewall",
+                "sequence": 39,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface Vlan718, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.409Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 42,
+                    "sequence": "000040"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_BEST_UDI_UPDATE",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>42: 000040: *Jan  2 00:01:08.409: %PNP-6-PNP_BEST_UDI_UPDATE: Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+                "provider": "firewall",
+                "sequence": 40,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Best UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified via (master-registry)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.409Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 43,
+                    "sequence": "000041"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_CDP_UPDATE",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>43: 000041: *Jan  2 00:01:08.409: %PNP-6-PNP_CDP_UPDATE: Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+                "provider": "firewall",
+                "sequence": 41,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "Device UDI [PID:WS-C2960C-8PC-L,VID:V01,SN:FOC1635Y3NN] identified for CDP",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:08.409Z",
+            "cisco": {
+                "ios": {
+                    "facility": "PNP",
+                    "message_count": 44,
+                    "sequence": "000042"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "PNP_DISCOVERY_STOPPED",
+                "original": "Aug 22 07:57:34 es-tf-sw-224.vceaa.votorantim.grupo <190>44: 000042: *Jan  2 00:01:08.409: %PNP-6-PNP_DISCOVERY_STOPPED: PnP Discovery stopped (Startup Config Present)",
+                "provider": "firewall",
+                "sequence": 42,
+                "severity": 6,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 190
+                }
+            },
+            "message": "PnP Discovery stopped (Startup Config Present)",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:10.179Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 45,
+                    "sequence": "000043"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:37 es-tf-sw-224.vceaa.votorantim.grupo <187>45: 000043: *Jan  2 00:01:10.179: %LINK-3-UPDOWN: Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 43,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:11.185Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 46,
+                    "sequence": "000044"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:57:37 es-tf-sw-224.vceaa.votorantim.grupo <189>46: 000044: *Jan  2 00:01:11.185: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/2, changed state to up",
+                "provider": "firewall",
+                "sequence": 44,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface GigabitEthernet0/2, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:17.846Z",
+            "cisco": {
+                "ios": {
+                    "facility": "ILPOWER",
+                    "message_count": 47,
+                    "sequence": "000046"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "POWER_GRANTED",
+                "original": "Aug 22 07:57:45 es-tf-sw-224.vceaa.votorantim.grupo <189>47: 000046: *Jan  2 00:01:17.846: %ILPOWER-5-POWER_GRANTED: Interface Fa0/1: Power granted",
+                "provider": "firewall",
+                "sequence": 46,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Interface Fa0/1: Power granted",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:01:58.774Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINK",
+                    "message_count": 48,
+                    "sequence": "000047"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:58:26 es-tf-sw-224.vceaa.votorantim.grupo <187>48: 000047: *Jan  2 00:01:58.774: %LINK-3-UPDOWN: Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 47,
+                "severity": 3,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "error",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 187
+                }
+            },
+            "message": "Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-01-02T00:02:00.796Z",
+            "cisco": {
+                "ios": {
+                    "facility": "LINEPROTO",
+                    "message_count": 49,
+                    "sequence": "000048"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "code": "UPDOWN",
+                "original": "Aug 22 07:58:28 es-tf-sw-224.vceaa.votorantim.grupo <189>49: 000048: *Jan  2 00:02:00.796: %LINEPROTO-5-UPDOWN: Line protocol on Interface FastEthernet0/1, changed state to up",
+                "provider": "firewall",
+                "sequence": 48,
+                "severity": 5,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "log": {
+                "level": "notification",
+                "syslog": {
+                    "hostname": "es-tf-sw-224.vceaa.votorantim.grupo",
+                    "priority": 189
+                }
+            },
+            "message": "Line protocol on Interface FastEthernet0/1, changed state to up",
+            "observer": {
+                "product": "IOS",
+                "type": "firewall",
+                "vendor": "Cisco"
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ios/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -39,6 +39,8 @@ processors:
         - '^%{CISCO_PRIORITY_MSGCOUNT}?%{SYSLOGTIMESTAMP} (?:%{IP}|%{CISCO_HOSTNAME:log.syslog.hostname}) %{NUMBER:cisco.ios.sequence}: (?:%{CISCO_UPTIME:cisco.ios.uptime}|%{CISCO_TIMESTAMP}): %{GREEDYDATA:_temp_.message}$'
         - '^%{CISCO_PRIORITY_MSGCOUNT}?(?:(?:%{CISCO_HOSTNAME:log.syslog.hostname}|%{IP})[:]? )?(?:%{NUMBER:cisco.ios.sequence}: )?(?:%{CISCO_UPTIME:cisco.ios.uptime}|%{CISCO_TIMESTAMP}): %{GREEDYDATA:_temp_.message}$'
         - '^%{CISCO_PRIORITY_MSGCOUNT}?%{SYSLOGTIMESTAMP} (?:%{IP:log.syslog.hostname}|%{CISCO_HOSTNAME:log.syslog.hostname}) %{GREEDYDATA:_temp_.message}$'
+        - '^%{SYSLOGTIMESTAMP} (?:%{IP}|%{HOSTNAME:log.syslog.hostname}) %{CISCO_PRIORITY_MSGCOUNT}?(?:%{NUMBER:cisco.ios.sequence}: )(\\*)?(?:%{CISCO_UPTIME:cisco.ios.uptime}|%{CISCO_TIMESTAMP}): %{GREEDYDATA:_temp_.message}$'
+        - '^%{SYSLOGTIMESTAMP} (?:%{IP}|%{HOSTNAME:log.syslog.hostname}) %{CISCO_PRIORITY_MSGCOUNT}?(?:%{NUMBER:cisco.ios.sequence}: )%{GREEDYDATA:_temp_.message}$'
       pattern_definitions:
         CISCO_PRIORITY_MSGCOUNT: '<%{NONNEGINT:log.syslog.priority:long}>(?:%{NONNEGINT:cisco.ios.message_count})?(?:: )?'
         CISCO_TIMESTAMP: '[*]?%{CISCOTIMESTAMP:_temp_.cisco_timestamp}(?: %{CISCO_TZ:_temp_.tz})?'

--- a/packages/cisco_ios/manifest.yml
+++ b/packages/cisco_ios/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ios
 title: Cisco IOS
-version: "1.26.10"
+version: "1.26.11"
 description: Collect logs from Cisco IOS with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix CISCO-IOS integration failed to parse logs coming from different application versions.

This fixes yet another SDH coming from the user that provided yet another sample of logs that have a different format.

@pkoutsovasilis I noticed the difference in the expected output files between 8.15 and 8.16 version of the stack when running the pipeline tests. Few files for the community_id added when running pipeline test against 8.16:
```
            "network": {
                "community_id": "1:NCx7UOZoQUvxIB+uzqMmGnZTSzI=",
```
Assuming this might be expected due to this change https://github.com/elastic/elasticsearch/pull/111528. But wanted to get your 👀  on this in case if this is not expected from Elasticsearch side.

This PR includes the files regenerated with 8.15 at the moment. Will see if CI complains, then can regenerate against 8.16.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

