### PR TITLE
[stormshield] Fix timestamp fields, move stormshield.msg to message

### DIFF
--- a/packages/stormshield/changelog.yml
+++ b/packages/stormshield/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.0.0
+  changes:
+    - description: Fix timestamp handling and move stormshield.msg to message. Release integration as GA.
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/1
 - version: 0.1.0
   changes:
     - description: Initial creation of the integration.

--- a/packages/stormshield/changelog.yml
+++ b/packages/stormshield/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Fix timestamp handling and move stormshield.msg to message. Release integration as GA.
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11177
 - version: 0.1.0
   changes:
     - description: Initial creation of the integration.

--- a/packages/stormshield/data_stream/log/_dev/test/pipeline/test-firewall.log-expected.json
+++ b/packages/stormshield/data_stream/log/_dev/test/pipeline/test-firewall.log-expected.json
@@ -6,8 +6,8 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T17:29:51.000Z",
                 "original": "id=firewall time=\"2024-03-08 17:29:51\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 17:29:51\" SavedEvaluation=621 DynamicMem=0 HostMem=0 FragMem=0 ICMPMem=0 ConnMem=0 AssocMem=0 EtherStateMem=0 IPStateMem=0 DTrackMem=0 Logged=11 LogOverflow=0 HostrepMax=0 HostrepScore=0 HostrepRequests=0 PvmFacts=0 PvmOverflow=0 Accepted=105 Blocked=0 Byte(i/o)=10592/14285 Fragmented=0 TCPPacket=0 TCPByte(i/o)=0/0 TCPConn=0 TCPConnNatSrc=0 TCPConnNatDst=0 TCPConnNoNatSrc=0 TCPConnNoNatDst=0 UDPPacket=104 UDPByte(i/o)=10283/14285 UDPConn=0 UDPConnNatSrc=0 UDPConnNatDst=0 UDPConnNoNatSrc=0 UDPConnNoNatDst=0 ICMPPacket=1 ICMPByte(i/o)=309/0 IPStatePacket=0 IPStateByte(i/o)=0/0 IPStateConn=0 IPStateConnNatSrc=0 IPStateConnNatDst=0 IPStateConnNoNatSrc=0 IPStateConnNoNatDst=0 SCTPAssocPacket=0 SCTPAssocByte(i/o)=0/0 SCTPAssoc=0 EtherStatePacket=0 EtherStateByte(i/o)=0/0 EtherStateConn=0 TLSCertCacheEntriesNb=0 TLSCertCacheLookup(miss/total)=0/0 TLSCertCacheInsert=0 TLSCertCacheFlushOp=0 TLSCertCachePurgeOp=0 TLSCertCacheFlushedNb=0 TLSCertCachePurgedNb=0 TLSCertCacheExpiredNb=0 logtype=\"filterstat\"",
+                "start": "2024-03-08T17:29:51.000Z",
                 "timezone": "+00:00"
             },
             "observer": {
@@ -106,15 +106,14 @@
                 },
                 "out_bytes": 14285,
                 "startime": "2024-03-08 17:29:51",
-                "time": "2024-03-08 17:29:51",
-                "tz": "+0000"
+                "time": "2024-03-08 17:29:51"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T12:27:28.000Z",
+            "@timestamp": "2024-03-08T17:29:30.000Z",
             "destination": {
                 "as": {
                     "number": 29518,
@@ -147,9 +146,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T12:27:28.000Z",
                 "duration": 90000000,
                 "original": "id=firewall time=\"2024-03-08 17:29:30\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 12:27:28\" pri=5 confid=01 slotlevel=0 ruleid=7 ipproto=udp dstif=\"Ethernet0\" dstifname=\"out\" proto=ntp src=192.168.197.134 srcport=123 srcportname=ntp srcname=Firewall_out dst=1.128.0.1 dstport=123 dstportname=ntp dstname=ntp2.stormshieldcs.eu dstcontinent=\"eu\" dstcountry=\"fr\" modsrc=192.168.197.134 modsrcport=123 origdst=89.160.20.182 origdstport=123 ipv=4 sent=48 rcvd=48 duration=0.09 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T12:27:28.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -196,8 +195,7 @@
                     "srcportname": "ntp"
                 },
                 "startime": "2024-03-08 12:27:28",
-                "time": "2024-03-08 17:29:30",
-                "tz": "+0000"
+                "time": "2024-03-08 17:29:30"
             },
             "tags": [
                 "preserve_original_event"
@@ -209,8 +207,8 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T17:30:58.000Z",
                 "original": "id=firewall time=\"2024-03-08 17:30:58\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 17:30:58\" auth=0 authtotp=0 authcaptive=0 authwebadmin=0 authsslvpn=0 authipsec=0 authconsole=0 logtype=\"authstat\"",
+                "start": "2024-03-08T17:30:58.000Z",
                 "timezone": "+00:00"
             },
             "observer": {
@@ -232,8 +230,7 @@
                     "id": "firewall"
                 },
                 "startime": "2024-03-08 17:30:58",
