### PR TITLE
[CI] Update updatecli configuration for 8.x SNAPSHOT

### DIFF
--- a/.github/workflows/updatecli/updatecli.d/bump-latest-snapshot-version.yml
+++ b/.github/workflows/updatecli/updatecli.d/bump-latest-snapshot-version.yml
@@ -29,13 +29,13 @@ sources:
     name: Get latest snapshot
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/main.json
+      file: https://storage.googleapis.com/artifacts-api/snapshots/8.x.json
       key: .version
   latestSnapshotMajorMinor:
     name: Get latest snapshort major and minor
     kind: json
     spec:
-      file: https://storage.googleapis.com/artifacts-api/snapshots/main.json
+      file: https://storage.googleapis.com/artifacts-api/snapshots/8.x.json
       key: .version
     transformers:
       - findsubmatch:


### PR DESCRIPTION
## Proposed commit message

Update `updatecli` configuration to use the new URL to retrieve the 8.x SNAPSHOT builds for the daily and weekly pipeline definitions.


## Related issues

- Relates https://github.com/elastic/elastic-package/pull/2103
- Depends on https://github.com/elastic/integrations/pull/11126

