### PR TITLE
carbon_black_cloud: fix timestamp type when using cursor value

### DIFF
--- a/packages/carbon_black_cloud/changelog.yml
+++ b/packages/carbon_black_cloud/changelog.yml
@@ -1,4 +1,9 @@
 # newer versions go on top
+- version: "2.5.3"
+  changes:
+    - description: Fix timestamp type when using cursor value.
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11221
 - version: "2.5.2"
   changes:
     - description: Ensure alert search range is a valid temporal ordering.

--- a/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
+++ b/packages/carbon_black_cloud/data_stream/alert_v7/agent/stream/cel.yml.hbs
@@ -37,7 +37,7 @@ program: |-
   				// to the last event we received.
   				// See https://developer.carbonblack.com/reference/carbon-black-cloud/guides/alert-bulk-export/
   				"time_range": (now - duration("60s")).as(delayed, {
-  					"start": state.?cursor.last_backend_update_timestamp.orValue(delayed - duration(state.initial_interval)),
+  					"start": timestamp(state.?cursor.last_backend_update_timestamp.orValue(delayed - duration(state.initial_interval))),
   					"end": delayed,
   				}).as(range, {
   					"start": string(range.start < range.end ? range.start : range.end),

--- a/packages/carbon_black_cloud/manifest.yml
+++ b/packages/carbon_black_cloud/manifest.yml
@@ -1,7 +1,7 @@
 format_version: "3.0.2"
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
-version: "2.5.2"
+version: "2.5.3"
 description: Collect logs from VMWare Carbon Black Cloud with Elastic Agent.
 type: integration
 categories:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

When using the cursor value, the start expression in the range macro is a string since state.cursor.last_backend_update_timestamp is a string. This results in a comparison of range.start (string) with range.end (timestamp) which is not a valid type match for the \< operator. So we end up with a "no such overload". If the value is optional.none, we use delayed (timestamp) which is the correct type. Ensure that the expression is always a timestamp by doing a conversion on the resulting value, noting that a timestamp(timestamp(x)) is valid if timestamp(x) is.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- 

## Screenshots

<!-- Optional
Add here screenshots presenting:
- Kibana UI forms presenting configuration options exposed by the integration
- dashboards with collected metrics or logs
-->