-                "time": "2024-03-08 17:30:58",
-                "tz": "+0000"
+                "time": "2024-03-08 17:30:58"
             },
             "tags": [
                 "preserve_original_event"
@@ -245,8 +242,8 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T17:31:09.000Z",
                 "original": "id=firewall time=\"2024-03-08 17:31:09\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 17:31:09\" security=0 system=0 CPU=1,1,1 Pvm=0,0,0,0,0,0,0,0,0,0,0 sslvpn1=sslvpn_udp,0,0,0,0,0,0 sslvpn0=sslvpn,0,0,0,0,0,0 ipsec=ipsec,0,0,0,0,0,0 Ethernet1=in,8,40,8,40,0,0 Ethernet0=out,86,424,177,536,75,0 Qid0=BYPASS_out,0,16032,0,0,82,0 Qid1=BYPASS_in,0,656,0,0,0,0 Qid2=BYPASS_ipsec,0,0,0,0,0,0 mem=0,0,0,0,0,0,0,0 logtype=\"monitor\"",
+                "start": "2024-03-08T17:31:09.000Z",
                 "timezone": "+00:00"
             },
             "observer": {
@@ -362,8 +359,7 @@
                 ],
                 "startime": "2024-03-08 17:31:09",
                 "system": "0",
-                "time": "2024-03-08 17:31:09",
-                "tz": "+0000"
+                "time": "2024-03-08 17:31:09"
             },
             "tags": [
                 "preserve_original_event"
@@ -375,10 +371,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T18:14:59.000Z",
                 "original": "id=firewall time=\"2024-03-08 18:14:59\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 18:14:59\" pri=5 service=userreqd msg=\"reloading daemon configuration (reason: SIGHUP)\" logtype=\"system\"",
+                "start": "2024-03-08T18:14:59.000Z",
                 "timezone": "+00:00"
             },
+            "message": "reloading daemon configuration (reason: SIGHUP)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -391,11 +388,9 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "reloading daemon configuration (reason: SIGHUP)",
                 "service": "userreqd",
                 "startime": "2024-03-08 18:14:59",
-                "time": "2024-03-08 18:14:59",
-                "tz": "+0000"
+                "time": "2024-03-08 18:14:59"
             },
             "tags": [
                 "preserve_original_event"
@@ -407,10 +402,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T18:15:00.000Z",
                 "original": "id=firewall time=\"2024-03-08 18:15:00\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 18:15:00\" pri=5 service=routerd msg=\"routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)\" logtype=\"system\"",
+                "start": "2024-03-08T18:15:00.000Z",
                 "timezone": "+00:00"
             },
+            "message": "routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -423,18 +419,16 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)",
                 "service": "routerd",
                 "startime": "2024-03-08 18:15:00",
-                "time": "2024-03-08 18:15:00",
-                "tz": "+0000"
+                "time": "2024-03-08 18:15:00"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2019-02-24T16:38:00.000+01:00",
+            "@timestamp": "2019-02-24T16:38:01.000+01:00",
             "destination": {
                 "ip": "10.10.10.10",
                 "port": 1900
@@ -444,9 +438,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2019-02-24T16:38:00.000+01:00",
                 "duration": 0,
                 "original": "id=firewall time=\"2019-02-24 16:38:01\" fw=\"SN310A17B0323A7\" tz=+0100 startime=\"2019-02-24 16:38:00\" pri=5 confid=00 slotlevel=2 ruleid=4 rulename=\"1690fb96019_7\" srcif=\"Ethernet0\" srcifname=\"out\" ipproto=udp proto=ssdp src=10.11.11.11 srcport=49907 srcportname=ephemeral_fw_udp srcname=user1 srcmac=11:11:11:11:11:11 dst=10.10.10.10 dstport=1900 dstportname=sdp ipv=4 sent=0 rcvd=0 duration=0.00 action=pass logtype=\"filter\"",
+                "start": "2019-02-24T16:38:00.000+01:00",
                 "timezone": "+01:00"
             },
             "network": {
@@ -492,8 +486,7 @@
                 "srcif": "Ethernet0",
                 "srcifname": "out",
                 "startime": "2019-02-24 16:38:00",
-                "time": "2019-02-24 16:38:01",
-                "tz": "+0100"
+                "time": "2019-02-24 16:38:01"
             },
             "tags": [
                 "preserve_original_event"
@@ -505,10 +498,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:08.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"CONFIG LOG SHOW\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
+            "message": "CONFIG LOG SHOW",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -528,10 +522,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "CONFIG LOG SHOW",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -546,10 +538,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:08.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"PKI SEARCH scope=local type=ca\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
+            "message": "PKI SEARCH scope=local type=ca",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -569,10 +562,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "PKI SEARCH scope=local type=ca",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -593,9 +584,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:14:08.000Z",
                 "duration": 10000000,
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" pri=5 confid=00 slotlevel=0 ruleid=4 srcif=\"Ethernet0\" srcifname=\"out\" ipproto=tcp proto=ssl version=TLSv1.3 src=192.168.197.1 srcport=61549 srcportname=ad2008-dyn_tcp srcmac=00:50:56:c0:00:08 dst=192.168.197.134 dstport=443 dstportname=https dstname=Firewall_out modsrc=192.168.197.1 modsrcport=61549 origdst=192.168.197.134 origdstport=443 ipv=4 sent=605 rcvd=3614 duration=0.01 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -640,8 +631,7 @@
                 "srcif": "Ethernet0",
                 "srcifname": "out",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -653,10 +643,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:08.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"SYSTEM LOGDISK LIST\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
+            "message": "SYSTEM LOGDISK LIST",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -676,10 +667,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "SYSTEM LOGDISK LIST",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -694,10 +683,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:08.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"CONFIG COMMUNICATION SYSLOG PROFILE SHOW index=0\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
+            "message": "CONFIG COMMUNICATION SYSLOG PROFILE SHOW index=0",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -717,10 +707,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "CONFIG COMMUNICATION SYSLOG PROFILE SHOW index=0",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -741,9 +729,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:14:08.000Z",
                 "duration": 320000000,
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" pri=5 confid=00 slotlevel=0 ruleid=4 srcif=\"Ethernet0\" srcifname=\"out\" ipproto=tcp proto=ssl version=TLSv1.3 src=192.168.197.1 srcport=61548 srcportname=ad2008-dyn_tcp srcmac=00:50:56:c0:00:08 dst=192.168.197.134 dstport=443 dstportname=https dstname=Firewall_out modsrc=192.168.197.1 modsrcport=61548 origdst=192.168.197.134 origdstport=443 ipv=4 sent=573 rcvd=3614 duration=0.32 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -788,8 +776,7 @@
                 "srcif": "Ethernet0",
                 "srcifname": "out",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
@@ -807,9 +794,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:14:08.000Z",
                 "duration": 320000000,
                 "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" pri=5 confid=00 slotlevel=0 ruleid=4 srcif=\"Ethernet0\" srcifname=\"out\" ipproto=tcp proto=ssl version=TLSv1.3 src=192.168.197.1 srcport=61550 srcportname=ad2008-dyn_tcp srcmac=00:50:56:c0:00:08 dst=192.168.197.134 dstport=443 dstportname=https dstname=Firewall_out modsrc=192.168.197.1 modsrcport=61550 origdst=192.168.197.134 origdstport=443 ipv=4 sent=605 rcvd=3614 duration=0.32 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:14:08.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -854,15 +841,14 @@
                 "srcif": "Ethernet0",
                 "srcifname": "out",
                 "startime": "2024-03-08 10:14:08",
-                "time": "2024-03-08 10:14:08",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:08"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T10:12:09.000Z",
+            "@timestamp": "2024-03-08T10:14:09.000Z",
             "destination": {
                 "ip": "192.168.236.254",
                 "port": 67
@@ -872,9 +858,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:12:09.000Z",
                 "duration": 0,
                 "original": "id=firewall time=\"2024-03-08 10:14:09\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:12:09\" pri=5 confid=01 slotlevel=0 ruleid=7 ipproto=udp dstif=\"Ethernet1\" dstifname=\"in\" proto=bootps src=192.168.236.131 srcport=68 srcportname=bootpc srcname=Firewall_in dst=192.168.236.254 dstport=67 dstportname=bootps modsrc=192.168.236.131 modsrcport=68 origdst=192.168.236.254 origdstport=67 ipv=4 sent=300 rcvd=300 duration=0.00 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:12:09.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -918,8 +904,7 @@
                     "srcportname": "bootpc"
                 },
                 "startime": "2024-03-08 10:12:09",
-                "time": "2024-03-08 10:14:09",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:09"
             },
             "tags": [
                 "preserve_original_event"
@@ -931,10 +916,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:11.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:11\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:11\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"CONFIG ACTIVATE cancelall\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:11.000Z",
                 "timezone": "+00:00"
             },
