### PR TITLE
[Cloud Security][Asset Inventory] Restore Azure and GCP streams for ^8.16

### DIFF
--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
+- version: "0.1.10"
+  changes:
+    - description: Restore Azure & GCP Asset Inventory for kibana ^8.16.0
+      type: enhancement
+      link: TBD
 - version: "0.1.9"
   changes:
     - description: Remove GCP/Azure Asset Inventory for kibana 8.15.0

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: Restore Azure & GCP Asset Inventory for kibana ^8.16.0
       type: enhancement
-      link: TBD
+      link: https://github.com/elastic/integrations/pull/11125
 - version: "0.1.9"
   changes:
     - description: Remove GCP/Azure Asset Inventory for kibana 8.15.0

--- a/packages/cloud_asset_inventory/changelog.yml
+++ b/packages/cloud_asset_inventory/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 # version map:
 # 0.1.x - 8.15.x
-- version: "0.1.10"
+- version: "0.2.0"
   changes:
     - description: Restore Azure & GCP Asset Inventory for kibana ^8.16.0
       type: enhancement

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/azure.yml.hbs
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/azure.yml.hbs
@@ -1,0 +1,34 @@
+period: 24h
+config:
+  v1:
+    type: asset_inventory
+    asset_inventory_provider: azure
+    azure:
+      {{#if azure.account_type}}
+      account_type: {{azure.account_type}}
+      {{/if}}
+      credentials:
+        {{#if azure.credentials.type}}
+        type: {{azure.credentials.type}}
+        {{/if}}
+        {{#if azure.credentials.client_id}}
+        client_id: {{azure.credentials.client_id}}
+        {{/if}}
+        {{#if azure.credentials.tenant_id}}
+        tenant_id: {{azure.credentials.tenant_id}}
+        {{/if}}
+        {{#if azure.credentials.client_secret}}
+        client_secret: {{azure.credentials.client_secret}}
+        {{/if}}
+        {{#if azure.credentials.client_username}}
+        client_username: {{azure.credentials.client_username}}
+        {{/if}}
+        {{#if azure.credentials.client_password}}
+        client_password: {{azure.credentials.client_password}}
+        {{/if}}
+        {{#if azure.credentials.client_certificate_path}}
+        client_certificate_path: {{azure.credentials.client_certificate_path}}
+        {{/if}}
+        {{#if azure.credentials.client_certificate_password}}
+        client_certificate_password: {{azure.credentials.client_certificate_password}}
+        {{/if}}

--- a/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/gcp.yml.hbs
+++ b/packages/cloud_asset_inventory/data_stream/asset_inventory/agent/stream/gcp.yml.hbs
@@ -1,0 +1,24 @@
+period: 24h
+config:
+  v1:
+    type: asset_inventory
+    asset_inventory_provider: gcp
+    gcp:
+      {{#if gcp.project_id}}
+      project_id: {{gcp.project_id}}
+      {{/if}}
+      {{#if gcp.organization_id}}
+      organization_id: "{{gcp.organization_id}}"
+      {{/if}}
+      {{#if gcp.account_type}}
+      account_type: {{gcp.account_type}}
+      {{else}}
+      account_type: single-account
+      {{/if}}
+      credentials:
+        {{#if gcp.credentials.file}}
+        credentials_file_path: {{gcp.credentials.file}}
+        {{/if}}
+        {{#if gcp.credentials.json}}
+        credentials_json: '{{gcp.credentials.json}}'
+        {{/if}}

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.1.10"
+version: "0.2.0"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.1.8"
+version: "0.1.10"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"
@@ -11,7 +11,7 @@ categories:
   - cloudsecurity_cdr
 conditions:
   kibana:
-    version: "^8.15.0"
+    version: "^8.16.0"
   elastic:
     subscription: basic
     capabilities:

--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: cloud_asset_inventory
 title: "Cloud Asset Inventory"
-version: "0.1.9"
+version: "0.1.8"
 source:
   license: "Elastic-2.0"
 description: "Discover and Create Cloud Assets Inventory"
@@ -36,10 +36,18 @@ policy_templates:
     data_streams:
       - asset_inventory
     inputs:
-      - type: cloudbeat/asset_inventory_aws
-        title: AWS Asset Inventory
-        description: AWS Asset Inventory
-        vars: []
+        - type: cloudbeat/asset_inventory_aws
+          title: AWS Asset Inventory
+          description: AWS Asset Inventory
+          vars: []
+        - type: cloudbeat/asset_inventory_azure
+          title: Azure Asset Inventory
+          description: Azure Asset Inventory
+          vars: []
+        - type: cloudbeat/asset_inventory_gcp
+          title: GCP Asset Inventory
+          description: GCP Asset Inventory
+          vars: []
     categories:
       - security
       - cloud


### PR DESCRIPTION
## Proposed commit message

This PR re-introduces Azure and GCP options for Asset Inventory for Kibana versions matching `^8.16.0`.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Follow-up to https://github.com/elastic/integrations/pull/11091

