### PR TITLE
Rename the ingestion-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -171,7 +171,7 @@
 /packages/digital_guardian @elastic/security-service-integrations
 /packages/docker @elastic/obs-cloudnative-monitoring
 /packages/elastic_agent @elastic/elastic-agent
-/packages/elastic_connectors @elastic/ingestion-team
+/packages/elastic_connectors @elastic/search-extract-and-transform
 /packages/elastic_package_registry @elastic/ecosystem
 /packages/elasticsearch @elastic/stack-monitoring
 /packages/enterprisesearch @elastic/stack-monitoring

--- a/packages/elastic_connectors/manifest.yml
+++ b/packages/elastic_connectors/manifest.yml
@@ -63,5 +63,5 @@ policy_templates:
         description: Connectors syncs data from an original data source to an Elasticsearch index.
         template_path: google_drive.yml.hbs
 owner:
-  github: elastic/ingestion-team
+  github: elastic/search-extract-and-transform
   type: elastic


### PR DESCRIPTION
### Description
As part of the GitHub teams renaming initiative, it's required to rename the @elastic/ingestion-team to @elastic/search-extract-and-transform.

This PR is dedicated to renaming @elastic/ingestion-team to @elastic/search-extract-and-transform 