+            "message": "CONFIG ACTIVATE cancelall",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -954,10 +940,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "CONFIG ACTIVATE cancelall",
                 "startime": "2024-03-08 10:14:11",
-                "time": "2024-03-08 10:14:11",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:11"
             },
             "tags": [
                 "preserve_original_event"
@@ -972,10 +956,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:11.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:11\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:11\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"SYSTEM IDENT\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:11.000Z",
                 "timezone": "+00:00"
             },
+            "message": "SYSTEM IDENT",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -995,10 +980,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "SYSTEM IDENT",
                 "startime": "2024-03-08 10:14:11",
-                "time": "2024-03-08 10:14:11",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:11"
             },
             "tags": [
                 "preserve_original_event"
@@ -1013,10 +996,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:11.000Z",
                 "original": "id=firewall time=\"2024-03-08 10:14:11\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:11\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"SYSTEM LANGUAGE\" logtype=\"server\"",
+                "start": "2024-03-08T10:14:11.000Z",
                 "timezone": "+00:00"
             },
+            "message": "SYSTEM LANGUAGE",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1036,10 +1020,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "SYSTEM LANGUAGE",
                 "startime": "2024-03-08 10:14:11",
-                "time": "2024-03-08 10:14:11",
-                "tz": "+0000"
+                "time": "2024-03-08 10:14:11"
             },
             "tags": [
                 "preserve_original_event"
@@ -1054,10 +1036,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:48.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:48\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:48\" pri=5 service=routerd msg=\"The gateway of the router is now used for routing router:Firewall_out_router gateway:Firewall_out_router ipv:4 (192.168.197.2)\" logtype=\"system\"",
+                "start": "2024-03-08T15:14:48.000Z",
                 "timezone": "+00:00"
             },
+            "message": "The gateway of the router is now used for routing router:Firewall_out_router gateway:Firewall_out_router ipv:4 (192.168.197.2)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1070,11 +1053,9 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "The gateway of the router is now used for routing router:Firewall_out_router gateway:Firewall_out_router ipv:4 (192.168.197.2)",
                 "service": "routerd",
                 "startime": "2024-03-08 15:14:48",
-                "time": "2024-03-08 15:14:48",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:48"
             },
             "tags": [
                 "preserve_original_event"
@@ -1086,10 +1067,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:48.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:48\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:48\" pri=5 service=routerd msg=\"routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)\" logtype=\"system\"",
+                "start": "2024-03-08T15:14:48.000Z",
                 "timezone": "+00:00"
             },
+            "message": "routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1102,11 +1084,9 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "routerd daemon configuration reloaded, modules: pbr_route, ip_version: all (reason: Refresh)",
                 "service": "routerd",
                 "startime": "2024-03-08 15:14:48",
