### PR TITLE
[CI] Fix script that retrieves oldest supported version

### DIFF
--- a/.buildkite/scripts/build_packages.sh
+++ b/.buildkite/scripts/build_packages.sh
@@ -43,7 +43,7 @@ report_build_failure() {
 
     # if running in Buildkite , add an annotation
     if [ -n "${BUILDKITE_BRANCH+x}" ]; then
-        buildkite-agent annotate "Build package ${package} failed, not published." --ctx "ctx-build-${package}" --style "warning"
+        buildkite-agent annotate "Build package ${package} failed, not published." --context "ctx-build-${package}" --style "warning"
     fi
 }
 

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -72,6 +72,11 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
         if int(major) == available_major and int(minor)>available_minor:
             older = False
             break
+        # available_major = available_parts[0]
+        # available_minor = available_parts[1]
+        # if major == available_major and minor>available_minor:
+        #     older = False
+        #     break
     if older:
         return version
 
@@ -231,6 +236,9 @@ class TestFindOldestSupportVersion(unittest.TestCase):
     def test_no_version_available_no_next_minor_in_current_major(self):
         # returns the version as in the manifest
         self.assertEqual(find_oldest_supported_version("8.11.3"), "8.11.3")
+
+    def test_available_next_minor_in_current_major(self):
+        self.assertEqual(find_oldest_supported_version("7.19.0"), "7.x-SNAPSHOT")
 
     def test_or(self):
         self.assertEqual(find_oldest_supported_version("8.6.0||8.7.0"), "8.6.0")

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -67,9 +67,9 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
         if len(available_parts) < 2:
             continue
 
-        available_major = available_parts[0]
-        available_minor = available_parts[1]
-        if major == available_major and minor > available_minor:
+        available_major = int(available_parts[0])
+        available_minor = int(available_parts[1])
+        if int(major) == available_major and int(minor)>available_minor:
             older = False
             break
     if older:
@@ -181,6 +181,7 @@ class TestFindOldestSupportVersion(unittest.TestCase):
             "8.11.0-SNAPSHOT"
         ],
         "aliases": [
+            "7.x-SNAPSHOT",
             "7.17-SNAPSHOT",
             "7.17",
             "8.7",
@@ -225,6 +226,11 @@ class TestFindOldestSupportVersion(unittest.TestCase):
     def test_too_old_to_be_in_api(self):
         self.assertEqual(find_oldest_supported_version("7.16.0"), "7.16.0")
         self.assertEqual(find_oldest_supported_version("8.6.0"), "8.6.0")
+        self.assertEqual(find_oldest_supported_version("7.6.0"), "7.6.0")
+
+    def test_no_version_available_no_next_minor_in_current_major(self):
+        # returns the version as in the manifest
+        self.assertEqual(find_oldest_supported_version("8.11.3"), "8.11.3")
 
     def test_or(self):
         self.assertEqual(find_oldest_supported_version("8.6.0||8.7.0"), "8.6.0")

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -69,14 +69,9 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
 
         available_major = int(available_parts[0])
         available_minor = int(available_parts[1])
-        if int(major) == available_major and int(minor)>available_minor:
+        if int(major) == available_major and int(minor) > available_minor:
             older = False
             break
-        # available_major = available_parts[0]
-        # available_minor = available_parts[1]
-        # if major == available_major and minor>available_minor:
-        #     older = False
-        #     break
     if older:
         return version
 


### PR DESCRIPTION
## Proposed commit message

Fix script in charge of retrieving the oldest supported version of the stack to use for `elastic-package stack up -v -d --version <version>` command.

Without the fix there were packages that the stack version assigned was `8.x-SNAPSHOT`, but the script should return the version in the manifest since it is older than the ones available in the artifacts-api response:

Example:

``` 
# Before
Manifest ^8.13.0 -> script 8.13.0 	[keycloak]
Manifest ^8.13.0 -> script 8.13.0 	[httpjson]
Manifest ^8.13.0 -> script 8.13.0 	[vectra_detect]
Manifest ^8.3.0 -> script 8.x-SNAPSHOT 	[fortinet_fortimail]
Manifest ^8.8.0 -> script 8.x-SNAPSHOT 	[juniper_junos]
Manifest ^8.7.1 -> script 8.x-SNAPSHOT 	[hid_bravura_monitor]

# after
Manifest ^8.13.0 -> script 8.13.0 	[keycloak]
Manifest ^8.13.0 -> script 8.13.0 	[httpjson]
Manifest ^8.13.0 -> script 8.13.0 	[vectra_detect]
Manifest ^8.3.0 -> script 8.3.0 	[fortinet_fortimail]
Manifest ^8.8.0 -> script 8.8.0 	[juniper_junos]
Manifest ^8.7.1 -> script 8.7.1 	[hid_bravura_monitor]
```

<details>

<summary>Example of artifacts-api response:</summary>
```json
{
  "versions": [
    "7.17.19",
    "7.17.20",
    "7.17.21",
    "7.17.22",
    "7.17.23",
    "7.17.24-SNAPSHOT",
    "7.17.24",
    "7.17.25-SNAPSHOT",
    "7.17.25",
    "8.12.3",
    "8.13.0+build202403222138",
    "8.13.0+build202403281537",
    "8.13.0+build202403281758",
    "8.13.0",
    "8.13.1+build202404121909",
    "8.13.1+build202404122010",
    "8.13.1",
    "8.13.2",
    "8.13.3",
    "8.13.4",
    "8.13.5",
    "8.14.0",
    "8.14.1",
    "8.14.2",
    "8.14.3",
    "8.14.4",
    "8.15.0",
    "8.15.1-SNAPSHOT",
    "8.15.1",
    "8.15.2-SNAPSHOT",
    "8.15.2",
    "8.16.0-SNAPSHOT",
    "9.0.0-SNAPSHOT"
  ],
  "aliases": [
    "7.17-SNAPSHOT",
    "7.17",
    "8.x-SNAPSHOT",
    "8.12",
    "8.13",
    "8.14",
    "8.15-SNAPSHOT",
    "8.15",
    "8.16-SNAPSHOT",
    "9.0-SNAPSHOT"
  ],
  "manifests": {
    "last-update-time": "Fri, 13 Sep 2024 11:36:29 UTC",
    "seconds-since-last-update": 139
  }
}
```

</details>


Additional changes:
Update context parameter used in `buildkite-agent annotate` command. It must be `--context`.


Example build failing:
https://buildkite.com/elastic/integrations/builds/15884
