### PR TITLE
[google_workspace] handle json.id.time missing

### DIFF
--- a/packages/google_workspace/changelog.yml
+++ b/packages/google_workspace/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.25.2"
+  changes:
+    - description: Handle json.id.time missing
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11068
 - version: "2.25.1"
   changes:
     - description: Fix definition of subfields of nested objects

--- a/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/admin/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,7 @@ processors:
       value: event
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -29,6 +30,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
         - yyyy/MM/dd HH:mm z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/drive/elasticsearch/ingest_pipeline/default.yml
@@ -21,6 +21,7 @@ processors:
       ignore_failure: true
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -28,6 +29,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/groups/elasticsearch/ingest_pipeline/default.yml
@@ -24,6 +24,7 @@ processors:
       ignore_failure: true
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -31,6 +32,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/login/elasticsearch/ingest_pipeline/default.yml
@@ -18,6 +18,7 @@ processors:
       value: event
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -25,6 +26,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/saml/elasticsearch/ingest_pipeline/default.yml
@@ -27,6 +27,7 @@ processors:
       ignore_failure: true
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -34,6 +35,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/google_workspace/data_stream/user_accounts/elasticsearch/ingest_pipeline/default.yml
@@ -27,6 +27,7 @@ processors:
       ignore_failure: true
   - date:
       field: json.id.time
+      if: ctx.json?.id?.time != null && ctx.json.id.time != ''
       timezone: UTC
       formats:
         - ISO8601
@@ -34,6 +35,10 @@ processors:
         - yyyy-MM-dd'T'HH:mm:ssZ
         - yyyy-MM-dd'T'HH:mm:ss.SSSZ
         - yyyy/MM/dd HH:mm:ss z
+      on_failure:
+        - append:
+            field: error.message
+            value: "{{{_ingest.on_failure_message}}}"
   - fingerprint:
       description: Hashes the ID object and uses it as the document id to avoid duplicate events.
       fields:

--- a/packages/google_workspace/manifest.yml
+++ b/packages/google_workspace/manifest.yml
@@ -1,6 +1,6 @@
 name: google_workspace
 title: Google Workspace
-version: "2.25.1"
+version: "2.25.2"
 source:
   license: Elastic-2.0
 description: Collect logs from Google Workspace with Elastic Agent.


### PR DESCRIPTION
## Proposed commit message

Regarding #10577, while the field missing is indeed an issue, the pipeline should still not error. This adds functionality the other pipelines already implement to the ones missing them, to check if json.id.time exists before running the date processor. 

Alternatively, if json.id.time is missing, just drop the entire event as malformed.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10577 

## Screenshots

n/a