### PR TITLE
[abnormal_security] Update data-collection to handle empty threats

### DIFF
--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Handles empty threats arrays correctly, ensuring REST calls continue during subsequent intervals.
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/10986
 - version: "0.1.1"
   changes:
     - description: Update pagination termination condition in threat data stream.

--- a/packages/abnormal_security/changelog.yml
+++ b/packages/abnormal_security/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.2"
+  changes:
+    - description: Handles empty threats arrays correctly, ensuring REST calls continue during subsequent intervals.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.1"
   changes:
     - description: Update pagination termination condition in threat data stream.

--- a/packages/abnormal_security/data_stream/threat/agent/stream/cel.yml.hbs
+++ b/packages/abnormal_security/data_stream/threat/agent/stream/cel.yml.hbs
@@ -25,7 +25,7 @@ redact:
     - access_token
 program: |
   (
-    has(state.worklist) && has(state.worklist.threats) && size(state.worklist.threats) > 0 ?
+    has(state.?worklist.threats) && size(state.worklist.threats) > 0 ?
       state
     :
       (

--- a/packages/abnormal_security/data_stream/threat/agent/stream/cel.yml.hbs
+++ b/packages/abnormal_security/data_stream/threat/agent/stream/cel.yml.hbs
@@ -25,7 +25,7 @@ redact:
     - access_token
 program: |
   (
-    has(state.worklist) && size(state.worklist) > 0 ?
+    has(state.worklist) && has(state.worklist.threats) && size(state.worklist.threats) > 0 ?
       state
     :
       (

--- a/packages/abnormal_security/data_stream/threat/sample_event.json
+++ b/packages/abnormal_security/data_stream/threat/sample_event.json
@@ -45,22 +45,22 @@
         }
     },
     "agent": {
-        "ephemeral_id": "b66f399f-ba1c-4fe5-af82-9ca7a0204545",
-        "id": "e2eadaf0-613d-41d9-913c-96125e06487a",
-        "name": "elastic-agent-55334",
+        "ephemeral_id": "900a737b-86e9-4b31-8902-9e933e02c4bc",
+        "id": "16312af4-ae1e-4ca5-855f-6cb7e433a5a4",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "abnormal_security.threat",
-        "namespace": "45319",
+        "namespace": "81591",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "e2eadaf0-613d-41d9-913c-96125e06487a",
+        "id": "16312af4-ae1e-4ca5-855f-6cb7e433a5a4",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -88,7 +88,7 @@
         ],
         "dataset": "abnormal_security.threat",
         "id": "2260288475997441000",
-        "ingested": "2024-08-23T05:40:07Z",
+        "ingested": "2024-09-03T05:30:00Z",
         "kind": "enrichment",
         "original": "{\"abxMessageId\":2260288475997441000,\"abxPortalUrl\":\"https://portal.abnormalsecurity.com/home/threat-center/remediation-history/3456765434567654\",\"attachmentCount\":0,\"attachmentNames\":[],\"attackStrategy\":\"Unknown Sender\",\"attackType\":\"Spam\",\"attackVector\":\"Link\",\"attackedParty\":\"Employee (Other)\",\"autoRemediated\":true,\"ccEmails\":[],\"fromAddress\":\"john@example.com\",\"fromName\":\"john\",\"impersonatedParty\":\"None / Others\",\"internetMessageId\":\"\\u003cAZz8NUMEST-qmuz77_koic@example\\u003e\",\"isRead\":false,\"postRemediated\":false,\"receivedTime\":\"2024-07-17T23:25:38Z\",\"recipientAddress\":\"bob@example.com\",\"remediationStatus\":\"Auto-Remediated\",\"remediationTimestamp\":\"2024-07-17T23:25:45.73564Z\",\"replyToEmails\":[],\"returnPath\":\"bounce-bob_H181S7GUCF@example.com\",\"senderDomain\":\"example.com\",\"senderIpAddress\":\"81.2.69.142\",\"sentTime\":\"2024-07-17T23:25:29Z\",\"subject\":\"YoU.have.𝗪𝟬0𝗡𝗡 a K0baIt 215-piece_ToooI_Set_Noo0wW..#GBOB\",\"summaryInsights\":[\"Abnormal Email Body HTML\",\"Invisible characters found in Email\",\"Suspicious Link\",\"Unusual Sender\",\"Unusual Sender Domain\"],\"threatId\":\"bf255f2d-a2ad-3f50-5075-fdcc24308bbd\",\"toAddresses\":[\"bob@example.com\"],\"urlCount\":1,\"urls\":[\"https://www.example.com/\"]}",
         "reference": "https://portal.abnormalsecurity.com/home/threat-center/remediation-history/3456765434567654",

--- a/packages/abnormal_security/docs/README.md
+++ b/packages/abnormal_security/docs/README.md
@@ -498,22 +498,22 @@ An example event for `threat` looks as following:
         }
     },
     "agent": {
-        "ephemeral_id": "b66f399f-ba1c-4fe5-af82-9ca7a0204545",
-        "id": "e2eadaf0-613d-41d9-913c-96125e06487a",
-        "name": "elastic-agent-55334",
+        "ephemeral_id": "900a737b-86e9-4b31-8902-9e933e02c4bc",
+        "id": "16312af4-ae1e-4ca5-855f-6cb7e433a5a4",
+        "name": "docker-fleet-agent",
         "type": "filebeat",
         "version": "8.13.0"
     },
     "data_stream": {
         "dataset": "abnormal_security.threat",
-        "namespace": "45319",
+        "namespace": "81591",
         "type": "logs"
     },
     "ecs": {
         "version": "8.11.0"
     },
     "elastic_agent": {
-        "id": "e2eadaf0-613d-41d9-913c-96125e06487a",
+        "id": "16312af4-ae1e-4ca5-855f-6cb7e433a5a4",
         "snapshot": false,
         "version": "8.13.0"
     },
