### PR TITLE
fix 'got types.Null, expected iterable type' error

### DIFF
--- a/packages/wiz/changelog.yml
+++ b/packages/wiz/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.8.1"
+  changes:
+    - description: Fix potential `got types.Null, expected iterable type` error.
+      type: bugfix
+      link: tba
 - version: "1.8.0"
   changes:
     - description: Add host.name for the vulnerability data stream.

--- a/packages/wiz/data_stream/audit/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/audit/agent/stream/cel.yml.hbs
@@ -75,7 +75,7 @@ program: |
         }
       }.encode_json()
     ).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, has(body.?data.auditLogEntries.nodes) ?
+        bytes(resp.Body).decode_json().as(body, body.?data.auditLogEntries.nodes.orValue(null) != null ?
           {
             "events": body.data.auditLogEntries.nodes.map(e, {
               "message": e.encode_json(),

--- a/packages/wiz/data_stream/cloud_configuration_finding/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/cloud_configuration_finding/agent/stream/cel.yml.hbs
@@ -96,7 +96,7 @@ program: |
         }
       }.encode_json()
     ).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, has(body.?data.configurationFindings.nodes) ?
+        bytes(resp.Body).decode_json().as(body, body.?data.configurationFindings.nodes.orValue(null) != null ?
           {
             "events": body.data.configurationFindings.nodes.map(e, {
               "message": e.encode_json(),

--- a/packages/wiz/data_stream/issue/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/issue/agent/stream/cel.yml.hbs
@@ -143,7 +143,7 @@ program: |
         }
       }.encode_json()
     ).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, has(body.?data.issues.nodes) ?
+        bytes(resp.Body).decode_json().as(body, body.?data.issues.nodes.orValue(null) != null ?
           {
             "events": body.data.issues.nodes.map(e, {
               "message": e.encode_json(),

--- a/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
+++ b/packages/wiz/data_stream/vulnerability/agent/stream/cel.yml.hbs
@@ -147,7 +147,7 @@ program: |
         }
       }.encode_json()
     ).do_request().as(resp, resp.StatusCode == 200 ?
-        bytes(resp.Body).decode_json().as(body, has(body.?data.vulnerabilityFindings.nodes) ?
+        bytes(resp.Body).decode_json().as(body, body.?data.vulnerabilityFindings.nodes.orValue(null) != null ?
           {
             "events": body.data.vulnerabilityFindings.nodes.map(e, {
               "message": e.encode_json(),

--- a/packages/wiz/manifest.yml
+++ b/packages/wiz/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.2
 name: wiz
 title: Wiz
-version: "1.8.0"
+version: "1.8.1"
 description: Collect logs from Wiz with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

Fix 'got types.Null, expected iterable type' error in all Wiz data streams discovered in https://github.com/elastic/security-team/issues/10390

backport of the fix https://github.com/elastic/integrations/pull/11098 

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- build package `elastic-package build`
- run stack `elastic-package stack up -v -d`
- ingest some Wiz data 
- over time there shouldn't be any documents with `error.message` in the Wiz documents

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- fixes https://github.com/elastic/security-team/issues/10390