### PR TITLE
Add daily build with logsdb enabled

### DIFF
--- a/.buildkite/pipeline.schedule-daily.yml
+++ b/.buildkite/pipeline.schedule-daily.yml
@@ -38,6 +38,19 @@ steps:
       - step: "check"
         allow_failure: false
 
+  - label: "Check integrations local stacks - Stack Version v8.16 - LogsDB"
+    trigger: "integrations"
+    build:
+      env:
+        SERVERLESS: "false"
+        FORCE_CHECK_ALL: "true"
+        STACK_VERSION: 8.16.0-SNAPSHOT
+        STACK_LOGSDB_ENABLED: "true"
+        PUBLISH_COVERAGE_REPORTS: "false"
+    depends_on:
+      - step: "check"
+        allow_failure: false
+
   - label: "Check integrations in serverless - project: Observability"
     key: "trigger-integrations-serverless-obs"
     trigger: "integrations-serverless"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -103,4 +103,4 @@ steps:
     soft_fail: true
     # run this step when if it is triggered by the daily job
     if: >
-      build.source == "trigger_job" &&  build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == "integrations-schedule-daily"
+      build.source == "trigger_job" &&  build.env('BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG') == "integrations-schedule-daily" && build.env('STACK_LOGSDB_ENABLED') != "true"

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -503,7 +503,7 @@ prepare_stack() {
         fi
     fi
 
-    if [ "${STACK_LOGSDB_ENABLED}" == "true" ]; then
+    if [ "${STACK_LOGSDB_ENABLED:-false}" == "true" ]; then
         args="${args} -U stack.logsdb_enabled=true"
     fi
 

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -503,6 +503,10 @@ prepare_stack() {
         fi
     fi
 
+    if [ "${STACK_LOGSDB_ENABLED}" == "true" ]; then
+        args="${args} -U stack.logsdb_enabled=true"
+    fi
+
     echo "Boot up the Elastic stack"
     if ! ${ELASTIC_PACKAGE_BIN} stack up -d ${args} ; then
         return 1

--- a/dev/testsreporter/_static/summary.tmpl
+++ b/dev/testsreporter/_static/summary.tmpl
@@ -4,6 +4,9 @@
 {{ if .serverless -}}
 - Serverless: {{ .serverlessProject}}
 {{ end -}}
+{{ if .logsDB -}}
+- LogsDB: enabled
+{{ end -}}
 - Package: {{ .packageName }}
 - Failing test: {{ .testName }}
 {{ if ne .dataStream "" -}}

--- a/dev/testsreporter/format.go
+++ b/dev/testsreporter/format.go
@@ -39,6 +39,7 @@ func (r ResultsFormatter) Summary() string {
 		"stackVersion":      r.result.StackVersion,
 		"serverless":        r.result.Serverless,
 		"serverlessProject": r.result.ServerlessProject,
+		"logsDB":            r.result.LogsDB,
 		"packageName":       r.result.PackageName,
 		"testName":          r.result.Name,
 		"dataStream":        r.result.DataStream,

--- a/dev/testsreporter/format_test.go
+++ b/dev/testsreporter/format_test.go
@@ -110,6 +110,24 @@ func TestSummary(t *testing.T) {
     - team2
 `,
 		},
+		{
+			title: "summary logsdb",
+			packageError: PackageError{
+				LogsDB:      true,
+				PackageName: "foo",
+				testCase: testCase{
+					Name: "mytest",
+				},
+				Teams: []string{"team1", "team2"},
+			},
+			expected: `- LogsDB: enabled
+- Package: foo
+- Failing test: mytest
+- Owners:
+    - team1
+    - team2
+`,
+		},
 	}
 
 	for _, c := range cases {

--- a/dev/testsreporter/packageerror.go
+++ b/dev/testsreporter/packageerror.go
@@ -15,6 +15,7 @@ type PackageError struct {
 	testCase
 	Serverless        bool
 	ServerlessProject string
+	LogsDB            bool
 	StackVersion      string
 	BuildURL          string
 	Teams             []string
@@ -27,6 +28,7 @@ type PackageError struct {
 type PackageErrorOptions struct {
 	Serverless        bool
 	ServerlessProject string
+	LogsDB            bool
 	StackVersion      string
 	BuildURL          string
 	TestCase          testCase
@@ -37,6 +39,7 @@ func NewPackageError(options PackageErrorOptions) (*PackageError, error) {
 	p := PackageError{
 		Serverless:        options.Serverless,
 		ServerlessProject: options.ServerlessProject,
+		LogsDB:            options.LogsDB,
 		StackVersion:      options.StackVersion,
 		BuildURL:          options.BuildURL,
 		testCase:          options.TestCase,
@@ -66,6 +69,9 @@ func NewPackageError(options PackageErrorOptions) (*PackageError, error) {
 func (p PackageError) String() string {
 	var sb strings.Builder
 
+	if p.LogsDB {
+		sb.WriteString("[LogsDB] ")
+	}
 	if p.Serverless {
 		sb.WriteString(fmt.Sprintf("[Serverless %s] ", p.ServerlessProject))
 	}

--- a/dev/testsreporter/testsreporter_test.go
+++ b/dev/testsreporter/testsreporter_test.go
@@ -97,8 +97,7 @@ func TestErrorsFromTest(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			errors, err := errorsFromTests(checkOptions{
-				ResultsPath:    c.xmlFolder,
+			errors, err := errorsFromTests(c.xmlFolder, CheckOptions{
 				Serverless:     false,
 				StackVersion:   "",
 				BuildURL:       "",
@@ -134,8 +133,7 @@ func TestErrorDataStream(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			errors, err := errorsFromTests(checkOptions{
-				ResultsPath:    c.xmlFolder,
+			errors, err := errorsFromTests(c.xmlFolder, CheckOptions{
 				Serverless:     false,
 				StackVersion:   "",
 				BuildURL:       "",
@@ -175,8 +173,7 @@ func TestErrorPackageName(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			errors, err := errorsFromTests(checkOptions{
-				ResultsPath:    c.xmlFolder,
+			errors, err := errorsFromTests(c.xmlFolder, CheckOptions{
 				Serverless:     false,
 				StackVersion:   "",
 				BuildURL:       "",

--- a/magefile.go
+++ b/magefile.go
@@ -166,6 +166,11 @@ func ReportFailedTests(testResultsFolder string) error {
 		}
 	}
 
+	logsDBEnabled := false
+	if v, found := os.LookupEnv("STACK_LOGSDB_ENABLED"); found && v == "true" {
+		logsDBEnabled = true
+	}
+
 	maxIssuesString := os.Getenv("CI_MAX_TESTS_REPORTED")
 	maxIssues := defaultMaximumTestsReported
 	if maxIssuesString != "" {
@@ -176,6 +181,15 @@ func ReportFailedTests(testResultsFolder string) error {
 		}
 	}
 
-	mg.Deps(mg.F(testsreporter.Check, testResultsFolder, buildURL, stackVersion, serverless, serverlessProjectEnv, defaultPreviousLinksNumber, maxIssues))
+	options := testsreporter.CheckOptions{
+		Serverless:        serverless,
+		ServerlessProject: serverlessProjectEnv,
+		LogsDB:            logsDBEnabled,
+		StackVersion:      stackVersion,
+		BuildURL:          buildURL,
+		MaxPreviousLinks:  defaultPreviousLinksNumber,
+		MaxTestsReported:  maxIssues,
+	}
+	mg.Deps(mg.F(testsreporter.Check, testResultsFolder, options))
 	return nil
 }


### PR DESCRIPTION
Moved from https://github.com/elastic/integrations/pull/10919.

Add a new daily build with logsdb enabled for logs data streams.