### PR TITLE
[proofpoint_on_demand] Adapt definitions of nested subfields

### DIFF
--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix definition of subfields of nested objects
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/10919
+      link: https://github.com/elastic/integrations/pull/11031
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/proofpoint_on_demand/changelog.yml
+++ b/packages/proofpoint_on_demand/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "0.1.1"
+  changes:
+    - description: Fix definition of subfields of nested objects
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/10919
 - version: "0.1.0"
   changes:
     - description: Initial release.

--- a/packages/proofpoint_on_demand/data_stream/audit/fields/fields.yml
+++ b/packages/proofpoint_on_demand/data_stream/audit/fields/fields.yml
@@ -74,13 +74,12 @@
               description: The IP address of the service.
         - name: tags
           type: nested
-          fields:
-            - name: name
-              type: keyword
-              description: Tag name for the particular instance of event.
-            - name: value
-              type: keyword
-              description: The value associated with the tag name.
+        - name: tags.name
+          type: keyword
+          description: Tag name for the particular instance of event.
+        - name: tags.value
+          type: keyword
+          description: The value associated with the tag name.
         - name: ts
           type: date
           description: Timestamp of when the event to be audited occurred.

--- a/packages/proofpoint_on_demand/docs/README.md
+++ b/packages/proofpoint_on_demand/docs/README.md
@@ -226,6 +226,7 @@ An example event for `audit` looks as following:
 | proofpoint_on_demand.audit.service.customer_id | The customer id of the service. | keyword |
 | proofpoint_on_demand.audit.service.id | The IDM service id. | keyword |
 | proofpoint_on_demand.audit.service.ip_address | The IP address of the service. | ip |
+| proofpoint_on_demand.audit.tags |  | nested |
 | proofpoint_on_demand.audit.tags.name | Tag name for the particular instance of event. | keyword |
 | proofpoint_on_demand.audit.tags.value | The value associated with the tag name. | keyword |
 | proofpoint_on_demand.audit.ts | Timestamp of when the event to be audited occurred. | date |

--- a/packages/proofpoint_on_demand/manifest.yml
+++ b/packages/proofpoint_on_demand/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: proofpoint_on_demand
 title: Proofpoint On Demand
-version: 0.1.0
+version: 0.1.1
 description: Collect logs from Proofpoint On Demand with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
Same change as https://github.com/elastic/integrations/pull/11016 that I forgot to apply to this package.

Adapt definitions of subfields of nested objects so they are actually installed by Fleet. New mappings are otherwise equivalent.

These mappings were correctly defined as expected by the spec, but Fleet was only installing empty nested objects. To workaround that, subfields can be moved to have their own definitions.

Issue in Fleet is fixed in https://github.com/elastic/kibana/pull/191730, but we can apply this workaround for older versions of the stack.