### PR TITLE
Refactor testsreporter tool

### DIFF
--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -161,8 +161,7 @@ with_docker() {
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     fi
     echo "deb [arch=${architecture} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${ubuntu_codename} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    # TODO: Remove "|| true" once errors updating are fixed
-    sudo apt-get update || true
+    sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get install --allow-change-held-packages --allow-downgrades -y "docker-ce=${debian_version}"
     sudo DEBIAN_FRONTEND=noninteractive apt-get install --allow-change-held-packages --allow-downgrades -y "docker-ce-cli=${debian_version}"
     retry 3 sudo systemctl restart docker

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -161,7 +161,8 @@ with_docker() {
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
     fi
     echo "deb [arch=${architecture} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${ubuntu_codename} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    sudo apt-get update
+    # TODO: Remove "|| true" once errors updating are fixed
+    sudo apt-get update || true
     sudo DEBIAN_FRONTEND=noninteractive apt-get install --allow-change-held-packages --allow-downgrades -y "docker-ce=${debian_version}"
     sudo DEBIAN_FRONTEND=noninteractive apt-get install --allow-change-held-packages --allow-downgrades -y "docker-ce-cli=${debian_version}"
     retry 3 sudo systemctl restart docker

--- a/dev/codeowners/codeowners.go
+++ b/dev/codeowners/codeowners.go
@@ -15,12 +15,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	codeownersPath = ".github/CODEOWNERS"
-)
+const DefaultCodeownersPath = ".github/CODEOWNERS"
 
 func Check() error {
-	codeowners, err := readGithubOwners(codeownersPath)
+	codeowners, err := readGithubOwners(DefaultCodeownersPath)
 	if err != nil {
 		return err
 	}
@@ -32,11 +30,7 @@ func Check() error {
 	return nil
 }
 
-func PackageOwners(packageName, dataStream string) ([]string, error) {
-	return PackageOwnersCustomCodeowners(packageName, dataStream, codeownersPath)
-}
-
-func PackageOwnersCustomCodeowners(packageName, dataStream, codeownersPath string) ([]string, error) {
+func PackageOwners(packageName, dataStream, codeownersPath string) ([]string, error) {
 	owners, err := readGithubOwners(codeownersPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CODEOWNERS file: %w", err)

--- a/dev/codeowners/codeowners_test.go
+++ b/dev/codeowners/codeowners_test.go
@@ -208,7 +208,7 @@ func TestReturnPackageOwners(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			owners, err := PackageOwnersCustomCodeowners(c.packageName, c.datastream, c.codeownersPath)
+			owners, err := PackageOwners(c.packageName, c.datastream, c.codeownersPath)
 			if c.expectedError {
 				assert.Error(t, err)
 				return

--- a/dev/testsreporter/packageerror.go
+++ b/dev/testsreporter/packageerror.go
@@ -51,13 +51,7 @@ func NewPackageError(options PackageErrorOptions) (*PackageError, error) {
 		p.DataStream = values[1]
 	}
 
-	var owners []string
-	var err error
-	if options.CodeownersPath != "" {
-		owners, err = codeowners.PackageOwnersCustomCodeowners(p.PackageName, p.DataStream, options.CodeownersPath)
-	} else {
-		owners, err = codeowners.PackageOwners(p.PackageName, p.DataStream)
-	}
+	owners, err := codeowners.PackageOwners(p.PackageName, p.DataStream, options.CodeownersPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find owners for package %s: %w", p.PackageName, err)
 	}

--- a/dev/testsreporter/packageerror_test.go
+++ b/dev/testsreporter/packageerror_test.go
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package testsreporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPackageError(t *testing.T) {
+	cases := []struct {
+		title         string
+		options       PackageErrorOptions
+		expectedError bool
+		expected      PackageError
+	}{
+		{
+			title: "Sample package error",
+			options: PackageErrorOptions{
+				Serverless:        true,
+				ServerlessProject: "observability",
+				LogsDB:            false,
+				StackVersion:      "8.16.0-SNAPSHOT",
+				BuildURL:          "https://buildkite.com/elastic/integrations/build/1",
+				TestCase: testCase{
+					Name:      "failing test",
+					ClassName: "elastic_package_registry.datastream",
+					Error:     "could not find hits",
+				},
+				CodeownersPath: "./testdata/CODEOWNERS-default-tests",
+			},
+			expectedError: false,
+			expected: PackageError{
+				testCase: testCase{
+					Name:      "failing test",
+					ClassName: "elastic_package_registry.datastream",
+					Error:     "could not find hits",
+				},
+				Serverless:        true,
+				ServerlessProject: "observability",
+				LogsDB:            false,
+				StackVersion:      "8.16.0-SNAPSHOT",
+				BuildURL:          "https://buildkite.com/elastic/integrations/build/1",
+				PackageName:       "elastic_package_registry",
+				DataStream:        "datastream",
+				Teams:             []string{"@elastic/ecosystem"},
+			},
+		},
+		{
+			title: "Sample package error no datastream",
+			options: PackageErrorOptions{
+				Serverless:        true,
+				ServerlessProject: "observability",
+				LogsDB:            false,
+				StackVersion:      "8.16.0-SNAPSHOT",
+				BuildURL:          "https://buildkite.com/elastic/integrations/build/1",
+				TestCase: testCase{
+					Name:      "failing test",
+					ClassName: "elastic_package_registry",
+					Error:     "could not find hits",
+				},
+				CodeownersPath: "./testdata/CODEOWNERS-default-tests",
+			},
+			expectedError: false,
+			expected: PackageError{
+				testCase: testCase{
+					Name:      "failing test",
+					ClassName: "elastic_package_registry",
+					Error:     "could not find hits",
+				},
+				Serverless:        true,
+				ServerlessProject: "observability",
+				LogsDB:            false,
+				StackVersion:      "8.16.0-SNAPSHOT",
+				BuildURL:          "https://buildkite.com/elastic/integrations/build/1",
+				PackageName:       "elastic_package_registry",
+				DataStream:        "",
+				Teams:             []string{"@elastic/ecosystem"},
+			},
+		},
+		{
+			title: "Not found package",
+			options: PackageErrorOptions{
+				Serverless:        true,
+				ServerlessProject: "observability",
+				LogsDB:            false,
+				StackVersion:      "8.16.0-SNAPSHOT",
+				BuildURL:          "https://buildkite.com/elastic/integrations/build/1",
+				TestCase: testCase{
+					Name:      "failing test",
+					ClassName: "notexist.datastream",
+					Error:     "could not find hits",
+				},
+				CodeownersPath: "./testdata/CODEOWNERS-default-tests",
+			},
+			expectedError: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			packageError, err := NewPackageError(c.options)
+			if c.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, c.expected, *packageError)
+		})
+	}
+}

--- a/dev/testsreporter/testsreporter.go
+++ b/dev/testsreporter/testsreporter.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/elastic/integrations/dev/codeowners"
 )
 
 type CheckOptions struct {
@@ -26,6 +28,12 @@ type CheckOptions struct {
 }
 
 func Check(resultsPath string, options CheckOptions) error {
+
+	if options.CodeownersPath == "" {
+		// set default value for the GitHub CODEOWNERS file
+		options.CodeownersPath = codeowners.DefaultCodeownersPath
+	}
+
 	fmt.Println("path: ", resultsPath)
 	packageErrors, err := errorsFromTests(resultsPath, options)
 	if err != nil {

--- a/dev/testsreporter/testsreporter.go
+++ b/dev/testsreporter/testsreporter.go
@@ -28,7 +28,6 @@ type CheckOptions struct {
 }
 
 func Check(resultsPath string, options CheckOptions) error {
-
 	if options.CodeownersPath == "" {
 		// set default value for the GitHub CODEOWNERS file
 		options.CodeownersPath = codeowners.DefaultCodeownersPath


### PR DESCRIPTION
## Proposed commit message

Refactor in testsreporter and codeowner tools to remove PackageOwnersCustomCodeowners function. By default, testsreporter it will use `.github/CODEOWNERS` file.

Currently, that function was just used in testsreporter.

