### PR TITLE
[CI] Update find oldest supported script

### DIFF
--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -221,7 +221,8 @@ class TestFindOldestSupportVersion(unittest.TestCase):
             "8.9",
             "8.10-SNAPSHOT",
             "8.10",
-            "8.11-SNAPSHOT"
+            "8.11-SNAPSHOT",
+            "8.x-SNAPSHOT"
         ],
         "manifests": {
             "last-update-time": "Thu, 14 Sep 2023 16:03:46 UTC",
@@ -261,13 +262,20 @@ class TestFindOldestSupportVersion(unittest.TestCase):
 
     def test_no_version_available_no_next_minor_in_current_major(self):
         # returns the version as in the manifest
-        self.assertEqual(find_oldest_supported_version("8.11.3"), "8.11.3")
+        # no exists in available_versions or snapshots, neither the current {major}-x.SNAPSHOT
+        self.assertEqual(find_oldest_supported_version("9.0.0"), "9.0.0")
 
     def test_available_next_minor_in_current_major(self):
         self.assertEqual(find_oldest_supported_version("7.19.0"), "7.x-SNAPSHOT")
 
+        # not sure if this test case should return 8.x-SNAPSHOT stack version,
+        # that would test with probably a newer stack (8.11.0-SNAPSHOT).
+        self.assertEqual(find_oldest_supported_version("8.8.3"), "8.x-SNAPSHOT")
+
     def test_available_version_in_current_major_but_missing_minor(self):
-        # 8.9.2 and 8.9.4 versions exist, but not 8.9.3 version
+        # 8.9.2 and 8.9.4 versions exist in the artifacts-api response and the alias
+        # 8.x-SNAPSHOT too exists,
+        # but there is no 8.9.3 version in the artifacts-api response.
         self.assertEqual(find_oldest_supported_version("8.9.3"), "8.9.3")
 
     def test_or(self):

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -61,6 +61,25 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
 
     # Old minors may not be available in artifacts-api, if it is older
     # than the others in the same major, return the version as is.
+    older = is_older_version(available_versions, major, minor)
+
+    # Check if there could be some version removed or missing from the
+    # artifacts-api response. If it is missing, return the version as is
+    newerPatch = exists_newer_patch(available_versions, major, minor, patch)
+
+    if older or newerPatch:
+        return version
+
+    # If no version has been found so far, try with the snapshot of the next version
+    # in the current major.
+    major_snapshot = f"{major}.x-SNAPSHOT"
+    if major_snapshot in available_aliases:
+        return major_snapshot
+
+    # Otherwise, return it, whatever this is.
+    return version
+
+def is_older_version(available_versions: list[str], major: str, minor: str) -> bool:
     older = True
     for available_version in available_versions:
         available_parts = available_version.split(".")
@@ -72,17 +91,28 @@ def find_oldest_supported_version(kibana_version_condition: str) -> str:
         if int(major) == available_major and int(minor) > available_minor:
             older = False
             break
-    if older:
-        return version
 
-    # If no version has been found so far, try with the snapshot of the next version
-    # in the current major.
-    major_snapshot = f"{major}.x-SNAPSHOT"
-    if major_snapshot in available_aliases:
-        return major_snapshot
+    return older
 
-    # Otherwise, return it, whatever this is.
-    return version
+def exists_newer_patch(available_versions: list[str], major: str, minor: str, patch: str) -> bool:
+    newer_patch = False
+    for available_version in available_versions:
+        available_parts = available_version.split(".")
+        if len(available_parts) < 2:
+            continue
+
+        available_major = int(available_parts[0])
+        available_minor = int(available_parts[1])
+        if int(major) == available_major and int(minor) == available_minor:
+            available_patch = available_parts[2]
+            # skip prerelease tags?
+            if "+" in available_patch or '-' in available_patch:
+                continue
+
+            if int(patch) < int(available_patch):
+                newer_patch = True
+                break
+    return newer_patch
 
 
 def remove_operator(kibana_version_condition: str) -> str:
@@ -175,6 +205,7 @@ class TestFindOldestSupportVersion(unittest.TestCase):
             "8.9.1",
             "8.9.2-SNAPSHOT",
             "8.9.2",
+            "8.9.4",
             "8.10.0-SNAPSHOT",
             "8.10.0",
             "8.10.1-SNAPSHOT",
@@ -234,6 +265,10 @@ class TestFindOldestSupportVersion(unittest.TestCase):
 
     def test_available_next_minor_in_current_major(self):
         self.assertEqual(find_oldest_supported_version("7.19.0"), "7.x-SNAPSHOT")
+
+    def test_available_version_in_current_major_but_missing_minor(self):
+        # 8.9.2 and 8.9.4 versions exist, but not 8.9.3 version
+        self.assertEqual(find_oldest_supported_version("8.9.3"), "8.9.3")
 
     def test_or(self):
         self.assertEqual(find_oldest_supported_version("8.6.0||8.7.0"), "8.6.0")

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -268,7 +268,7 @@ class TestFindOldestSupportVersion(unittest.TestCase):
     def test_available_next_minor_in_current_major(self):
         self.assertEqual(find_oldest_supported_version("7.19.0"), "7.x-SNAPSHOT")
 
-        # not sure if this test case should return 8.x-SNAPSHOT stack version,
+        # not sure if this test case for 8.8.3 should return 8.x-SNAPSHOT stack version,
         # that would test with probably a newer stack (8.11.0-SNAPSHOT).
         self.assertEqual(find_oldest_supported_version("8.8.3"), "8.x-SNAPSHOT")
         self.assertEqual(find_oldest_supported_version("8.12.0"), "8.x-SNAPSHOT")

--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -271,6 +271,7 @@ class TestFindOldestSupportVersion(unittest.TestCase):
         # not sure if this test case should return 8.x-SNAPSHOT stack version,
         # that would test with probably a newer stack (8.11.0-SNAPSHOT).
         self.assertEqual(find_oldest_supported_version("8.8.3"), "8.x-SNAPSHOT")
+        self.assertEqual(find_oldest_supported_version("8.12.0"), "8.x-SNAPSHOT")
 
     def test_available_version_in_current_major_but_missing_minor(self):
         # 8.9.2 and 8.9.4 versions exist in the artifacts-api response and the alias


### PR DESCRIPTION
## Proposed commit message

Add support in `find_oldest_supported_version.py` script to return the version as is when that version does not exist, but exist a next patch (newer) version.

Currently, `8.13.0` version is not part of the `versions`  reported in the artifacts-api response. But that Elastic stack version exists.

Before:
```
Manifest ^8.13.0 -> script 8.x-SNAPSHOT 	[keycloak]
Manifest ^8.13.0 -> script 8.x-SNAPSHOT 	[httpjson]
Manifest ^8.13.0 -> script 8.x-SNAPSHOT 	[vectra_detect]
Manifest ^8.3.0 -> script 8.3.0 	[fortinet_fortimail]
```

After:
```
Manifest ^8.13.0 -> script 8.13.0 	[keycloak]
Manifest ^8.13.0 -> script 8.13.0 	[httpjson]
Manifest ^8.13.0 -> script 8.13.0 	[vectra_detect]
Manifest ^8.3.0 -> script 8.3.0 	[fortinet_fortimail]
```

<details>

<summary>Current example of artifacts-api-response</summary>

```json
{
  "versions": [
    "7.17.20",
    "7.17.21",
    "7.17.22",
    "7.17.23",
    "7.17.24-SNAPSHOT",
    "7.17.24",
    "7.17.25-SNAPSHOT",
    "7.17.25",
    "8.12.3",
    "8.13.0+build202403281537",
    "8.13.0+build202403281758",
    "8.13.1+build202404121909",
    "8.13.1+build202404122010",
    "8.13.1",
    "8.13.2",
    "8.13.3",
    "8.13.4",
    "8.13.5",
    "8.14.0",
    "8.14.1",
    "8.14.2",
    "8.14.3",
    "8.14.4",
    "8.15.0",
    "8.15.1-SNAPSHOT",
    "8.15.1",
    "8.15.2-SNAPSHOT",
    "8.15.2",
    "8.16.0-SNAPSHOT",
    "9.0.0-SNAPSHOT"
  ],
  "aliases": [
    "7.17-SNAPSHOT",
    "7.17",
    "8.x-SNAPSHOT",
    "8.12",
    "8.13",
    "8.14",
    "8.15-SNAPSHOT",
    "8.15",
    "8.16-SNAPSHOT",
    "9.0-SNAPSHOT"
  ],
  "manifests": {
    "last-update-time": "Tue, 24 Sep 2024 07:41:14 UTC",
    "seconds-since-last-update": 236
  }
}
```

</details>




## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] 

## How to test this PR locally

```
python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path <manifest_path>

python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path packages/vsphere/manifest.yml
8.15.2-SNAPSHOT

python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path packages/zoom/manifest.yml
8.13.0
```

It could be checked stack version reported for all packages with this script:
```shell
#!/bin/bash
set -euo pipefail

for manifest in $(find . -maxdepth 3 -mindepth 3 -name manifest.yml | LC_ALL=C sort) ; do
    package=$(echo $manifest |awk -F '/' '{print $3}')
    version_manifest=$(cat $manifest |yq -r '.conditions.kibana.version')
    if [[ $version_manifest == null ]]; then
        version_manifest=$(cat $manifest |yq -r '.conditions."kibana.version"')
    fi
    
    script_version=$(python3 .buildkite/scripts/find_oldest_supported_version.py --manifest-path $manifest)
    
    echo -e "Manifest ${version_manifest} -> script ${script_version} \t[$package]"
done
```

## Related issues

- Follows https://github.com/elastic/integrations/pull/11126

