### PR TITLE
[cisco_ftd] Fix grok failure with username with spaces on ftd messageID.

### DIFF
--- a/packages/cisco_ftd/changelog.yml
+++ b/packages/cisco_ftd/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "3.4.1"
+  changes:
+    - description: "Fix grok failure with username with spaces on ftd messageID."
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/
 - version: "3.4.0"
   changes:
     - description: "Allow @custom pipeline access to event.original without setting preserve_original_event."

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-username_with_spaces.log
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-username_with_spaces.log
@@ -1,0 +1,1 @@
+<166>: 2024 Aug 07 10:29:42 UTC ccafa9b4-b48a-4156-b3af-de2d35e5f432 : %FTD-auth-6-113039: Group <GroupPolicy_XXX> User <MacBook Pro belonging to bob.dylan.xyz.local> IP <10.10.4.100> AnyConnect parent session started.

--- a/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-username_with_spaces.log-expected.json
+++ b/packages/cisco_ftd/data_stream/log/_dev/test/pipeline/test-ftd-username_with_spaces.log-expected.json
@@ -1,0 +1,59 @@
+{
+    "expected": [
+        {
+            "cisco": {
+                "ftd": {
+                    "suffix": "auth"
+                }
+            },
+            "ecs": {
+                "version": "8.11.0"
+            },
+            "event": {
+                "action": "client-vpn-connected",
+                "code": "113039",
+                "original": "<166>: 2024 Aug 07 10:29:42 UTC ccafa9b4-b48a-4156-b3af-de2d35e5f432 : %FTD-auth-6-113039: Group <GroupPolicy_XXX> User <MacBook Pro belonging to bob.dylan.xyz.local> IP <10.10.4.100> AnyConnect parent session started.",
+                "severity": 6,
+                "timezone": "UTC"
+            },
+            "log": {
+                "level": "informational",
+                "syslog": {
+                    "facility": {
+                        "code": 20
+                    },
+                    "priority": 166,
+                    "severity": {
+                        "code": 6
+                    }
+                }
+            },
+            "observer": {
+                "product": "ftd",
+                "type": "idps",
+                "vendor": "Cisco"
+            },
+            "related": {
+                "ip": [
+                    "10.10.4.100"
+                ],
+                "user": [
+                    "MacBook Pro belonging to bob.dylan.xyz.local"
+                ]
+            },
+            "source": {
+                "address": "10.10.4.100",
+                "ip": "10.10.4.100",
+                "user": {
+                    "group": {
+                        "name": "GroupPolicy_XXX"
+                    },
+                    "name": "MacBook Pro belonging to bob.dylan.xyz.local"
+                }
+            },
+            "tags": [
+                "preserve_original_event"
+            ]
+        }
+    ]
+}

--- a/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/cisco_ftd/data_stream/log/elasticsearch/ingest_pipeline/default.yml
@@ -388,13 +388,15 @@ processors:
       if: '["113029","113030","113031","113032","113033","113034","113035","113036","113038","113039"].contains(ctx._temp_.cisco.message_id)'
       field: "message"
       description: "113029, 113030, 113031, 113032, 113033, 113034, 113035, 113036, 113038, 113039"
+      tag: "113039_group_user_ip"
       patterns:
         - "Group <%{NOTSPACE:source.user.group.name}> User <%{CISCO_USER:source.user.name}> IP <%{IP:source.address}>"
         - "Group %{NOTSPACE:source.user.group.name} User %{CISCO_USER:source.user.name} IP %{IP:source.address}"
       pattern_definitions:
         HOSTNAME: "\\b(?:[0-9A-Za-z][0-9A-Za-z_-]{0,62})(?:\\.(?:[0-9A-Za-z][0-9A-Za-z_-]{0,62}))*(\\.?|\\b)"
         IPORHOST: "(?:%{IP}|%{HOSTNAME})"
-        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)
+        CISCO_USER_ALT: (?:%{DATA})
+        CISCO_USER: ((LOCAL\\)?(%{HOSTNAME}\\)?%{USERNAME}(@%{HOSTNAME})?(, *%{NUMBER})?)|%{CISCO_USER_ALT}
   - grok:
       if: "ctx._temp_.cisco.message_id == '113042'"
       field: "message"
@@ -2691,4 +2693,5 @@ on_failure:
       value: pipeline_error
   - append:
       field: "error.message"
-      value: "{{{ _ingest.on_failure_message }}}"
+      value: 'Processor {{{_ingest.on_failure_processor_type}}} with tag {{{_ingest.on_failure_processor_tag}}} in pipeline {{{_ingest.on_failure_pipeline}}} failed with message: {{{_ingest.on_failure_message}}}'
+

--- a/packages/cisco_ftd/manifest.yml
+++ b/packages/cisco_ftd/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.3"
 name: cisco_ftd
 title: Cisco FTD
-version: "3.4.0"
+version: "3.4.1"
 description: Collect logs from Cisco FTD with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Fix grok failure with username with spaces on ftd messageID.

* Added alternative pattern as suggested in original issue ticket 
https://github.com/elastic/integrations/issues/10721
It is currently just DATA pattern match, not sure if we should tighten this further.
* Improved on failure message.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Related issues

- Closes https://github.com/elastic/integrations/issues/10721

