### PR TITLE
[CI] Fix call to testsreporter check

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -190,6 +190,5 @@ func ReportFailedTests(testResultsFolder string) error {
 		MaxPreviousLinks:  defaultPreviousLinksNumber,
 		MaxTestsReported:  maxIssues,
 	}
-	mg.Deps(mg.F(testsreporter.Check, testResultsFolder, options))
-	return nil
+	return testsreporter.Check(testResultsFolder, options)
 }


### PR DESCRIPTION
Call directly to the method instead of using `Deps`. I don't think we need to call it as a dependency.