-                "time": "2024-03-08 15:14:48",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:48"
             },
             "tags": [
                 "preserve_original_event"
@@ -1118,10 +1098,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:48.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:48\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:48\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"CONFIG DNS ACTIVATE\" logtype=\"server\"",
+                "start": "2024-03-08T15:14:48.000Z",
                 "timezone": "+00:00"
             },
+            "message": "CONFIG DNS ACTIVATE",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1141,10 +1122,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "CONFIG DNS ACTIVATE",
                 "startime": "2024-03-08 15:14:48",
-                "time": "2024-03-08 15:14:48",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:48"
             },
             "tags": [
                 "preserve_original_event"
@@ -1154,7 +1133,7 @@
             }
         },
         {
-            "@timestamp": "2024-03-08T15:14:48.000Z",
+            "@timestamp": "2024-03-08T15:14:49.000Z",
             "destination": {
                 "ip": "0.0.0.0"
             },
@@ -1162,10 +1141,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:48.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:49\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:48\" pri=5 src=192.168.197.2 dst=0.0.0.0 msg=\"Remote host reachable:  through Firewall_out_router(192.168.197.2) on router Firewall_out_router\" service=sysevent alarmid=82 logtype=\"system\"",
+                "start": "2024-03-08T15:14:48.000Z",
                 "timezone": "+00:00"
             },
+            "message": "Remote host reachable:  through Firewall_out_router(192.168.197.2) on router Firewall_out_router",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1188,11 +1168,9 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "Remote host reachable:  through Firewall_out_router(192.168.197.2) on router Firewall_out_router",
                 "service": "sysevent",
                 "startime": "2024-03-08 15:14:48",
-                "time": "2024-03-08 15:14:49",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:49"
             },
             "tags": [
                 "preserve_original_event"
@@ -1204,8 +1182,8 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:51.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:51\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:51\" SavedEvaluation=153 DynamicMem=0 HostMem=0 FragMem=0 ICMPMem=0 ConnMem=0 AssocMem=0 EtherStateMem=0 IPStateMem=0 DTrackMem=0 Logged=10 LogOverflow=0 HostrepMax=0 HostrepScore=0 HostrepRequests=0 PvmFacts=0 PvmOverflow=0 Accepted=289 Blocked=0 Byte(i/o)=97364/145065 Fragmented=0 TCPPacket=178 TCPByte(i/o)=86297/116839 TCPConn=3 TCPConnNatSrc=0 TCPConnNatDst=0 TCPConnNoNatSrc=0 TCPConnNoNatDst=0 UDPPacket=111 UDPByte(i/o)=11067/28226 UDPConn=0 UDPConnNatSrc=0 UDPConnNatDst=0 UDPConnNoNatSrc=0 UDPConnNoNatDst=0 ICMPPacket=0 ICMPByte(i/o)=0/0 IPStatePacket=0 IPStateByte(i/o)=0/0 IPStateConn=0 IPStateConnNatSrc=0 IPStateConnNatDst=0 IPStateConnNoNatSrc=0 IPStateConnNoNatDst=0 SCTPAssocPacket=0 SCTPAssocByte(i/o)=0/0 SCTPAssoc=0 EtherStatePacket=0 EtherStateByte(i/o)=0/0 EtherStateConn=0 TLSCertCacheEntriesNb=0 TLSCertCacheLookup(miss/total)=0/0 TLSCertCacheInsert=0 TLSCertCacheFlushOp=0 TLSCertCachePurgeOp=0 TLSCertCacheFlushedNb=0 TLSCertCachePurgedNb=0 TLSCertCacheExpiredNb=0 logtype=\"filterstat\"",
+                "start": "2024-03-08T15:14:51.000Z",
                 "timezone": "+00:00"
             },
             "observer": {
@@ -1304,8 +1282,7 @@
                 },
                 "out_bytes": 145065,
                 "startime": "2024-03-08 15:14:51",
-                "time": "2024-03-08 15:14:51",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:51"
             },
             "tags": [
                 "preserve_original_event"
@@ -1317,10 +1294,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:54.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:54\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:54\" pri=5 service=userreqd msg=\"reloading daemon configuration (reason: SIGHUP)\" logtype=\"system\"",
+                "start": "2024-03-08T15:14:54.000Z",
                 "timezone": "+00:00"
             },
+            "message": "reloading daemon configuration (reason: SIGHUP)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1333,26 +1311,25 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "reloading daemon configuration (reason: SIGHUP)",
                 "service": "userreqd",
                 "startime": "2024-03-08 15:14:54",
-                "time": "2024-03-08 15:14:54",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:54"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T10:14:54.000Z",
+            "@timestamp": "2024-03-08T15:14:55.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:54.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:55\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:54\" pri=5 msg=\"Active Update: update successful IPData\" service=sysevent alarmid=41 logtype=\"system\"",
+                "start": "2024-03-08T10:14:54.000Z",
                 "timezone": "+00:00"
             },
+            "message": "Active Update: update successful IPData",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1366,11 +1343,9 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "Active Update: update successful IPData",
                 "service": "sysevent",
                 "startime": "2024-03-08 10:14:54",
-                "time": "2024-03-08 15:14:55",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:55"
             },
             "tags": [
                 "preserve_original_event"
@@ -1382,10 +1357,11 @@
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T15:14:56.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:56\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 15:14:56\" error=1 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"QUIT\" logtype=\"server\"",
+                "start": "2024-03-08T15:14:56.000Z",
                 "timezone": "+00:00"
             },
+            "message": "QUIT",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1405,10 +1381,8 @@
                     "id": "firewall",
                     "sessionid": "1"
                 },