@@ -541,7 +541,7 @@ An example event for `threat` looks as following:
         ],
         "dataset": "abnormal_security.threat",
         "id": "2260288475997441000",
-        "ingested": "2024-08-23T05:40:07Z",
+        "ingested": "2024-09-03T05:30:00Z",
         "kind": "enrichment",
         "original": "{\"abxMessageId\":2260288475997441000,\"abxPortalUrl\":\"https://portal.abnormalsecurity.com/home/threat-center/remediation-history/3456765434567654\",\"attachmentCount\":0,\"attachmentNames\":[],\"attackStrategy\":\"Unknown Sender\",\"attackType\":\"Spam\",\"attackVector\":\"Link\",\"attackedParty\":\"Employee (Other)\",\"autoRemediated\":true,\"ccEmails\":[],\"fromAddress\":\"john@example.com\",\"fromName\":\"john\",\"impersonatedParty\":\"None / Others\",\"internetMessageId\":\"\\u003cAZz8NUMEST-qmuz77_koic@example\\u003e\",\"isRead\":false,\"postRemediated\":false,\"receivedTime\":\"2024-07-17T23:25:38Z\",\"recipientAddress\":\"bob@example.com\",\"remediationStatus\":\"Auto-Remediated\",\"remediationTimestamp\":\"2024-07-17T23:25:45.73564Z\",\"replyToEmails\":[],\"returnPath\":\"bounce-bob_H181S7GUCF@example.com\",\"senderDomain\":\"example.com\",\"senderIpAddress\":\"81.2.69.142\",\"sentTime\":\"2024-07-17T23:25:29Z\",\"subject\":\"YoU.have.𝗪𝟬0𝗡𝗡 a K0baIt 215-piece_ToooI_Set_Noo0wW..#GBOB\",\"summaryInsights\":[\"Abnormal Email Body HTML\",\"Invisible characters found in Email\",\"Suspicious Link\",\"Unusual Sender\",\"Unusual Sender Domain\"],\"threatId\":\"bf255f2d-a2ad-3f50-5075-fdcc24308bbd\",\"toAddresses\":[\"bob@example.com\"],\"urlCount\":1,\"urls\":[\"https://www.example.com/\"]}",
         "reference": "https://portal.abnormalsecurity.com/home/threat-center/remediation-history/3456765434567654",

--- a/packages/abnormal_security/manifest.yml
+++ b/packages/abnormal_security/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.1
 name: abnormal_security
 title: Abnormal Security
-version: 0.1.1
+version: 0.1.2
 description: Collect logs from Abnormal Security with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Type of change
- Bug

## Proposed commit message

When we receive empty threat data, CEL stores the `worklist` as `{"total": 0, "threats": [], "pageNumber": 1}` instead of an empty object `{}`. As a result, in the next interval, the condition `size(state.worklist) > 0` evaluates to true, preventing the CEL from making REST calls to the `/threats` endpoint and causing it to get stuck in a loop until it is restarted.

To address this issue, we updated the condition to `size(state.worklist.threats) > 0` for the `threat` data stream, ensuring that empty threat arrays are handled correctly and REST calls continue during subsequent intervals.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

- Clone integrations repo.
- Install elastic package locally.
- Start elastic stack using elastic-package.
- Move to integrations/packages/abnormal_security directory.
- Run the following command to run tests.
> elastic-package test

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
