### PR TITLE
[ti_crowdstrike] Fix intel pagination bug due to cursor formatting

### DIFF
--- a/packages/ti_crowdstrike/changelog.yml
+++ b/packages/ti_crowdstrike/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.1.6"
+  changes:
+    - description: Fix intel pagination bug due to cursor formatting
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11063
 - version: "1.1.5"
   changes:
     - description: Add missing fields in transform

--- a/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
@@ -39,7 +39,7 @@ program: |
         "/intel/combined/indicators/v1?" + {
           "sort": ["_marker.asc"],
           "offset": ["0"],
-          "limit": [string(int(state.batch_size))],
+          "limit": [string(state.batch_size)],
           "filter": [
             '_marker:>"' + string(int(state.?cursor.last_timestamp.orValue(now - duration(state.initial_interval)))) + '"'
           ],
@@ -67,13 +67,13 @@ program: |
       {
         "events": {
           "error": {
-            "code": string(int(resp.StatusCode)),
+            "code": string(resp.StatusCode),
             "id": string(resp.Status),
             "message": "GET:"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :
-                string(resp.Status) + ' (' + string(int(resp.StatusCode)) + ')'
+                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
             ),
           },
         },

--- a/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/intel/agent/stream/cel.yml.hbs
@@ -39,9 +39,9 @@ program: |
         "/intel/combined/indicators/v1?" + {
           "sort": ["_marker.asc"],
           "offset": ["0"],
-          "limit": [string(state.batch_size)],
+          "limit": [string(int(state.batch_size))],
           "filter": [
-            '_marker:>"' + string(state.?cursor.last_timestamp.orValue(int(now - duration(state.initial_interval)))) + '"'
+            '_marker:>"' + string(int(state.?cursor.last_timestamp.orValue(now - duration(state.initial_interval)))) + '"'
           ],
         }.format_query()
     ))
@@ -67,13 +67,13 @@ program: |
       {
         "events": {
           "error": {
-            "code": string(resp.StatusCode),
+            "code": string(int(resp.StatusCode)),
             "id": string(resp.Status),
             "message": "GET:"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                string(resp.Status) + ' (' + string(int(resp.StatusCode)) + ')'
             ),
           },
         },

--- a/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
@@ -38,14 +38,14 @@ program: |
         {
           "sort": ["modified_on"],
           "offset": [string(int(state.offset))],
-          "limit": [string(int(state.batch_size))],
+          "limit": [string(state.batch_size)],
           "filter": ['modified_on:>"' + state.?cursor.first_timestamp.orValue("") + '"'],
         }
       :
         {
           "sort": ["modified_on"],
           "offset": ["0"],
-          "limit": [string(int(state.batch_size))],
+          "limit": [string(state.batch_size)],
           "filter": [
             'modified_on:>"' + state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)) + '"',
           ],
@@ -82,13 +82,13 @@ program: |
       {
         "events": {
           "error": {
-            "code": string(int(resp.StatusCode)),
+            "code": string(resp.StatusCode),
             "id": string(resp.Status),
             "message": "GET:"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :
-                string(resp.Status) + ' (' + string(int(resp.StatusCode)) + ')'
+                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
             ),
           },
         },

--- a/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
+++ b/packages/ti_crowdstrike/data_stream/ioc/agent/stream/cel.yml.hbs
@@ -37,15 +37,15 @@ program: |
       state.want_more ?
         {
           "sort": ["modified_on"],
-          "offset": [string(state.offset)],
-          "limit": [string(state.batch_size)],
+          "offset": [string(int(state.offset))],
+          "limit": [string(int(state.batch_size))],
           "filter": ['modified_on:>"' + state.?cursor.first_timestamp.orValue("") + '"'],
         }
       :
         {
           "sort": ["modified_on"],
           "offset": ["0"],
-          "limit": [string(state.batch_size)],
+          "limit": [string(int(state.batch_size))],
           "filter": [
             'modified_on:>"' + state.?cursor.last_timestamp.orValue((now - duration(state.initial_interval)).format(time_layout.RFC3339)) + '"',
           ],
@@ -82,13 +82,13 @@ program: |
       {
         "events": {
           "error": {
-            "code": string(resp.StatusCode),
+            "code": string(int(resp.StatusCode)),
             "id": string(resp.Status),
             "message": "GET:"+(
               size(resp.Body) != 0 ?
                 string(resp.Body)
               :
-                string(resp.Status) + ' (' + string(resp.StatusCode) + ')'
+                string(resp.Status) + ' (' + string(int(resp.StatusCode)) + ')'
             ),
           },
         },

--- a/packages/ti_crowdstrike/manifest.yml
+++ b/packages/ti_crowdstrike/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.3
 name: ti_crowdstrike
 title: CrowdStrike Falcon Intelligence
-version: "1.1.5"
+version: "1.1.6"
 description: Collect logs from CrowdStrike Falcon Intelligence with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

```
[ti_crowdstrike] Fix intel pagination bug caused by cursor formatting

Integer numbers of 1 million or more should be cast to int before
they're cast to string so that they are not formatted with an exponent.

The second example below shows how the timestamp used in the intel
filter condition was being misformatted:

  mito -data <(echo '{"n": 1725646291}') <(echo 'state.n')
  # => 1725646291

  mito -data <(echo '{"n": 1725646291}') <(echo 'string(state.n)')
  # => "1.725646291e+09"

  mito -data <(echo '{"n": 1725646291}') <(echo 'string(int(state.n))')
  # => "1725646291"
```

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