-                "msg": "QUIT",
                 "startime": "2024-03-08 15:14:56",
-                "time": "2024-03-08 15:14:56",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:56"
             },
             "tags": [
                 "preserve_original_event"
@@ -1418,15 +1392,16 @@
             }
         },
         {
-            "@timestamp": "2024-03-08T10:14:56.000Z",
+            "@timestamp": "2024-03-08T15:14:57.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:56.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:57\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:56\" pri=4 msg=\"Connection terminated for  webadmin (timeout)\" class=system alarmid=3 logtype=\"alarm\"",
+                "start": "2024-03-08T10:14:56.000Z",
                 "timezone": "+00:00"
             },
+            "message": "Connection terminated for  webadmin (timeout)",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1441,17 +1416,15 @@
                     "id": "firewall",
                     "pri": "4"
                 },
-                "msg": "Connection terminated for  webadmin (timeout)",
                 "startime": "2024-03-08 10:14:56",
-                "time": "2024-03-08 15:14:57",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:57"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T10:14:51.000Z",
+            "@timestamp": "2024-03-08T15:14:57.000Z",
             "destination": {
                 "domain": "update2-sns.stormshieldcs.eu",
                 "geo": {
@@ -1465,9 +1438,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:14:51.000Z",
                 "duration": 2147483647,
                 "original": "id=firewall time=\"2024-03-08 15:14:57\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:51\" pri=5 confid=01 slotlevel=0 ruleid=7 ipproto=tcp dstif=\"Ethernet0\" dstifname=\"out\" proto=https src=192.168.197.134 srcport=19883 srcname=Firewall_out dst=192.168.36.20 dstport=443 dstportname=https dstname=update2-sns.stormshieldcs.eu dstcontinent=\"eu\" dstcountry=\"fr\" modsrc=192.168.197.134 modsrcport=19883 origdst=192.168.36.20 origdstport=443 ipv=4 sent=3721 rcvd=921861 duration=5.52 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:14:51.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -1511,15 +1484,14 @@
                     "srcname": "Firewall_out"
                 },
                 "startime": "2024-03-08 10:14:51",
-                "time": "2024-03-08 15:14:57",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:57"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T10:14:54.000Z",
+            "@timestamp": "2024-03-08T15:14:57.000Z",
             "destination": {
                 "domain": "update1-sns.stormshieldcs.eu",
                 "geo": {
@@ -1533,9 +1505,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-03-08T10:14:54.000Z",
                 "duration": 2147483647,
                 "original": "id=firewall time=\"2024-03-08 15:14:57\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:54\" pri=5 confid=01 slotlevel=0 ruleid=7 ipproto=tcp dstif=\"Ethernet0\" dstifname=\"out\" proto=https src=192.168.197.134 srcport=15908 srcname=Firewall_out dst=192.168.36.4 dstport=443 dstportname=https dstname=update1-sns.stormshieldcs.eu dstcontinent=\"eu\" dstcountry=\"fr\" modsrc=192.168.197.134 modsrcport=15908 origdst=192.168.36.4 origdstport=443 ipv=4 sent=1467 rcvd=4863757 duration=2.98 action=pass logtype=\"connection\"",
+                "start": "2024-03-08T10:14:54.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -1579,23 +1551,23 @@
                     "srcname": "Firewall_out"
                 },
                 "startime": "2024-03-08 10:14:54",
-                "time": "2024-03-08 15:14:57",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:57"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-03-08T10:14:56.000Z",
+            "@timestamp": "2024-03-08T15:14:58.000Z",
             "ecs": {
                 "version": "8.11.0"
             },
             "event": {
-                "created": "2024-03-08T10:14:56.000Z",
                 "original": "id=firewall time=\"2024-03-08 15:14:58\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:56\" pri=5 msg=\"Active Update: update successful CompromisedUrls\" service=sysevent  logtype=\"system\" alarmid=41",
+                "start": "2024-03-08T10:14:56.000Z",
                 "timezone": "+00:00"
             },
+            "message": "Active Update: update successful CompromisedUrls",
             "observer": {
                 "name": "stormy-1",
                 "type": "firewall",
@@ -1609,18 +1581,16 @@
                     "id": "firewall",
                     "pri": "5"
                 },
-                "msg": "Active Update: update successful CompromisedUrls",
                 "service": "sysevent",
                 "startime": "2024-03-08 10:14:56",
-                "time": "2024-03-08 15:14:58",
-                "tz": "+0000"
+                "time": "2024-03-08 15:14:58"
             },
             "tags": [
                 "preserve_original_event"
             ]
         },
         {
-            "@timestamp": "2024-06-07T10:40:42.000Z",
+            "@timestamp": "2024-06-07T18:46:18.000Z",
             "destination": {
                 "as": {
                     "number": 1221,
@@ -1640,9 +1610,9 @@
             },
             "event": {
                 "action": "pass",
-                "created": "2024-06-07T10:40:42.000Z",
                 "duration": 60000000,
                 "original": "id=firewall time=\"2024-06-07 18:46:18\" fw=\"stormy-1\" tz=+0000 startime=\"2024-06-07 10:40:42\" pri=5 confid=01 slotlevel=2 ruleid=7 srcif=\"Ethernet1\" srcifname=\"segment0\" ipproto=tcp dstif=\"Ethernet0\" dstifname=\"out\" proto=http src=89.160.20.128 srcport=55008 srcportname=ephemeral_fw_tcp srcname=vm-internal srcmac=00:0c:29:8d:6c:55 srccontinent=\"eu\" srccountry=\"se\" dst=1.128.91.48 dstport=80 dstportname=http dstname=connectivity-check.ubuntu.com dstcontinent=\"na\" dstcountry=\"us\" modsrc=192.168.197.134 modsrcport=55008 origdst=1.128.91.48 origdstport=80 ipv=4 sent=77 rcvd=177 duration=0.06 action=pass op=GET result=204 arg=\"/\" logtype=\"plugin\"",
+                "start": "2024-06-07T10:40:42.000Z",
                 "timezone": "+00:00"
             },
             "network": {
@@ -1718,8 +1688,7 @@
                 "srcif": "Ethernet1",
                 "srcifname": "segment0",
                 "startime": "2024-06-07 10:40:42",
-                "time": "2024-06-07 18:46:18",
-                "tz": "+0000"
+                "time": "2024-06-07 18:46:18"
             },
             "tags": [
                 "preserve_original_event"

--- a/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/stormshield/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -57,13 +57,25 @@ processors:
           }
         }
 
+  - remove:
+      field: message
+      ignore_missing: true
+  - rename:
+      tag: set_message
+      target_field: message
+      field: stormshield.msg
+      ignore_missing: true
+
   - grok:
       field: stormshield.tz
       patterns:
         - "(?:%{OFFSET:_temp_.tz_offset})(?:%{HOUR:_temp_.tz_hour}):?(?:%{MINUTE:_temp_.tz_minute})"
       pattern_definitions:
         OFFSET: "[+-]?"
-  
+  - remove:
+      field: stormshield.tz
+      ignore_missing: true
+
   # rename some fields
 
   - set:
@@ -72,22 +84,25 @@ processors:
       if: ctx._temp_?.tz_hour != null
 
   - date:
-      tag: format_startime
-      field: stormshield.startime
-      target_field: "event.created"
+      tag: process_time
+      field: stormshield.time
       formats:
         - "yyyy-MM-dd HH:mm:ss"
       timezone: "{{{event.timezone}}}"
+      if: ctx.stormshield?.time != null
+
+  - date:
+      tag: format_startime
+      field: stormshield.startime
+      target_field: "event.start"
+      formats:
+        - "yyyy-MM-dd HH:mm:ss"
+      timezone: "{{{event.timezone}}}"
+      if: ctx.stormshield?.startime != null
       on_failure:
         - remove:
-            field: event.created
+            field: event.start
             ignore_missing: true
-
-  # Set @timestamp to the time when the log indicates.
-  - set:
-      copy_from: event.created
-      field: '@timestamp'
-      if: ctx.event?.created != null
 
   - pipeline:
       name: '{{ IngestPipeline "filterstat" }}'
@@ -488,11 +503,6 @@ processors:
       if: ctx.tags == null || !(ctx.tags.contains('preserve_original_event'))
       ignore_failure: true
       ignore_missing: true
-  - remove:
-      field: message
-      ignore_failure: true
-      ignore_missing: true
-
 
 on_failure:
 - append:

--- a/packages/stormshield/data_stream/log/fields/ecs.yml
+++ b/packages/stormshield/data_stream/log/fields/ecs.yml
@@ -45,11 +45,15 @@
 - external: ecs
   name: destination.ip
 - external: ecs
+  name: destination.mac
+- external: ecs
   name: destination.nat.ip
 - external: ecs
   name: destination.port
 - external: ecs
   name: destination.nat.port
+- external: ecs
+  name: message
 - external: ecs
   name: source.geo.city_name
 - external: ecs

--- a/packages/stormshield/data_stream/log/sample_event.json
+++ b/packages/stormshield/data_stream/log/sample_event.json
@@ -1,118 +1,83 @@
 {
+    "@timestamp": "2024-03-08T10:14:08.000Z",
     "agent": {
-        "name": "ubuntu",
-        "id": "4ef1feb0-bb75-4728-9415-c84920a76292",
+        "ephemeral_id": "fbc0ca2c-7300-45ce-84b1-6ece2bc46905",
+        "id": "e0b60804-99ad-435e-865c-35384901d186",
+        "name": "elastic-agent-45518",
         "type": "filebeat",
-        "ephemeral_id": "713a4ebd-2cc4-47dd-9940-b836b1612470",
-        "version": "8.11.4"
+        "version": "8.14.1"
     },
-    "process": {
-        "name": "asqd"
+    "data_stream": {
+        "dataset": "stormshield.log",
+        "namespace": "65295",
+        "type": "logs"
     },
-    "log": {
-        "source": {
-            "address": "192.168.197.134:17502"
-        },
-        "syslog": {
-            "severity": {
-                "code": 6,
-                "name": "Informational"
-            },
-            "hostname": "stormy-1",
-            "appname": "asqd",
-            "priority": 14,
-            "version": "1",
-            "facility": {
-                "code": 1,
-                "name": "user-level"
-            }
-        }
-    },
-    "elastic_agent": {
-        "id": "4ef1feb0-bb75-4728-9415-c84920a76292",
-        "version": "8.11.4",
-        "snapshot": false
-    },
-    "destination": {
-        "geo": {
-            "country_iso_code": "gb"
-        },
-        "port": 80,
-        "ip": "185.125.190.48",
-        "domain": "connectivity-check.ubuntu.com"
-    },
-    "rule": {
-        "id": "7"
-    },
-    "source": {
-        "geo": {
-            "country_iso_code": "au"
-        },
-        "as": {
-            "number": 1221,
-            "organization": {
-                "name": "Telstra Pty Ltd"
-            }
-        },
-        "port": 33828,
-        "bytes": 0,
-        "ip": "1.128.7.128",
-        "mac": "00-0C-29-8D-6C-55"
-    },
-    "tags": [
-        "forwarded"
-    ],
-    "network": {
-        "protocol": "http",
-        "transport": "tcp",
-        "type": "ipv4"
-    },
-    "input": {
-        "type": "udp"
-    },
-    "observer": {
-        "vendor": "Stormshield"
-    },
-    "@timestamp": "2024-06-06T04:32:19.000Z",
     "ecs": {
         "version": "8.11.0"
     },
-    "data_stream": {
-        "namespace": "default",
-        "type": "logs",
-        "dataset": "stormshield.log"
-    },
-    "stormshield": {
-        "metadata": {
-            "confid": "01",
-            "slotlevel": "2",
-            "dstcontinent": "eu",
-            "srcname": "vm-internal",
-            "pri": "5",
-            "dstportname": "http",
-            "rcvd": "0",
-            "id": "firewall",
-            "srccontinent": "oc",
-            "srcportname": "ephemeral_fw_tcp",
-            "sent": "0"
-        },
-        "tz": "+0000",
-        "srcifname": "segment0",
-        "srcif": "Ethernet1",
-        "fw": "stormy-1",
-        "logtype": "filter",
-        "dstif": "Ethernet0",
-        "dstifname": "out",
-        "startime": "2024-06-06 04:32:19",
-        "time": "2024-06-06 04:32:19"
+    "elastic_agent": {
+        "id": "e0b60804-99ad-435e-865c-35384901d186",
+        "snapshot": false,
+        "version": "8.14.1"
     },
     "event": {
-        "duration": 0,
         "agent_id_status": "verified",
-        "ingested": "2024-06-06T04:33:16Z",
-        "timezone": "+00:00",
-        "created": "2024-06-06T04:32:19.000Z",
-        "action": "pass",
-        "dataset": "stormshield.log"
+        "dataset": "stormshield.log",
+        "ingested": "2024-09-18T14:01:36Z",
+        "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"PKI SEARCH scope=local type=ca\" logtype=\"server\"",
+        "start": "2024-03-08T10:14:08.000Z",
+        "timezone": "+00:00"
+    },
+    "input": {
+        "type": "tcp"
+    },
+    "log": {
+        "source": {
+            "address": "172.27.0.3:40024"
+        },
+        "syslog": {
+            "appname": "serverd",
+            "facility": {
+                "code": 1,
+                "name": "user-level"
+            },
+            "hostname": "stormy-1",
+            "priority": 13,
+            "severity": {
+                "code": 5,
+                "name": "Notice"
+            },
+            "version": "1"
+        }
+    },
+    "message": "PKI SEARCH scope=local type=ca",
+    "observer": {
+        "name": "stormy-1",
+        "type": "firewall",
+        "vendor": "Stormshield"
+    },
+    "related": {
+        "user": [
+            "admin"
+        ]
+    },
+    "stormshield": {
+        "fw": "stormy-1",
+        "logtype": "server",
+        "metadata": {
+            "address": "192.168.197.1",
+            "error": "0",
+            "id": "firewall",
+            "sessionid": "1"
+        },
+        "startime": "2024-03-08 10:14:08",
+        "time": "2024-03-08 10:14:08"
+    },
+    "tags": [
+        "preserve_original_event",
+        "forwarded"
+    ],
+    "user": {
+        "name": "admin"
     }
 }

--- a/packages/stormshield/docs/README.md
+++ b/packages/stormshield/docs/README.md
@@ -33,124 +33,88 @@ An example event for `log` looks as following:
 
 ```json
 {
+    "@timestamp": "2024-03-08T10:14:08.000Z",
     "agent": {
-        "name": "ubuntu",
-        "id": "4ef1feb0-bb75-4728-9415-c84920a76292",
+        "ephemeral_id": "fbc0ca2c-7300-45ce-84b1-6ece2bc46905",
+        "id": "e0b60804-99ad-435e-865c-35384901d186",
+        "name": "elastic-agent-45518",
         "type": "filebeat",
-        "ephemeral_id": "713a4ebd-2cc4-47dd-9940-b836b1612470",
-        "version": "8.11.4"
+        "version": "8.14.1"
     },
-    "process": {
-        "name": "asqd"
+    "data_stream": {
+        "dataset": "stormshield.log",
+        "namespace": "65295",
+        "type": "logs"
     },
-    "log": {
-        "source": {
-            "address": "192.168.197.134:17502"
-        },
-        "syslog": {
-            "severity": {
-                "code": 6,
-                "name": "Informational"
-            },
-            "hostname": "stormy-1",
-            "appname": "asqd",
-            "priority": 14,
-            "version": "1",
-            "facility": {
-                "code": 1,
-                "name": "user-level"
-            }
-        }
-    },
-    "elastic_agent": {
-        "id": "4ef1feb0-bb75-4728-9415-c84920a76292",
-        "version": "8.11.4",
-        "snapshot": false
-    },
-    "destination": {
-        "geo": {
-            "country_iso_code": "gb"
-        },
-        "port": 80,
-        "ip": "185.125.190.48",
-        "domain": "connectivity-check.ubuntu.com"
-    },
-    "rule": {
-        "id": "7"
-    },
-    "source": {
-        "geo": {
-            "country_iso_code": "au"
-        },
-        "as": {
-            "number": 1221,
-            "organization": {
-                "name": "Telstra Pty Ltd"
-            }
-        },
-        "port": 33828,
-        "bytes": 0,
-        "ip": "1.128.7.128",
-        "mac": "00-0C-29-8D-6C-55"
-    },
-    "tags": [
-        "forwarded"
-    ],
-    "network": {
-        "protocol": "http",
-        "transport": "tcp",
-        "type": "ipv4"
-    },
-    "input": {
-        "type": "udp"
-    },
-    "observer": {
-        "vendor": "Stormshield"
-    },
-    "@timestamp": "2024-06-06T04:32:19.000Z",
     "ecs": {
         "version": "8.11.0"
     },
-    "data_stream": {
-        "namespace": "default",
-        "type": "logs",
-        "dataset": "stormshield.log"
-    },
-    "stormshield": {
-        "metadata": {
-            "confid": "01",
-            "slotlevel": "2",
-            "dstcontinent": "eu",
-            "srcname": "vm-internal",
-            "pri": "5",
-            "dstportname": "http",
-            "rcvd": "0",
-            "id": "firewall",
-            "srccontinent": "oc",
-            "srcportname": "ephemeral_fw_tcp",
-            "sent": "0"
-        },
-        "tz": "+0000",
-        "srcifname": "segment0",
-        "srcif": "Ethernet1",
-        "fw": "stormy-1",
-        "logtype": "filter",
-        "dstif": "Ethernet0",
-        "dstifname": "out",
-        "startime": "2024-06-06 04:32:19",
-        "time": "2024-06-06 04:32:19"
+    "elastic_agent": {
+        "id": "e0b60804-99ad-435e-865c-35384901d186",
+        "snapshot": false,
+        "version": "8.14.1"
     },
     "event": {
-        "duration": 0,
         "agent_id_status": "verified",
-        "ingested": "2024-06-06T04:33:16Z",
-        "timezone": "+00:00",
-        "created": "2024-06-06T04:32:19.000Z",
-        "action": "pass",
-        "dataset": "stormshield.log"
+        "dataset": "stormshield.log",
+        "ingested": "2024-09-18T14:01:36Z",
+        "original": "id=firewall time=\"2024-03-08 10:14:08\" fw=\"stormy-1\" tz=+0000 startime=\"2024-03-08 10:14:08\" error=0 user=\"admin\" address=192.168.197.1 sessionid=1 msg=\"PKI SEARCH scope=local type=ca\" logtype=\"server\"",
+        "start": "2024-03-08T10:14:08.000Z",
+        "timezone": "+00:00"
+    },
+    "input": {
+        "type": "tcp"
+    },
+    "log": {
+        "source": {
+            "address": "172.27.0.3:40024"
+        },
+        "syslog": {
+            "appname": "serverd",
+            "facility": {
+                "code": 1,
+                "name": "user-level"
+            },
+            "hostname": "stormy-1",
+            "priority": 13,
+            "severity": {
+                "code": 5,
+                "name": "Notice"
+            },
+            "version": "1"
+        }
+    },
+    "message": "PKI SEARCH scope=local type=ca",
+    "observer": {
+        "name": "stormy-1",
+        "type": "firewall",
+        "vendor": "Stormshield"
+    },
+    "related": {
+        "user": [
+            "admin"
+        ]
+    },
+    "stormshield": {
+        "fw": "stormy-1",
+        "logtype": "server",
+        "metadata": {
+            "address": "192.168.197.1",
+            "error": "0",
+            "id": "firewall",
+            "sessionid": "1"
+        },
+        "startime": "2024-03-08 10:14:08",
+        "time": "2024-03-08 10:14:08"
+    },
+    "tags": [
+        "preserve_original_event",
+        "forwarded"
+    ],
+    "user": {
+        "name": "admin"
     }
 }
-
 ```
 
 **Exported fields**
@@ -174,6 +138,7 @@ An example event for `log` looks as following:
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
 | destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
+| destination.mac | MAC address of the destination. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | destination.nat.ip | Translated ip of destination based NAT sessions (e.g. internet to private DMZ) Typically used with load balancers, firewalls, or routers. | ip |
 | destination.nat.port | Port the source session is translated to by NAT Device. Typically used with load balancers, firewalls, or routers. | long |
 | destination.port | Port of the destination. | long |
@@ -189,6 +154,7 @@ An example event for `log` looks as following:
 | log.syslog.severity.code | The Syslog numeric severity of the log event, if available. If the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`. | long |
 | log.syslog.severity.name | The Syslog numeric severity of the log event, if available. If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`. | keyword |
 | log.syslog.version | The version of the Syslog protocol specification. Only applicable for RFC 5424 messages. | keyword |
+| message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | match_only_text |
 | network.protocol | In the OSI Model this would be the Application Layer protocol. For example, `http`, `dns`, or `ssh`. The field value must be normalized to lowercase for querying. | keyword |
 | network.transport | Same as network.iana_number, but instead using the Keyword name of the transport layer (udp, tcp, ipv6-icmp, etc.) The field value must be normalized to lowercase for querying. | keyword |
 | network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc The field value must be normalized to lowercase for querying. | keyword |

--- a/packages/stormshield/manifest.yml
+++ b/packages/stormshield/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.1
 name: stormshield
 title: "StormShield SNS"
-version: 0.1.0
+version: 1.0.0
 source:
   license: "Elastic-2.0"
 description: "Stormshield SNS integration."


### PR DESCRIPTION
## Proposed commit message

- Use stormshield.time for `@timestamp`
- Use stormshield.starttime for event.start
- Move stormshield.msg to message
- Release integration as GA

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally

```
cd packages/stormshield
elastic-package test
```

## Related issues

- Relates #10985
- Relates #11005
