### PR TITLE
[carbon_black_cloud] Return full state in CEL program results

### DIFF
--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.1"
+  changes:
+    - description: "Return full state in CEL program results, to fix a bug causing the loss of 'state.api_key'."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11046
 - version: "2.5.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -30,13 +30,13 @@ program: |
             },
             "Body":{
                 "time_range": {
-                    "start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))), 
+                    "start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))),
                     "end":   string(now + duration("-15m"))
                 },
                 "sort" : [{ "field": "backend_update_timestamp", "order": "ASC"}],
             }.encode_json(),
         }).do_request().as(resp, resp.StatusCode == 200 ?
-            bytes(resp.Body).decode_json().as(body, {
+            bytes(resp.Body).decode_json().as(body, state.with({
                 "events": body.results.map(e, {
                     "message": e.encode_json(),
                 }),
@@ -56,11 +56,9 @@ program: |
                     ),
                 },
                 "want_more": body.?num_found != body.?num_available,
-                "api_key": state.api_key,
-                "initial_interval": state.initial_interval,
-            })
+            }))
         :
-            {
+            state.with({
                 "events": {
                     "error": {
                         "code": string(resp.StatusCode),
@@ -74,7 +72,7 @@ program: |
                     },
                 },
                 "want_more": false,
-            }
+            })
         )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -70,7 +70,7 @@ program: |-
   				"error": {
   					"code": string(resp.StatusCode),
   					"id": string(resp.Status),
-  					"message": "POST:" + 
+  					"message": "POST:" +
   					(
   						(size(resp.Body) != 0) ?
   							string(resp.Body)

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -23,57 +23,59 @@ redact:
         - api_key
 # The alert data stream has a 15-minute delay to ensure that no occurrences are missed.
 program: |
-    request("POST", state.url).with({
-            "Header":{
-                "Content-Type": ["application/json"],
-                "X-Auth-Token": [state.api_key],
-            },
-            "Body":{
-                "time_range": {
-                    "start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))),
-                    "end":   string(now + duration("-15m"))
+    state.with(
+        request("POST", state.url).with({
+                "Header":{
+                    "Content-Type": ["application/json"],
+                    "X-Auth-Token": [state.api_key],
                 },
-                "sort" : [{ "field": "backend_update_timestamp", "order": "ASC"}],
-            }.encode_json(),
-        }).do_request().as(resp, resp.StatusCode == 200 ?
-            bytes(resp.Body).decode_json().as(body, state.with({
-                "events": body.results.map(e, {
-                    "message": e.encode_json(),
-                }),
-                "cursor": {
-                    ?"last_backend_update_timestamp": (
-                        has(body.results) && body.results.size() > 0 ?
-                            optional.of(body.results.map(e, e.backend_update_timestamp).max().as(last_update,
-                                !has(state.?cursor.last_backend_update_timestamp) ?
-                                    last_update
-                                : last_update < state.cursor.last_backend_update_timestamp ?
-                                    state.cursor.last_backend_update_timestamp
-                                :
-                                    last_update
-                            ))
-                        :
-                            state.?cursor.last_backend_update_timestamp
-                    ),
-                },
-                "want_more": body.?num_found != body.?num_available,
-            }))
-        :
-            state.with({
-                "events": {
-                    "error": {
-                        "code": string(resp.StatusCode),
-                        "id": string(resp.Status),
-                        "message": "POST:"+(
-                            size(resp.Body) != 0 ?
-                                string(resp.Body)
+                "Body":{
+                    "time_range": {
+                        "start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))),
+                        "end":   string(now + duration("-15m"))
+                    },
+                    "sort" : [{ "field": "backend_update_timestamp", "order": "ASC"}],
+                }.encode_json(),
+            }).do_request().as(resp, resp.StatusCode == 200 ?
+                bytes(resp.Body).decode_json().as(body, {
+                    "events": body.results.map(e, {
+                        "message": e.encode_json(),
+                    }),
+                    "cursor": {
+                        ?"last_backend_update_timestamp": (
+                            has(body.results) && body.results.size() > 0 ?
+                                optional.of(body.results.map(e, e.backend_update_timestamp).max().as(last_update,
+                                    !has(state.?cursor.last_backend_update_timestamp) ?
+                                        last_update
+                                    : last_update < state.cursor.last_backend_update_timestamp ?
+                                        state.cursor.last_backend_update_timestamp
+                                    :
+                                        last_update
+                                ))
                             :
-                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                                state.?cursor.last_backend_update_timestamp
                         ),
                     },
-                },
-                "want_more": false,
-            })
-        )
+                    "want_more": body.?num_found != body.?num_available,
+                })
+            :
+                {
+                    "events": {
+                        "error": {
+                            "code": string(resp.StatusCode),
+                            "id": string(resp.Status),
+                            "message": "POST:"+(
+                                size(resp.Body) != 0 ?
+                                    string(resp.Body)
+                                :
+                                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                            ),
+                        },
+                    },
+                    "want_more": false,
+                }
+            )
+    )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -22,60 +22,67 @@ redact:
     fields:
         - api_key
 # The alert data stream has a 15-minute delay to ensure that no occurrences are missed.
-program: |
-    state.with(
-        request("POST", state.url).with({
-                "Header":{
-                    "Content-Type": ["application/json"],
-                    "X-Auth-Token": [state.api_key],
-                },
-                "Body":{
-                    "time_range": {
-                        "start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))),
-                        "end":   string(now + duration("-15m"))
-                    },
-                    "sort" : [{ "field": "backend_update_timestamp", "order": "ASC"}],
-                }.encode_json(),
-            }).do_request().as(resp, resp.StatusCode == 200 ?
-                bytes(resp.Body).decode_json().as(body, {
-                    "events": body.results.map(e, {
-                        "message": e.encode_json(),
-                    }),
-                    "cursor": {
-                        ?"last_backend_update_timestamp": (
-                            has(body.results) && body.results.size() > 0 ?
-                                optional.of(body.results.map(e, e.backend_update_timestamp).max().as(last_update,
-                                    !has(state.?cursor.last_backend_update_timestamp) ?
-                                        last_update
-                                    : last_update < state.cursor.last_backend_update_timestamp ?
-                                        state.cursor.last_backend_update_timestamp
-                                    :
-                                        last_update
-                                ))
-                            :
-                                state.?cursor.last_backend_update_timestamp
-                        ),
-                    },
-                    "want_more": body.?num_found != body.?num_available,
-                })
-            :
-                {
-                    "events": {
-                        "error": {
-                            "code": string(resp.StatusCode),
-                            "id": string(resp.Status),
-                            "message": "POST:"+(
-                                size(resp.Body) != 0 ?
-                                    string(resp.Body)
-                                :
-                                    string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                            ),
-                        },
-                    },
-                    "want_more": false,
-                }
-            )
-    )
+program: |-
+  state.with(
+  	request("POST", state.url).with(
+  		{
+  			"Header": {
+  				"Content-Type": ["application/json"],
+  				"X-Auth-Token": [state.api_key],
+  			},
+  			"Body": {
+  				"time_range": {
+  					"start": state.?cursor.last_backend_update_timestamp.orValue(string(now - duration(state.initial_interval) + duration("-15m"))),
+  					"end": string(now + duration("-15m")),
+  				},
+  				"sort": [{"field": "backend_update_timestamp", "order": "ASC"}],
+  			}.encode_json(),
+  		}
+  	).do_request().as(resp, (resp.StatusCode == 200) ?
+  		bytes(resp.Body).decode_json().as(body,
+  			{
+  				"events": body.results.map(e,
+  					{
+  						"message": e.encode_json(),
+  					}
+  				),
+  				"cursor": {
+  					?"last_backend_update_timestamp": (has(body.results) && body.results.size() > 0) ?
+  						optional.of(
+  							body.results.map(e, e.backend_update_timestamp).max().as(last_update,
+  								!has(state.?cursor.last_backend_update_timestamp) ?
+  									last_update
+  								: (last_update < state.cursor.last_backend_update_timestamp) ?
+  									state.cursor.last_backend_update_timestamp
+  								:
+  									last_update
+  							)
+  						)
+  					:
+  						state.?cursor.last_backend_update_timestamp,
+  				},
+  				"want_more": body.?num_found != body.?num_available,
+  			}
+  		)
+  	:
+  		{
+  			"events": {
+  				"error": {
+  					"code": string(resp.StatusCode),
+  					"id": string(resp.Status),
+  					"message": "POST:" + 
+  					(
+  						(size(resp.Body) != 0) ?
+  							string(resp.Body)
+  						:
+  							string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+  					),
+  				},
+  			},
+  			"want_more": false,
+  		}
+  	)
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
@@ -56,7 +56,7 @@ program: |-
   				"error": {
   					"code": string(resp.StatusCode),
   					"id": string(resp.Status),
-  					"message": "POST:" + 
+  					"message": "POST:" +
   					(
   						(size(resp.Body) != 0) ?
   							string(resp.Body)

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
@@ -20,50 +20,55 @@ state:
 redact:
     fields:
         - api_key
-program: |
-    state.with(
-        request("POST", state.url).with({
-            "Header":{
-                "Content-Type": ["application/json"],
-                "X-Auth-Token": [state.api_key],
-            },
-            "Body":{
-                "start": state.?cursor.processed_num_rows.orValue(0),
-                "rows": 1000,
-            }.encode_json(),
-        }).do_request().as(resp, resp.StatusCode == 200 ?
-            bytes(resp.Body).decode_json().as(body, {
-                "events": body.results.map(e, {
-                    "message": e.encode_json(),
-                }),
-                "cursor": {
-                    ?"processed_num_rows": (
-                        has(body.results) && body.results.size() >= 1000 ?
-                            optional.of(state.?cursor.processed_num_rows.orValue(0) + 1000)
-                        :
-                            state.?cursor.processed_num_rows
-                    )
-                },
-                "want_more": has(body.results) && body.results.size() >= 1000,
-            })
-        :
-            {
-                "events": {
-                    "error": {
-                        "code": string(resp.StatusCode),
-                        "id": string(resp.Status),
-                        "message": "POST:"+(
-                            size(resp.Body) != 0 ?
-                                string(resp.Body)
-                            :
-                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                        ),
-                    },
-                },
-                "want_more": false,
-            }
-        )
-    )
+program: |-
+  state.with(
+  	request("POST", state.url).with(
+  		{
+  			"Header": {
+  				"Content-Type": ["application/json"],
+  				"X-Auth-Token": [state.api_key],
+  			},
+  			"Body": {
+  				"start": state.?cursor.processed_num_rows.orValue(0),
+  				"rows": 1000,
+  			}.encode_json(),
+  		}
+  	).do_request().as(resp, (resp.StatusCode == 200) ?
+  		bytes(resp.Body).decode_json().as(body,
+  			{
+  				"events": body.results.map(e,
+  					{
+  						"message": e.encode_json(),
+  					}
+  				),
+  				"cursor": {
+  					?"processed_num_rows": (has(body.results) && body.results.size() >= 1000) ?
+  						optional.of(state.?cursor.processed_num_rows.orValue(0) + 1000)
+  					:
+  						state.?cursor.processed_num_rows,
+  				},
+  				"want_more": has(body.results) && body.results.size() >= 1000,
+  			}
+  		)
+  	:
+  		{
+  			"events": {
+  				"error": {
+  					"code": string(resp.StatusCode),
+  					"id": string(resp.Status),
+  					"message": "POST:" + 
+  					(
+  						(size(resp.Body) != 0) ?
+  							string(resp.Body)
+  						:
+  							string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+  					),
+  				},
+  			},
+  			"want_more": false,
+  		}
+  	)
+  )
 tags:
 {{#if preserve_original_event}}
   - preserve_original_event

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
@@ -31,7 +31,7 @@ program: |
             "rows": 1000,
         }.encode_json(),
     }).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, {
+        bytes(resp.Body).decode_json().as(body, state.with({
             "events": body.results.map(e, {
                 "message": e.encode_json(),
             }),
@@ -44,10 +44,9 @@ program: |
                 )
             },
             "want_more": has(body.results) && body.results.size() >= 1000,
-            "api_key": state.api_key,
-        })
+        }))
     :
-        {
+        state.with({
             "events": {
                 "error": {
                     "code": string(resp.StatusCode),
@@ -61,7 +60,7 @@ program: |
                 },
             },
             "want_more": false,
-        }
+        })
     )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/asset_vulnerability_summary/agent/stream/cel.yml.hbs
@@ -21,46 +21,48 @@ redact:
     fields:
         - api_key
 program: |
-    request("POST", state.url).with({
-        "Header":{
-            "Content-Type": ["application/json"],
-            "X-Auth-Token": [state.api_key],
-        },
-        "Body":{
-            "start": state.?cursor.processed_num_rows.orValue(0),
-            "rows": 1000,
-        }.encode_json(),
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, state.with({
-            "events": body.results.map(e, {
-                "message": e.encode_json(),
-            }),
-            "cursor": {
-                ?"processed_num_rows": (
-                    has(body.results) && body.results.size() >= 1000 ?
-                        optional.of(state.?cursor.processed_num_rows.orValue(0) + 1000)
-                    :
-                        state.?cursor.processed_num_rows
-                )
+    state.with(
+        request("POST", state.url).with({
+            "Header":{
+                "Content-Type": ["application/json"],
+                "X-Auth-Token": [state.api_key],
             },
-            "want_more": has(body.results) && body.results.size() >= 1000,
-        }))
-    :
-        state.with({
-            "events": {
-                "error": {
-                    "code": string(resp.StatusCode),
-                    "id": string(resp.Status),
-                    "message": "POST:"+(
-                        size(resp.Body) != 0 ?
-                            string(resp.Body)
+            "Body":{
+                "start": state.?cursor.processed_num_rows.orValue(0),
+                "rows": 1000,
+            }.encode_json(),
+        }).do_request().as(resp, resp.StatusCode == 200 ?
+            bytes(resp.Body).decode_json().as(body, {
+                "events": body.results.map(e, {
+                    "message": e.encode_json(),
+                }),
+                "cursor": {
+                    ?"processed_num_rows": (
+                        has(body.results) && body.results.size() >= 1000 ?
+                            optional.of(state.?cursor.processed_num_rows.orValue(0) + 1000)
                         :
-                            string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-                    ),
+                            state.?cursor.processed_num_rows
+                    )
                 },
-            },
-            "want_more": false,
-        })
+                "want_more": has(body.results) && body.results.size() >= 1000,
+            })
+        :
+            {
+                "events": {
+                    "error": {
+                        "code": string(resp.StatusCode),
+                        "id": string(resp.Status),
+                        "message": "POST:"+(
+                            size(resp.Body) != 0 ?
+                                string(resp.Body)
+                            :
+                                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                        ),
+                    },
+                },
+                "want_more": false,
+            }
+        )
     )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
@@ -17,32 +17,34 @@ redact:
   fields:
     - api_key
 program: |
-  request("GET", state.url).with({
-    "Header": {
-      "Content-Type": ["application/json"],
-      "X-Auth-Token": [state.api_key],
-    },
-  }).do_request().as(resp, resp.StatusCode == 200 ?
-    bytes(resp.Body).decode_json().as(body, state.with({
-      "events": body.notifications.map(e, {
-        "message": e.encode_json(),
-      }),
-    }))
-  :
-    state.with({
-      "events": dyn({
-        "error": {
-          "code": string(resp.StatusCode),
-          "id": string(resp.Status),
-          "message": "GET:"+(
-            size(resp.Body) != 0 ?
-              string(resp.Body)
-            :
-              string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-          ),
-        },
-      }),
-    })
+  state.with(
+    request("GET", state.url).with({
+      "Header": {
+        "Content-Type": ["application/json"],
+        "X-Auth-Token": [state.api_key],
+      },
+    }).do_request().as(resp, resp.StatusCode == 200 ?
+      bytes(resp.Body).decode_json().as(body, {
+        "events": body.notifications.map(e, {
+          "message": e.encode_json(),
+        }),
+      })
+    :
+      {
+        "events": dyn({
+          "error": {
+            "code": string(resp.StatusCode),
+            "id": string(resp.Status),
+            "message": "GET:"+(
+              size(resp.Body) != 0 ?
+                string(resp.Body)
+              :
+                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+            ),
+          },
+        }),
+      }
+    )
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
@@ -42,7 +42,7 @@ program: |-
   					"error": {
   						"code": string(resp.StatusCode),
   						"id": string(resp.Status),
-  						"message": "GET:" + 
+  						"message": "GET:" +
   						(
   							(size(resp.Body) != 0) ?
   								string(resp.Body)

--- a/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
@@ -23,13 +23,13 @@ program: |
       "X-Auth-Token": [state.api_key],
     },
   }).do_request().as(resp, resp.StatusCode == 200 ?
-    bytes(resp.Body).decode_json().as(body, {
+    bytes(resp.Body).decode_json().as(body, state.with({
       "events": body.notifications.map(e, {
         "message": e.encode_json(),
       }),
-    })
+    }))
   :
-    {
+    state.with({
       "events": dyn({
         "error": {
           "code": string(resp.StatusCode),
@@ -42,7 +42,7 @@ program: |
           ),
         },
       }),
-    }
+    })
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/audit/agent/stream/cel.yml.hbs
@@ -16,35 +16,44 @@ state:
 redact:
   fields:
     - api_key
-program: |
+program: |-
   state.with(
-    request("GET", state.url).with({
-      "Header": {
-        "Content-Type": ["application/json"],
-        "X-Auth-Token": [state.api_key],
-      },
-    }).do_request().as(resp, resp.StatusCode == 200 ?
-      bytes(resp.Body).decode_json().as(body, {
-        "events": body.notifications.map(e, {
-          "message": e.encode_json(),
-        }),
-      })
-    :
-      {
-        "events": dyn({
-          "error": {
-            "code": string(resp.StatusCode),
-            "id": string(resp.Status),
-            "message": "GET:"+(
-              size(resp.Body) != 0 ?
-                string(resp.Body)
-              :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
-            ),
-          },
-        }),
-      }
-    )
+  	request("GET", state.url).with(
+  		{
+  			"Header": {
+  				"Content-Type": ["application/json"],
+  				"X-Auth-Token": [state.api_key],
+  			},
+  		}
+  	).do_request().as(resp, (resp.StatusCode == 200) ?
+  		bytes(resp.Body).decode_json().as(body,
+  			{
+  				"events": body.notifications.map(e,
+  					{
+  						"message": e.encode_json(),
+  					}
+  				),
+  			}
+  		)
+  	:
+  		{
+  			"events": dyn(
+  				{
+  					"error": {
+  						"code": string(resp.StatusCode),
+  						"id": string(resp.Status),
+  						"message": "GET:" + 
+  						(
+  							(size(resp.Body) != 0) ?
+  								string(resp.Body)
+  							:
+  								string(resp.Status) + " (" + string(resp.StatusCode) + ")"
+  						),
+  					},
+  				}
+  			),
+  		}
+  	)
   )
 tags:
 {{#if preserve_original_event}}

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.5.0"
+version: "2.5.1"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[carbon_black_cloud] Return full state in CEL program results

Returning state with relevant field overridden resolves the problem of
losing `state.api_key` for later evaluations.
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
