### PR TITLE
[Cloud Security][Asset Inventory] Add template variables to all input streams

### DIFF
--- a/packages/cloud_asset_inventory/manifest.yml
+++ b/packages/cloud_asset_inventory/manifest.yml
@@ -39,15 +39,50 @@ policy_templates:
         - type: cloudbeat/asset_inventory_aws
           title: AWS Asset Inventory
           description: AWS Asset Inventory
-          vars: []
+          vars:
+            - name: cloud_formation_template
+              type: text
+              title: CloudFormation Template
+              multi: false
+              required: true
+              show_user: false
+              description: Template URL to Cloud Formation Quick Create Stack
+              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-ACCOUNT_TYPE-8.15.0.yml&stackName=Elastic-Cloud-Security-Posture-Management&param_EnrollmentToken=FLEET_ENROLLMENT_TOKEN&param_FleetUrl=FLEET_URL&param_ElasticAgentVersion=KIBANA_VERSION&param_ElasticArtifactServer=https://artifacts.elastic.co/downloads/beats/elastic-agent
+            - name: cloud_formation_credentials_template
+              type: text
+              title: CloudFormation Credentials Template
+              multi: false
+              required: true
+              show_user: false
+              description: Template URL to Cloud Formation Cloud Credentials Stack
+              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+              default: https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://elastic-cspm-cft.s3.eu-central-1.amazonaws.com/cloudformation-cspm-direct-access-key-ACCOUNT_TYPE-8.15.0.yml
         - type: cloudbeat/asset_inventory_azure
           title: Azure Asset Inventory
           description: Azure Asset Inventory
-          vars: []
+          vars:
+            - name: arm_template_url
+              type: text
+              title: ARM Template URL
+              multi: false
+              required: true
+              show_user: false
+              description: A URL to the ARM Template for creating a new deployment
+              # ACCOUNT_TYPE value should be either "single-account" or "organization-account"
+              default: https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Felastic%2Fcloudbeat%2F8.15%2Fdeploy%2Fazure%2FARM-for-ACCOUNT_TYPE.json
         - type: cloudbeat/asset_inventory_gcp
           title: GCP Asset Inventory
           description: GCP Asset Inventory
-          vars: []
+          vars:
+            - name: cloud_shell_url
+              type: text
+              title: CloudShell URL
+              multi: false
+              required: true
+              show_user: false
+              description: A URL to CloudShell for creating a new deployment
+              default: https://shell.cloud.google.com/cloudshell/?ephemeral=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Felastic%2Fcloudbeat&cloudshell_git_branch=8.15&cloudshell_workspace=deploy%2Fdeployment-manager&show=terminal
     categories:
       - security
       - cloud


### PR DESCRIPTION
## Proposed commit message

Add template URL variables to all streams. The URLs will be used by Kibana the same way they are used in CSPM - to redirect user straight to cloud provider's deployment page.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

Related to https://github.com/elastic/security-team/issues/10320

