### PR TITLE
[pfsense] Add SNORT log processing

### DIFF
--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,5 +1,5 @@
 # newer versions go on top
-- version: "1.19.3"
+- version: "1.20.0"
   changes:
     - description: Add SNORT log processing
       type: enhancement

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "1.19.3"
+  changes:
+    - description: Add SNORT log processing
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "1.19.2"
   changes:
     - description: Fix firewall ICMPv6 message parsing error

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Add SNORT log processing
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/
+      link: https://github.com/elastic/integrations/pull/11182
 - version: "1.19.2"
   changes:
     - description: Fix firewall ICMPv6 message parsing error

--- a/packages/pfsense/changelog.yml
+++ b/packages/pfsense/changelog.yml
@@ -2,7 +2,7 @@
 - version: "1.19.3"
   changes:
     - description: Add SNORT log processing
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/integrations/pull/11182
 - version: "1.19.2"
   changes:

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log
@@ -1,0 +1,2 @@
+<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222
+<190>Jul 23 18:12:00 snort[87537]: [119:4:1] (http_inspect) BARE BYTE UNICODE ENCODING [Classification: Not Suspicious Traffic] [Priority: 3] {TCP} 67.43.156.0:63651 -> 89.160.20.128:8080

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log
@@ -1,2 +1,2 @@
-<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222
+<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 67.43.156.1:16856 -> 89.160.20.128:2222
 <190>Jul 23 18:12:00 snort[87537]: [119:4:1] (http_inspect) BARE BYTE UNICODE ENCODING [Classification: Not Suspicious Traffic] [Priority: 3] {TCP} 67.43.156.0:63651 -> 89.160.20.128:8080

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log-expected.json
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log-expected.json
@@ -1,0 +1,191 @@
+{
+    "expected": [
+        {
+            "@timestamp": "2024-07-23T18:12:00.000-04:00",
+            "destination": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 2222
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "original": "<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222",
+                "provider": "snort",
+                "timezone": "-04:00"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 190
+                }
+            },
+            "message": "[136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222",
+            "network": {
+                "protocol": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "type": "firewall",
+                "vendor": "netgate"
+            },
+            "process": {
+                "name": "snort",
+                "pid": 87537
+            },
+            "related": {
+                "ip": [
+                    "89.160.20.128"
+                ]
+            },
+            "snort": {
+                "alert_message": "packets blacklisted",
+                "classification": "Potentially Bad Traffic",
+                "generator_id": "136",
+                "preprocessor": "spp_reputation",
+                "priority": 2,
+                "signature_id": "1",
+                "signature_revision": "1"
+            },
+            "source": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 16856
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        },
+        {
+            "@timestamp": "2024-07-23T18:12:00.000-04:00",
+            "destination": {
+                "address": "89.160.20.128",
+                "as": {
+                    "number": 29518,
+                    "organization": {
+                        "name": "Bredband2 AB"
+                    }
+                },
+                "geo": {
+                    "city_name": "Linköping",
+                    "continent_name": "Europe",
+                    "country_iso_code": "SE",
+                    "country_name": "Sweden",
+                    "location": {
+                        "lat": 58.4167,
+                        "lon": 15.6167
+                    },
+                    "region_iso_code": "SE-E",
+                    "region_name": "Östergötland County"
+                },
+                "ip": "89.160.20.128",
+                "port": 8080
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "category": [
+                    "network"
+                ],
+                "kind": "event",
+                "original": "<190>Jul 23 18:12:00 snort[87537]: [119:4:1] (http_inspect) BARE BYTE UNICODE ENCODING [Classification: Not Suspicious Traffic] [Priority: 3] {TCP} 67.43.156.0:63651 -> 89.160.20.128:8080",
+                "provider": "snort",
+                "timezone": "-04:00"
+            },
+            "log": {
+                "syslog": {
+                    "priority": 190
+                }
+            },
+            "message": "[119:4:1] (http_inspect) BARE BYTE UNICODE ENCODING [Classification: Not Suspicious Traffic] [Priority: 3] {TCP} 67.43.156.0:63651 -> 89.160.20.128:8080",
+            "network": {
+                "protocol": "tcp",
+                "type": "ipv4"
+            },
+            "observer": {
+                "type": "firewall",
+                "vendor": "netgate"
+            },
+            "process": {
+                "name": "snort",
+                "pid": 87537
+            },
+            "related": {
+                "ip": [
+                    "89.160.20.128",
+                    "67.43.156.0"
+                ]
+            },
+            "snort": {
+                "alert_message": "BARE BYTE UNICODE ENCODING",
+                "classification": "Not Suspicious Traffic",
+                "generator_id": "119",
+                "preprocessor": "http_inspect",
+                "priority": 3,
+                "signature_id": "4",
+                "signature_revision": "1"
+            },
+            "source": {
+                "address": "67.43.156.0",
+                "as": {
+                    "number": 35908
+                },
+                "geo": {
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
+                    "location": {
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
+                },
+                "ip": "67.43.156.0",
+                "port": 63651
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log-expected.json
+++ b/packages/pfsense/data_stream/log/_dev/test/pipeline/test-pfsense-snort.log-expected.json
@@ -33,7 +33,7 @@
                     "network"
                 ],
                 "kind": "event",
-                "original": "<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222",
+                "original": "<190>Jul 23 18:12:00 snort[87537]: [136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 67.43.156.1:16856 -> 89.160.20.128:2222",
                 "provider": "snort",
                 "timezone": "-04:00"
             },
@@ -42,7 +42,7 @@
                     "priority": 190
                 }
             },
