### PR TITLE
GA Deployment and Devices integrations

### DIFF
--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release package as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11157
 - version: "0.3.1"
   changes:
     - description: Fix udp_options in UDP agent file.

--- a/packages/fortinet_fortiproxy/changelog.yml
+++ b/packages/fortinet_fortiproxy/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release package as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.3.1"
   changes:
     - description: Fix udp_options in UDP agent file.

--- a/packages/fortinet_fortiproxy/manifest.yml
+++ b/packages/fortinet_fortiproxy/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.3
 name: fortinet_fortiproxy
 title: "Fortinet FortiProxy"
-version: 0.3.1
+version: 1.0.0
 description: "Collect logs from Fortinet FortiProxy with Elastic Agent."
 type: integration
 categories:

--- a/packages/watchguard_firebox/changelog.yml
+++ b/packages/watchguard_firebox/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Release package as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11157
 - version: "0.1.2"
   changes:
     - description: Add optional cluster member information

--- a/packages/watchguard_firebox/changelog.yml
+++ b/packages/watchguard_firebox/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.0.0"
+  changes:
+    - description: Release package as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: "0.1.2"
   changes:
     - description: Add optional cluster member information

--- a/packages/watchguard_firebox/manifest.yml
+++ b/packages/watchguard_firebox/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.4
 name: watchguard_firebox
 title: WatchGuard Firebox
-version: 0.1.2
+version: 1.0.0
 description: Collect logs from WatchGuard Firebox with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

- Release fortinet_fortiproxy and watchguard_firebox as GA

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- ~~[ ] I have verified that all data streams collect metrics or logs.~~
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Relates #10985
- Relates #11005

