### PR TITLE
Adapt definitions of nested subfields to current Fleet implementation

### DIFF
--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.25.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "2.25.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/akamai/changelog.yml
+++ b/packages/akamai/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "2.25.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/akamai/data_stream/siem/fields/fields.yml
+++ b/packages/akamai/data_stream/siem/fields/fields.yml
@@ -19,29 +19,27 @@
       type: nested
       description: >
         Rules triggered by this request
-
-      fields:
-        - name: ruleVersions
-          type: keyword
-          description: Versions of rules triggered for this request.
-        - name: ruleMessages
-          type: keyword
-          description: Messages of rules that triggered for this request.
-        - name: ruleTags
-          type: keyword
-          description: Tags of rules that triggered for this request.
-        - name: ruleActions
-          type: keyword
-          description: Actions of rules that triggered for this request.
-        - name: rules
-          type: keyword
-          description: Rules that triggered for this request.
-        - name: ruleData
-          type: keyword
-          description: User data of rules that triggered for this request.
-        - name: ruleSelectors
-          type: keyword
-          description: Selectors of rules that triggered for this request.
+    - name: rules.ruleVersions
+      type: keyword
+      description: Versions of rules triggered for this request.
+    - name: rules.ruleMessages
+      type: keyword
+      description: Messages of rules that triggered for this request.
+    - name: rules.ruleTags
+      type: keyword
+      description: Tags of rules that triggered for this request.
+    - name: rules.ruleActions
+      type: keyword
+      description: Actions of rules that triggered for this request.
+    - name: rules.rules
+      type: keyword
+      description: Rules that triggered for this request.
+    - name: rules.ruleData
+      type: keyword
+      description: User data of rules that triggered for this request.
+    - name: rules.ruleSelectors
+      type: keyword
+      description: Selectors of rules that triggered for this request.
     - name: rule_actions
       type: keyword
       description: >

