### PR TITLE
[Kubernetes] Use filestream fingerprint mode by default for container_logs datastream

### DIFF
--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: 1.68.0
+  changes:
+    - description: Use filestream fingerprint mode by default for container_logs datastream
+      type: enhancement
+      link: https://github.com/elastic/integrations/pull/10593
 - version: 1.67.0
   changes:
     - description: Add both pod.{cpu,memory}.usage.node.pct and pod.{cpu,memory}.usage.limit.pct metrics to the Overview dashboard

--- a/packages/kubernetes/changelog.yml
+++ b/packages/kubernetes/changelog.yml
@@ -3,7 +3,7 @@
   changes:
     - description: Use filestream fingerprint mode by default for container_logs datastream
       type: enhancement
-      link: https://github.com/elastic/integrations/pull/10593
+      link: https://github.com/elastic/integrations/pull/11212
 - version: 1.67.0
   changes:
     - description: Add both pod.{cpu,memory}.usage.node.pct and pod.{cpu,memory}.usage.limit.pct metrics to the Overview dashboard

--- a/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
+++ b/packages/kubernetes/data_stream/container_logs/agent/stream/stream.yml.hbs
@@ -5,7 +5,11 @@ paths:
 {{/each}}
 data_stream:
   dataset: {{data_stream.dataset}}
-prospector.scanner.symlinks: {{ symlinks }}
+prospector:
+  scanner:
+    fingerprint.enabled: true
+    symlinks: {{ symlinks }}
+file_identity.fingerprint: ~
 {{#if condition}}
 condition: {{ condition }}
 {{/if}}

--- a/packages/kubernetes/manifest.yml
+++ b/packages/kubernetes/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.1.2
 name: kubernetes
 title: Kubernetes
-version: 1.67.0
+version: 1.68.0
 description: Collect logs and metrics from Kubernetes clusters with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
## Proposed commit message

Please explain:

- WHAT: Use filestream fingerprint mode by default for container_logs datastream
- WHY:  Avoid logs duplication

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<img width="712" alt="Screenshot 2024-09-24 at 11 25 19" src="https://github.com/user-attachments/assets/ca23a3b3-f922-424f-abcc-9ca03486d0aa">

