### PR TITLE
[cisco_asa] Remove test for missing message_id

### DIFF
--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: "Customer is having poor experience when logs are missing message_id field."
       type: bugfix
-      link: https://github.com/elastic/integrations/pull/1
+      link: https://github.com/elastic/integrations/pull/11191
 - version: "2.37.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/cisco_asa/changelog.yml
+++ b/packages/cisco_asa/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.37.1"
+  changes:
+    - description: "Customer is having poor experience when logs are missing message_id field."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/1
 - version: "2.37.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_asa/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -1199,7 +1199,7 @@ processors:
   #
   # The result of this decoding is saved as _temp_.orig_security.{Key}: {Value}
   - kv:
-      if: '["430001", "430002", "430003", "430004", "430005", ""].contains(ctx._temp_.cisco.message_id)'
+      if: '["430001", "430002", "430003", "430004", "430005"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       tag: "kv_message_43000x"
       description: "430001, 430002, 430003, 430004, 430005"

--- a/packages/cisco_asa/manifest.yml
+++ b/packages/cisco_asa/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_asa
 title: Cisco ASA
-version: "2.37.0"
+version: "2.37.1"
 description: Collect logs from Cisco ASA with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION

## Proposed commit message

[cisco_asa] Remove check for missing message_id
* Customer reported a check for a missing message_id was causing failures in processing.
* This check was removed and verified that no existing tests failed.
* Customer did not provide sample data, so this is guesswork.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
