### PR TITLE
[osquery_manager] Upgrade osquery to 5.13.1

### DIFF
--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.14.0"
+  changes:
+    - description: Update schema for osquery 5.13.1
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.13.0"
   changes:
     - description: Update schema for osquery 5.12.1

--- a/packages/osquery_manager/changelog.yml
+++ b/packages/osquery_manager/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Update schema for osquery 5.13.1
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/11146
 - version: "1.13.0"
   changes:
     - description: Update schema for osquery 5.12.1

--- a/packages/osquery_manager/data_stream/result/fields/osquery.yml
+++ b/packages/osquery_manager/data_stream/result/fields/osquery.yml
@@ -8893,7 +8893,7 @@
           default_field: false
     - name: process
       description: |-
-        alf_explicit_auths.process - Process name explicitly allowed
+        alf_explicit_auths.process - Process name that is explicitly allowed
         unified_log.process - the name of the process that made the entry
       type: keyword
       ignore_above: 1024

--- a/packages/osquery_manager/manifest.yml
+++ b/packages/osquery_manager/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.0.0
 name: osquery_manager
 title: Osquery Manager
-version: 1.13.0
+version: 1.14.0
 description: Deploy Osquery with Elastic Agent, then run and schedule queries in Kibana
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Upgrade osquery to 5.13.1

The mapping is generated from osquery 5.13.1 schema

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates https://github.com/elastic/beats/pull/40849