--- a/packages/akamai/docs/README.md
+++ b/packages/akamai/docs/README.md
@@ -41,6 +41,7 @@ See [Akamai API get started](https://techdocs.akamai.com/siem-integration/refere
 | akamai.siem.response.headers | HTTP response headers | flattened |
 | akamai.siem.rule_actions | Actions taken for this request. | keyword |
 | akamai.siem.rule_tags | The set of categories for the triggered rule. | keyword |
+| akamai.siem.rules | Rules triggered by this request | nested |
 | akamai.siem.rules.ruleActions | Actions of rules that triggered for this request. | keyword |
 | akamai.siem.rules.ruleData | User data of rules that triggered for this request. | keyword |
 | akamai.siem.rules.ruleMessages | Messages of rules that triggered for this request. | keyword |

--- a/packages/akamai/manifest.yml
+++ b/packages/akamai/manifest.yml
@@ -1,6 +1,6 @@
 name: akamai
 title: Akamai
-version: "2.25.0"
+version: "2.25.1"
 description: Collect logs from Akamai with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/falco/changelog.yml
+++ b/packages/falco/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "0.1.0"
   changes:
     - description: Initial release of the Falco package

--- a/packages/falco/changelog.yml
+++ b/packages/falco/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "0.1.0"
   changes:
     - description: Initial release of the Falco package

--- a/packages/falco/data_stream/alerts/fields/fields.yml
+++ b/packages/falco/data_stream/alerts/fields/fields.yml
@@ -32,17 +32,16 @@
     - name: container.mounts
       type: nested
       description: List of mount information.
-      fields:
-        - name: source
-          type: keyword
-        - name: dest
-          type: keyword
-        - name: mode
-          type: keyword
-        - name: rdrw
-          type: keyword
-        - name: propagation
-          type: keyword
+    - name: container.mounts.source
+      type: keyword
+    - name: container.mounts.dest
+      type: keyword
+    - name: container.mounts.mode
+      type: keyword
+    - name: container.mounts.rdrw
+      type: keyword
+    - name: container.mounts.propagation
+      type: keyword
     - name: output
       type: text
       index: false

--- a/packages/falco/docs/README.md
+++ b/packages/falco/docs/README.md
@@ -52,6 +52,7 @@ Falco alerts can contain a multitude of various fields pertaining to the type of
 | data_stream.type | Data stream type. | constant_keyword |  |
 | event.dataset | Data stream / event dataset. | constant_keyword |  |
 | event.module | The module the event belongs to. | constant_keyword |  |
+| falco.container.mounts | List of mount information. | nested |  |
 | falco.container.mounts.dest |  | keyword |  |
 | falco.container.mounts.mode |  | keyword |  |
 | falco.container.mounts.propagation |  | keyword |  |

--- a/packages/falco/manifest.yml
+++ b/packages/falco/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: falco
 title: Falco
-version: 0.1.0
+version: 0.1.1
 description: Collect events and alerts from Falco using Elastic Agent
 type: integration
 categories:

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "2.37.1"
   changes:
     - description: Improve GCP Billing documentation.

--- a/packages/gcp/changelog.yml
+++ b/packages/gcp/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.37.2"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "2.37.1"
   changes:
     - description: Improve GCP Billing documentation.

--- a/packages/gcp/data_stream/audit/fields/fields.yml
+++ b/packages/gcp/data_stream/audit/fields/fields.yml
@@ -30,31 +30,30 @@
       type: nested
       description: |
         Authorization information for the operation.
+    - name: authorization_info.permission
+      type: keyword
+      description: "The required IAM permission."
+    - name: authorization_info.granted
+      type: boolean
+      description: "Whether or not authorization for resource and permission was granted."
+    - name: authorization_info.resource
+      type: keyword
+      description: "The resource being accessed, as a REST-style string."
+    - name: authorization_info.resource_attributes
+      type: group
       fields:
-        - name: permission
+        - name: service
           type: keyword
-          description: "The required IAM permission."
-        - name: granted
-          type: boolean
-          description: "Whether or not authorization for resource and permission was granted."
-        - name: resource
+          description: |
+            The name of the service.
+        - name: name
           type: keyword
-          description: "The resource being accessed, as a REST-style string."
-        - name: resource_attributes
-          type: group
-          fields:
-            - name: service
-              type: keyword
-              description: |
-                The name of the service.
-            - name: name
-              type: keyword
-              description: |
-                The name of the resource.
-            - name: type
-              type: keyword
-              description: |
-                The type of the resource.
+          description: |
+            The name of the resource.
+        - name: type
+          type: keyword
+          description: |
+            The type of the resource.
     - name: labels
       type: flattened
       description: "A map of key, value pairs that provides additional information about the log entry. The labels can be user-defined or system-defined."

--- a/packages/gcp/data_stream/billing/fields/fields.yml
+++ b/packages/gcp/data_stream/billing/fields/fields.yml
@@ -38,8 +38,7 @@
     - name: tags
       type: nested
       description: A collection of key-value pairs that provide additional metadata.
-      fields:
-        - name: key
-          type: keyword
-        - name: value
-          type: keyword
+    - name: tags.key
+      type: keyword
+    - name: tags.value
+      type: keyword

--- a/packages/gcp/docs/README.md
+++ b/packages/gcp/docs/README.md
@@ -236,6 +236,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | gcp.audit.authentication_info.service_account_delegation_info | Identity delegation history of an authenticated service account that makes the request. It contains information on the real authorities that try to access GCP resources by delegating on a service account. When multiple authorities present, they are guaranteed to be sorted based on the original ordering of the identity delegation events. | flattened |
 | gcp.audit.authentication_info.service_account_key_name | The service account key that was used to request the OAuth 2.0 access token. This field identifies the service account key by its full resource name. | keyword |
 | gcp.audit.authentication_info.third_party_principal | The third party identification (if any) of the authenticated user making the request. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the @type property. | flattened |
+| gcp.audit.authorization_info | Authorization information for the operation. | nested |
 | gcp.audit.authorization_info.granted | Whether or not authorization for resource and permission was granted. | boolean |
 | gcp.audit.authorization_info.permission | The required IAM permission. | keyword |
 | gcp.audit.authorization_info.resource | The resource being accessed, as a REST-style string. | keyword |
@@ -1132,6 +1133,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | gcp.billing.service_id | The ID of the service that the usage is associated with. | keyword |
 | gcp.billing.sku_description | A description of the resource type used by the service. For example, a resource type for Cloud Storage is Standard Storage US. | keyword |
 | gcp.billing.sku_id | The ID of the resource used by the service. | keyword |
+| gcp.billing.tags | A collection of key-value pairs that provide additional metadata. | nested |
 | gcp.billing.tags.key |  | keyword |
 | gcp.billing.tags.value |  | keyword |
 | gcp.billing.total | Total billing amount. | float |

--- a/packages/gcp/docs/audit.md
+++ b/packages/gcp/docs/audit.md
@@ -25,6 +25,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | gcp.audit.authentication_info.service_account_delegation_info | Identity delegation history of an authenticated service account that makes the request. It contains information on the real authorities that try to access GCP resources by delegating on a service account. When multiple authorities present, they are guaranteed to be sorted based on the original ordering of the identity delegation events. | flattened |
 | gcp.audit.authentication_info.service_account_key_name | The service account key that was used to request the OAuth 2.0 access token. This field identifies the service account key by its full resource name. | keyword |
 | gcp.audit.authentication_info.third_party_principal | The third party identification (if any) of the authenticated user making the request. When the JSON object represented here has a proto equivalent, the proto name will be indicated in the @type property. | flattened |
+| gcp.audit.authorization_info | Authorization information for the operation. | nested |
 | gcp.audit.authorization_info.granted | Whether or not authorization for resource and permission was granted. | boolean |
 | gcp.audit.authorization_info.permission | The required IAM permission. | keyword |
 | gcp.audit.authorization_info.resource | The resource being accessed, as a REST-style string. | keyword |

--- a/packages/gcp/docs/billing.md
+++ b/packages/gcp/docs/billing.md
@@ -147,6 +147,7 @@ Please refer to the following [document](https://www.elastic.co/guide/en/ecs/cur
 | gcp.billing.service_id | The ID of the service that the usage is associated with. | keyword |
 | gcp.billing.sku_description | A description of the resource type used by the service. For example, a resource type for Cloud Storage is Standard Storage US. | keyword |
 | gcp.billing.sku_id | The ID of the resource used by the service. | keyword |
+| gcp.billing.tags | A collection of key-value pairs that provide additional metadata. | nested |
 | gcp.billing.tags.key |  | keyword |
 | gcp.billing.tags.value |  | keyword |
 | gcp.billing.total | Total billing amount. | float |

--- a/packages/gcp/manifest.yml
+++ b/packages/gcp/manifest.yml
@@ -1,6 +1,6 @@
 name: gcp
 title: Google Cloud Platform
-version: "2.37.1"
+version: "2.37.2"
 description: Collect logs and metrics from Google Cloud Platform with Elastic Agent.
 type: integration
 icons:

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of nested subfields
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "1.29.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/github/changelog.yml
+++ b/packages/github/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.29.1"
+  changes:
+    - description: Fix definition of nested subfields
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "1.29.0"
   changes:
     - description: Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/github/data_stream/dependabot/fields/fields.yml
+++ b/packages/github/data_stream/dependabot/fields/fields.yml
@@ -143,21 +143,20 @@
               description: >
                 CWEs associated with this Advisory.
 
-              fields:
-                - name: cwe_id
-                  type: keyword
-                  description: >
-                    The id of the CWE.
+            - name: cwes.cwe_id
+              type: keyword
+              description: >
+                The id of the CWE.
 
-                - name: description
-                  type: keyword
-                  description: >
-                    The name of this CWE.
+            - name: cwes.description
+              type: keyword
+              description: >
+                The name of this CWE.
 
-                - name: name
-                  type: keyword
-                  description: >
-                    A detailed description of this CWE.
+            - name: cwes.name
+              type: keyword
+              description: >
+                A detailed description of this CWE.
 
             - name: ghsa_id
               type: keyword
@@ -169,16 +168,15 @@
               description: >
                 A list of identifiers for this advisory.
 
-              fields:
-                - name: type
-                  type: keyword
-                  description: >
-                    The identifier type, e.g. GHSA, CVE.
+            - name: identifiers.type
+              type: keyword
+              description: >
+                The identifier type, e.g. GHSA, CVE.
 
-                - name: value
-                  type: keyword
-                  description: >
-                    The identifier.
+            - name: identifiers.value
+              type: keyword
+              description: >
+                The identifier.
 
             - name: origin
               type: keyword

--- a/packages/github/docs/README.md
+++ b/packages/github/docs/README.md
@@ -466,10 +466,12 @@ To use this integration, you must be an administrator for the repository or for 
 | github.dependabot.number | Identifies the alert number. | integer |
 | github.dependabot.security_advisory.classification | The classification of the advisory. | keyword |
 | github.dependabot.security_advisory.cvss.vector_string | The CVSS vector string associated with this advisory. | keyword |
+| github.dependabot.security_advisory.cwes | CWEs associated with this Advisory. | nested |
 | github.dependabot.security_advisory.cwes.cwe_id | The id of the CWE. | keyword |
 | github.dependabot.security_advisory.cwes.description | The name of this CWE. | keyword |
 | github.dependabot.security_advisory.cwes.name | A detailed description of this CWE. | keyword |
 | github.dependabot.security_advisory.ghsa_id | The GitHub Security Advisory ID. | keyword |
+| github.dependabot.security_advisory.identifiers | A list of identifiers for this advisory. | nested |
 | github.dependabot.security_advisory.identifiers.type | The identifier type, e.g. GHSA, CVE. | keyword |
 | github.dependabot.security_advisory.identifiers.value | The identifier. | keyword |
 | github.dependabot.security_advisory.origin | The organization that originated the advisory. | keyword |

--- a/packages/github/manifest.yml
+++ b/packages/github/manifest.yml
@@ -1,6 +1,6 @@
 name: github
 title: GitHub
-version: "1.29.0"
+version: "1.29.1"
 description: Collect logs from GitHub with Elastic Agent.
 type: integration
 format_version: "3.0.2"

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "2.25.0"
   changes:
     - description: Add GeoIP processors to all data streams.

--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.25.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "2.25.0"
   changes:
     - description: Add GeoIP processors to all data streams.

--- a/packages/google_workspace/data_stream/alert/fields/fields.yml
+++ b/packages/google_workspace/data_stream/alert/fields/fields.yml
@@ -375,9 +375,8 @@
                         - name: info
                           type: nested
                           description: Metadata related to the triggered actions.
-                          fields:
-                            - name: object
-                              type: keyword
+                        - name: info.object
+                          type: keyword
                         - name: types
                           type: keyword
                           description: Actions applied as a consequence of the rule being triggered.

--- a/packages/google_workspace/docs/README.md
+++ b/packages/google_workspace/docs/README.md
@@ -1564,6 +1564,7 @@ An example event for `alert` looks as following:
 | google_workspace.alert.data.rule.violation_info.suppressed.action.types | Actions suppressed due to other actions with higher priority. | keyword |
 | google_workspace.alert.data.rule.violation_info.trigger.user.email | Email of the user who caused the violation. Value could be empty if not applicable, for example, a violation found by drive continuous scan. | keyword |
 | google_workspace.alert.data.rule.violation_info.trigger.value | Trigger of the rule. | keyword |
+| google_workspace.alert.data.rule.violation_info.triggered.action.info | Metadata related to the triggered actions. | nested |
 | google_workspace.alert.data.rule.violation_info.triggered.action.info.object |  | keyword |
 | google_workspace.alert.data.rule.violation_info.triggered.action.types | Actions applied as a consequence of the rule being triggered. | keyword |
 | google_workspace.alert.data.rule_description | Description of the rule. | text |

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.25.0"
+version: "2.25.1"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.6.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "2.6.0"
   changes:
     - description: Added a lowercased host.name field to the telemetry data stream.

--- a/packages/jamf_protect/changelog.yml
+++ b/packages/jamf_protect/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "2.6.0"
   changes:
     - description: Added a lowercased host.name field to the telemetry data stream.

--- a/packages/jamf_protect/data_stream/telemetry/fields/fields.yml
+++ b/packages/jamf_protect/data_stream/telemetry/fields/fields.yml
@@ -274,10 +274,9 @@
         - name: timer_wakeups
           type: nested
           description: Timer wakeups for the task
-          fields:
-            - name: wakeups
-              type: long
-              description: Number of wakeups
+        - name: timer_wakeups.wakeups
+          type: long
+          description: Number of wakeups
     - name: error_message
       type: keyword
       description: Contains the event specific error message

--- a/packages/jamf_protect/docs/README.md
+++ b/packages/jamf_protect/docs/README.md
@@ -570,6 +570,7 @@ An example event for `telemetry` looks as following:
 | jamf_protect.telemetry.system_performance.qos_utility_ms_per_s | QoS utility time in milliseconds per second for the task | double |
 | jamf_protect.telemetry.system_performance.qos_utility_ns | QoS utility time in nanoseconds for the task | long |
 | jamf_protect.telemetry.system_performance.started_abstime_ns | Absolute start time in nanoseconds for the task | long |
+| jamf_protect.telemetry.system_performance.timer_wakeups | Timer wakeups for the task | nested |
 | jamf_protect.telemetry.system_performance.timer_wakeups.wakeups | Number of wakeups | long |
 | jamf_protect.telemetry.to_username | Username to which an action is directed | keyword |
 | jamf_protect.telemetry.tty | Software terminal device file that the process is associated with | keyword |

--- a/packages/jamf_protect/manifest.yml
+++ b/packages/jamf_protect/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: jamf_protect
 title: Jamf Protect
-version: "2.6.0"
+version: "2.6.1"
 description: Receives events from Jamf Protect with Elastic Agent.
 type: integration
 categories:

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "1.10.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/tanium/changelog.yml
+++ b/packages/tanium/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.10.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "1.10.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/tanium/data_stream/endpoint_config/fields/fields.yml
+++ b/packages/tanium/data_stream/endpoint_config/fields/fields.yml
@@ -24,16 +24,15 @@
           description: Item count of the manifest.
         - name: items
           type: nested
-          fields:
-            - name: data_category
-              type: keyword
-              description: Data category of the items of manifest.
-            - name: domain
-              type: keyword
-              description: Items domain of the manifest.
-            - name: ids
-              type: long
-              description: Item Ids of the manifest.
+        - name: items.data_category
+          type: keyword
+          description: Data category of the items of manifest.
+        - name: items.domain
+          type: keyword
+          description: Items domain of the manifest.
+        - name: items.ids
+          type: long
+          description: Item Ids of the manifest.
         - name: non_windows_saved_action_id
           type: long
           description: Non Windows saved action id of the user.

--- a/packages/tanium/data_stream/threat_response/fields/fields.yml
+++ b/packages/tanium/data_stream/threat_response/fields/fields.yml
@@ -110,265 +110,262 @@
                       description: Threat id.
                     - name: whats
                       type: nested
+                    - name: whats.artifact_activity
+                      type: group
                       fields:
-                        - name: artifact_activity
+                        - name: acting_artifact
                           type: group
                           fields:
-                            - name: acting_artifact
+                            - name: artifact_hash
+                              type: keyword
+                              description: Artifact hash of activity.
+                            - name: is_intel_target
+                              type: boolean
+                              description: Intel target or not.
+                            - name: instance_hash
+                              type: keyword
+                              description: Instance hash of activity.
+                            - name: process
                               type: group
                               fields:
-                                - name: artifact_hash
+                                - name: arguments
                                   type: keyword
-                                  description: Artifact hash of activity.
-                                - name: is_intel_target
-                                  type: boolean
-                                  description: Intel target or not.
-                                - name: instance_hash
-                                  type: keyword
-                                  description: Instance hash of activity.
-                                - name: process
-                                  type: group
-                                  fields:
-                                    - name: arguments
-                                      type: keyword
-                                      description: Process arguments.
-                                    - name: file
-                                      type: group
-                                      fields:
-                                        - name: artifact_hash
-                                          type: keyword
-                                          description: Artifact hash of file.
-                                        - name: instance_hash
-                                          type: keyword
-                                          description: Instance hash of file.
-                                        - name: path
-                                          type: keyword
-                                          description: Path of file.
-                                    - name: handles
-                                      type: keyword
-                                      description: Process handles.
-                                    - name: parent
-                                      type: group
-                                      fields:
-                                        - name: artifact_hash
-                                          type: keyword
-                                          description: Artifact hash.
-                                        - name: instance_hash
-                                          type: keyword
-                                          description: Instance hash.
-                                        - name: process
-                                          type: group
-                                          fields:
-                                            - name: arguments
-                                              type: keyword
-                                              description: Process arguments.
-                                            - name: file
-                                              type: group
-                                              fields:
-                                                - name: artifact_hash
-                                                  type: keyword
-                                                  description: Artifact hash of file.
-                                                - name: instance_hash
-                                                  type: keyword
-                                                  description: Instance hash of file.
-                                                - name: path
-                                                  type: keyword
-                                                  description: Path of file.
-                                            - name: handles
-                                              type: keyword
-                                              description: Process handles.
-                                            - name: parent
-                                              type: group
-                                              fields:
-                                                - name: artifact_hash
-                                                  type: keyword
-                                                  description: Artifact hash.
-                                                - name: instance_hash
-                                                  type: keyword
-                                                  description: Instance hash.
-                                                - name: process
-                                                  type: group
-                                                  fields:
-                                                    - name: arguments
-                                                      type: keyword
-                                                      description: Process arguments.
-                                                    - name: file
-                                                      type: group
-                                                      fields:
-                                                        - name: artifact_hash
-                                                          type: keyword
-                                                          description: Artifact hash of file.
-                                                        - name: hash
-                                                          type: group
-                                                          fields:
-                                                            - name: md5
-                                                              type: keyword
-                                                              description: MD5 hash.
-                                                        - name: instance_hash
-                                                          type: keyword
-                                                          description: Instance hash of file.
-                                                        - name: path
-                                                          type: keyword
-                                                          description: Path of file.
-                                                    - name: handles
-                                                      type: keyword
-                                                      description: Process handles.
-                                                    - name: md5
-                                                      type: keyword
-                                                      description: MD5 keyword.
-                                                    - name: pid
-                                                      type: keyword
-                                                      description: Process id.
-                                                    - name: start_time
-                                                      type: date
-                                                      description: Start time.
-                                                    - name: tanium_unique_id
-                                                      type: keyword
-                                                      description: Tanium unique id.
-                                                    - name: user
-                                                      type: group
-                                                      fields:
-                                                        - name: domain
-                                                          type: keyword
-                                                          description: User domain.
-                                                        - name: id
-                                                          type: keyword
-                                                          description: User id.
-                                                        - name: name
-                                                          type: keyword
-                                                          description: User name.
-                                            - name: pid
-                                              type: keyword
-                                              description: Process id.
-                                            - name: start_time
-                                              type: date
-                                              description: Start time.
-                                            - name: tanium_unique_id
-                                              type: keyword
-                                              description: Tanium unique id.
-                                            - name: user
-                                              type: group
-                                              fields:
-                                                - name: domain
-                                                  type: keyword
-                                                  description: User domain.
-                                                - name: group_id
-                                                  type: keyword
-                                                  description: User group id.
-                                                - name: id
-                                                  type: keyword
-                                                  description: User id.
-                                                - name: name
-                                                  type: keyword
-                                                  description: User name.
-                                    - name: pid
-                                      type: keyword
-                                      description: Parent id.
-                                    - name: start_time
-                                      type: date
-                                      description: Start time.
-                                    - name: tanium_unique_id
-                                      type: keyword
-                                      description: Tanium unique id.
-                                    - name: user
-                                      type: group
-                                      fields:
-                                        - name: domain
-                                          type: keyword
-                                          description: User domain.
-                                        - name: group_id
-                                          type: keyword
-                                          description: User group id.
-                                        - name: id
-                                          type: keyword
-                                          description: User id.
-                                        - name: name
-                                          type: keyword
-                                          description: User name.
-                            - name: relevant_actions
-                              type: nested
-                              fields:
-                                - name: tanium_recorder_context
-                                  type: group
-                                  fields:
-                                    - name: event
-                                      type: group
-                                      fields:
-                                        - name: file_create
-                                          type: group
-                                          fields:
-                                            - name: path
-                                              type: keyword
-                                              description: Path of file.
-                                        - name: timestamp_ms
-                                          type: date
-                                          description: Timestamp in milliseconds.
-                                    - name: file
-                                      type: group
-                                      fields:
-                                        - name: unique_event_id
-                                          type: keyword
-                                          description: Unique event id.
-                                - name: tanium_recorder_event_table_id
-                                  type: keyword
-                                  description: Tanium recorder event table id.
-                                - name: target
+                                  description: Process arguments.
+                                - name: file
                                   type: group
                                   fields:
                                     - name: artifact_hash
                                       type: keyword
                                       description: Artifact hash of file.
-                                    - name: file
-                                      type: group
-                                      fields:
-                                        - name: hash
-                                          type: group
-                                          fields:
-                                            - name: md5
-                                              type: keyword
-                                              description: MD5 hash.
-                                            - name: sha1
-                                              type: keyword
-                                              description: MD5 sha1.
-                                            - name: sha256
-                                              type: keyword
-                                              description: MD5 sha256.
-                                        - name: instance_hash_salt
-                                          type: keyword
-                                          description: Instance hash salt.
-                                        - name: magic_number_hex
-                                          type: keyword
-                                          description: Magic number.
-                                        - name: modification_time
-                                          type: date
-                                          description: Modification time of file.
-                                        - name: path
-                                          type: keyword
-                                          description: Path of file.
-                                        - name: size_bytes
-                                          type: long
-                                          description: File size in bytes.
-                                        - name: instance_hash
-                                          type: keyword
-                                          description: Instance hash.
+                                    - name: instance_hash
+                                      type: keyword
+                                      description: Instance hash of file.
+                                    - name: path
+                                      type: keyword
+                                      description: Path of file.
+                                - name: handles
+                                  type: keyword
+                                  description: Process handles.
+                                - name: parent
+                                  type: group
+                                  fields:
+                                    - name: artifact_hash
+                                      type: keyword
+                                      description: Artifact hash.
                                     - name: instance_hash
                                       type: keyword
                                       description: Instance hash.
-                                - name: timestamp
+                                    - name: process
+                                      type: group
+                                      fields:
+                                        - name: arguments
+                                          type: keyword
+                                          description: Process arguments.
+                                        - name: file
+                                          type: group
+                                          fields:
+                                            - name: artifact_hash
+                                              type: keyword
+                                              description: Artifact hash of file.
+                                            - name: instance_hash
+                                              type: keyword
+                                              description: Instance hash of file.
+                                            - name: path
+                                              type: keyword
+                                              description: Path of file.
+                                        - name: handles
+                                          type: keyword
+                                          description: Process handles.
+                                        - name: parent
+                                          type: group
+                                          fields:
+                                            - name: artifact_hash
+                                              type: keyword
+                                              description: Artifact hash.
+                                            - name: instance_hash
+                                              type: keyword
+                                              description: Instance hash.
+                                            - name: process
+                                              type: group
+                                              fields:
+                                                - name: arguments
+                                                  type: keyword
+                                                  description: Process arguments.
+                                                - name: file
+                                                  type: group
+                                                  fields:
+                                                    - name: artifact_hash
+                                                      type: keyword
+                                                      description: Artifact hash of file.
+                                                    - name: hash
+                                                      type: group
+                                                      fields:
+                                                        - name: md5
+                                                          type: keyword
+                                                          description: MD5 hash.
+                                                    - name: instance_hash
+                                                      type: keyword
+                                                      description: Instance hash of file.
+                                                    - name: path
+                                                      type: keyword
+                                                      description: Path of file.
+                                                - name: handles
+                                                  type: keyword
+                                                  description: Process handles.
+                                                - name: md5
+                                                  type: keyword
+                                                  description: MD5 keyword.
+                                                - name: pid
+                                                  type: keyword
+                                                  description: Process id.
+                                                - name: start_time
+                                                  type: date
+                                                  description: Start time.
+                                                - name: tanium_unique_id
+                                                  type: keyword
+                                                  description: Tanium unique id.
+                                                - name: user
+                                                  type: group
+                                                  fields:
+                                                    - name: domain
+                                                      type: keyword
+                                                      description: User domain.
+                                                    - name: id
+                                                      type: keyword
+                                                      description: User id.
+                                                    - name: name
+                                                      type: keyword
+                                                      description: User name.
+                                        - name: pid
+                                          type: keyword
+                                          description: Process id.
+                                        - name: start_time
+                                          type: date
+                                          description: Start time.
+                                        - name: tanium_unique_id
+                                          type: keyword
+                                          description: Tanium unique id.
+                                        - name: user
+                                          type: group
+                                          fields:
+                                            - name: domain
+                                              type: keyword
+                                              description: User domain.
+                                            - name: group_id
+                                              type: keyword
+                                              description: User group id.
+                                            - name: id
+                                              type: keyword
+                                              description: User id.
+                                            - name: name
+                                              type: keyword
+                                              description: User name.
+                                - name: pid
+                                  type: keyword
+                                  description: Parent id.
+                                - name: start_time
                                   type: date
-                                  description: Timestamp.
-                                - name: verb
-                                  type: long
-                                  description: Verb.
-                        - name: intel_intra_ids
+                                  description: Start time.
+                                - name: tanium_unique_id
+                                  type: keyword
+                                  description: Tanium unique id.
+                                - name: user
+                                  type: group
+                                  fields:
+                                    - name: domain
+                                      type: keyword
+                                      description: User domain.
+                                    - name: group_id
+                                      type: keyword
+                                      description: User group id.
+                                    - name: id
+                                      type: keyword
+                                      description: User id.
+                                    - name: name
+                                      type: keyword
+                                      description: User name.
+                        - name: relevant_actions
                           type: nested
+                        - name: relevant_actions.tanium_recorder_context
+                          type: group
                           fields:
-                            - name: id
-                              type: keyword
-                              description: Array of intel intra id.
-                        - name: source_name
+                            - name: event
+                              type: group
+                              fields:
+                                - name: file_create
+                                  type: group
+                                  fields:
+                                    - name: path
+                                      type: keyword
+                                      description: Path of file.
+                                - name: timestamp_ms
+                                  type: date
+                                  description: Timestamp in milliseconds.
+                            - name: file
+                              type: group
+                              fields:
+                                - name: unique_event_id
+                                  type: keyword
+                                  description: Unique event id.
+                        - name: relevant_actions.tanium_recorder_event_table_id
                           type: keyword
-                          description: Source name.
+                          description: Tanium recorder event table id.
+                        - name: relevant_actions.target
+                          type: group
+                          fields:
+                            - name: artifact_hash
+                              type: keyword
+                              description: Artifact hash of file.
+                            - name: file
+                              type: group
+                              fields:
+                                - name: hash
+                                  type: group
+                                  fields:
+                                    - name: md5
+                                      type: keyword
+                                      description: MD5 hash.
+                                    - name: sha1
+                                      type: keyword
+                                      description: MD5 sha1.
+                                    - name: sha256
+                                      type: keyword
+                                      description: MD5 sha256.
+                                - name: instance_hash_salt
+                                  type: keyword
+                                  description: Instance hash salt.
+                                - name: magic_number_hex
+                                  type: keyword
+                                  description: Magic number.
+                                - name: modification_time
+                                  type: date
+                                  description: Modification time of file.
+                                - name: path
+                                  type: keyword
+                                  description: Path of file.
+                                - name: size_bytes
+                                  type: long
+                                  description: File size in bytes.
+                                - name: instance_hash
+                                  type: keyword
+                                  description: Instance hash.
+                            - name: instance_hash
+                              type: keyword
+                              description: Instance hash.
+                        - name: relevant_actions.timestamp
+                          type: date
+                          description: Timestamp.
+                        - name: relevant_actions.verb
+                          type: long
+                          description: Verb.
+                    - name: whats.intel_intra_ids
+                      type: nested
+                    - name: whats.intel_intra_ids.id
+                      type: keyword
+                      description: Array of intel intra id.
+                    - name: whats.source_name
+                      type: keyword
+                      description: Source name.
                 - name: intel_id
                   type: keyword
                   description: Intel id.
@@ -377,25 +374,24 @@
                   fields:
                     - name: contexts
                       type: nested
+                    - name: contexts.event
+                      type: group
                       fields:
-                        - name: event
+                        - name: file_create
                           type: group
                           fields:
-                            - name: file_create
-                              type: group
-                              fields:
-                                - name: path
-                                  type: keyword
-                                  description: Path of file.
-                            - name: timestampMs
-                              type: date
-                              description: Timestamp in milliseconds.
-                        - name: file
-                          type: group
-                          fields:
-                            - name: unique_event_id
+                            - name: path
                               type: keyword
-                              description: Unique event id of file.
+                              description: Path of file.
+                        - name: timestampMs
+                          type: date
+                          description: Timestamp in milliseconds.
+                    - name: contexts.file
+                      type: group
+                      fields:
+                        - name: unique_event_id
+                          type: keyword
+                          description: Unique event id of file.
                     - name: hash
                       type: keyword
                       description: Hash value.

--- a/packages/tanium/docs/README.md
+++ b/packages/tanium/docs/README.md
@@ -511,6 +511,7 @@ An example event for `endpoint_config` looks as following:
 | tanium.endpoint_config.item.domain | Domain of the config item. | keyword |
 | tanium.endpoint_config.item.id | Id of the config item. | long |
 | tanium.endpoint_config.manifest.item_count | Item count of the manifest. | long |
+| tanium.endpoint_config.manifest.items |  | nested |
 | tanium.endpoint_config.manifest.items.data_category | Data category of the items of manifest. | keyword |
 | tanium.endpoint_config.manifest.items.domain | Items domain of the manifest. | keyword |
 | tanium.endpoint_config.manifest.items.ids | Item Ids of the manifest. | long |
@@ -996,6 +997,7 @@ An example event for `threat_response` looks as following:
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.system_info.os.version | OS version. | version |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.system_info.platform | OS type. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.threat_id | Threat id. | keyword |
+| tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats |  | nested |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.artifact_hash | Artifact hash of activity. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.instance_hash | Instance hash of activity. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.is_intel_target | Intel target or not. | boolean |
@@ -1040,6 +1042,7 @@ An example event for `threat_response` looks as following:
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.process.user.group_id | User group id. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.process.user.id | User id. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.acting_artifact.process.user.name | User name. | keyword |
+| tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions |  | nested |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.tanium_recorder_context.event.file_create.path | Path of file. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.tanium_recorder_context.event.timestamp_ms | Timestamp in milliseconds. | date |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.tanium_recorder_context.file.unique_event_id | Unique event id. | keyword |
@@ -1057,9 +1060,11 @@ An example event for `threat_response` looks as following:
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.target.instance_hash | Instance hash. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.timestamp | Timestamp. | date |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.artifact_activity.relevant_actions.verb | Verb. | long |
+| tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.intel_intra_ids |  | nested |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.intel_intra_ids.id | Array of intel intra id. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.finding.whats.source_name | Source name. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.intel_id | Intel id. | keyword |
+| tanium.threat_response.other_parameters.log_details.payload_decoded.match.contexts |  | nested |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.match.contexts.event.file_create.path | Path of file. | keyword |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.match.contexts.event.timestampMs | Timestamp in milliseconds. | date |
 | tanium.threat_response.other_parameters.log_details.payload_decoded.match.contexts.file.unique_event_id | Unique event id of file. | keyword |

--- a/packages/tanium/manifest.yml
+++ b/packages/tanium/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: tanium
 title: Tanium
-version: "1.10.0"
+version: "1.10.1"
 description: This Elastic integration collects logs from Tanium with Elastic Agent.
 type: integration
 categories:

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11016
 - version: "1.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/trellix_edr_cloud/changelog.yml
+++ b/packages/trellix_edr_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "1.2.0"
   changes:
     - description: Removed import_mappings. Update the kibana constraint to ^8.13.0. Modified the field definitions to remove ECS fields made redundant by the ecs@mappings component template.

--- a/packages/trellix_edr_cloud/data_stream/event/fields/fields.yml
+++ b/packages/trellix_edr_cloud/data_stream/event/fields/fields.yml
@@ -13,13 +13,12 @@
       type: long
     - name: certs
       type: nested
-      fields:
-        - name: issuer_name
-          type: keyword
-        - name: public_key_hash
-          type: keyword
-        - name: type
-          type: keyword
+    - name: certs.issuer_name
+      type: keyword
+    - name: certs.public_key_hash
+      type: keyword
+    - name: certs.type
+      type: keyword
     - name: cmd_line
       type: keyword
     - name: commands

--- a/packages/trellix_edr_cloud/docs/README.md
+++ b/packages/trellix_edr_cloud/docs/README.md
@@ -362,6 +362,7 @@ An example event for `event` looks as following:
 | trellix_edr_cloud.event.arguments |  | keyword |
 | trellix_edr_cloud.event.author_name |  | keyword |
 | trellix_edr_cloud.event.bytes_received |  | long |
+| trellix_edr_cloud.event.certs |  | nested |
 | trellix_edr_cloud.event.certs.issuer_name |  | keyword |
 | trellix_edr_cloud.event.certs.public_key_hash |  | keyword |
 | trellix_edr_cloud.event.certs.type |  | keyword |

--- a/packages/trellix_edr_cloud/manifest.yml
+++ b/packages/trellix_edr_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: trellix_edr_cloud
 title: Trellix EDR Cloud
-version: "1.2.0"
+version: "1.2.1"
 description: Collect logs from Trellix EDR Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Adapt definitions of subfields of nested objects so they are actually installed by Fleet. New mappings are otherwise equivalent.

These mappings were correctly defined as expected by the spec, but Fleet was only installing empty nested objects. To workaround that, subfields can be moved to have their own definitions.

Issue in Fleet is fixed in https://github.com/elastic/kibana/pull/191730, but we can apply this workaround for older versions of the stack. 

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition). 

## How to test this PR locally

Install one of these packages, and check that the index templates include the mappings for the fields of the nested objects.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes https://github.com/elastic/package-spec/issues/784
- Related to https://github.com/elastic/kibana/pull/191730
- Originally part of to https://github.com/elastic/integrations/pull/10919