### PR TITLE
adding the files to include kubeadm parameter

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.68.0
+  changes:
+    - description: Add use_kubeadm config option in order to toggle Kubeadm config api requests 
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/
 - version: 1.67.0
   changes:
     - description: Add both pod.{cpu,memory}.usage.node.pct and pod.{cpu,memory}.usage.limit.pct metrics to the Overview dashboard

--- a/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/apiserver/agent/stream/stream.yml.hbs
@@ -16,7 +16,7 @@ condition: ${kubernetes_leaderelection.leader} == true
 condition: {{ condition }}
 {{/if}}
 {{/if}}
-
+use_kubeadm: {{use_kubeadm}}
 {{#if bearer_token_file}}
 bearer_token_file: {{bearer_token_file}}
 ssl.certificate_authorities:

--- a/packages/kubernetes/data_stream/apiserver/manifest.yml
+++ b/packages/kubernetes/data_stream/apiserver/manifest.yml
@@ -34,6 +34,15 @@ streams:
         required: true
         show_user: true
         default: 30s
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities

--- a/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/audit_logs/agent/stream/stream.yml.hbs
@@ -7,10 +7,13 @@ parsers:
 - ndjson:
     add_error_key: true
     target: "kubernetes.audit"
+
 {{#if processors}}
 processors:
 {{processors}}
 {{/if}}
+use_kubeadm: {{use_kubeadm}}
+
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/kubernetes/data_stream/audit_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/audit_logs/manifest.yml
@@ -26,6 +26,15 @@ streams:
         show_user: false
         description: >-
           Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: condition
         title: Condition
         description: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.

--- a/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container/agent/stream/stream.yml.hbs
@@ -1,5 +1,6 @@
 metricsets: ["container"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
 {{#if add_resource_metadata_config}}
 {{add_resource_metadata_config}}
 {{/if}}

--- a/packages/kubernetes/data_stream/container/manifest.yml
+++ b/packages/kubernetes/data_stream/container/manifest.yml
@@ -12,6 +12,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: bearer_token_file
         type: text
         title: Bearer Token File

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -6,6 +6,8 @@ paths:
 data_stream:
   dataset: {{data_stream.dataset}}
 prospector.scanner.symlinks: {{ symlinks }}
+use_kubeadm: {{use_kubeadm}}
+
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/kubernetes/data_stream/container_logs/manifest.yml
+++ b/packages/kubernetes/data_stream/container_logs/manifest.yml
@@ -61,6 +61,15 @@ streams:
           #     pattern: '^\['
           #     negate: true
           #     match: after
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/controllermanager/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/controllermanager/agent/stream/stream.yml.hbs
@@ -10,6 +10,7 @@ period: {{period}}
 bearer_token_file: {{bearer_token_file}}
 ssl.verification_mode: {{ssl.verification_mode}}
 {{/if}}
+use_kubeadm: {{use_kubeadm}}
 
 {{#if condition }}
 condition: ${kubernetes.labels.{{~controller_manager_label_key~}} } == '{{controller_manager_label_value}}' and {{ condition }}

--- a/packages/kubernetes/data_stream/controllermanager/manifest.yml
+++ b/packages/kubernetes/data_stream/controllermanager/manifest.yml
@@ -28,6 +28,15 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: ssl.verification_mode
         type: text
         title: SSL Verification Mode

--- a/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/event/agent/stream/stream.yml.hbs
@@ -1,6 +1,7 @@
 metricsets: ["event"]
 period: {{period}}
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
 skip_older: {{skip_older}}
 {{#if leaderelection }}
 {{#if condition }}

--- a/packages/kubernetes/data_stream/event/manifest.yml
+++ b/packages/kubernetes/data_stream/event/manifest.yml
@@ -17,6 +17,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: skip_older
         type: bool
         title: Skip older events

--- a/packages/kubernetes/data_stream/node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/node/agent/stream/stream.yml.hbs
@@ -1,5 +1,6 @@
 metricsets: ["node"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/node/manifest.yml
+++ b/packages/kubernetes/data_stream/node/manifest.yml
@@ -12,6 +12,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: bearer_token_file
         type: text
         title: Bearer Token File

--- a/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/pod/agent/stream/stream.yml.hbs
@@ -1,5 +1,6 @@
 metricsets: ["pod"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
 {{#if add_resource_metadata_config}}
 {{add_resource_metadata_config}}
 {{/if}}

--- a/packages/kubernetes/data_stream/pod/manifest.yml
+++ b/packages/kubernetes/data_stream/pod/manifest.yml
@@ -12,6 +12,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: bearer_token_file
         type: text
         title: Bearer Token File

--- a/packages/kubernetes/data_stream/proxy/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/proxy/agent/stream/stream.yml.hbs
@@ -3,6 +3,7 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+use_kubeadm: {{use_kubeadm}}
 period: {{period}}
 
 {{#if processors}}

--- a/packages/kubernetes/data_stream/proxy/manifest.yml
+++ b/packages/kubernetes/data_stream/proxy/manifest.yml
@@ -20,6 +20,15 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: processors
         type: yaml
         title: Processors

--- a/packages/kubernetes/data_stream/scheduler/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/scheduler/agent/stream/stream.yml.hbs
@@ -3,6 +3,8 @@ hosts:
 {{#each hosts}}
   - {{this}}
 {{/each}}
+use_kubeadm: {{use_kubeadm}}
+
 period: {{period}}
 
 {{#if bearer_token_file}}

--- a/packages/kubernetes/data_stream/scheduler/manifest.yml
+++ b/packages/kubernetes/data_stream/scheduler/manifest.yml
@@ -28,6 +28,15 @@ streams:
         required: true
         show_user: true
         default: 10s
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: ssl.verification_mode
         type: text
         title: SSL Verification Mode

--- a/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_container/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_container"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 {{#if add_resource_metadata_config}}
 {{add_resource_metadata_config}}
 {{/if}}

--- a/packages/kubernetes/data_stream/state_container/manifest.yml
+++ b/packages/kubernetes/data_stream/state_container/manifest.yml
@@ -48,6 +48,15 @@ streams:
         required: false
         show_user: false
         default: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities

--- a/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_cronjob/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_cronjob"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_cronjob/manifest.yml
+++ b/packages/kubernetes/data_stream/state_cronjob/manifest.yml
@@ -48,6 +48,15 @@ streams:
         required: false
         show_user: false
         default: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: ssl.certificate_authorities
         type: text
         title: SSL Certificate Authorities

--- a/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_daemonset/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_daemonset"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_daemonset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_daemonset/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_deployment/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_deployment"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_deployment/manifest.yml
+++ b/packages/kubernetes/data_stream/state_deployment/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_job/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_job"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_job/manifest.yml
+++ b/packages/kubernetes/data_stream/state_job/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_namespace/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_namespace/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_namespace"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_namespace/manifest.yml
+++ b/packages/kubernetes/data_stream/state_namespace/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_node/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_node"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_node/manifest.yml
+++ b/packages/kubernetes/data_stream/state_node/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolume/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_persistentvolume"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolume/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_persistentvolumeclaim"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
+++ b/packages/kubernetes/data_stream/state_persistentvolumeclaim/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_pod/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_pod"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 {{#if add_resource_metadata_config}}
 {{add_resource_metadata_config}}
 {{/if}}

--- a/packages/kubernetes/data_stream/state_pod/manifest.yml
+++ b/packages/kubernetes/data_stream/state_pod/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_replicaset/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_replicaset"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_replicaset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_replicaset/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_resourcequota/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_resourcequota"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
+++ b/packages/kubernetes/data_stream/state_resourcequota/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_service/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_service"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_service/manifest.yml
+++ b/packages/kubernetes/data_stream/state_service/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_statefulset/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_statefulset"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_statefulset/manifest.yml
+++ b/packages/kubernetes/data_stream/state_statefulset/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/state_storageclass/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["state_storageclass"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/state_storageclass/manifest.yml
+++ b/packages/kubernetes/data_stream/state_storageclass/manifest.yml
@@ -13,6 +13,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: hosts
         type: text
         title: Hosts

--- a/packages/kubernetes/data_stream/system/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/system/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["system"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/system/manifest.yml
+++ b/packages/kubernetes/data_stream/system/manifest.yml
@@ -12,6 +12,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: bearer_token_file
         type: text
         title: Bearer Token File

--- a/packages/kubernetes/data_stream/volume/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/volume/agent/stream/stream.yml.hbs
@@ -1,5 +1,7 @@
 metricsets: ["volume"]
 add_metadata: {{add_metadata}}
+use_kubeadm: {{use_kubeadm}}
+
 hosts:
 {{#each hosts}}
   - {{this}}

--- a/packages/kubernetes/data_stream/volume/manifest.yml
+++ b/packages/kubernetes/data_stream/volume/manifest.yml
@@ -12,6 +12,15 @@ streams:
         required: true
         show_user: true
         default: true
+      - name: use_kubeadm
+        type: bool
+        title: Kubeadm 
+        multi: false
+        required: false
+        show_user: true
+        default: true
+        description: >
+          Toggle requests to kubeadm config map. Requests to kubeadm-config API endpoint are made by default in order to enrich cluster name
       - name: bearer_token_file
         type: text
         title: Bearer Token File

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.67.0
+version: 1.68.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
- Enhancement

## Proposed commit message

WHAT: Adding use_kubeadm variable in all the datastreams of kubernetes integrations
WHY: As per https://github.com/elastic/beats/issues/40276

## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).


## How to test this PR locally

1. Clone this repo
2. Navigate to elastic/integrations/packages/kubernetes
3. Build integration with `elastic-package build` command
4. Within the same folder run `elastic-package stack up -d -v --version=8.16.0-SNAPSHOT`
5. Open Local kibana page and install Kubernetes Integration v1.68.0. The use_kubeadm option should be available

## Related issues

-  #https://github.com/elastic/beats/issues/40276

NOTE: I would like to run some tests with sue_kubeadm: false and elastic agent to verify the actual gain we have by disabling those commands

## Screenshots


