### PR TITLE
[citrix_adc] Improve handling of SSLVPN Message

### DIFF
--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Improve handling of SSLVPN Message."
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/11121
 - version: "1.8.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/citrix_adc/changelog.yml
+++ b/packages/citrix_adc/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: "Improve handling of SSLVPN Message."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.8.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-sslvpn-message.log
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-sslvpn-message.log
@@ -1,0 +1,1 @@
+<135> 09/09/2024:14:13:39 PRODSY3VPX01 0-PPE-0 : default SSLVPN Message 30461998 0 : "[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400"

--- a/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-sslvpn-message.log-expected.json
+++ b/packages/citrix_adc/data_stream/log/_dev/test/pipeline/test-citrix-sslvpn-message.log-expected.json
@@ -1,0 +1,47 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-09-09T14:13:39.000Z",
+            "citrix": {
+                "cef_format": false,
+                "default_class": true,
+                "detail": "<135> 09/09/2024:14:13:39 PRODSY3VPX01 0-PPE-0 : default SSLVPN Message 30461998 0 : \"[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400\"",
+                "device_event_class_id": "SSLVPN",
+                "extended": {
+                    "message": "[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400"
+                },
+                "host": "PRODSY3VPX01",
+                "name": "Message"
+            },
+            "citrix_adc": {
+                "log": {
+                    "message": "[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "authentication"
+                ],
+                "id": "30461998",
+                "original": "<135> 09/09/2024:14:13:39 PRODSY3VPX01 0-PPE-0 : default SSLVPN Message 30461998 0 : \"[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400\"",
+                "severity": 0,
+                "timezone": "UTC",
+                "type": [
+                    "info"
+                ]
+            },
+            "observer": {
+                "product": "Netscaler",
+                "type": "firewall",
+                "vendor": "Citrix"
+            },
+            "tags": [
+                "preserve_original_event",
+                "preserve_duplicate_custom_fields"
+            ]
+        }
+    ]
+}

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
@@ -85,7 +85,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "sslvpn_and_aaatm_feature" }}'
       tag: pipeline_sslvpn_and_aaatm_feature
-      if: ctx.citrix?.device_event_class_id != null && ((ctx.citrix.device_event_class_id == "SSLVPN" && ctx.citrix.name.toUpperCase() != "MESSAGE") || ctx.citrix.device_event_class_id == "AAATM")
+      if: ctx.citrix?.device_event_class_id != null && ((ctx.citrix.device_event_class_id == "SSLVPN" && !ctx.citrix?.name?.equalsIgnoreCase("MESSAGE")) || ctx.citrix.device_event_class_id == "AAATM")
   - pipeline:
       name: '{{ IngestPipeline "ci_feature" }}'
       tag: pipeline_ci_feature

--- a/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
+++ b/packages/citrix_adc/data_stream/log/elasticsearch/ingest_pipeline/native.yml
@@ -10,9 +10,11 @@ processors:
       tag: grok_detail
       field: citrix.detail
       patterns:
+        - '^%{SPACE}%{HEADER_NOTIMEZONE} : %{DATA:_tmp.details} : +"%{GREEDYDATA:citrix.extended.message}"'
         - '^%{SPACE}%{HEADER} : %{DATA:_tmp.details} : +"%{GREEDYDATA:citrix.extended.message}"'
         - '^%{SPACE}%{HEADER} : %{DATA:_tmp.details} : +%{GREEDYDATA:citrix.extended.message}'
       pattern_definitions:
+        HEADER_NOTIMEZONE: '(?:<%{NUMBER}>%{SPACE})?%{NATIVE_TIMESTAMP:_tmp.timestamp_native} (?:%{SYSLOGHOST:citrix.host} )?%{INT}-PPE-%{INT}'
         HEADER: '(?:<%{NUMBER}>%{SPACE})?%{NATIVE_TIMESTAMP:_tmp.timestamp_native} %{WORD:event.timezone}? (?:%{SYSLOGHOST:citrix.host} )?%{INT}-PPE-%{INT}'
         NATIVE_TIMESTAMP: '(?:%{MONTHNUM}/%{MONTHDAY}/%{YEAR}|%{YEAR}/%{MONTHNUM}/%{MONTHDAY}|%{MONTHDAY}/%{MONTHNUM}/%{YEAR}):%{HOUR}:%{MINUTE}:%{SECOND}'  
   - grok:
@@ -83,7 +85,7 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "sslvpn_and_aaatm_feature" }}'
       tag: pipeline_sslvpn_and_aaatm_feature
-      if: ctx.citrix?.device_event_class_id != null && (ctx.citrix.device_event_class_id == "SSLVPN" || ctx.citrix.device_event_class_id == "AAATM")
+      if: ctx.citrix?.device_event_class_id != null && ((ctx.citrix.device_event_class_id == "SSLVPN" && ctx.citrix.name.toUpperCase() != "MESSAGE") || ctx.citrix.device_event_class_id == "AAATM")
   - pipeline:
       name: '{{ IngestPipeline "ci_feature" }}'
       tag: pipeline_ci_feature

--- a/packages/citrix_adc/manifest.yml
+++ b/packages/citrix_adc/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: citrix_adc
 title: Citrix ADC
-version: "1.8.0"
+version: "1.8.1"
 description: This Elastic integration collects logs and metrics from Citrix ADC product.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

[citrix_adc] Improve handling of SSLVPN Message

Handle the following log 
```
<135> 09/09/2024:14:13:39 PRODSY3VPX01 0-PPE-0 : default SSLVPN Message 30461998 0 : "[Remote ip = 109.117.241.115:5019] {ns_handle_free_resources:13910} freeing sta resource for pcb:{src-ip:port=109.117.241.115:5019} <-> {dst-ip:port=75.60.204.46:443} pcbdevno=0xa14452, user_domain=(, ns_aaa->csg_flags=0x400"
```

This king of format, namely ```SSLVPN Message``` doesn't seem to be documented:
https://developer-docs.netscaler.com/en-us/netscaler-syslog-message-reference/current-release.html
but that's what we got from one of the users
The message substring looks like a freetext (debug?) message that we are not attempting to parse in this case.
The message is still preserved in ```citrix.extended.message``` field. 

Another problem was the timestamp without timezone ```09/09/2024:14:13:39 PRODSY3VPX01``` which cased the timezone to be set to ```PRODSY3VPX01``` and error out on unrecognizable timezone. Fixing this too with another pattern to match.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

