### PR TITLE
[Cloud Security] Added deployment_mode and properties CSPM, Elastic Connector

### DIFF
--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -26,9 +26,6 @@
       link: https://github.com/elastic/integrations/pull/11274
 - version: "1.11.0-preview08"
   changes:
-   - description: Added deployment_mode agentless to the policy template
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/11203
     - description: Change gcp.credentials.json secret to true
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10479

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -21,6 +21,9 @@
       link: https://github.com/elastic/integrations/pull/11274
 - version: "1.11.0-preview08"
   changes:
+   - description: Added deployment_mode agentless to the policy template
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10479
     - description: Change gcp.credentials.json secret to true
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10479

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -23,7 +23,7 @@
   changes:
    - description: Added deployment_mode agentless to the policy template
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10479
+      link: https://github.com/elastic/integrations/pull/11203
     - description: Change gcp.credentials.json secret to true
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10479

--- a/packages/cloud_security_posture/changelog.yml
+++ b/packages/cloud_security_posture/changelog.yml
@@ -9,6 +9,11 @@
 # 1.4.x - 8.9.x
 # 1.3.x - 8.8.x
 # 1.2.x - 8.7.x
+- version: "1.11.0-preview11"
+  changes:
+    - description: Add deployment_mode agentless to the policy template
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11203
 - version: "1.11.0-preview10"
   changes:
     - description: Adding deployment_modes to cspm policy template and secret field linting checks

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.2.2
+format_version: 3.2.3
 name: cloud_security_posture
 title: "Security Posture Management"
 version: "1.11.0-preview10"
@@ -90,6 +90,14 @@ policy_templates:
     title: Cloud Security Posture Management (CSPM)
     description: Identify & remediate configuration risks in the Cloud services you leverage
     multiple: true
+    deployment_modes:
+      default:
+        enabled: true
+      agentless:
+        enabled: true
+        organization: elastic
+        division: engineering
+        team: cloud-security-posture
     categories:
       - security
       - cloud

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -90,14 +90,6 @@ policy_templates:
     title: Cloud Security Posture Management (CSPM)
     description: Identify & remediate configuration risks in the Cloud services you leverage
     multiple: true
-    deployment_modes:
-      default:
-        enabled: true
-      agentless:
-        enabled: true
-        organization: elastic
-        division: engineering
-        team: cloud-security-posture
     categories:
       - security
       - cloud
@@ -115,6 +107,9 @@ policy_templates:
         enabled: true
       agentless:
         enabled: true
+        organization: elastic
+        division: engineering
+        team: cloud-security-posture
     inputs:
       - type: cloudbeat/cis_aws
         title: Amazon Web Services

--- a/packages/cloud_security_posture/manifest.yml
+++ b/packages/cloud_security_posture/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.2.3
 name: cloud_security_posture
 title: "Security Posture Management"
-version: "1.11.0-preview10"
+version: "1.11.0-preview11"
 source:
   license: "Elastic-2.0"
 description: "Identify & remediate configuration risks in your Cloud infrastructure"

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -6,6 +6,9 @@
       link: https://github.com/elastic/integrations/pull/11267
 - version: 0.0.1
   changes:
+    - description: Added owner information when deployment_mode has agentless enabled
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11203
     - description: Initial draft of the package
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10898

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 0.0.3
+  changes:
+    - description: Add deployment_mode agentless to the policy template
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/11203
 - version: 0.0.2
   changes:
     - description: Add connector_name as the connector input variable

--- a/packages/elastic_connectors/changelog.yml
+++ b/packages/elastic_connectors/changelog.yml
@@ -11,9 +11,6 @@
       link: https://github.com/elastic/integrations/pull/11267
 - version: 0.0.1
   changes:
-    - description: Added owner information when deployment_mode has agentless enabled
-      type: enhancement
-      link: https://github.com/elastic/integrations/pull/11203
     - description: Initial draft of the package
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10898

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -37,6 +37,9 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+        organization: elastic
+        division: engineering
+        team: ingestion-team
     multiple: false
     inputs:
       - type: connectors-py

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -39,7 +39,7 @@ policy_templates:
         enabled: true
         organization: elastic
         division: engineering
-        team: ingestion-team
+        team: search-extract-and-transform
     multiple: false
     inputs:
       - type: connectors-py

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -1,4 +1,4 @@
-format_version: 3.2.1
+format_version: 3.2.3
 name: elastic_connectors
 title: "Elastic Connectors"
 version: 0.0.2
@@ -64,6 +64,9 @@ policy_templates:
         enabled: false
       agentless:
         enabled: true
+        organization: elastic
+        division: engineering
+        team: ingestion-team
     multiple: false
     inputs:
       - type: connectors-py

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -69,7 +69,7 @@ policy_templates:
         enabled: true
         organization: elastic
         division: engineering
-        team: ingestion-team
+        team: search-extract-and-transform
     multiple: false
     inputs:
       - type: connectors-py


### PR DESCRIPTION
We are updating the `elastic-connector` and the `cloud-security-posture` integrations to package-spec version 3.2.3 so that when deployment_mode agentless is selected we can pass the org, division and team information to the Agentless-API.

This will only be merged when package-spec version 3.2.3 is released.


## Checklist

- [x] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [x] I have verified that all data streams collect metrics or logs.
- [x] I have added an entry to my package's `changelog.yml` file.
- [x] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## How to test this PR locally
- Add a CSPM integration


## Related issues

- Closes https://github.com/elastic/agentless-api/issues/304
- Relates https://github.com/elastic/security-team/issues/10436

