### PR TITLE
[DOCS] Add new section on Azure Functions hosting plans

### DIFF
--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -4,6 +4,11 @@ The Azure Functions integration allows you to monitor Azure Functions. Azure Fun
 
 Use this integration to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
 
+## Hosting plans
+
+Each Azure Functions app requires a hosting plan: Consumption plan, Flex Consumption plan, Premium plan, Dedicated plan, or Container Apps. For more details on the various plans, check the [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale?WT.mc_id=Portal-WebsitesExtension).
+
+These plans differ from eachother in the number of metrics they generate, which are then exported outside of Azure for other monitoring solutions like Elastic Observability. For example, metrics specific to Azure Function Apps, such as 'FunctionExecutionCount' and 'FunctionExecutionUnits', are only available for function apps operating on a Consumption (serverless) plan and are not observed in other plans. On the other hand, all other metrics are generated exclusively for Premium and Dedicated plans and are not available for the Consumption plan.
 
 ## Data streams
 The Azure Functions integration contains two data streams: [Function App Logs](#logs) and [Metrics](#metrics)

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -4,7 +4,7 @@ The Azure Functions integration allows you to monitor Azure Functions. Azure Fun
 
 Use Azure Functions to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
 
-## Hosting plans
+## Hosting plans and metrics
 
 Each Azure Functions app requires a hosting plan: Consumption plan, Flex Consumption plan, Premium plan, Dedicated plan, or Container Apps. For more details on the various plans, check the [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale?WT.mc_id=Portal-WebsitesExtension).
 

--- a/packages/azure_functions/_dev/build/docs/README.md
+++ b/packages/azure_functions/_dev/build/docs/README.md
@@ -2,7 +2,7 @@
 
 The Azure Functions integration allows you to monitor Azure Functions. Azure Functions is an event-driven, serverless compute platform that helps you develop more efficiently using the programming language of your choice. Triggers cause a function to run. A trigger defines how a function is invoked and a function must have exactly one trigger. 
 
-Use this integration to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
+Use Azure Functions to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
 
 ## Hosting plans
 

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -4,7 +4,7 @@ The Azure Functions integration allows you to monitor Azure Functions. Azure Fun
 
 Use Azure Functions to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
 
-## Hosting plans
+## Hosting plans and metrics
 
 Each Azure Functions app requires a hosting plan: Consumption plan, Flex Consumption plan, Premium plan, Dedicated plan, or Container Apps. For more details on the various plans, check the [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale?WT.mc_id=Portal-WebsitesExtension).
 

--- a/packages/azure_functions/docs/README.md
+++ b/packages/azure_functions/docs/README.md
@@ -2,8 +2,13 @@
 
 The Azure Functions integration allows you to monitor Azure Functions. Azure Functions is an event-driven, serverless compute platform that helps you develop more efficiently using the programming language of your choice. Triggers cause a function to run. A trigger defines how a function is invoked and a function must have exactly one trigger. 
 
-Use this integration to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
+Use Azure Functions to build web APIs, respond to database changes, process IoT streams, manage message queues, and more. Refer common [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios?pivots=programming-language-csharp) for more information.
 
+## Hosting plans
+
+Each Azure Functions app requires a hosting plan: Consumption plan, Flex Consumption plan, Premium plan, Dedicated plan, or Container Apps. For more details on the various plans, check the [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale?WT.mc_id=Portal-WebsitesExtension).
+
+These plans differ from eachother in the number of metrics they generate, which are then exported outside of Azure for other monitoring solutions like Elastic Observability. For example, metrics specific to Azure Function Apps, such as 'FunctionExecutionCount' and 'FunctionExecutionUnits', are only available for function apps operating on a Consumption (serverless) plan and are not observed in other plans. On the other hand, all other metrics are generated exclusively for Premium and Dedicated plans and are not available for the Consumption plan.
 
 ## Data streams
 The Azure Functions integration contains two data streams: [Function App Logs](#logs) and [Metrics](#metrics)


### PR DESCRIPTION
This PR adds a new section on the different hosting plans for Azure Functions metrics.

Closes [#123](https://github.com/elastic/integrations/issues/9010)

<img width="478" alt="image" src="https://github.com/user-attachments/assets/41e382fc-2d3e-43e8-a899-9fdc90586f5c">