-            "message": "[136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 89.160.20.128:16856 -> 89.160.20.128:2222",
+            "message": "[136:1:1] (spp_reputation) packets blacklisted [Classification: Potentially Bad Traffic] [Priority: 2] {TCP} 67.43.156.1:16856 -> 89.160.20.128:2222",
             "network": {
                 "protocol": "tcp",
                 "type": "ipv4"
@@ -57,7 +57,8 @@
             },
             "related": {
                 "ip": [
-                    "89.160.20.128"
+                    "89.160.20.128",
+                    "67.43.156.1"
                 ]
             },
             "snort": {
@@ -70,26 +71,20 @@
                 "signature_revision": "1"
             },
             "source": {
-                "address": "89.160.20.128",
+                "address": "67.43.156.1",
                 "as": {
-                    "number": 29518,
-                    "organization": {
-                        "name": "Bredband2 AB"
-                    }
+                    "number": 35908
                 },
                 "geo": {
-                    "city_name": "Linköping",
-                    "continent_name": "Europe",
-                    "country_iso_code": "SE",
-                    "country_name": "Sweden",
+                    "continent_name": "Asia",
+                    "country_iso_code": "BT",
+                    "country_name": "Bhutan",
                     "location": {
-                        "lat": 58.4167,
-                        "lon": 15.6167
-                    },
-                    "region_iso_code": "SE-E",
-                    "region_name": "Östergötland County"
+                        "lat": 27.5,
+                        "lon": 90.5
+                    }
                 },
-                "ip": "89.160.20.128",
+                "ip": "67.43.156.1",
                 "port": 16856
             },
             "tags": [

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -86,8 +86,11 @@ processors:
   - pipeline:
       name: '{{ IngestPipeline "squid" }}'
       if: ctx.event.provider == 'squid'
+  - pipeline:
+      name: '{{ IngestPipeline "snort" }}'
+      if: ctx.event.provider == 'snort'
   - drop:
-      if: '!["filterlog", "openvpn", "charon", "dhcpd", "dhclient", "dhcp6c", "unbound", "haproxy", "php-fpm", "squid"].contains(ctx.event?.provider)'
+      if: '!["filterlog", "openvpn", "charon", "dhcpd", "dhclient", "dhcp6c", "unbound", "haproxy", "php-fpm", "squid", "snort"].contains(ctx.event?.provider)'
   - append:
       field: event.category
       value: network

--- a/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/snort.yml
+++ b/packages/pfsense/data_stream/log/elasticsearch/ingest_pipeline/snort.yml
@@ -1,0 +1,14 @@
+---
+description: Pipeline for PFsense SNORT logs.
+processors:
+    - grok:
+            field: message
+            patterns:
+                - '\[%{NUMBER:snort.generator_id}:%{NUMBER:snort.signature_id}:%{NUMBER:snort.signature_revision}\] \(%{DATA:snort.preprocessor}\) %{GREEDYDATA:snort.alert_message} \[Classification: %{DATA:snort.classification}\] \[Priority: %{NONNEGINT:snort.priority:long}\] \{%{WORD:network.protocol}\} %{IP:source.address}:%{NUMBER:source.port:long} -> %{IP:destination.address}:%{NUMBER:destination.port:long}'
+    - lowercase:
+        field: network.protocol
+        ignore_missing: true
+on_failure:
+    - set:
+          field: error.message
+          value: "{{{ _ingest.on_failure_message }}}"

--- a/packages/pfsense/data_stream/log/fields/fields.yml
+++ b/packages/pfsense/data_stream/log/fields/fields.yml
@@ -281,3 +281,27 @@
     - name: hierarchy_status
       type: keyword
       description: The proxy hierarchy route; the route Content Gateway used to retrieve the object.
+- name: snort
+  type: group
+  fields:
+    - name: alert_message
+      type: keyword
+      description: Snort alert message.
+    - name: classification
+      type: keyword
+      description: Snort classification.
+    - name: generator_id
+      type: keyword
+      description: Snort generator id.
+    - name: preprocessor
+      type: keyword
+      description: Snort preprocessor.
+    - name: priority
+      type: long
+      description: Snort priority.
+    - name: signature_id
+      type: keyword
+      description: Snort signature id.
+    - name: signature_revision
+      type: keyword
+      description: Snort signature revision.

--- a/packages/pfsense/docs/README.md
+++ b/packages/pfsense/docs/README.md
@@ -385,6 +385,13 @@ An example event for `log` looks as following:
 | server.ip | IP address of the server (IPv4 or IPv6). | ip |
 | server.mac | MAC address of the server. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
 | server.port | Port of the server. | long |
+| snort.alert_message | Snort alert message. | keyword |
+| snort.classification | Snort classification. | keyword |
+| snort.generator_id | Snort generator id. | keyword |
+| snort.preprocessor | Snort preprocessor. | keyword |
+| snort.priority | Snort priority. | long |
+| snort.signature_id | Snort signature id. | keyword |
+| snort.signature_revision | Snort signature revision. | keyword |
 | source.address | Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is. | keyword |
 | source.as.number | Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet. | long |
 | source.as.organization.name | Organization name. | keyword |

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.19.2"
+version: "1.19.3"
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration
 icons:

--- a/packages/pfsense/manifest.yml
+++ b/packages/pfsense/manifest.yml
@@ -1,6 +1,6 @@
 name: pfsense
 title: pfSense
-version: "1.19.3"
+version: "1.20.0"
 description: Collect logs from pfSense and OPNsense with Elastic Agent.
 type: integration
 icons:


### PR DESCRIPTION
## Proposed commit message

Add SNORT log processing

Didn't have any data samples in the original issue https://github.com/elastic/integrations/issues/10558, so had to look around and invent a couple.

It was not clear how to map some of the snort fields to ECS, mapped what was obvious and have put the rest under ```"snort"``` field similar to how it was done for ```"squid"``` logs.

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/10558
