### PR TITLE
[vSphere][network] fix issue with TSDB network name

### DIFF
--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 - version: "1.15.0-next"
   changes:
-    - description: fix issue with TSDB network.name
+    - description: Fix issue with TSDB network.name.
       type: bugfix
       link: https://github.com/elastic/integrations/pull/11229
     - description: Add new network datastream.

--- a/packages/vsphere/changelog.yml
+++ b/packages/vsphere/changelog.yml
@@ -1,6 +1,9 @@
 # newer versions go on top
 - version: "1.15.0-next"
   changes:
+    - description: fix issue with TSDB network.name
+      type: bugfix
+      link: https://github.com/elastic/integrations/pull/11229
     - description: Add new network datastream.
       type: enhancement
       link: https://github.com/elastic/integrations/pull/10993

--- a/packages/vsphere/data_stream/network/fields/fields.yml
+++ b/packages/vsphere/data_stream/network/fields/fields.yml
@@ -25,6 +25,7 @@
             Number of hosts connected to this network.
     - name: name
       type: keyword
+      dimension: true
       description: >
         Name of the network.
     - name: status


### PR DESCRIPTION
- Bug

## Description

Events are dropped because of network.name is not dimensioned.