### PR TITLE
[CI] Enable wolfi images in CI except weekly builds

### DIFF
--- a/.buildkite/pipeline.serverless.yml
+++ b/.buildkite/pipeline.serverless.yml
@@ -26,6 +26,8 @@ env:
   ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
   # Set maximum number of parallel tests to run if package allows it
   ELASTIC_PACKAGE_MAXIMUM_NUMBER_PARALLEL_TESTS: "5"
+  # Enable/Disable the usage of wolfi images for Elastic Agent
+  ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
 
 steps:
   - input: "Input values for the variables"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ env:
   ELASTIC_PACKAGE_TEST_ENABLE_INDEPENDENT_AGENT: "true"
   # Set maximum number of parallel tests to run if package allows it
   ELASTIC_PACKAGE_MAXIMUM_NUMBER_PARALLEL_TESTS: "5"
-  # Disable the usage of wolfi images for Elastic Agent
+  # Enable/Disable the usage of wolfi images for Elastic Agent
   ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
 
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ env:
   # Set maximum number of parallel tests to run if package allows it
   ELASTIC_PACKAGE_MAXIMUM_NUMBER_PARALLEL_TESTS: "5"
   # Disable the usage of wolfi images for Elastic Agent
-  ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-true}"
+  ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI: "${ELASTIC_PACKAGE_DISABLE_ELASTIC_AGENT_WOLFI:-false}"
 
 steps:
   - label: "Get reference from target branch"


### PR DESCRIPTION
## Proposed commit message

Enable Elastic Agent wolfi images for CI pipelines ([PRs](https://buildkite.com/elastic/integrations) and [daily](https://buildkite.com/elastic/integrations-schedule-daily/) jobs) except for [weekly](https://buildkite.com/elastic/integrations-schedule-weekly/) job.

Weekly pipeline:
https://github.com/elastic/integrations/blob/d5f72523ef4d33b3cef93ce35697cd28acc310e3/.buildkite/pipeline.schedule-weekly.yml#L26

[Integrations serverless job](https://buildkite.com/elastic/integrations-serverless) would run also these wolfi docker images, but currently system tests are not executed in those builds:
https://github.com/elastic/integrations/blob/d5f72523ef4d33b3cef93ce35697cd28acc310e3/.buildkite/scripts/common.sh#L806-L827

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

